### PR TITLE
chore: bump VS Code extension version to 0.0.26

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,15 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.26]
+
+### ✨ Features & Improvements
+- Split usage analysis view into 3 tabs for better navigation (#540)
+- Added missing friendly display names for MCP and VS Code tools (#539)
+
+### 🐛 Bug Fixes
+- Fixed loading stalls during session discovery (#545)
+
 ## [0.0.24] - 2026-03-28
 
 ### ✨ Features & Improvements

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
Bumps the VS Code extension version from 0.0.25 to 0.0.26 to enable publishing a new release.

## Changes since 0.0.25
- Split usage analysis view into 3 tabs (#540)
- Added missing friendly display names for MCP and VS Code tools (#539)
- Fixed loading stalls during session discovery (#545)