### PR TITLE
fix: track token usage from sub-agent calls in Copilot agent mode (#567)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -68,6 +68,7 @@ import {
   createEmptyContextRefs as _createEmptyContextRefs,
   getTotalTokensFromModelUsage as _getTotalTokensFromModelUsage,
   reconstructJsonlStateAsync as _reconstructJsonlStateAsync,
+  extractSubAgentData as _extractSubAgentData,
 } from './tokenEstimation';
 import { SessionDiscovery } from './sessionDiscovery';
 import { CacheManager } from './cacheManager';
@@ -3853,6 +3854,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 							// Separate thinking tokens
 							if (responseItem.kind === 'thinking' && responseItem.value) {
 								totalThinkingTokens += this.estimateTokensFromText(responseItem.value, this.getModelFromRequest(request));
+								continue;
+							}
+							// Sub-agent invocations: count prompt (input) + result (output)
+							const subAgent = _extractSubAgentData(responseItem);
+							if (subAgent) {
+								const saModel = subAgent.modelName || this.getModelFromRequest(request);
+								if (subAgent.prompt) { totalInputTokens += this.estimateTokensFromText(subAgent.prompt, saModel); }
+								if (subAgent.result) { totalOutputTokens += this.estimateTokensFromText(subAgent.result, saModel); }
 								continue;
 							}
 							if (responseItem.value) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3716,12 +3716,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private extractResponseData(response: any[]): {
 		responseText: string;
 		thinkingText: string;
-		toolCalls: { toolName: string; arguments?: string; result?: string }[];
+		toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string }[];
 		mcpTools: { server: string; tool: string }[];
 	} {
 		let responseText = '';
 		let thinkingText = '';
-		const toolCalls: { toolName: string; arguments?: string; result?: string }[] = [];
+		const toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string }[] = [];
 		const mcpTools: { server: string; tool: string }[] = [];
 
 		for (const item of response) {
@@ -3742,19 +3742,31 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 			// Extract tool invocations
 			if (item.kind === 'toolInvocationSerialized' || item.kind === 'prepareToolInvocation') {
-				const toolName = item.toolId || item.toolName || item.invocationMessage?.toolName || item.toolSpecificData?.kind || 'unknown';
-
-				// Check if this is an MCP tool by name pattern
-				if (this.isMcpTool(toolName)) {
-					const serverName = this.extractMcpServerName(toolName);
-					mcpTools.push({ server: serverName, tool: toolName });
-				} else {
-					// Add to regular tool calls
+				// Detect sub-agent calls first — tag them for the log viewer
+				const subAgentData = _extractSubAgentData(item);
+				if (subAgentData) {
+					const displayName = (item.toolSpecificData?.agentName as string | undefined) || 'Sub-Agent';
 					toolCalls.push({
-						toolName,
-						arguments: item.input ? JSON.stringify(item.input) : undefined,
-						result: item.result ? (typeof item.result === 'string' ? item.result : JSON.stringify(item.result)) : undefined
+						toolName: displayName,
+						arguments: subAgentData.prompt || undefined,
+						result: undefined,
+						isSubAgent: true,
+						subAgentModel: subAgentData.modelName || undefined,
 					});
+				} else {
+					const toolName = item.toolId || item.toolName || item.invocationMessage?.toolName || item.toolSpecificData?.kind || 'unknown';
+					// Check if this is an MCP tool by name pattern
+					if (this.isMcpTool(toolName)) {
+						const serverName = this.extractMcpServerName(toolName);
+						mcpTools.push({ server: serverName, tool: toolName });
+					} else {
+						// Add to regular tool calls
+						toolCalls.push({
+							toolName,
+							arguments: item.input ? JSON.stringify(item.input) : undefined,
+							result: item.result ? (typeof item.result === 'string' ? item.result : JSON.stringify(item.result)) : undefined
+						});
+					}
 				}
 			}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+﻿import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -3572,22 +3572,37 @@ class CopilotTokenTracker implements vscode.Disposable {
 						lastTurn.outputTokensEstimate = this.estimateTokensFromText(lastTurn.assistantResponse, lastTurn.model || 'gpt-4o');
 					}
 
-					// Handle CLI tool calls
-					if ((event.type === 'tool.call' || event.type === 'tool.result') && turns.length > 0) {
+					// Handle CLI tool calls (tool.execution_start is the actual event type in current CLI format)
+					const CLI_SUB_AGENT_TOOLS = new Set(['task', 'read_agent', 'write_agent', 'list_agents']);
+					if ((event.type === 'tool.call' || event.type === 'tool.result' || event.type === 'tool.execution_start') && turns.length > 0) {
 						const lastTurn = turns[turns.length - 1];
 						const toolName = event.data?.toolName || event.toolName || 'unknown';
+						const isSubAgent = CLI_SUB_AGENT_TOOLS.has(toolName);
 
 						// Check if this is an MCP tool by name pattern
 						if (this.isMcpTool(toolName)) {
 							const serverName = this.extractMcpServerName(toolName);
 							lastTurn.mcpTools.push({ server: serverName, tool: toolName });
-						} else {
-							// Add to regular tool calls
+						} else if (isSubAgent) {
 							lastTurn.toolCalls.push({
 								toolName,
-								arguments: event.type === 'tool.call' ? JSON.stringify(event.data?.arguments || {}) : undefined,
-								result: event.type === 'tool.result' ? event.data?.output : undefined
+								arguments: event.data?.arguments ? JSON.stringify(event.data.arguments) : undefined,
+								result: undefined,
+								isSubAgent: true,
 							});
+						} else {
+							// Add to regular tool calls (skip duplicate execution_start events per toolCallId)
+							const callId: string | undefined = event.data?.toolCallId;
+							const alreadyAdded = callId && lastTurn.toolCalls.some((tc: any) => tc._callId === callId);
+							if (!alreadyAdded) {
+								const tc: any = {
+									toolName,
+									arguments: event.type !== 'tool.result' ? JSON.stringify(event.data?.arguments || {}) : undefined,
+									result: event.type === 'tool.result' ? event.data?.output : undefined
+								};
+								if (callId) { tc._callId = callId; }
+								lastTurn.toolCalls.push(tc);
+							}
 						}
 					}
 

--- a/vscode-extension/src/sessionParser.ts
+++ b/vscode-extension/src/sessionParser.ts
@@ -2,6 +2,8 @@ export interface ModelUsage {
     [model: string]: { inputTokens: number; outputTokens: number };
 }
 
+import { extractSubAgentData } from './tokenEstimation';
+
 type JsonObject = Record<string, unknown>;
 
 function isObject(value: unknown): value is JsonObject {
@@ -292,6 +294,19 @@ export function parseSessionFileContent(
 					if (thinkingText) {
 						totalThinkingTokens += estimateTokensFromText(thinkingText, model);
 					}
+
+					// Also count sub-agent invocations (tracked under the sub-agent's own model)
+					const responseItems = (request as any).response;
+					if (Array.isArray(responseItems)) {
+						for (const responseItem of responseItems) {
+							const subAgent = extractSubAgentData(responseItem);
+							if (subAgent) {
+								const saModel = subAgent.modelName || model;
+								if (subAgent.prompt) { addInput(saModel, subAgent.prompt); }
+								if (subAgent.result) { addOutput(saModel, subAgent.result); }
+							}
+						}
+					}
 				}
 			}
 
@@ -347,6 +362,14 @@ export function parseSessionFileContent(
 			// Separate thinking tokens
 			if (responseItem?.kind === 'thinking' && typeof responseItem?.value === 'string' && responseItem.value) {
 				totalThinkingTokens += estimateTokensFromText(responseItem.value, model);
+				continue;
+			}
+			// Sub-agent invocations: count prompt (input) + result (output) under sub-agent model
+			const subAgent = extractSubAgentData(responseItem);
+			if (subAgent) {
+				const saModel = subAgent.modelName || model;
+				if (subAgent.prompt) { addInput(saModel, subAgent.prompt); }
+				if (subAgent.result) { addOutput(saModel, subAgent.result); }
 				continue;
 			}
 			if (typeof responseItem?.value === 'string' && responseItem.value) {

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -21,6 +21,52 @@ export function estimateTokensFromText(text: string, model: string = 'gpt-4', to
 }
 
 /**
+ * Normalize a display model name (e.g. "Claude Haiku 4.5") to a model ID slug
+ * (e.g. "claude-haiku-4.5") so it can be matched against tokenEstimators keys.
+ */
+export function normalizeDisplayModelName(displayName: string): string {
+	return displayName.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+/**
+ * Extract sub-agent prompt (input) and result (output) text from a
+ * `toolInvocationSerialized` response item where `toolSpecificData.kind === 'subagent'`.
+ *
+ * Returns null if the item is not a completed sub-agent invocation.
+ *
+ * The `result` field may be stored as:
+ *   - a plain string, or
+ *   - a streaming-char object: { "0": "H", "1": "i", ... }
+ */
+export function extractSubAgentData(item: unknown): { prompt: string; result: string; modelName: string } | null {
+	if (!item || typeof item !== 'object') { return null; }
+	const i = item as Record<string, unknown>;
+	if (i['kind'] !== 'toolInvocationSerialized') { return null; }
+	const tsd = i['toolSpecificData'];
+	if (!tsd || typeof tsd !== 'object') { return null; }
+	const t = tsd as Record<string, unknown>;
+	if (t['kind'] !== 'subagent') { return null; }
+
+	const prompt = typeof t['prompt'] === 'string' ? t['prompt'] : '';
+
+	let result = '';
+	const rawResult = t['result'];
+	if (typeof rawResult === 'string') {
+		result = rawResult;
+	} else if (rawResult && typeof rawResult === 'object') {
+		// Streaming char format: {"0":"H","1":"i",...} — sort by numeric key then join
+		const entries = Object.entries(rawResult as Record<string, unknown>);
+		entries.sort(([a], [b]) => Number(a) - Number(b));
+		result = entries.map(([, v]) => (typeof v === 'string' ? v : '')).join('');
+	}
+
+	const rawModel = typeof t['modelName'] === 'string' ? t['modelName'] : '';
+	const modelName = rawModel ? normalizeDisplayModelName(rawModel) : '';
+
+	return (prompt || result) ? { prompt, result, modelName } : null;
+}
+
+/**
  * Estimate tokens from a JSONL session file (used by Copilot CLI/Agent mode and VS Code incremental format)
  * Each line is a separate JSON object representing an event in the session
  */
@@ -89,6 +135,9 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 						totalThinkingTokens += estimateTokensFromText(responseItem.value);
 						continue;
 					}
+					// Sub-agent items are built up incrementally via delta events; their
+					// result text may be incomplete here. Skip and count from reconstructed state below.
+					if (extractSubAgentData(responseItem)) { continue; }
 					if (responseItem.value) {
 						totalTokens += estimateTokensFromText(responseItem.value);
 					} else if (responseItem.kind === 'markdownContent' && responseItem.content?.value) {
@@ -147,6 +196,23 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 
 	// If CLI session.shutdown provided actual totals, use them; otherwise fall back to per-request delta totals
 	const finalActualTokens = !isDeltaBased && cliActualTokens > 0 ? cliActualTokens : totalActualTokens;
+
+	// For delta-based sessions, extract sub-agent token estimates from the fully reconstructed state.
+	// Sub-agent results are built up char-by-char via delta events and are only complete in sessionState.
+	if (isDeltaBased) {
+		const requests = Array.isArray(sessionState.requests) ? sessionState.requests : [];
+		for (const request of requests) {
+			if (!request?.response || !Array.isArray(request.response)) { continue; }
+			for (const responseItem of request.response) {
+				const subAgent = extractSubAgentData(responseItem);
+				if (subAgent) {
+					if (subAgent.prompt) { totalTokens += estimateTokensFromText(subAgent.prompt); }
+					if (subAgent.result) { totalTokens += estimateTokensFromText(subAgent.result); }
+				}
+			}
+		}
+	}
+
 	return { tokens: totalTokens + totalThinkingTokens, thinkingTokens: totalThinkingTokens, actualTokens: finalActualTokens };
 }
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -330,7 +330,7 @@ export interface ChatTurn {
   userMessage: string;
   assistantResponse: string;
   model: string | null;
-  toolCalls: { toolName: string; arguments?: string; result?: string }[];
+  toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string }[];
   contextReferences: ContextReferenceUsage;
   mcpTools: { server: string; tool: string }[];
   inputTokensEstimate: number;

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -28,6 +28,7 @@ import {
 	estimateTokensFromText,
 	extractPerRequestUsageFromRawLines,
 	createEmptyContextRefs,
+	extractSubAgentData,
 } from './tokenEstimation';
 import {
 	getModeType,
@@ -1752,6 +1753,19 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 							}
 						}
 					}
+
+					// Sub-agent invocations are additive: not included in parent actual token counts
+					if (request.response && Array.isArray(request.response)) {
+						for (const responseItem of request.response) {
+							const subAgent = extractSubAgentData(responseItem);
+							if (subAgent) {
+								const saModel = subAgent.modelName || requestModel;
+								if (!modelUsage[saModel]) { modelUsage[saModel] = { inputTokens: 0, outputTokens: 0 }; }
+								if (subAgent.prompt) { modelUsage[saModel].inputTokens += estimateTokensFromText(subAgent.prompt, saModel, deps.tokenEstimators); }
+								if (subAgent.result) { modelUsage[saModel].outputTokens += estimateTokensFromText(subAgent.result, saModel, deps.tokenEstimators); }
+							}
+						}
+					}
 				}
 			}
 
@@ -1818,6 +1832,19 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 								const tokens = estimateTokensFromText(responseItem.value, model, deps.tokenEstimators);
 								modelUsage[model].outputTokens += tokens;
 							}
