### PR TITLE
chore: bump VS Code extension version to 0.1.1

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,32 +6,50 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-### ✨ Features & Improvements
-- Added GitHub authentication support using VS Code's built-in authentication provider
-- New commands: "Authenticate with GitHub" and "Sign Out from GitHub"
+## [0.1.1] - 2026-04-10
+
+### Features and Improvements
+- Added GitHub authentication support using VS Code's built-in authentication provider (#182)
+- New commands: Authenticate with GitHub and Sign Out from GitHub
 - GitHub Auth tab in Diagnostic Report panel showing authentication status
 - Foundation for future GitHub-specific features (repository tracking, team collaboration, advanced analytics)
+- Added Claude Desktop Cowork session support (#572)
+- Added per-tool suppression for unknown tool name notifications (#563)
+- Show git branch in status bar when running in debug mode (#576)
+
+### Bug Fixes
+- Fixed tracking of token usage from sub-agent calls in Copilot agent mode (#573)
+- Fixed long MCP tool names wrapping in session viewer (#574)
+- Fixed Copilot CLI session titles showing empty (#575)
+- Hide 0-interaction sessions in diagnostics view
+
+### Dependencies
+- Bumped basic-ftp (#577)
+
+## [0.1.0]
+
+Release notes: https://github.com/rajbos/github-copilot-token-usage/compare/vscode/v0.0.23...vscode/v0.1.0
 
 ## [0.0.27] - 2026-04-07
 
-### ✨ Features & Improvements
-- Added friendly display names for `mcp_gitkraken_git_log_or_diff`, `copilot_runInTerminal`, `mcp_laravel-boost_tinker`, and Power BI MCP tools (#553, #554, #555)
+### Features and Improvements
+- Added friendly display names for mcp_gitkraken_git_log_or_diff, copilot_runInTerminal, mcp_laravel-boost_tinker, and Power BI MCP tools (#553, #554, #555)
 
-### 🐛 Bug Fixes
+### Bug Fixes
 - Fixed integration test activation timing (#548)
 
 ## [0.0.26] - 2026-04-04
 
-### ✨ Features & Improvements
+### Features and Improvements
 - Split usage analysis view into 3 tabs for better navigation (#540)
 - Added missing friendly display names for MCP and VS Code tools (#539)
 
-### 🐛 Bug Fixes
+### Bug Fixes
 - Fixed loading stalls during session discovery (#545)
 
 ## [0.0.24] - 2026-03-28
 
-### ✨ Features & Improvements
+### Features and Improvements
 - Added Claude Code session file support as a usage analysis data source
 - Added formatting options to details and log viewer panels
 - Added friendly display names for container-tools and github-pull-request tools
@@ -39,8 +57,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [0.0.23] - 2026-03-26
 
-### ✨ Features & Improvements
-- Renamed extension to **AI Engineering Fluency** (was "Copilot Token Tracker")
+### Features and Improvements
+- Renamed extension to AI Engineering Fluency (was Copilot Token Tracker)
 - Added friendly display names for CMakeTools and misc non-MCP tools
 - Added friendly display names for Python and Pylance MCP tools
 - Improved maturity scoring view with updated labels and layout

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep - VS Code extension v0.1.1

This PR bumps the VS Code extension version from \