### PR TITLE
Potential fix for code scanning alert no. 32: Client-side cross-site scripting

### DIFF
--- a/src/webview/diagnostics/main.ts
+++ b/src/webview/diagnostics/main.ts
@@ -283,11 +283,8 @@ function safeText(value: unknown): string {
   if (value === null || value === undefined) {
     return "";
   }
-  if (typeof value === "string") {
-    // Use existing HTML escaping to avoid XSS when inserting into innerHTML.
-    return escapeHtml(value);
-  }
-  return String(value);
+  // Always convert to string and escape HTML to avoid XSS when inserting into innerHTML.
+  return escapeHtml(String(value));
 }
 
 function renderSessionTable(


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/32](https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/32)

In general, to fix DOM-based XSS when writing dynamic content into `innerHTML`, every value derived from untrusted input must be properly HTML-escaped, regardless of its apparent runtime type. Here the intended safety wrapper `safeText` only escapes strings; for non-strings it falls back to `String(value)`, leaving a gap if a non-string (for example, a number-like object or any future refactor that passes something else) contains characters meaningful in HTML. The safest fix is to ensure `safeText` always produces an HTML-escaped string, independent of the input type.

The concrete change is to modify `safeText` in `src/webview/diagnostics/main.ts` so that it converts any non-null value to a string and then passes it through `escapeHtml`. This keeps existing behavior for strings but strengthens it for all other types, and fixes the CodeQL-reported flow through `safeText(totalContextRefs)` into `innerHTML`. No other call sites or logic need to change. You do not need any new imports; `escapeHtml` is already used in the file.

Specifically:
- In `safeText`, replace the current conditional that treats strings and non-strings differently with logic that:
  - Returns `""` for `null`/`undefined`.
  - Calls `escapeHtml(String(value))` for anything else.
This change occurs around lines 282–291 in `src/webview/diagnostics/main.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
