### PR TITLE
chore: bump versions for release (VS Code extension)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.0.27",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.0.27",
+      "version": "0.1.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.0.27",
+  "version": "0.1.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.0.27 | v0.1.0 |

### After merging, run these workflows:

- **Extensions - Release** (\elease.yml\) — Actions → _Extensions - Release_ → Run workflow (on \main\) — publishes VS Code extension **v0.1.0** to the VS Code Marketplace