+						}
+					}
+				}
+
+				// Sub-agent invocations are additive: not included in parent actual token counts
+				if (request.response && Array.isArray(request.response)) {
+					for (const responseItem of request.response) {
+						const subAgent = extractSubAgentData(responseItem);
+						if (subAgent) {
+							const saModel = subAgent.modelName || model;
+							if (!modelUsage[saModel]) { modelUsage[saModel] = { inputTokens: 0, outputTokens: 0 }; }
+							if (subAgent.prompt) { modelUsage[saModel].inputTokens += estimateTokensFromText(subAgent.prompt, saModel, deps.tokenEstimators); }
+							if (subAgent.result) { modelUsage[saModel].outputTokens += estimateTokensFromText(subAgent.result, saModel, deps.tokenEstimators); }
 						}
 					}
 				}

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -25,7 +25,7 @@ type ChatTurn = {
 	userMessage: string;
 	assistantResponse: string;
 	model: string | null;
-	toolCalls: { toolName: string; arguments?: string; result?: string }[];
+	toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string }[];
 	contextReferences: ContextReferenceUsage;
 	mcpTools: { server: string; tool: string }[];
 	inputTokensEstimate: number;
@@ -412,8 +412,10 @@ function renderTurnCard(turn: ChatTurn): string {
 	// Build tool call summary
 	let toolCallsHtml = '';
 	if (hasToolCalls) {
+		const regularCalls = turn.toolCalls.filter(tc => !tc.isSubAgent);
+		const subAgentCallsInTurn = turn.toolCalls.filter(tc => tc.isSubAgent);
 		const toolCounts: { [key: string]: number } = {};
-		turn.toolCalls.forEach(tc => {
+		regularCalls.forEach(tc => {
 			const toolName = lookupToolName(tc.toolName);
 			toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
 		});
@@ -421,6 +423,9 @@ function renderTurnCard(turn: ChatTurn): string {
 		const toolSummary = Object.entries(toolCounts)
 			.map(([name, count]) => `<span class="tool-summary-item">${escapeHtml(name)}: <strong>${count}</strong></span>`)
 			.join('');
+		const subAgentSummary = subAgentCallsInTurn.length > 0
+			? `<span class="sub-agent-summary-item">🤖 Sub-Agents: <strong>${subAgentCallsInTurn.length}</strong></span>`
+			: '';
 		
 		toolCallsHtml = `
 			<div class="turn-tools">
@@ -428,7 +433,7 @@ function renderTurnCard(turn: ChatTurn): string {
 					<summary class="tool-calls-summary">
 						<span class="collapse-arrow">▶</span>
 						<span class="tools-header-inline">🔧 TOOL CALLS (${turn.toolCalls.length})</span>
-						<span class="tool-summary-text">${toolSummary}</span>
+						<span class="tool-summary-text">${toolSummary}${subAgentSummary}</span>
 					</summary>
 					<table class="tools-table">
 						<thead>
@@ -439,14 +444,15 @@ function renderTurnCard(turn: ChatTurn): string {
 						</thead>
 						<tbody>
 							${turn.toolCalls.map((tc, idx) => `
-								<tr class="tool-row">
+								<tr class="tool-row${tc.isSubAgent ? ' sub-agent-row' : ''}">
 									<td class="tool-name-cell">
-										<span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(lookupToolName(tc.toolName))}</span>
-										${tc.arguments ? `<details class="tool-details"><summary>Arguments</summary><pre>${escapeHtml(tc.arguments)}</pre></details>` : ''}
-										${tc.result ? `<details class="tool-details"><summary>Result</summary><pre>${escapeHtml(truncateText(tc.result, 500))}</pre></details>` : ''}
+										<span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(tc.isSubAgent ? `🤖 ${tc.toolName}` : lookupToolName(tc.toolName))}</span>
+										${tc.isSubAgent && tc.subAgentModel ? `<span class="sub-agent-model-badge">${escapeHtml(tc.subAgentModel)}</span>` : ''}
+										${tc.arguments && !tc.isSubAgent ? `<details class="tool-details"><summary>Arguments</summary><pre>${escapeHtml(tc.arguments)}</pre></details>` : ''}
+										${tc.result && !tc.isSubAgent ? `<details class="tool-details"><summary>Result</summary><pre>${escapeHtml(truncateText(tc.result, 500))}</pre></details>` : ''}
 									</td>
 									<td class="tool-action-cell">
-										<span class="tool-call-pretty" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="View pretty JSON" style="cursor:pointer;color:#22c55e;">Investigate</span>
+										${!tc.isSubAgent ? `<span class="tool-call-pretty" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="View pretty JSON" style="cursor:pointer;color:#22c55e;">Investigate</span>` : ''}
 									</td>
 								</tr>
 							`).join('')}
@@ -528,7 +534,8 @@ function renderLayout(data: SessionLogData): void {
 	
 	const totalTokens = data.turns.reduce((sum, t) => sum + t.inputTokensEstimate + t.outputTokensEstimate + t.thinkingTokensEstimate, 0);
 	const totalThinkingTokens = data.turns.reduce((sum, t) => sum + t.thinkingTokensEstimate, 0);
-	const totalToolCalls = data.turns.reduce((sum, t) => sum + t.toolCalls.length, 0);
+	const totalToolCalls = data.turns.reduce((sum, t) => sum + t.toolCalls.filter(tc => !tc.isSubAgent).length, 0);
+	const totalSubAgentCalls = data.turns.reduce((sum, t) => sum + t.toolCalls.filter(tc => tc.isSubAgent).length, 0);
 	const totalMcpTools = data.turns.reduce((sum, t) => sum + t.mcpTools.length, 0);
 	const turnsWithThinking = data.turns.filter(t => t.thinkingTokensEstimate > 0).length;
 	const totalRefs = getTotalContextRefs(data.contextReferences);
@@ -621,6 +628,11 @@ function renderLayout(data: SessionLogData): void {
 					<div class="summary-label">🧠 Thinking Tokens</div>
 					<div class="summary-value">${formatCompact(totalThinkingTokens)}</div>
 					<div class="summary-sub">${turnsWithThinking} of ${data.turns.length} turns used thinking</div>
+				</div>` : ''}
+				${totalSubAgentCalls > 0 ? `<div class="summary-card">
+					<div class="summary-label">🤖 Sub-Agent Calls</div>
+					<div class="summary-value">${totalSubAgentCalls}</div>
+					<div class="summary-sub">Agent mode sub-agent invocations</div>
 				</div>` : ''}
 				<div class="summary-card">
 					<div class="summary-label">🔧 Tool Calls</div>

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -437,6 +437,32 @@ details[open] > summary .collapse-arrow {
 	border-bottom: none;
 }
 
+.tools-table tbody .tool-row.sub-agent-row {
+	background: rgba(99, 102, 241, 0.06);
+}
+
+.sub-agent-model-badge {
+	display: inline-block;
+	margin-left: 8px;
+	padding: 1px 7px;
+	border-radius: 10px;
+	font-size: 11px;
+	font-weight: 600;
+	background: rgba(99, 102, 241, 0.18);
+	color: #a5b4fc;
+	vertical-align: middle;
+}
+
+.sub-agent-summary-item {
+	display: inline-block;
+	margin-left: 6px;
+	padding: 2px 8px;
+	border-radius: 10px;
+	font-size: 11px;
+	background: rgba(99, 102, 241, 0.18);
+	color: #a5b4fc;
+}
+
 .tool-name-cell {
 	padding: 10px 12px;
 	vertical-align: top;

--- a/vscode-extension/test/unit/sessionParser.test.ts
+++ b/vscode-extension/test/unit/sessionParser.test.ts
@@ -458,3 +458,144 @@ test('JSON session: actualTokens is 0 when no result usage fields present', () =
 	const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
 	assert.equal(result.actualTokens, 0);
 });
+
+// Sub-agent token tracking tests
+
+test('JSON session: sub-agent with plain string result is counted under sub-agent model', () => {
+	const subAgentItem = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: 'find files',        // 10 chars
+			result: 'here are files',    // 14 chars
+		}
+	};
+	const content = JSON.stringify({
+		requests: [
+			{
+				model: 'claude-opus-4',
+				message: { text: 'go' },            // 2 input chars under opus
+				response: [
+					{ value: 'ok' },                  // 2 output chars under opus
+					subAgentItem,
+				]
+			}
+		]
+	});
+	const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
+	// Sub-agent model name normalized: "claude-haiku-4.5"
+	assert.ok(result.modelUsage['claude-haiku-4.5'], 'sub-agent model should have usage');
+	assert.equal(result.modelUsage['claude-haiku-4.5'].inputTokens, 10, 'sub-agent prompt chars');
+	assert.equal(result.modelUsage['claude-haiku-4.5'].outputTokens, 14, 'sub-agent result chars');
+	// Parent model still has its own tokens
+	assert.equal(result.modelUsage['claude-opus-4'].outputTokens, 2);
+});
+
+test('JSON session: sub-agent with streaming char object result is counted correctly', () => {
+	// Build streaming char result: "Hi" => {"0":"H","1":"i"}
+	const streamingResult: Record<string, string> = {};
+	Array.from('Hi').forEach((c, i) => { streamingResult[String(i)] = c; });
+	const subAgentItem = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: 'ping',
+			result: streamingResult,
+		}
+	};
+	const content = JSON.stringify({
+		requests: [{ model: 'gpt-4o', message: { text: 'x' }, response: [subAgentItem] }]
+	});
+	const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
+	assert.ok(result.modelUsage['claude-haiku-4.5']);
+	assert.equal(result.modelUsage['claude-haiku-4.5'].inputTokens, 4, 'prompt: "ping"');
+	assert.equal(result.modelUsage['claude-haiku-4.5'].outputTokens, 2, 'result: "Hi"');
+});
+
+test('JSON session: sub-agent with missing modelName falls back to parent model', () => {
+	const subAgentItem = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			// no modelName
+			prompt: 'search',
+			result: 'found it',
+		}
+	};
+	const content = JSON.stringify({
+		requests: [{ model: 'gpt-4o', message: { text: 'do' }, response: [subAgentItem] }]
+	});
+	const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
+	assert.ok(result.modelUsage['gpt-4o']);
+	// Falls back to parent model
+	assert.equal(result.modelUsage['gpt-4o'].inputTokens, 2 + 6, 'parent input + sub-agent prompt');
+	assert.equal(result.modelUsage['gpt-4o'].outputTokens, 8, 'sub-agent result under parent');
+});
+
+test('delta-based JSONL: sub-agent tokens are counted from reconstructed state', () => {
+	const subAgentItem = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: 'list',       // 4 chars
+			result: 'file.ts',   // 7 chars
+		}
+	};
+	const filePath = 'C:/tmp/session.jsonl';
+	const content = [
+		JSON.stringify({ kind: 0, v: { requests: [] } }),
+		JSON.stringify({
+			kind: 2,
+			k: ['requests'],
+			v: [{
+				requestId: 'r1',
+				modelId: 'copilot/claude-opus-4.6',
+				message: { text: 'go' },
+				response: [subAgentItem],
+			}]
+		})
+	].join('\n');
+
+	const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+	assert.ok(result.modelUsage['claude-haiku-4.5'], 'sub-agent model should appear in delta path');
+	assert.equal(result.modelUsage['claude-haiku-4.5'].inputTokens, 4);
+	assert.equal(result.modelUsage['claude-haiku-4.5'].outputTokens, 7);
+});
+
+test('delta-based JSONL: sub-agent items do not contribute to parent model output', () => {
+	const subAgentItem = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: 'search query',
+			result: 'search results here',
+		}
+	};
+	const filePath = 'C:/tmp/session.jsonl';
+	const content = [
+		JSON.stringify({ kind: 0, v: { requests: [] } }),
+		JSON.stringify({
+			kind: 2,
+			k: ['requests'],
+			v: [{
+				requestId: 'r1',
+				modelId: 'copilot/claude-opus-4.6',
+				message: { text: 'help' },
+				response: [
+					{ kind: 'markdownContent', content: { value: 'sure' } },
+					subAgentItem,
+				],
+			}]
+		})
+	].join('\n');
+
+	const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+	// Parent model only has "sure" (4 chars) as output, not the sub-agent text
+	assert.equal(result.modelUsage['claude-opus-4.6'].outputTokens, 4, 'parent output should not include sub-agent result');
+	// Sub-agent is tracked separately
+	assert.ok(result.modelUsage['claude-haiku-4.5']);
+});

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { extractSubAgentData, normalizeDisplayModelName } from '../../src/tokenEstimation';
+
+test('normalizeDisplayModelName: lowercases and replaces spaces with hyphens', () => {
+	assert.equal(normalizeDisplayModelName('Claude Haiku 4.5'), 'claude-haiku-4.5');
+	assert.equal(normalizeDisplayModelName('GPT 4 Turbo'), 'gpt-4-turbo');
+	assert.equal(normalizeDisplayModelName('claude-sonnet-4'), 'claude-sonnet-4');
+	assert.equal(normalizeDisplayModelName('  Gemini 2.5 Pro  '), 'gemini-2.5-pro');
+});
+
+test('extractSubAgentData: returns null for non-subagent items', () => {
+	assert.equal(extractSubAgentData(null), null);
+	assert.equal(extractSubAgentData(undefined), null);
+	assert.equal(extractSubAgentData({ kind: 'markdownContent', value: 'hello' }), null);
+	assert.equal(extractSubAgentData({ kind: 'toolInvocationSerialized', toolSpecificData: { kind: 'other' } }), null);
+	assert.equal(extractSubAgentData({ kind: 'toolInvocationSerialized' }), null);
+	assert.equal(extractSubAgentData({ kind: 'toolInvocationSerialized', toolSpecificData: {} }), null);
+});
+
+test('extractSubAgentData: extracts data from plain string result', () => {
+	const item = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: 'search for files',
+			result: 'found 3 files',
+		}
+	};
+	const data = extractSubAgentData(item);
+	assert.ok(data, 'should return data');
+	assert.equal(data.prompt, 'search for files');
+	assert.equal(data.result, 'found 3 files');
+	assert.equal(data.modelName, 'claude-haiku-4.5');
+});
+
+test('extractSubAgentData: decodes streaming char object result in correct order', () => {
+	// Numeric keys in non-sequential order to verify sort
+	const item = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: 'go',
+			result: { '2': 'l', '0': 'h', '1': 'e', '3': 'p' }
+		}
+	};
+	const data = extractSubAgentData(item);
+	assert.ok(data);
+	assert.equal(data.result, 'help', 'should sort numerically: 0=h,1=e,2=l,3=p');
+});
+
+test('extractSubAgentData: returns null when both prompt and result are empty', () => {
+	const item = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			modelName: 'Claude Haiku 4.5',
+			prompt: '',
+			result: '',
+		}
+	};
+	assert.equal(extractSubAgentData(item), null);
+});
+
+test('extractSubAgentData: handles missing modelName gracefully', () => {
+	const item = {
+		kind: 'toolInvocationSerialized',
+		toolSpecificData: {
+			kind: 'subagent',
+			prompt: 'list files',
+			result: 'file.ts',
+		}
+	};
+	const data = extractSubAgentData(item);
+	assert.ok(data);
+	assert.equal(data.modelName, '', 'empty string when modelName is absent');
+	assert.equal(data.prompt, 'list files');
+	assert.equal(data.result, 'file.ts');
+});


