### PR TITLE
fix(ci): correct working-directory for extension npm ci step

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install extension dependencies
         run: npm ci
-        working-directory: .
+        working-directory: vscode-extension
 
       - name: Install CLI dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

The **CLI - Publish to npm and GitHub** workflow was failing at the "Install extension dependencies" step because `working-directory: .` points to the repo root, which has no `package.json`.

## Fix

Changed `working-directory: .` → `working-directory: vscode-extension` so `npm ci` runs in the correct directory.

**Failing run:** https://github.com/rajbos/github-copilot-token-usage/actions/runs/23869096577/job/69596046550