### PR TITLE
chore: bump versions for release 0.0.27 / 1.0.4 / 0.0.7

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.3"
+              Version="1.0.4"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,7 +6,15 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## [0.0.26]
+## [0.0.27] - 2026-04-07
+
+### ✨ Features & Improvements
+- Added friendly display names for `mcp_gitkraken_git_log_or_diff`, `copilot_runInTerminal`, `mcp_laravel-boost_tinker`, and Power BI MCP tools (#553, #554, #555)
+
+### 🐛 Bug Fixes
+- Fixed integration test activation timing (#548)
+
+## [0.0.26] - 2026-04-04
 
 ### ✨ Features & Improvements
 - Split usage analysis view into 3 tabs for better navigation (#540)

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.0.25",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.0.25",
+      "version": "0.0.27",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release bump

Bumps all releasable packages to their next version.

| Package | Old | New |
|---|---|---|
| VS Code extension | 0.0.26 | 0.0.27 |
| Visual Studio extension | 1.0.3 | 1.0.4 |
| CLI npm package | 0.0.6 | 0.0.7 |

### What's new in 0.0.27

#### ✨ Features & Improvements
- Added friendly display names for \mcp_gitkraken_git_log_or_diff\, \copilot_runInTerminal\, \mcp_laravel-boost_tinker\, and Power BI MCP tools (#553, #554, #555)

#### 🐛 Bug Fixes
- Fixed integration test activation timing (#548)

### After merging

- Trigger **Extensions - Release** workflow (\workflow_dispatch\) to publish the VS Code extension and create the \scode/v0.0.27\ tag
- Trigger **CLI - Publish to npm** workflow (\workflow_dispatch\) to publish the CLI npm package