### PR DESCRIPTION
## Summary

Fixes #567 — sub-agent token usage was completely invisible in all stats views.

When Copilot runs in agent mode, it can invoke sub-agents (Explore, task runners, etc.) using `toolInvocationSerialized` response items with `toolSpecificData.kind === "subagent"`. These sub-agents run under a **different model** (e.g., Claude Haiku 4.5) than the parent agent (e.g., Claude Opus 4.6). Their prompt and result text live entirely inside `toolSpecificData` — never in the main response text — so every token-counting path silently ignored them.

## Root cause confirmed

Examined real session files from the past 15 days and found sessions with 100+ LLM turns and 9+ sub-agent invocations where **zero sub-agent tokens** were reflected in any stat. Sub-agent results can be 14,000+ characters that were simply dropped.

## Changes

| File | What changed |
|---|---|
| `tokenEstimation.ts` | New exported `extractSubAgentData()` and `normalizeDisplayModelName()` helpers; delta-JSONL path skips partial sub-agent items during line-by-line scan and counts them from the fully-reconstructed state instead |
| `sessionParser.ts` | Sub-agent detection in both reconstructed-JSONL and plain-JSON response loops; tokens attributed to sub-agent's own model |
| `extension.ts` | Same detection in `estimateTokensFromSession` JSON loop |
| `usageAnalysis.ts` | `getModelUsageFromSession` updated for both JSONL and JSON paths; sub-agent entries are additive (not replaced by parent actual-token data) |
| `test/unit/sessionParser.test.ts` | 6 new sub-agent scenario tests |
| `test/unit/tokenEstimation.test.ts` | New file — 6 tests for `extractSubAgentData` and `normalizeDisplayModelName` |

## Key design decisions

- **Reconstructed state, not delta events**: Sub-agent results are built character-by-character via delta events and only complete in the final reconstructed session state. The line-by-line path skips sub-agent items to avoid counting partial results.
- **Sub-agent model attribution**: `toolSpecificData.modelName` (display name like "Claude Haiku 4.5") is normalised to a slug ("claude-haiku-4.5") so it matches tokenEstimators keys. Tokens go under the sub-agent's model, not the parent.
- **Fallback**: If `modelName` is missing, sub-agent tokens fall back to the parent model — no silent drops.
- **Streaming char format**: Results stored as `{"0":"H","1":"e",...}` objects are decoded by sorting keys numerically before joining.
- **Always additive**: Even when a parent request has actual API token counts, sub-agent tokens are still estimated from text and added separately (the API counts never include sub-agent calls).

## Test results

638 pass, 0 fail