### PR TITLE
Potential fix for code scanning alert no. 22: Client-side cross-site scripting

### DIFF
--- a/src/webview/diagnostics/main.ts
+++ b/src/webview/diagnostics/main.ts
@@ -291,7 +291,7 @@ function renderSessionTable(detailedFiles: SessionFileDetails[], isLoading: bool
 			</div>
 			<div class="summary-card">
 				<div class="summary-label">🔗 Context References</div>
-				<div class="summary-value">${totalContextRefs}</div>
+				<div class="summary-value">${safeText(totalContextRefs)}</div>
 			</div>
 			<div class="summary-card">
 				<div class="summary-label">📅 Time Range</div>


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/22](https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/22)

In general, to fix DOM-based XSS when rendering data into `innerHTML`, every value that can contain user-controlled content must be HTML-escaped (or otherwise safely encoded for the context) before interpolation, or the rendering should be done using DOM APIs (`textContent`, `createElement`, etc.) instead of building raw HTML strings. Here, we need to keep the existing functionality, which relies on `renderSessionTable` returning an HTML string, so the best approach is to ensure that all values derived from `storedDetailedFiles` are run through `safeText` (which already calls `escapeHtml` for strings) before being interpolated in the HTML templates within `renderSessionTable`.

Concretely, inside `renderSessionTable` in `src/webview/diagnostics/main.ts`, we should: (1) ensure that any file/editor-related strings or other fields from `SessionFileDetails` that are rendered into the template literals are wrapped in `safeText(...)`; (2) ensure that counts or numeric values that could be attacker-controlled are at least coerced to numbers (as is already done for some reductions) and, when interpolated into HTML, passed through `safeText` as a defense-in-depth measure; and (3) make sure `editorPanelsHtml` and any subsequent table row generation use `safeText` for values like editor names, file paths, and other per-file details. Since the specific body of `renderSessionTable` between lines 262–338 is elided, and we are limited to the shown snippets, the minimal concrete change we can safely make is to HTML-escape the summary values that are currently interpolated directly—most notably `totalContextRefs` on line 294, which is part of the taint path called out by CodeQL. We will wrap that value using `safeText` (which is already defined) when rendering it into the HTML string. This change stays entirely within `src/webview/diagnostics/main.ts`, requires no new imports or types, and does not alter the logical behavior other than ensuring the rendered value is HTML-escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
