### PR TITLE
fix: gate VS extension job and harden marketplace version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,6 +447,8 @@ jobs:
   build-visualstudio:
     name: Publish Visual Studio Extension
     needs: release
+    # Only run on tag pushes (to attach vsix to release) or when explicitly building the VS extension
+    if: github.event_name == 'push' || inputs.vs_only == true
     # Windows required: Node.js SEA (bundle-exe.ps1) and MSBuild/VSSDK are Windows-only
     runs-on: windows-latest
     permissions:
@@ -587,7 +589,12 @@ jobs:
             -Uri "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=3.0-preview.1" `
             -Headers @{ "Content-Type" = "application/json"; "Accept" = "application/json;api-version=3.0-preview.1" } `
             -Body $body
-          $marketplaceVersion = $r.results[0].extensions[0].versions[0].version
+          $ext = $r.results[0].extensions[0]
+          if (-not $ext -or -not $ext.versions) {
+            Write-Host "⚠️  Extension not found on VS Marketplace — proceeding with first publish."
+            exit 0
+          }
+          $marketplaceVersion = $ext.versions[0].version
           if (-not $marketplaceVersion) {
             Write-Host "⚠️  Extension not found on VS Marketplace — proceeding with first publish."
             exit 0
@@ -599,7 +606,8 @@ jobs:
           }
           Write-Host "✅ Version check passed: $localVersion is newer than marketplace $marketplaceVersion"
         } catch {
-          Write-Warning "⚠️  Could not query VS Marketplace — proceeding with publish. Error: $_"
+          Write-Error "❌ Could not query VS Marketplace — aborting to prevent duplicate publish. Error: $_"
+          exit 1
         }
 
     - name: Publish to Visual Studio Marketplace


### PR DESCRIPTION
## Problem

When running \elease.yml\ with default settings (VS Code only intent), the \uild-visualstudio\ job always ran because it had no job-level \if:\ guard — only \
eeds: release\. This caused two issues:

1. The expensive VS extension build (~10 min) ran on every VS Code release unnecessarily
2. Because \publish_marketplace: true\ is the default, it attempted to re-publish the already-published VS extension version, which the marketplace rejected with a duplicate-version error

A secondary bug in the marketplace version check meant the null-array error was silently swallowed (\Cannot index into a null array\), letting execution fall through to the publish step instead of stopping cleanly.

## Changes

| Fix | Detail |
|-----|--------|
| Job-level \if:\ on \uild-visualstudio\ | Only runs on tag pushes (\scode/v*\) or when \s_only == true\; skipped for manual VS Code-only releases |
| Null-safe extension lookup | Dereferences \xtensions[0]\ safely before accessing \.versions\, treating a missing extension as a first-publish |
| Catch block now hard-fails | A failed Marketplace query exits with code 1 instead of warning and proceeding, preventing silent duplicate publishes |