### PR TITLE
Add marketplace and npm download badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Token usage tracking inside Visual Studio 2022+, reading Copilot Chat session fi
 
 Run anywhere with Node.js — no editor required. Get usage stats, fluency scores, and environmental impact from the terminal.
 
+[![npm downloads](https://img.shields.io/npm/dm/@rajbos/ai-engineering-fluency)](https://www.npmjs.com/package/@rajbos/ai-engineering-fluency)
+
 ```bash
 npx @rajbos/ai-engineering-fluency stats
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Studio, and the command line. All data is read from local session logs — nothing leaves your machine unless you opt in to cloud sync.
 
 [![Build](https://github.com/rajbos/github-copilot-token-usage/actions/workflows/build.yml/badge.svg)](https://github.com/rajbos/github-copilot-token-usage/actions/workflows/build.yml)
+[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/RobBos.AIEngineeringFluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.AIEngineeringFluency)
 
 ## Supported AI engineering tools
 
@@ -24,6 +25,8 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 ### 🖥️ VS Code Extension
 
 Real-time token usage in the status bar, fluency score dashboard, usage analysis, cloud sync, and more.
+
+[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/RobBos.copilot-token-tracker)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker)
 
 ```bash
 # Install from the VS Code Marketplace


### PR DESCRIPTION
Adds live download count badges to the README so visitors can see at a glance how widely each distribution channel is used.

**Changes:**
- Top of README: `AIEngineeringFluency` VS Marketplace downloads badge alongside the build badge
- VS Code Extension section: `copilot-token-tracker` VS Marketplace downloads badge before the install command
- CLI section: `@rajbos/ai-engineering-fluency` npm monthly downloads badge before the `npx` command

All badges link directly to their respective marketplace/registry pages.