### PR TITLE
Potential fix for code scanning alert no. 53: Client-side cross-site scripting

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -473,9 +473,20 @@ function sanitizeRepoPrStatsData(input: unknown): RepoPrStatsResult {
 				aiReviewRequestedPrs: toSafeNumber(r.aiReviewRequestedPrs),
 				aiDetails: aiDetails.map((d) => {
 					const detail = (d && typeof d === 'object') ? (d as Record<string, unknown>) : {};
+					const validAiTypes = ['copilot', 'claude', 'openai', 'other-ai'] as const;
+					const validRoles = ['author', 'reviewer-requested'] as const;
+					const aiType = validAiTypes.includes(detail.aiType as typeof validAiTypes[number])
+						? detail.aiType as typeof validAiTypes[number]
+						: 'other-ai';
+					const role = validRoles.includes(detail.role as typeof validRoles[number])
+						? detail.role as typeof validRoles[number]
+						: 'author';
 					return {
-						label: escapeHtml(typeof detail.label === 'string' ? detail.label : ''),
-						count: toSafeNumber(detail.count),
+						number: toSafeNumber(detail.number),
+						title: escapeHtml(typeof detail.title === 'string' ? detail.title : ''),
+						url: toSafeHttpUrl(detail.url),
+						aiType,
+						role,
 					};
 				}),
 			};

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -436,6 +436,53 @@ function setupTabs(): void {
 	});
 }
 
+function toSafeNumber(value: unknown): number {
+	const n = Number(value);
+	return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+function toSafeHttpUrl(value: unknown): string {
+	const raw = typeof value === 'string' ? value.trim() : '';
+	try {
+		const parsed = new URL(raw);
+		if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+			return parsed.toString();
+		}
+	} catch {
+		// Ignore invalid URL and fall back to placeholder.
+	}
+	return '#';
+}
+
+function sanitizeRepoPrStatsData(input: unknown): RepoPrStatsResult {
+	const src = (input && typeof input === 'object') ? (input as Record<string, unknown>) : {};
+	const repos = Array.isArray(src.repos) ? src.repos : [];
+	return {
+		authenticated: Boolean(src.authenticated),
+		since: typeof src.since === 'string' || typeof src.since === 'number' ? src.since : Date.now(),
+		repos: repos.map((repo) => {
+			const r = (repo && typeof repo === 'object') ? (repo as Record<string, unknown>) : {};
+			const aiDetails = Array.isArray(r.aiDetails) ? r.aiDetails : [];
+			return {
+				repoUrl: toSafeHttpUrl(r.repoUrl),
+				owner: escapeHtml(typeof r.owner === 'string' ? r.owner : ''),
+				repo: escapeHtml(typeof r.repo === 'string' ? r.repo : ''),
+				error: typeof r.error === 'string' ? escapeHtml(r.error) : '',
+				totalPrs: toSafeNumber(r.totalPrs),
+				aiAuthoredPrs: toSafeNumber(r.aiAuthoredPrs),
+				aiReviewRequestedPrs: toSafeNumber(r.aiReviewRequestedPrs),
+				aiDetails: aiDetails.map((d) => {
+					const detail = (d && typeof d === 'object') ? (d as Record<string, unknown>) : {};
+					return {
+						label: escapeHtml(typeof detail.label === 'string' ? detail.label : ''),
+						count: toSafeNumber(detail.count),
+					};
+				}),
+			};
+		}),
+	} as RepoPrStatsResult;
+}
+
 function renderReposPrContent(data: RepoPrStatsResult): string {
 	const sinceDate = escapeHtml(new Date(data.since).toLocaleDateString());
 	if (!data.authenticated) {
@@ -1356,7 +1403,7 @@ window.addEventListener('message', (event) => {
 			break;
 		}
 		case 'repoPrStatsLoaded': {
-			repoPrStatsData = message.data as RepoPrStatsResult;
+			repoPrStatsData = sanitizeRepoPrStatsData(message.data);
 			// Reset the loaded flag when not authenticated so re-authenticating and clicking the tab
 			// again triggers a fresh fetch instead of showing the stale "not authenticated" placeholder.
 			if (!repoPrStatsData.authenticated) {


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/53](https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/53)

Best fix: **validate and sanitize the incoming `repoPrStatsData` at the message boundary** before storing/rendering it, and ensure all dynamic fields used in HTML templates are escaped or type-coerced to safe primitives.

In this file (`vscode-extension/src/webview/usage/main.ts`), the least disruptive, functionality-preserving fix is:

1. Add small helper sanitizers (string/number/url coercion).
2. Add a `sanitizeRepoPrStatsData` function that:
   - enforces expected structure,
   - escapes text fields (`owner`, `repo`, `error`, AI detail labels),
   - constrains URLs to http/https (or safe fallback),
   - coerces count fields to finite non-negative numbers.
3. In `repoPrStatsLoaded` message case, sanitize `message.data` before assigning to `repoPrStatsData` and rendering.
4. In `renderReposPrContent`, ensure numeric outputs are explicitly formatted from safe numbers (defense in depth).

This keeps existing UI behavior while eliminating tainted raw values flowing into `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
