### PR TITLE
Fix: wrap long MCP tool names in session viewer

### DIFF
--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -517,6 +517,7 @@ details[open] > summary .collapse-arrow {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 6px;
+	min-width: 0;
 }
 
 .mcp-item {
@@ -526,6 +527,11 @@ details[open] > summary .collapse-arrow {
 	border-radius: 4px;
 	font-size: 12px;
 	color: var(--text-primary);
+	/* Allow long tool names to wrap instead of overflowing the card */
+	white-space: normal;
+	word-break: break-word;
+	overflow-wrap: anywhere;
+	max-width: 100%;
 }
 
 .mcp-server {


### PR DESCRIPTION
Why

Long MCP tool names could overflow their card in the session viewer, causing the UI to break out of its container (see attached screenshot). This makes the dashboard look broken for long tool identifiers.

What I changed

- Allow tool-name badges to wrap and constrain their container width:
  - vscode-extension/src/webview/logviewer/styles.css
    - .mcp-list: added min-width: 0
    - .mcp-item: enabled wrapping (white-space: normal; word-break: break-word; overflow-wrap: anywhere; max-width: 100%)

Approach

A minimal CSS change prevents long tokenized MCP names from overflowing while preserving the existing look-and-feel. No JS or behavior changes were made — this is a visual fix only.

Notes for reviewers

- Small, focused change (single CSS file). Should be safe to merge without runtime impact.
- I couldn't run the full TypeScript build in this environment, but the change is CSS-only. Recommend verifying visually in the Extension Development Host or by loading the webview.

Files changed

- vscode-extension/src/webview/logviewer/styles.css

N/A: No migrations, no API changes.