### PR TITLE
Change CodeQL language matrix to include actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["javascript", "typescript"]
+        language: ["actions", "typescript"]
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
This pull request makes a small change to the CodeQL workflow configuration. The `language` matrix in `.github/workflows/codeql.yml` has been updated to include `actions` instead of `javascript`. This ensures that CodeQL analysis will now cover GitHub Actions workflows in addition to TypeScript and prevents warnings about duplicate languages, as javascript and typescript are treated the same in CodeQL.