### PR TITLE
Add per-tool suppression for unknown tool name notifications (#560)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -270,6 +270,14 @@
           "type": "string",
           "default": "",
           "description": "Screenshot/demo mode: when set to a folder path, overrides all session file scanning and returns only .json/.jsonl files from this directory. Leave empty for normal operation."
+        },
+        "copilotTokenTracker.suppressedUnknownTools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "List of tool names to suppress from the 'Unknown Tools Found' section in the Usage Analysis dashboard. Useful for tools you are testing that don't yet have friendly display names."
         }
       }
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3837,6 +3837,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 						vscode.commands.executeCommand('workbench.action.chat.open', { query: message.prompt, isNewChat: true })
 					);
 					break;
+				case 'suppressUnknownTool': {
+					const toolName = message.toolName as string;
+					if (toolName) {
+						const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+						const current = config.get<string[]>('suppressedUnknownTools', []);
+						if (!current.includes(toolName)) {
+							await config.update('suppressedUnknownTools', [...current, toolName], vscode.ConfigurationTarget.Global);
+							this.log(`🔇 Suppressed unknown tool: ${toolName}`);
+						}
+						await this.dispatch('refresh:analysis', () => this.refreshAnalysisPanel());
+					}
+					break;
+				}
 			}
 		});
 
@@ -7068,6 +7081,10 @@ ${hashtag}`;
       `[Usage Analysis] Test format 1234567.89: ${new Intl.NumberFormat(detectedLocale).format(1234567.89)}`,
     );
 
+    const suppressedUnknownTools = vscode.workspace
+      .getConfiguration('copilotTokenTracker')
+      .get<string[]>('suppressedUnknownTools', []);
+
     const initialData = JSON.stringify({
       today: stats.today,
       last30Days: stats.last30Days,
@@ -7078,6 +7095,7 @@ ${hashtag}`;
       lastUpdated: stats.lastUpdated.toISOString(),
       backendConfigured: this.isBackendConfigured(),
       currentWorkspacePaths: vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [],
+      suppressedUnknownTools,
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -47,6 +47,7 @@ type UsageAnalysisStats = {
 	missedPotential?: MissedPotentialWorkspace[];
 	backendConfigured?: boolean;
 	currentWorkspacePaths?: string[];
+	suppressedUnknownTools?: string[];
 };
 
 declare function acquireVsCodeApi<TState = unknown>(): {
@@ -159,9 +160,11 @@ function getUnknownMcpTools(stats: UsageAnalysisStats): string[] {
 	Object.entries(stats.today.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
 	Object.entries(stats.last30Days.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
 	Object.entries(stats.month.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
+
+	const suppressed = new Set<string>(stats.suppressedUnknownTools ?? []);
 	
-	// Filter to only unknown tools (where lookupToolName returns the same value)
-	return Array.from(allTools).filter(tool => lookupToolName(tool) === tool).sort();
+	// Filter to only unknown tools (where lookupToolName returns the same value) and not suppressed
+	return Array.from(allTools).filter(tool => lookupToolName(tool) === tool && !suppressed.has(tool)).sort();
 }
 
 function createMcpToolIssueUrl(unknownTools: string[]): string {
@@ -948,7 +951,8 @@ function renderLayout(stats: UsageAnalysisStats): void {
 								if (last30Count > todayCount) { countParts.push(`${last30Count} in the last 30d`); }
 								if (monthCount > last30Count) { countParts.push(`${monthCount} this month`); }
 								const countHtml = countParts.length > 0 ? `<span style="color:var(--text-muted);"> (${countParts.join(' | ')})</span>` : '';
-								return `<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px; background:var(--bg-primary); border:1px solid var(--border-color); border-radius:3px; font-family:monospace; font-size:11px;">${escapeHtml(tool)}${countHtml}</span>`;
+								const suppressBtn = `<button data-suppress-tool="${escapeHtml(tool)}" title="Suppress this tool from the unknown list" style="background:none; border:none; cursor:pointer; padding:0 2px; color:var(--text-muted); font-size:11px; line-height:1;" aria-label="Suppress ${escapeHtml(tool)}">🔇</button>`;
+								return `<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px; background:var(--bg-primary); border:1px solid var(--border-color); border-radius:3px; font-family:monospace; font-size:11px;">${escapeHtml(tool)}${countHtml}${suppressBtn}</span>`;
 							}).join(' ');
 							return `
 								<div id="unknown-mcp-tools-section" style="margin-bottom: 12px; padding: 10px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;">
@@ -1702,6 +1706,15 @@ async function bootstrap(): Promise<void> {
 	console.log('[Usage Analysis] Test format 1234567.89 with received locale:', new Intl.NumberFormat(initialData.locale).format(1234567.89));
 	setFormatLocale(initialData.locale);
 	renderLayout(initialData);
+
+	// Event delegation for suppress-tool buttons (rendered dynamically in the tools section)
+	document.addEventListener('click', (event) => {
+		const target = event.target as HTMLElement;
+		const toolName = target.getAttribute('data-suppress-tool');
+		if (toolName) {
+			vscode.postMessage({ command: 'suppressUnknownTool', toolName });
+		}
+	});
 }
 
 void bootstrap();


### PR DESCRIPTION
Closes #560

## Summary

Users can now suppress individual tool names from the **Unknown Tools Found** section in the Usage Analysis dashboard. This is useful when testing a new MCP server that doesn't yet have a friendly display name, without losing visibility into other unrecognised tools.

## Changes

### `vscode-extension/package.json`
- Added new setting `copilotTokenTracker.suppressedUnknownTools` (array of strings, default `[]`) with a clear description.

### `vscode-extension/src/extension.ts`
- `getUsageAnalysisHtml()` — reads `suppressedUnknownTools` from VS Code settings and injects it into `__INITIAL_USAGE__`.
- Message handler in `showUsageAnalysis()` — handles the new `suppressUnknownTool` webview message: appends the tool name to the setting (global scope) and refreshes the panel.

### `vscode-extension/src/webview/usage/main.ts`
- `UsageAnalysisStats` — extended with optional `suppressedUnknownTools?: string[]`.
- `getUnknownMcpTools()` — filters out suppressed tool names before returning the list.
- Unknown tool chip — each chip now renders a 🔇 button (`data-suppress-tool` attribute); event delegation in `bootstrap()` posts `suppressUnknownTool` to the extension host.

## How it works

1. User sees an unknown tool name in the *Unknown Tools Found* section.
2. They click the 🔇 button next to that tool.
3. The extension adds the tool name to `copilotTokenTracker.suppressedUnknownTools` in VS Code global settings and refreshes the dashboard.
4. The tool no longer appears in the section; all other unrecognised tools remain visible.
5. Users can remove a name from the setting at any time via VS Code Settings to make it reappear.