### PR TITLE
Potential fix for code scanning alert no. 22: Client-side cross-site scripting

### DIFF
--- a/src/webview/diagnostics/main.ts
+++ b/src/webview/diagnostics/main.ts
@@ -271,8 +271,8 @@ function renderSessionTable(detailedFiles: SessionFileDetails[], isLoading: bool
 								${sf.title ? `<a href="#" class="session-file-link" data-file="${encodeURIComponent(sf.file)}" title="${escapeHtml(sf.title)}">${escapeHtml(sf.title.length > 40 ? sf.title.substring(0, 40) + '...' : sf.title)}</a>` : '<span style="color: #666;">—</span>'}
 							</td>
 							<td>${formatFileSize(sf.size)}</td>
-							<td>${sf.interactions}</td>
-							<td title="${getContextRefsSummary(sf.contextReferences)}">${getTotalContextRefs(sf.contextReferences)}</td>
+							<td>${sanitizeNumber(sf.interactions)}</td>
+							<td title="${getContextRefsSummary(sf.contextReferences)}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td>
 							<td>${formatDate(sf.firstInteraction)}</td>
 							<td>${formatDate(sf.lastInteraction)}</td>
 						</tr>


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/22](https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/22)

In general, to fix DOM-based XSS when rendering untrusted data, every value interpolated into HTML should be either (a) properly HTML-escaped for its context, or (b) validated and restricted to a safe, narrow type (for example, numbers only) before stringification. For data that should be numeric, converting with validation and then stringifying (or using an existing numeric sanitizer) prevents arbitrary HTML or script injection.

The best targeted fix here is to ensure the untrusted numeric-looking values in the session table—`sf.interactions` and the result of `getTotalContextRefs(sf.contextReferences)`—are passed through the existing `sanitizeNumber` function before they are interpolated into the HTML template. This keeps the visible behavior identical for valid numeric values, while forcing any non-numeric or infinite values to render as `'0'` instead of arbitrary attacker-controlled content.

Concretely, in `src/webview/diagnostics/main.ts`, inside `renderSessionTable`, locate the table row template where each `sf` is rendered (lines around 266–278). Change:

- `<td>${sf.interactions}</td>` to `<td>${sanitizeNumber(sf.interactions)}</td>`
- `<td title="${getContextRefsSummary(sf.contextReferences)}">${getTotalContextRefs(sf.contextReferences)}</td>` to `<td title="${getContextRefsSummary(sf.contextReferences)}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td>`

No new imports are needed because `sanitizeNumber` is already defined at the top of the file. No other structural changes are necessary; this keeps the existing formatting and behavior while eliminating the XSS risk from those fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
