### PR TITLE
Add permissions for release job in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release:
+    permissions: 
+      contents: write
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
This pull request introduces a small change to the GitHub Actions workflow configuration. It updates the release workflow to explicitly set permissions for writing to repository contents, which is necessary for certain release automation tasks. 

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R10-R11): Added `permissions: contents: write` to the `release` job configuration.