### PR TITLE
detect implicit selections

### DIFF
--- a/src/webview/usage/main.ts
+++ b/src/webview/usage/main.ts
@@ -6,6 +6,7 @@ type ModeUsage = { ask: number; edit: number; agent: number };
 type ContextReferenceUsage = {
 	file: number;
 	selection: number;
+	implicitSelection: number;
 	symbol: number;
 	codebase: number;
 	workspace: number;
@@ -67,7 +68,7 @@ function escapeHtml(text: string): string {
 }
 
 function getTotalContextRefs(refs: ContextReferenceUsage): number {
-	return refs.file + refs.selection + refs.symbol + refs.codebase +
+	return refs.file + refs.selection + refs.implicitSelection + refs.symbol + refs.codebase +
 		refs.workspace + refs.terminal + refs.vscode;
 }
 
@@ -205,6 +206,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 				padding: 12px;
 				box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 			}
+			.stat-card[title] { cursor: help; }
 			.stat-label { font-size: 11px; color: #b8b8b8; margin-bottom: 4px; }
 			.stat-value { font-size: 20px; font-weight: 700; color: #f6f6f6; }
 			.bar-chart {
@@ -320,6 +322,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 				<div class="stats-grid">
 					<div class="stat-card"><div class="stat-label">📄 #file</div><div class="stat-value">${stats.month.contextReferences.file}</div><div style="font-size: 10px; color: #999; margin-top: 4px;">Today: ${stats.today.contextReferences.file}</div></div>
 					<div class="stat-card"><div class="stat-label">✂️ #selection</div><div class="stat-value">${stats.month.contextReferences.selection}</div><div style="font-size: 10px; color: #999; margin-top: 4px;">Today: ${stats.today.contextReferences.selection}</div></div>
+					<div class="stat-card" title="Text selected in your editor providing passive context to Copilot"><div class="stat-label">✨ Implicit Selection</div><div class="stat-value">${stats.month.contextReferences.implicitSelection}</div><div style="font-size: 10px; color: #999; margin-top: 4px;">Today: ${stats.today.contextReferences.implicitSelection}</div></div>
 					<div class="stat-card"><div class="stat-label">🔤 #symbol</div><div class="stat-value">${stats.month.contextReferences.symbol}</div><div style="font-size: 10px; color: #999; margin-top: 4px;">Today: ${stats.today.contextReferences.symbol}</div></div>
 					<div class="stat-card"><div class="stat-label">🗂️ #codebase</div><div class="stat-value">${stats.month.contextReferences.codebase}</div><div style="font-size: 10px; color: #999; margin-top: 4px;">Today: ${stats.today.contextReferences.codebase}</div></div>
 					<div class="stat-card"><div class="stat-label">📁 @workspace</div><div class="stat-value">${stats.month.contextReferences.workspace}</div><div style="font-size: 10px; color: #999; margin-top: 4px;">Today: ${stats.today.contextReferences.workspace}</div></div>


### PR DESCRIPTION
This pull request adds tracking and visualization for "implicit selection" context references—cases where text is selected in the editor and passively provides context to Copilot. The change updates both the backend tracking logic and the usage stats webview to include this new metric, ensuring it is counted, merged, and displayed consistently alongside other context reference types.

**Context reference tracking and logic updates:**

* Added `implicitSelection` to the `ContextReferenceUsage` type/interface in both `src/extension.ts` and `src/webview/usage/main.ts`, ensuring all context reference objects now include this metric. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R107) [[2]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cR9)
* Updated logic to detect and increment `implicitSelection` when selections are present in input state events, both at session start and during updates.
* Modified context reference initialization, merging, and cache versioning to support `implicitSelection`, ensuring accurate aggregation and cache invalidation. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L197-R198) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R984) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1084) [[4]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1365) [[5]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1780) [[6]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L1808-R1823) [[7]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L2269-R2284)

**Usage statistics visualization:**

* Updated the usage stats webview to display the "Implicit Selection" metric with a tooltip explanation, and included it in total context reference calculations. [[1]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cL70-R71) [[2]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cR325) [[3]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cR209)