### PR TITLE
feat: Add Claude Desktop Cowork session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 - OpenCode + GitHub Copilot
 - Crush + GitHub Copilot
 - Claude Code (Anthropic)
+- Claude Desktop Cowork (Anthropic)
 - Visual Studio + GitHub Copilot
 
 ---

--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -138,6 +138,7 @@ function getEditorDisplayName(source: string): string {
 		'copilot-cli': 'Copilot CLI',
 		'opencode': 'OpenCode',
 		'claude-code': 'Claude Code',
+		'claude-desktop-cowork': 'Claude Desktop (Cowork)',
 	};
 	return names[source] || source;
 }

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -12,6 +12,7 @@ import { CrushDataAccess } from '../../vscode-extension/src/crush';
 import { ContinueDataAccess } from '../../vscode-extension/src/continue';
 import { VisualStudioDataAccess } from '../../vscode-extension/src/visualstudio';
 import { ClaudeCodeDataAccess } from '../../vscode-extension/src/claudecode';
+import { ClaudeDesktopCoworkDataAccess } from '../../vscode-extension/src/claudedesktop';
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, getModelTier } from '../../vscode-extension/src/tokenEstimation';
 import type { DetailedStats, PeriodStats, ModelUsage, EditorUsage, SessionFileCache, UsageAnalysisStats, UsageAnalysisPeriod } from '../../vscode-extension/src/types';
@@ -66,16 +67,22 @@ function createClaudeCode(): ClaudeCodeDataAccess {
 	return new ClaudeCodeDataAccess();
 }
 
+/** Create Claude Desktop Cowork data access instance for CLI */
+function createClaudeDesktopCowork(): ClaudeDesktopCoworkDataAccess {
+	return new ClaudeDesktopCoworkDataAccess();
+}
+
 // Module-level singletons so sql.js WASM is only initialised once across all session files
 const _openCodeInstance = createOpenCode();
 const _crushInstance = createCrush();
 const _continueInstance = createContinue();
 const _visualStudioInstance = createVisualStudio();
 const _claudeCodeInstance = createClaudeCode();
+const _claudeDesktopCoworkInstance = createClaudeDesktopCowork();
 
 /** Create session discovery instance for CLI */
 function createSessionDiscovery(): SessionDiscovery {
-	return new SessionDiscovery({ log, warn, error, openCode: _openCodeInstance, crush: _crushInstance, continue_: _continueInstance, visualStudio: _visualStudioInstance, claudeCode: _claudeCodeInstance });
+	return new SessionDiscovery({ log, warn, error, openCode: _openCodeInstance, crush: _crushInstance, continue_: _continueInstance, visualStudio: _visualStudioInstance, claudeCode: _claudeCodeInstance, claudeDesktopCowork: _claudeDesktopCoworkInstance });
 }
 
 /** Discover all session files on this machine */
