### PR TITLE
Fix null safety in response array loops and OpenCode method reference

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7041,7 +7041,7 @@ export function activate(context: vscode.ExtensionContext) {
       isOpenCodeSession: (sessionFile: string) =>
         (tokenTracker as any).openCode.isOpenCodeSessionFile(sessionFile),
       getOpenCodeSessionData: (sessionFile: string) =>
-        (tokenTracker as any).getOpenCodeSessionData(sessionFile),
+        (tokenTracker as any).openCode.getOpenCodeSessionData(sessionFile),
     });
 
     const backendHandler = new BackendCommandHandler({

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -811,6 +811,7 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 					// Track edit scope and apply usage
 					if (request.response && Array.isArray(request.response)) {
 						for (const resp of request.response) {
+							if (!resp) { continue; }
 							if (resp.kind === 'textEditGroup' && resp.uri) {
 								const filePath = resp.uri.path || JSON.stringify(resp.uri);
 								editedFiles.add(filePath);
@@ -866,6 +867,7 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 					// Track edit scope and apply usage
 					if (request.response && Array.isArray(request.response)) {
 						for (const resp of request.response) {
+							if (!resp) { continue; }
 							if (resp.kind === 'textEditGroup' && resp.uri) {
 								const filePath = resp.uri.path || JSON.stringify(resp.uri);
 								editedFiles.add(filePath);
@@ -1258,6 +1260,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 					// Extract tool calls and MCP tools from request.response array
 					if (request.response && Array.isArray(request.response)) {
 						for (const responseItem of request.response) {
+							if (!responseItem) { continue; }
 							if (responseItem.kind === 'toolInvocationSerialized' || responseItem.kind === 'prepareToolInvocation') {
 								const toolName = responseItem.toolId || responseItem.toolName || responseItem.invocationMessage?.toolName || responseItem.toolSpecificData?.kind || 'unknown';
 
@@ -1365,6 +1368,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 							// Extract tool calls from request.response array (when full request is added)
 							if (request.response && Array.isArray(request.response)) {
 								for (const responseItem of request.response) {
+									if (!responseItem) { continue; }
 									if (responseItem.kind === 'toolInvocationSerialized' || responseItem.kind === 'prepareToolInvocation') {
 										analysis.toolCalls.total++;
 										const toolName = responseItem.toolId || responseItem.toolName || responseItem.invocationMessage?.toolName || responseItem.toolSpecificData?.kind || 'unknown';
@@ -1378,6 +1382,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 					// Handle VS Code incremental format - tool invocations in responses
 					if (event.kind === 2 && event.k?.includes('response') && Array.isArray(event.v)) {
 						for (const responseItem of event.v) {
+							if (!responseItem) { continue; }
 							if (responseItem.kind === 'toolInvocationSerialized') {
 								analysis.toolCalls.total++;
 								const toolName = responseItem.toolId || responseItem.toolName || responseItem.invocationMessage?.toolName || responseItem.toolSpecificData?.kind || 'unknown';
@@ -1485,6 +1490,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 				// Analyze response for tool calls and MCP tools
 				if (request.response && Array.isArray(request.response)) {
 					for (const responseItem of request.response) {
+						if (!responseItem) { continue; }
 						// Detect tool invocations
 						if (responseItem.kind === 'toolInvocationSerialized' ||
 							responseItem.kind === 'prepareToolInvocation') {
@@ -1698,7 +1704,7 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 						}
 						if (request.response && Array.isArray(request.response)) {
 							for (const responseItem of request.response) {
-								if (responseItem.value) {
+								if (responseItem?.value) {
 									modelUsage[requestModel].outputTokens += estimateTokensFromText(responseItem.value, requestModel, deps.tokenEstimators);
 								}
 							}
@@ -1766,7 +1772,7 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 					// Estimate tokens from assistant response (output)
 					if (request.response && Array.isArray(request.response)) {
 						for (const responseItem of request.response) {
-							if (responseItem.value) {
+							if (responseItem?.value) {
 								const tokens = estimateTokensFromText(responseItem.value, model, deps.tokenEstimators);
 								modelUsage[model].outputTokens += tokens;
 							}


### PR DESCRIPTION
## Problem

Three distinct `WARNING` log entries appeared during backend sync:

1. `TypeError: tokenTracker.getOpenCodeSessionData is not a function` — fired for every OpenCode session file during sync.
2. `TypeError: Cannot read properties of undefined (reading 'value')` — from `getModelUsageFromSession` when processing VS Code Insiders JSONL delta-format files.
3. `TypeError: Cannot read properties of undefined (reading 'kind')` — from `analyzeSessionUsage` / `trackEnhancedMetrics` for the same files.

## Root Causes

### 1. Wrong receiver for `getOpenCodeSessionData` (`extension.ts`)
The backend facade wired `getOpenCodeSessionData` by calling it on `tokenTracker` directly, but the method lives on `tokenTracker.openCode` (the `OpenCodeDataAccess` instance):
```ts
// Before (broken)
(tokenTracker as any).getOpenCodeSessionData(sessionFile)

// After (fixed)
(tokenTracker as any).openCode.getOpenCodeSessionData(sessionFile)
```

### 2. Null entries in reconstructed `response` arrays (`usageAnalysis.ts`)
VS Code Copilot Chat now stores some sessions as JSONL delta streams (`{"kind":0/1/2,...}`). When the `applyDelta` reconstruction rebuilds `requests[].response`, the resulting array can contain `null`/`undefined` entries. Multiple loops iterated over these arrays and accessed `.kind` or `.value` without guarding for nulls.

## Fixes

| File | Change |
|------|--------|
| `extension.ts` | Route `getOpenCodeSessionData` through `tokenTracker.openCode` |
| `usageAnalysis.ts` | Add `if (!responseItem) continue` guard in 5 `response`-array loops (`analyzeSessionUsage` delta-path x2, JSON-path x1, `trackEnhancedMetrics` x2) |
| `usageAnalysis.ts` | Use `responseItem?.value` (optional chain) instead of `responseItem.value` in `getModelUsageFromSession` (x2) |

## Notes on other logged messages

- **"spans 2 days"** — informational `log()` messages (not warnings), correctly noting a session file spans midnight. No change needed.
- **`type=undefined`** — debug log for the first 3 lines of today's JSONL files; VS Code delta-format events use `kind` not `type`, so `event.type` is `undefined`. The sync service already skips those lines harmlessly. No change needed.