### PR TITLE
Sanitize model names in usage analysis display to prevent XSS vulnerabilities

### DIFF
--- a/src/webview/diagnostics/main.ts
+++ b/src/webview/diagnostics/main.ts
@@ -121,7 +121,7 @@ function formatDate(isoString: string | null): string {
   try {
     return new Date(isoString).toLocaleString();
   } catch {
-    return isoString;
+    return escapeHtml(isoString);
   }
 }
 

--- a/src/webview/usage/main.ts
+++ b/src/webview/usage/main.ts
@@ -686,19 +686,19 @@ function renderLayout(stats: UsageAnalysisStats): void {
 								${stats.today.modelSwitching.standardModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: var(--link-color);">🔵 Standard:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.today.modelSwitching.standardModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.today.modelSwitching.standardModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 								${stats.today.modelSwitching.premiumModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: #fbbf24;">⭐ Premium:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.today.modelSwitching.premiumModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.today.modelSwitching.premiumModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 								${stats.today.modelSwitching.unknownModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: var(--text-muted);">❓ Unknown:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.today.modelSwitching.unknownModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.today.modelSwitching.unknownModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : ''}
 							</div>
@@ -755,19 +755,19 @@ function renderLayout(stats: UsageAnalysisStats): void {
 								${stats.last30Days.modelSwitching.standardModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: var(--link-color);">🔵 Standard:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.last30Days.modelSwitching.standardModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.last30Days.modelSwitching.standardModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 								${stats.last30Days.modelSwitching.premiumModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: #fbbf24;">⭐ Premium:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.last30Days.modelSwitching.premiumModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.last30Days.modelSwitching.premiumModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 								${stats.last30Days.modelSwitching.unknownModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: var(--text-muted);">❓ Unknown:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.last30Days.modelSwitching.unknownModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.last30Days.modelSwitching.unknownModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : ''}
 							</div>
@@ -824,19 +824,19 @@ function renderLayout(stats: UsageAnalysisStats): void {
 								${stats.month.modelSwitching.standardModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: var(--link-color);">🔵 Standard:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.month.modelSwitching.standardModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.month.modelSwitching.standardModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 								${stats.month.modelSwitching.premiumModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: #fbbf24;">⭐ Premium:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.month.modelSwitching.premiumModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.month.modelSwitching.premiumModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 								${stats.month.modelSwitching.unknownModels.length > 0 ? `
 									<div style="margin-bottom: 6px;">
 										<span style="color: var(--text-muted);">❓ Unknown:</span>
-										<span style="font-size: 11px; color: var(--text-primary);">${stats.month.modelSwitching.unknownModels.join(', ')}</span>
+										<span style="font-size: 11px; color: var(--text-primary);">${stats.month.modelSwitching.unknownModels.map(escapeHtml).join(', ')}</span>
 									</div>
 								` : ''}
 							</div>
@@ -1358,7 +1358,7 @@ function renderRepositoryHygienePanels(): void {
 						${escapeHtml(ws.workspaceName)}
 					</div>
 					<div style="font-size: 10px; color: #999; margin-top: 2px;">
-						${ws.sessionCount} ${ws.sessionCount === 1 ? 'session' : 'sessions'} · ${ws.interactionCount} ${ws.interactionCount === 1 ? 'interaction' : 'interactions'} · Score: ${scoreLabel}
+						${ws.sessionCount} ${ws.sessionCount === 1 ? 'session' : 'sessions'} · ${ws.interactionCount} ${ws.interactionCount === 1 ? 'interaction' : 'interactions'} · Score: ${escapeHtml(scoreLabel)}
 					</div>
 				</div>
 				<vscode-button class="btn-repo-action" data-action="${buttonAction}" data-workspace-path="${escapeHtml(ws.workspacePath)}" ${isCurrentSelection ? 'disabled="true"' : ''} style="min-width: 80px;">


### PR DESCRIPTION
This pull request focuses on improving the security of the webview by ensuring that all dynamic content rendered in the UI is properly escaped to prevent potential HTML injection vulnerabilities. The changes primarily update how model names, labels, and other dynamic strings are displayed in the diagnostics and usage panels.

**HTML escaping improvements:**

* All model names displayed in the usage stats panels are now escaped using `escapeHtml` to prevent injection issues in `src/webview/usage/main.ts`. This applies to standard, premium, and unknown model lists for today, last 30 days, and month views. [[1]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cL689-R701) [[2]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cL758-R770) [[3]](diffhunk://#diff-4084fc689cd4cdb1b475ff955296667f3023f44e8b63eb65605b2838f4b1938cL827-R839)
* The repository hygiene score label is now escaped when rendered, ensuring that any dynamic score label content cannot inject HTML.
* The `formatDate` function in `src/webview/diagnostics/main.ts` now escapes the date string if parsing fails, rather than returning it raw.