### PR TITLE
Update GitHub Script action version in workflow

### DIFF
--- a/.github/workflows/check-models.yml
+++ b/.github/workflows/check-models.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Close GitHub Issue if all models are up-to-date
         if: steps.check_missing.outputs.needs_update == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by pinning the `actions/github-script` action to a specific commit SHA for improved security and reproducibility.

- **Workflow dependency pinning:**
  - Updated the `actions/github-script` action in `.github/workflows/check-models.yml` to use a specific commit SHA (`f28e40c7f34bde8b3046d885e986cb6290c5673b`) instead of the general `v7` tag.