@@ -143,6 +150,7 @@ function getEditorSourceFromPath(filePath: string): string {
 	if (normalized.includes('/.copilot/')) { return 'copilot-cli'; }
 	if (normalized.includes('/.crush/crush.db#')) { return 'crush'; }
 	if (normalized.includes('/opencode/')) { return 'opencode'; }
+	if (normalized.includes('/local-agent-mode-sessions/')) { return 'claude-desktop-cowork'; }
 	if (normalized.includes('/.claude/projects/')) { return 'claude-code'; }
 	if (normalized.includes('.vscode-server')) { return 'vscode-remote'; }
 	if (normalized.includes('/.vs/') && normalized.includes('/copilot-chat/')) { return 'Visual Studio'; }
@@ -248,6 +256,24 @@ const crushResult: SessionData = {
                         setCached(filePath, stats.mtimeMs, stats.size, vsResult);
                         return vsResult;
                 }
+
+		// Handle Claude Desktop Cowork sessions (JSONL with actual Anthropic API token counts)
+		if (_claudeDesktopCoworkInstance.isCoworkSessionFile(filePath)) {
+			const result = _claudeDesktopCoworkInstance.getTokensFromCoworkSession(filePath);
+			const interactions = _claudeDesktopCoworkInstance.countCoworkInteractions(filePath);
+			const modelUsage = _claudeDesktopCoworkInstance.getCoworkModelUsage(filePath);
+			const coworkResult: SessionData = {
+				file: filePath,
+				tokens: result.tokens,
+				thinkingTokens: result.thinkingTokens,
+				interactions,
+				modelUsage,
+				lastModified: stats.mtime,
+				editorSource: getEditorSourceFromPath(filePath),
+			};
+			setCached(filePath, stats.mtimeMs, stats.size, coworkResult);
+			return coworkResult;
+		}
 
 		// Handle Claude Code sessions (JSONL with actual Anthropic API token counts)
 		if (_claudeCodeInstance.isClaudeCodeSessionFile(filePath)) {
@@ -460,6 +486,7 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 		continue_: _continueInstance,
 		visualStudio: _visualStudioInstance,
 		claudeCode: _claudeCodeInstance,
+		claudeDesktopCowork: _claudeDesktopCoworkInstance,
 		tokenEstimators,
 		modelPricing,
 		toolNameMap,

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -162,6 +162,7 @@ The CLI scans the same session files as the [VS Code extension](../vscode-extens
 - **Copilot CLI** agent mode sessions
 - **OpenCode** sessions (JSON and SQLite)
 - **Claude Code** sessions (Anthropic CLI/IDE extension, actual API token counts)
+- **Claude Desktop Cowork** sessions (Windows only, local agent mode sessions with actual API token counts)
 
 ---
 

--- a/vscode-extension/src/claudecode.ts
+++ b/vscode-extension/src/claudecode.ts
@@ -56,10 +56,13 @@ export class ClaudeCodeDataAccess {
 
 	/**
 	 * Check if a file path is a Claude Code session file.
+	 * Requires the path to be under the user's ~/.claude/projects/ directory to avoid
+	 * false-positives on Cowork sessions that have a nested .claude/projects/ sub-path.
 	 */
 	isClaudeCodeSessionFile(filePath: string): boolean {
 		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
-		return normalized.includes('/.claude/projects/') && normalized.endsWith('.jsonl');
+		const projectsDir = this.getClaudeCodeProjectsDir().toLowerCase().replace(/\\/g, '/');
+		return normalized.startsWith(projectsDir) && normalized.endsWith('.jsonl');
 	}
 
 	/**

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -1,16 +1,57 @@
 /**
  * Claude Desktop Cowork data access layer.
- * Handles reading session data from Claude Desktop's Cowork feature.
+ * Handles reading session data from Claude Desktop's Cowork (local agent mode) feature.
  *
  * Cowork sessions are stored at:
  *   Windows: %LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions\
  *
  * Directory structure:
- *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>.json       — session metadata (title, timestamps, model)
- *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>/.claude/projects/<hash>/<uuid>.jsonl — JSONL token data
+ *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>.json        — session metadata (title, timestamps, model)
+ *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>/
+ *     .claude/projects/<hash>/<uuid>.jsonl                          — JSONL conversation + token data
+ *     audit.jsonl                                                   — SKIP: HMAC audit trail, no usage data
+ *     agent/                                                        — SKIP: background ditto sub-sessions
  *
- * The JSONL format is identical to Claude Code sessions.
- * Token data is ACTUAL Anthropic API counts — no estimation needed.
+ * ── JSONL FORMAT ────────────────────────────────────────────────────────────────────────────────
+ *
+ * Each line is a JSON object. Event types:
+ *
+ *   Queue bookends:
+ *     {"type":"queue-operation","operation":"enqueue|dequeue",...}
+ *
+ *   User messages (two kinds — distinguish by content):
+ *     Real human turn:   {"type":"user","isSidechain":false,"parentUuid":null,
+ *                          "message":{"role":"user","content":"<text>"|[{"type":"text","text":"..."}]},
+ *                          "timestamp":"<ISO>","uuid":"<uuid>"}
+ *     Tool result:       {"type":"user","isSidechain":false,"parentUuid":"<assistant-uuid>",
+ *                          "message":{"role":"user","content":[{"type":"tool_result",...}]}}
+ *     Distinction: real turns have parentUuid=null/empty and content without tool_result blocks.
+ *
+ *   Assistant messages (streaming + final share the SAME top-level type):
+ *     Streaming fragment: {"type":"assistant","requestId":"req_...","isSidechain":false,
+ *                           "parentUuid":"<prev-uuid>",
+ *                           "message":{"role":"assistant","model":"claude-*","stop_reason":"",
+ *                                      "usage":{...with output_tokens:0...},"content":[...]}}
+ *     Final event:        {"type":"assistant","requestId":"req_...","isSidechain":false,
+ *                           "parentUuid":"<prev-uuid>",
+ *                           "message":{"role":"assistant","model":"claude-*","stop_reason":"tool_use"|"end_turn",
+ *                                      "usage":{...with real output_tokens...},"content":[...]}}
+ *     CRITICAL: stop_reason is "" (empty string) on fragments, "tool_use"/"end_turn" on final events.
+ *     Use falsy check (!stop_reason) to skip fragments — === null / === undefined will NOT work.
+ *     Both streaming and final share the same requestId → use requestId dedup to count each turn once.
+ *
+ *   Other events (ignore for token/interaction counting):
+ *     {"type":"last-prompt","lastPrompt":"..."}
+ *     {"type":"attachment","attachment":{"type":"deferred_tools_delta","addedNames":[...]}}
+ *
+ * ── TOKEN USAGE ─────────────────────────────────────────────────────────────────────────────────
+ *   Tokens are in final assistant events: message.usage.{input_tokens, output_tokens,
+ *   cache_creation_input_tokens, cache_read_input_tokens}. These are ACTUAL Anthropic API counts.
+ *   De-duplicate by requestId, taking only the event where !stop_reason is falsy (i.e., has value).
+ *
+ * ── INTERACTION COUNTING ────────────────────────────────────────────────────────────────────────
+ *   Count only real human turns: type==='user' && !isSidechain && content has text but no tool_result.
+ *   Tool-result user events (parentUuid set, content=[{type:'tool_result'}]) are NOT interactions.
  */
 import * as fs from 'fs';
 import * as path from 'path';

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -130,15 +130,16 @@ export class ClaudeDesktopCoworkDataAccess {
 		const seenRequestIds = new Set<string>();
 
 		for (const event of events) {
-			// Cowork format: assistant messages have message.role === 'assistant', no top-level type
-			if (event.message?.role !== 'assistant') { continue; }
+			// Cowork format: ALL assistant events (streaming and final) have type:'assistant'
+			if (event.type !== 'assistant') { continue; }
 			const usage = event.message?.usage;
 			if (!usage) { continue; }
 
 			const requestId = event.requestId;
 			if (requestId) {
-				if (event.message?.stop_reason === null || event.message?.stop_reason === undefined) {
-					continue; // Streaming fragment — skip
+				// stop_reason is '' on streaming fragments, 'tool_use'/'end_turn' on final events
+				if (!event.message?.stop_reason) {
+					continue; // Streaming fragment — skip (falsy catches null, undefined, and '')
 				}
 				if (seenRequestIds.has(requestId)) { continue; }
 				seenRequestIds.add(requestId);
@@ -187,14 +188,15 @@ export class ClaudeDesktopCoworkDataAccess {
 		const seenRequestIds = new Set<string>();
 
 		for (const event of events) {
-			// Cowork format: assistant messages have message.role === 'assistant', no top-level type
-			if (event.message?.role !== 'assistant') { continue; }
+			// Cowork format: ALL assistant events have type:'assistant' at top level
+			if (event.type !== 'assistant') { continue; }
 			const usage = event.message?.usage;
 			if (!usage) { continue; }
 
 			const requestId = event.requestId;
 			if (requestId) {
-				if (event.message?.stop_reason === null || event.message?.stop_reason === undefined) { continue; }
+				// stop_reason is '' on streaming fragments, 'tool_use'/'end_turn' on final events
+				if (!event.message?.stop_reason) { continue; }
 				if (seenRequestIds.has(requestId)) { continue; }
 				seenRequestIds.add(requestId);
 			}

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -77,8 +77,13 @@ export class ClaudeDesktopCoworkDataAccess {
 		for (const entry of entries) {
 			const fullPath = path.join(dir, entry.name);
 			if (entry.isDirectory()) {
+				// Skip the internal 'agent' directory — it contains background Cowork agent sessions
+				// that the user didn't create directly and that have no user-visible title.
+				if (entry.name === 'agent') { continue; }
 				this.walkForJsonlFiles(fullPath, results, depth + 1, maxDepth);
-			} else if (entry.name.endsWith('.jsonl')) {
+			} else if (entry.name.endsWith('.jsonl') && entry.name !== 'audit.jsonl') {
+				// Skip audit.jsonl — it's a signed audit trail, not the Claude API session JSONL.
+				// The token data is in the UUID-named JSONL under .claude/projects/.
 				try {
 					const stats = fs.statSync(fullPath);
 					if (stats.size > 0) {

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -1,0 +1,270 @@
+/**
+ * Claude Desktop Cowork data access layer.
+ * Handles reading session data from Claude Desktop's Cowork feature.
+ *
+ * Cowork sessions are stored at:
+ *   Windows: %LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions\
+ *
+ * Directory structure:
+ *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>.json       — session metadata (title, timestamps, model)
+ *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>/.claude/projects/<hash>/<uuid>.jsonl — JSONL token data
+ *
+ * The JSONL format is identical to Claude Code sessions.
+ * Token data is ACTUAL Anthropic API counts — no estimation needed.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { normalizeClaudeModelId } from './claudecode';
+import type { ModelUsage } from './types';
+
+/** Package name for the Claude Desktop Windows Store app. */
+const CLAUDE_DESKTOP_PACKAGE = 'Claude_pzs8sxrjxfjjc';
+
+export class ClaudeDesktopCoworkDataAccess {
+
+	/**
+	 * Get the Claude Desktop Cowork sessions base directory.
+	 * Returns an empty string on non-Windows platforms.
+	 */
+	getCoworkBaseDir(): string {
+		if (os.platform() !== 'win32') { return ''; }
+		const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+		return path.join(
+			localAppData,
+			'Packages',
+			CLAUDE_DESKTOP_PACKAGE,
+			'LocalCache',
+			'Roaming',
+			'Claude',
+			'local-agent-mode-sessions'
+		);
+	}
+
+	/**
+	 * Check if a file path is a Claude Desktop Cowork session file.
+	 * Cowork session files live inside local-agent-mode-sessions/ and end with .jsonl.
+	 */
+	isCoworkSessionFile(filePath: string): boolean {
+		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
+		return normalized.includes('/local-agent-mode-sessions/') && normalized.endsWith('.jsonl');
+	}
+
+	/**
+	 * Get all Cowork session JSONL file paths.
+	 * Walks the nested directory structure: <base>/<app>/<machine>/<session>/.claude/projects/<hash>/<uuid>.jsonl
+	 */
+	getCoworkSessionFiles(): string[] {
+		const baseDir = this.getCoworkBaseDir();
+		if (!baseDir || !fs.existsSync(baseDir)) { return []; }
+		const results: string[] = [];
+		try {
+			this.walkForJsonlFiles(baseDir, results, 0, 8);
+		} catch {
+			// Ignore top-level errors
+		}
+		return results;
+	}
+
+	private walkForJsonlFiles(dir: string, results: string[], depth: number, maxDepth: number): void {
+		if (depth > maxDepth) { return; }
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				this.walkForJsonlFiles(fullPath, results, depth + 1, maxDepth);
+			} else if (entry.name.endsWith('.jsonl')) {
+				try {
+					const stats = fs.statSync(fullPath);
+					if (stats.size > 0) {
+						results.push(fullPath);
+					}
+				} catch {
+					// Ignore inaccessible files
+				}
+			}
+		}
+	}
+
+	/**
+	 * Parse all JSONL events from a Cowork session file.
+	 */
+	private readSessionEvents(sessionFilePath: string): any[] {
+		try {
+			const content = fs.readFileSync(sessionFilePath, 'utf8');
+			const lines = content.trim().split('\n');
+			const events: any[] = [];
+			for (const line of lines) {
+				if (!line.trim()) { continue; }
+				try {
+					events.push(JSON.parse(line));
+				} catch {
+					// Skip malformed lines
+				}
+			}
+			return events;
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * Get token counts from a Cowork session.
+	 * Uses actual Anthropic API counts; de-duplicates by requestId using only final events.
+	 */
+	getTokensFromCoworkSession(sessionFilePath: string): { tokens: number; thinkingTokens: number } {
+		const events = this.readSessionEvents(sessionFilePath);
+		let totalInputTokens = 0;
+		let totalOutputTokens = 0;
+		const seenRequestIds = new Set<string>();
+
+		for (const event of events) {
+			if (event.type !== 'assistant') { continue; }
+			const usage = event.message?.usage;
+			if (!usage) { continue; }
+
+			const requestId = event.requestId;
+			if (requestId) {
+				if (event.message?.stop_reason === null || event.message?.stop_reason === undefined) {
+					continue; // Streaming fragment — skip
+				}
+				if (seenRequestIds.has(requestId)) { continue; }
+				seenRequestIds.add(requestId);
+			}
+
+			const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
+				+ (typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0)
+				+ (typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0);
+			const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+
+			totalInputTokens += inputTokens;
+			totalOutputTokens += outputTokens;
+		}
+
+		return { tokens: totalInputTokens + totalOutputTokens, thinkingTokens: 0 };
+	}
+
+	/**
+	 * Count user interactions in a Cowork session.
+	 */
+	countCoworkInteractions(sessionFilePath: string): number {
+		const events = this.readSessionEvents(sessionFilePath);
+		let count = 0;
+		for (const event of events) {
+			if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user') {
+				const content = event.message?.content;
+				if (typeof content === 'string') {
+					count++;
+				} else if (Array.isArray(content)) {
+					const hasText = content.some((c: any) => c.type === 'text');
+					if (hasText && !content.some((c: any) => c.type === 'tool_result')) {
+						count++;
+					}
+				}
+			}
+		}
+		return count;
+	}
+
+	/**
+	 * Get per-model token usage from a Cowork session.
+	 */
+	getCoworkModelUsage(sessionFilePath: string): ModelUsage {
+		const events = this.readSessionEvents(sessionFilePath);
+		const modelUsage: ModelUsage = {};
+		const seenRequestIds = new Set<string>();
+
+		for (const event of events) {
+			if (event.type !== 'assistant') { continue; }
+			const usage = event.message?.usage;
+			if (!usage) { continue; }
+
+			const requestId = event.requestId;
+			if (requestId) {
+				if (event.message?.stop_reason === null || event.message?.stop_reason === undefined) { continue; }
+				if (seenRequestIds.has(requestId)) { continue; }
+				seenRequestIds.add(requestId);
+			}
+
+			const model = normalizeClaudeModelId(event.message?.model || 'unknown');
+			if (!modelUsage[model]) {
+				modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+			}
+
+			const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
+				+ (typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0)
+				+ (typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0);
+			const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+
+			modelUsage[model].inputTokens += inputTokens;
+			modelUsage[model].outputTokens += outputTokens;
+		}
+
+		return modelUsage;
+	}
+
+	/**
+	 * Derive the metadata JSON file path from a Cowork session JSONL path.
+	 *
+	 * Structure: .../local-agent-mode-sessions/<app>/<machine>/local_<id>/.claude/.../<uuid>.jsonl
+	 * Metadata:  .../local-agent-mode-sessions/<app>/<machine>/local_<id>.json
+	 */
+	private getMetadataPathFromJsonl(jsonlPath: string): string | null {
+		const normalized = jsonlPath.replace(/\\/g, '/');
+		const parts = normalized.split('/');
+		// Find the index of '.claude' — session directory is just before it
+		const dotClaudeIdx = parts.lastIndexOf('.claude');
+		if (dotClaudeIdx < 1) { return null; }
+		// The session dir component starts with 'local_'
+		const sessionDirName = parts[dotClaudeIdx - 1];
+		if (!sessionDirName.startsWith('local_')) { return null; }
+		// Metadata file is a sibling of the session dir
+		const parentDir = parts.slice(0, dotClaudeIdx - 1).join('/');
+		return `${parentDir}/${sessionDirName}.json`;
+	}
+
+	/**
+	 * Read session metadata (title, timestamps, cwd) for a Cowork session.
+	 * The metadata comes from the sibling .json file alongside the session directory.
+	 */
+	getCoworkSessionMeta(sessionFilePath: string): {
+		title?: string;
+		firstInteraction?: string;
+		lastInteraction?: string;
+		cwd?: string;
+	} | null {
+		const metaPath = this.getMetadataPathFromJsonl(sessionFilePath);
+		if (!metaPath) { return null; }
+
+		try {
+			const raw = fs.readFileSync(metaPath, 'utf8');
+			const meta = JSON.parse(raw);
+
+			const firstInteraction = meta.createdAt
+				? new Date(meta.createdAt).toISOString()
+				: undefined;
+			const lastInteraction = meta.lastActivityAt
+				? new Date(meta.lastActivityAt).toISOString()
+				: undefined;
+
+			// cwd: prefer userSelectedFolders[0] over the internal session cwd
+			const cwd = (Array.isArray(meta.userSelectedFolders) && meta.userSelectedFolders.length > 0)
+				? meta.userSelectedFolders[0]
+				: meta.cwd;
+
+			return {
+				title: meta.title || undefined,
+				firstInteraction,
+				lastInteraction,
+				cwd: typeof cwd === 'string' ? cwd : undefined,
+			};
+		} catch {
+			return null;
+		}
+	}
+}

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -98,8 +98,9 @@ export class ClaudeDesktopCoworkDataAccess {
 
 	/**
 	 * Parse all JSONL events from a Cowork session file.
+	 * Public so extension.ts can use it for log viewer turn building.
 	 */
-	private readSessionEvents(sessionFilePath: string): any[] {
+	readCoworkEvents(sessionFilePath: string): any[] {
 		try {
 			const content = fs.readFileSync(sessionFilePath, 'utf8');
 			const lines = content.trim().split('\n');
@@ -123,13 +124,14 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Uses actual Anthropic API counts; de-duplicates by requestId using only final events.
 	 */
 	getTokensFromCoworkSession(sessionFilePath: string): { tokens: number; thinkingTokens: number } {
-		const events = this.readSessionEvents(sessionFilePath);
+		const events = this.readCoworkEvents(sessionFilePath);
 		let totalInputTokens = 0;
 		let totalOutputTokens = 0;
 		const seenRequestIds = new Set<string>();
 
 		for (const event of events) {
-			if (event.type !== 'assistant') { continue; }
+			// Cowork format: assistant messages have message.role === 'assistant', no top-level type
+			if (event.message?.role !== 'assistant') { continue; }
 			const usage = event.message?.usage;
 			if (!usage) { continue; }
 
@@ -158,7 +160,7 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Count user interactions in a Cowork session.
 	 */
 	countCoworkInteractions(sessionFilePath: string): number {
-		const events = this.readSessionEvents(sessionFilePath);
+		const events = this.readCoworkEvents(sessionFilePath);
 		let count = 0;
 		for (const event of events) {
 			if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user') {
@@ -180,12 +182,13 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Get per-model token usage from a Cowork session.
 	 */
 	getCoworkModelUsage(sessionFilePath: string): ModelUsage {
-		const events = this.readSessionEvents(sessionFilePath);
+		const events = this.readCoworkEvents(sessionFilePath);
 		const modelUsage: ModelUsage = {};
 		const seenRequestIds = new Set<string>();
 
 		for (const event of events) {
-			if (event.type !== 'assistant') { continue; }
+			// Cowork format: assistant messages have message.role === 'assistant', no top-level type
+			if (event.message?.role !== 'assistant') { continue; }
 			const usage = event.message?.usage;
 			if (!usage) { continue; }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2648,6 +2648,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 			details.editorName = 'Crush';
 			return;
 		}
+		if (this.claudeDesktopCowork.isCoworkSessionFile(sessionFile)) {
+			details.editorRoot = this.claudeDesktopCowork.getCoworkBaseDir();
+			details.editorName = 'Claude Desktop Cowork';
+			return;
+		}
+		if (this.claudeCode.isClaudeCodeSessionFile(sessionFile)) {
+			details.editorRoot = this.claudeCode.getClaudeCodeProjectsDir();
+			details.editorName = 'Claude Code';
+			return;
+		}
 		try {
 			const parts = sessionFile.split(/[/\\]/);
 			const userIdx = parts.findIndex(p => p.toLowerCase() === 'user');

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2928,6 +2928,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return details;
 			}
 
+			// Handle Claude Desktop Cowork sessions
+			if (this.claudeDesktopCowork.isCoworkSessionFile(sessionFile)) {
+				const meta = this.claudeDesktopCowork.getCoworkSessionMeta(sessionFile);
+				if (meta?.title) { details.title = meta.title; }
+				if (meta?.firstInteraction) { details.firstInteraction = meta.firstInteraction; }
+				if (meta?.lastInteraction) { details.lastInteraction = meta.lastInteraction; }
+				details.interactions = this.claudeDesktopCowork.countCoworkInteractions(sessionFile);
+				details.editorRoot = this.claudeDesktopCowork.getCoworkBaseDir();
+				details.editorName = 'Claude Desktop Cowork';
+				await this.updateCacheWithSessionDetails(sessionFile, stat, details);
+				return details;
+			}
+
 			const fileContent = await fs.promises.readFile(sessionFile, 'utf8');
 
 			// Check if this is a UUID-only file (new Copilot CLI format where the file contains just a session ID)
@@ -3416,6 +3429,97 @@ class CopilotTokenTracker implements vscode.Disposable {
 					title: details.title || null,
 					editorSource: details.editorSource,
 					editorName: details.editorName || 'Continue',
+					size: details.size,
+					modified: details.modified,
+					interactions: details.interactions,
+					contextReferences: details.contextReferences,
+					firstInteraction: details.firstInteraction,
+					lastInteraction: details.lastInteraction,
+					turns,
+					usageAnalysis: undefined
+				};
+			}
+
+			// Handle Claude Desktop Cowork sessions
+			if (this.claudeDesktopCowork.isCoworkSessionFile(sessionFile)) {
+				const events = this.claudeDesktopCowork.readCoworkEvents(sessionFile);
+				let currentUserEvent: any = null;
+				const pendingAssistantEvents: any[] = [];
+
+				const emitTurn = () => {
+					if (!currentUserEvent) { return; }
+					const content = currentUserEvent.message?.content;
+					const userMessage = typeof content === 'string' ? content
+						: Array.isArray(content) ? content.filter((c: any) => c.type === 'text').map((c: any) => c.text || '').join('\n')
+						: '';
+					let assistantText = '';
+					let actualInputTokens = 0;
+					let actualOutputTokens = 0;
+					let model: string | null = null;
+					const toolCalls: { toolName: string; arguments?: string }[] = [];
+					const mcpTools: { server: string; tool: string }[] = [];
+
+					for (const ae of pendingAssistantEvents) {
+						const msg = ae.message;
+						if (!model && msg?.model) { model = msg.model; }
+						const usage = msg?.usage;
+						if (usage) {
+							actualInputTokens += (usage.input_tokens || 0) + (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0);
+							actualOutputTokens += usage.output_tokens || 0;
+						}
+						const contentArr: any[] = Array.isArray(msg?.content) ? msg.content : [];
+						for (const block of contentArr) {
+							if (block.type === 'text') { assistantText += block.text || ''; }
+							else if (block.type === 'tool_use') {
+								const toolName: string = block.name || 'unknown';
+								if (this.isMcpTool(toolName)) {
+									mcpTools.push({ server: this.extractMcpServerName(toolName), tool: toolName });
+								} else {
+									toolCalls.push({ toolName, arguments: block.input ? JSON.stringify(block.input) : undefined });
+								}
+							}
+						}
+					}
+
+					const usedModel = model || 'claude-sonnet-4-6';
+					const actualUsage: ActualUsage | undefined = (actualInputTokens > 0 || actualOutputTokens > 0) ? {
+						promptTokens: actualInputTokens,
+						completionTokens: actualOutputTokens
+					} : undefined;
+
+					turns.push({
+						turnNumber: turns.length + 1,
+						timestamp: currentUserEvent.timestamp ? new Date(currentUserEvent.timestamp).toISOString() : null,
+						mode: 'agent',
+						userMessage,
+						assistantResponse: assistantText,
+						model: usedModel,
+						toolCalls,
+						contextReferences: _createEmptyContextRefs(),
+						mcpTools,
+						inputTokensEstimate: actualInputTokens || this.estimateTokensFromText(userMessage, usedModel),
+						outputTokensEstimate: actualOutputTokens || this.estimateTokensFromText(assistantText, usedModel),
+						thinkingTokensEstimate: 0,
+						actualUsage
+					});
+				};
+
+				for (const event of events) {
+					if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user') {
+						emitTurn();
+						currentUserEvent = event;
+						pendingAssistantEvents.length = 0;
+					} else if (!event.type && event.message?.role === 'assistant') {
+						pendingAssistantEvents.push(event);
+					}
+				}
+				emitTurn();
+
+				return {
+					file: details.file,
+					title: details.title || null,
+					editorSource: details.editorSource,
+					editorName: 'Claude Desktop Cowork',
 					size: details.size,
 					modified: details.modified,
 					interactions: details.interactions,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3504,12 +3504,22 @@ class CopilotTokenTracker implements vscode.Disposable {
 					});
 				};
 
+				const isRealUserMessage = (event: any): boolean => {
+					const content = event.message?.content;
+					if (typeof content === 'string') { return !!content.trim(); }
+					if (!Array.isArray(content)) { return false; }
+					const hasText = content.some((c: any) => c.type === 'text');
+					const hasToolResult = content.some((c: any) => c.type === 'tool_result');
+					return hasText && !hasToolResult;
+				};
+
 				for (const event of events) {
-					if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user') {
+					if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user' && isRealUserMessage(event)) {
 						emitTurn();
 						currentUserEvent = event;
 						pendingAssistantEvents.length = 0;
-					} else if (!event.type && event.message?.role === 'assistant') {
+					} else if (event.type === 'assistant' && event.message?.stop_reason && event.message?.role === 'assistant') {
+						// Only collect final (non-streaming) assistant events — stop_reason is '' on fragments
 						pendingAssistantEvents.push(event);
 					}
 				}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -55,6 +55,7 @@ import { CrushDataAccess } from './crush';
 import { VisualStudioDataAccess } from './visualstudio';
 import { ContinueDataAccess } from './continue';
 import { ClaudeCodeDataAccess } from './claudecode';
+import { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
 import {
   estimateTokensFromText as _estimateTokensFromText,
   estimateTokensFromJsonlSession as _estimateTokensFromJsonlSession,
@@ -156,10 +157,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private visualStudio: VisualStudioDataAccess;
 	private continue_: ContinueDataAccess;
 	private claudeCode: ClaudeCodeDataAccess;
+	private claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
 	private cacheManager: CacheManager;
 
 	private get usageAnalysisDeps(): UsageAnalysisDeps {
-		return { warn: (m: string) => this.warn(m), openCode: this.openCode, crush: this.crush, visualStudio: this.visualStudio, continue_: this.continue_, claudeCode: this.claudeCode, tokenEstimators: this.tokenEstimators, modelPricing: this.modelPricing, toolNameMap: this.toolNameMap };
+		return { warn: (m: string) => this.warn(m), openCode: this.openCode, crush: this.crush, visualStudio: this.visualStudio, continue_: this.continue_, claudeCode: this.claudeCode, claudeDesktopCowork: this.claudeDesktopCowork, tokenEstimators: this.tokenEstimators, modelPricing: this.modelPricing, toolNameMap: this.toolNameMap };
 	}
 	private sessionDiscovery: SessionDiscovery;
 	private statusBarItem: vscode.StatusBarItem;
@@ -804,6 +806,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.continue_ = new ContinueDataAccess();
 		this.visualStudio = new VisualStudioDataAccess();
 		this.claudeCode = new ClaudeCodeDataAccess();
+		this.claudeDesktopCowork = new ClaudeDesktopCoworkDataAccess();
 		this.cacheManager = new CacheManager(context, { log: (m: string) => this.log(m), warn: (m: string) => this.warn(m), error: (m: string) => this.error(m) }, CopilotTokenTracker.CACHE_VERSION);
 		this.sessionDiscovery = new SessionDiscovery({
 			log: (m) => this.log(m),
@@ -814,6 +817,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			visualStudio: this.visualStudio,
 			continue_: this.continue_,
 			claudeCode: this.claudeCode,
+			claudeDesktopCowork: this.claudeDesktopCowork,
 			sampleDataDirectoryOverride: () => this.localRegressionSampleDataDir,
 		});
 		this.context = context;
@@ -2171,6 +2175,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return this.continue_.countContinueInteractions(sessionFile);
 			}
 
+			// Handle Claude Desktop Cowork sessions
+			if (this.claudeDesktopCowork.isCoworkSessionFile(sessionFile)) {
+				return this.claudeDesktopCowork.countCoworkInteractions(sessionFile);
+			}
+
 			// Handle Claude Code sessions
 			if (this.claudeCode.isClaudeCodeSessionFile(sessionFile)) {
 				return this.claudeCode.countClaudeCodeInteractions(sessionFile);
@@ -2407,6 +2416,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return { title, firstInteraction, lastInteraction };
 			}
 
+			// Handle Claude Desktop Cowork sessions
+			if (this.claudeDesktopCowork.isCoworkSessionFile(sessionFile)) {
+				const meta = this.claudeDesktopCowork.getCoworkSessionMeta(sessionFile);
+				return {
+					title: meta?.title,
+					firstInteraction: meta?.firstInteraction || null,
+					lastInteraction: meta?.lastInteraction || null,
+				};
+			}
+
 			// Handle Claude Code sessions
 			if (this.claudeCode.isClaudeCodeSessionFile(sessionFile)) {
 				const meta = this.claudeCode.getClaudeCodeSessionMeta(sessionFile);
@@ -2515,6 +2534,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.visualStudio.isVSSessionFile(sessionFilePath) ||
 			this.crush.isCrushSessionFile(sessionFilePath) ||
 			this.continue_.isContinueSessionFile(sessionFilePath) ||
+			this.claudeDesktopCowork.isCoworkSessionFile(sessionFilePath) ||
 			this.claudeCode.isClaudeCodeSessionFile(sessionFilePath);
 		if (!isSpecialSession) {
 			preloadedContent = await fs.promises.readFile(sessionFilePath, 'utf8');
@@ -3808,6 +3828,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (this.continue_.isContinueSessionFile(sessionFilePath)) {
 				const result = this.continue_.getTokensFromContinueSession(sessionFilePath);
 				return { ...result, actualTokens: result.tokens }; // Continue has actual counts
+			}
+
+			// Handle Claude Desktop Cowork sessions — actual Anthropic API token counts
+			if (this.claudeDesktopCowork.isCoworkSessionFile(sessionFilePath)) {
+				const result = this.claudeDesktopCowork.getTokensFromCoworkSession(sessionFilePath);
+				return { ...result, actualTokens: result.tokens };
 			}
 
 			// Handle Claude Code sessions - actual Anthropic API token counts

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -10,6 +10,7 @@ import type { CrushDataAccess } from './crush';
 import type { ContinueDataAccess } from './continue';
 import type { VisualStudioDataAccess } from "./visualstudio";
 import type { ClaudeCodeDataAccess } from './claudecode';
+import type { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
 
 export interface SessionDiscoveryDeps {
 	log: (message: string) => void;
@@ -20,6 +21,7 @@ export interface SessionDiscoveryDeps {
 	continue_: ContinueDataAccess;
 	visualStudio: VisualStudioDataAccess;
 	claudeCode: ClaudeCodeDataAccess;
+	claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
 	sampleDataDirectoryOverride?: () => string | undefined;
 }
 
@@ -190,6 +192,14 @@ export class SessionDiscovery {
 		let claudeCodeExists = false;
 		try { claudeCodeExists = fs.existsSync(claudeCodeProjectsDir); } catch { /* ignore */ }
 		candidates.push({ path: claudeCodeProjectsDir, exists: claudeCodeExists, source: 'Claude Code' });
+
+		// Claude Desktop Cowork sessions directory
+		const coworkBaseDir = this.deps.claudeDesktopCowork.getCoworkBaseDir();
+		if (coworkBaseDir) {
+			let coworkExists = false;
+			try { coworkExists = fs.existsSync(coworkBaseDir); } catch { /* ignore */ }
+			candidates.push({ path: coworkBaseDir, exists: coworkExists, source: 'Claude Desktop (Cowork)' });
+		}
 
 		return candidates;
 	}
@@ -501,6 +511,17 @@ export class SessionDiscovery {
 				}
 			} catch (claudeError) {
 				this.deps.warn(`Could not read Claude Code session files: ${claudeError}`);
+			}
+
+			// Check for Claude Desktop Cowork session files
+			try {
+				const coworkFiles = this.deps.claudeDesktopCowork.getCoworkSessionFiles();
+				if (coworkFiles.length > 0) {
+					this.deps.log(`📄 Found ${coworkFiles.length} session file(s) in Claude Desktop Cowork`);
+					sessionFiles.push(...coworkFiles);
+				}
+			} catch (coworkError) {
+				this.deps.warn(`Could not read Claude Desktop Cowork session files: ${coworkError}`);
 			}
 
 			// Log summary

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -41,6 +41,7 @@ import type { ContinueDataAccess } from './continue';
 import type { VisualStudioDataAccess } from './visualstudio';
 import type { ClaudeCodeDataAccess } from './claudecode';
 import { normalizeClaudeModelId } from './claudecode';
+import type { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
 
 export interface UsageAnalysisDeps {
 	warn: (msg: string) => void;
@@ -49,6 +50,7 @@ export interface UsageAnalysisDeps {
 	continue_: ContinueDataAccess;
 	visualStudio?: VisualStudioDataAccess;
 	claudeCode?: ClaudeCodeDataAccess;
+	claudeDesktopCowork?: ClaudeDesktopCoworkDataAccess;
 	tokenEstimators: { [key: string]: number };
 	modelPricing: { [key: string]: ModelPricing };
 	toolNameMap: { [key: string]: string };
@@ -1137,6 +1139,48 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 			return analysis;
 		}
 
+		// Handle Claude Desktop Cowork sessions — same JSONL format as Claude Code
+		if (deps.claudeDesktopCowork?.isCoworkSessionFile(sessionFile)) {
+			const events = readClaudeCodeEventsForAnalysis(sessionFile);
+			const models: string[] = [];
+			const seenRequestIds = new Set<string>();
+			for (const event of events) {
+				if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user') {
+					analysis.modeUsage.agent++;
+				}
+				if (event.type === 'assistant') {
+					const requestId = event.requestId;
+					if (requestId) {
+						if (event.message?.stop_reason === null || event.message?.stop_reason === undefined) { continue; }
+						if (seenRequestIds.has(requestId)) { continue; }
+						seenRequestIds.add(requestId);
+					}
+					const model = normalizeClaudeModelId(event.message?.model);
+					if (model) { models.push(model); }
+					if (Array.isArray(event.message?.content)) {
+						for (const block of event.message.content) {
+							if (block.type === 'tool_use' && block.name) {
+								analysis.toolCalls.total++;
+								const toolName = block.name;
+								analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+							}
+						}
+					}
+				}
+			}
+			const uniqueModels = [...new Set(models)];
+			analysis.modelSwitching.uniqueModels = uniqueModels;
+			analysis.modelSwitching.modelCount = uniqueModels.length;
+			analysis.modelSwitching.totalRequests = models.length;
+			let switchCountCW = 0;
+			for (let cwi = 1; cwi < models.length; cwi++) {
+				if (models[cwi] !== models[cwi - 1]) { switchCountCW++; }
+			}
+			analysis.modelSwitching.switchCount = switchCountCW;
+			applyModelTierClassification(deps, uniqueModels, models, analysis);
+			return analysis;
+		}
+
 		// Handle Claude Code sessions
 		if (deps.claudeCode?.isClaudeCodeSessionFile(sessionFile)) {
 			// Claude Code has actual token counts; usage analysis extracts tool calls and modes
@@ -1599,6 +1643,11 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 	// Handle Continue sessions
 	if (deps.continue_.isContinueSessionFile(sessionFile)) {
 		return deps.continue_.getContinueModelUsage(sessionFile);
+	}
+
+	// Handle Claude Desktop Cowork sessions
+	if (deps.claudeDesktopCowork?.isCoworkSessionFile(sessionFile)) {
+		return deps.claudeDesktopCowork.getCoworkModelUsage(sessionFile);
 	}
 
 	// Handle Claude Code sessions

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1622,7 +1622,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 	return analysis;
 }
 
-export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'warn' | 'openCode' | 'crush' | 'continue_' | 'visualStudio' | 'claudeCode' | 'tokenEstimators' | 'modelPricing'>, sessionFile: string, preloadedContent?: string): Promise<ModelUsage> {
+export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'warn' | 'openCode' | 'crush' | 'continue_' | 'visualStudio' | 'claudeCode' | 'claudeDesktopCowork' | 'tokenEstimators' | 'modelPricing'>, sessionFile: string, preloadedContent?: string): Promise<ModelUsage> {
 	const modelUsage: ModelUsage = {};
 
 	// Handle OpenCode sessions

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -36,6 +36,8 @@ export function getEditorIcon(editor: string): string {
 		'Copilot CLI': '🤖',
 		'OpenCode': '🟢',
             'Visual Studio': '🪟',
+		'Claude Code': '🟠',
+		'Claude Desktop Cowork': '🟠',
 		'Unknown': '❓'
 	};
 	return icons[editor] || '📝';

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -679,6 +679,9 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
 	if (normalizedPath.includes('/.continue/sessions/')) {
 		return 'Continue';
 	}
+	if (normalizedPath.includes('/local-agent-mode-sessions/')) {
+		return 'Claude Desktop Cowork';
+	}
 	if (normalizedPath.includes('/.claude/projects/')) {
 		return 'Claude Code';
 	}
@@ -719,6 +722,7 @@ export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p:
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
 	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
 	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }
+	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (lowerPath.includes('/.claude/projects/')) { return 'Claude Code'; }
 	if (lowerPath.includes('cursor')) { return 'Cursor'; }
 	if (lowerPath.includes('code - insiders') || lowerPath.includes('code-insiders')) { return 'VS Code Insiders'; }


### PR DESCRIPTION
## Summary

Adds support for **Claude Desktop Cowork** (local agent mode) sessions as a new data source.

### What is Claude Desktop Cowork?

Claude Desktop's "Cowork" (local agent mode) stores sessions locally on Windows at:
```
%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions\
  <app-uuid>/<machine-uuid>/
    local_<session-id>.json          ← metadata (title, timestamps, model, cwd)
    local_<session-id>/
      .claude/projects/<hash>/<uuid>.jsonl   ← JSONL with actual API token counts
```

The JSONL format is identical to Claude Code (same `message.usage.*` fields), so actual API token counts are available — no estimation needed.

### Changes

- **New** `vscode-extension/src/claudedesktop.ts` — `ClaudeDesktopCoworkDataAccess` class with full session discovery, token counting, interaction counting, model usage, and metadata extraction
- **Fixed** `isClaudeCodeSessionFile()` in `claudecode.ts` — restricted to paths strictly under `~/.claude/projects/` to prevent false-positives on cowork session paths (which also contain `/.claude/projects/` as a sub-path)
- **VS Code extension**: wired into `sessionDiscovery`, `extension.ts`, and `usageAnalysis.ts`
- **CLI**: wired into `helpers.ts` and `stats.ts` display name map
- **Docs**: updated root `README.md` and `docs/cli/README.md` Data Sources section

Closes part of #444