### PR TITLE
Add daily stats tracking for improved chart data visualization

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -737,6 +737,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private outputChannel: vscode.OutputChannel;
 	private sessionFileCache: Map<string, SessionFileCache> = new Map();
 	private lastDetailedStats: DetailedStats | undefined;
+	private lastDailyStats: DailyTokenStats[] | undefined;
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private tokenEstimators: { [key: string]: number } = tokenEstimatorsData.estimators;
 	private co2Per1kTokens = 0.2; // gCO2e per 1000 tokens, a rough estimate
@@ -1489,6 +1490,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.diagnosticsCachedFiles = [];
 			// Clear cached computed stats so details panel doesn't show stale data
 			this.lastDetailedStats = undefined;
+			this.lastDailyStats = undefined;
 			this.lastUsageAnalysisStats = undefined;
 
 			this.log(`Cache cleared successfully. Removed ${cacheSize} entries.`);
@@ -1757,9 +1759,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 				}
 			}
 
-			// If the chart panel is open, update its content
-			if (this.chartPanel) {
-				const dailyStats = await this.calculateDailyStats();
+			// If the chart panel is open, update its content (daily stats were computed in calculateDetailedStats)
+			if (this.chartPanel && this.lastDailyStats) {
+				const dailyStats = this.lastDailyStats;
 				if (silent) {
 					// Background update: send data via postMessage to preserve the active chart view toggle
 					void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: this.buildChartData(dailyStats) });
@@ -1880,6 +1882,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const lastMonthStats = { tokens: 0, thinkingTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
 		const last30DaysStats = { tokens: 0, thinkingTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
 
+		// Also compute daily stats for the chart as a byproduct (avoids a second full file scan)
+		const dailyStatsMap = new Map<string, DailyTokenStats>();
+
 		try {
 			// Clean expired cache entries
 			this.clearExpiredCache();
@@ -1969,6 +1974,42 @@ class CopilotTokenTracker implements vscode.Disposable {
 							}
 							last30DaysStats.modelUsage[model].inputTokens += usage.inputTokens;
 							last30DaysStats.modelUsage[model].outputTokens += usage.outputTokens;
+						}
+
+						// Accumulate daily stats for the chart view
+						const dateKey = this.formatDateKey(lastActivity);
+						const repository = sessionData.repository || 'Unknown';
+						if (!dailyStatsMap.has(dateKey)) {
+							dailyStatsMap.set(dateKey, {
+								date: dateKey,
+								tokens: 0,
+								sessions: 0,
+								interactions: 0,
+								modelUsage: {},
+								editorUsage: {},
+								repositoryUsage: {}
+							});
+						}
+						const dailyEntry = dailyStatsMap.get(dateKey)!;
+						dailyEntry.tokens += tokens;
+						dailyEntry.sessions += 1;
+						dailyEntry.interactions += interactions;
+						if (!dailyEntry.editorUsage[editorType]) {
+							dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 };
+						}
+						dailyEntry.editorUsage[editorType].tokens += tokens;
+						dailyEntry.editorUsage[editorType].sessions += 1;
+						if (!dailyEntry.repositoryUsage[repository]) {
+							dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 };
+						}
+						dailyEntry.repositoryUsage[repository].tokens += tokens;
+						dailyEntry.repositoryUsage[repository].sessions += 1;
+						for (const [model, usage] of Object.entries(modelUsage)) {
+							if (!dailyEntry.modelUsage[model]) {
+								dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+							}
+							dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
+							dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
 						}
 					}
 
@@ -2064,6 +2105,28 @@ class CopilotTokenTracker implements vscode.Disposable {
 		} catch (error) {
 			this.error('Error calculating detailed stats:', error);
 		}
+
+		// Finalize daily stats: fill in missing days with zero values
+		const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+		const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const existingDates = new Set(dailyStatsMap.keys());
+		const fillDate = new Date(thirtyDaysAgo);
+		while (fillDate <= today) {
+			const dateKey = this.formatDateKey(fillDate);
+			if (!existingDates.has(dateKey)) {
+				dailyStatsMap.set(dateKey, {
+					date: dateKey,
+					tokens: 0,
+					sessions: 0,
+					interactions: 0,
+					modelUsage: {},
+					editorUsage: {},
+					repositoryUsage: {}
+				});
+			}
+			fillDate.setDate(fillDate.getDate() + 1);
+		}
+		this.lastDailyStats = Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
 
 		const todayCo2 = (todayStats.tokens / 1000) * this.co2Per1kTokens;
 		const monthCo2 = (monthStats.tokens / 1000) * this.co2Per1kTokens;
@@ -6655,8 +6718,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return;
 		}
 
-		// Get daily stats
-		const dailyStats = await this.calculateDailyStats();
+		// Use daily stats computed by calculateDetailedStats if available, otherwise compute them
+		const dailyStats = this.lastDailyStats ?? await this.calculateDailyStats();
 
 		// Create webview panel
 		this.chartPanel = vscode.window.createWebviewPanel(


### PR DESCRIPTION
This pull request optimizes how daily token usage statistics are computed and cached in the `CopilotTokenTracker` class within `src/extension.ts`. Instead of recalculating daily stats separately, it now computes and stores them as part of the detailed stats calculation, reducing redundant file scans and improving performance for chart updates.

**Performance and caching improvements:**

* Daily token usage statistics (`lastDailyStats`) are now computed as a byproduct of the detailed stats calculation, eliminating the need for a separate full file scan and reducing redundant work. (`[[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1885-R1887)`, `[[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1978-R2013)`)
* The `lastDailyStats` cache is cleared alongside other cached stats to prevent stale data in the details panel. (`[src/extension.tsR1493](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1493)`)

**Chart and UI updates:**

* When updating the chart panel, the extension now uses the cached `lastDailyStats` if available, further reducing unnecessary recomputation. (`[[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L1760-R1764)`, `[[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L6658-R6722)`)
* The daily stats array is finalized to include all days in the last 30 days, filling missing days with zero values to ensure consistent chart data. (`[src/extension.tsR2109-R2130](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R2109-R2130)`)

**Internal state changes:**

* The `CopilotTokenTracker` class now includes a `lastDailyStats` property to cache the most recent daily stats for efficient reuse. (`[src/extension.tsR740](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R740)`)