### PR TITLE
feat: add thinking effort (reasoning effort) tracking

### DIFF
--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -48,7 +48,11 @@ The entire extension's logic is contained within the `CopilotTokenTracker` class
 - **Watch Mode**: For active development, use `npm run watch` from `vscode-extension/`. This will automatically recompile the extension on file changes.
 - **Testing/Debugging**: Press `F5` in VS Code to open the Extension Development Host. This will launch a new VS Code window with the extension running. `console.log` statements from `vscode-extension/src/extension.ts` will appear in the Developer Tools console of this new window (Help > Toggle Developer Tools).
 
-**Important build guidance:** After making changes to source code or related files (TypeScript, JavaScript, JSON, or other code files used by the extension), always run `npm run compile` from `vscode-extension/` to validate that the project still builds and lints cleanly before opening a pull request or releasing. You do not need to run the full compile step for documentation-only changes (Markdown files), but you should run it after any edits that touch source, configuration, or JSON data files.
+**Important build guidance:** After making changes to source code or related files (TypeScript, JavaScript, JSON, or other code files used by the extension), always run both `npm ci` and then `npm run compile` from `vscode-extension/` to validate that the project still builds and lints cleanly before opening a pull request or releasing. Also run the unit tests with `npm run test:node` to catch any regressions. You do not need to run the full compile step for documentation-only changes (Markdown files), but you should run it after any edits that touch source, configuration, or JSON data files.
+
+**Always use `npm ci` (not `npm install`) when validating a build** — `npm ci` installs from the lockfile exactly, mirroring what CI does, and will catch any dependency drift. Use `npm install` only when intentionally adding or updating packages.
+
+> ⚠️ **Common mistake**: The `edit` tool's old_str/new_str replacement can accidentally drop comment delimiters (e.g. `/**` opening a JSDoc block) when the match boundary falls exactly at that line. After editing `tokenEstimation.ts` or any file with JSDoc comments, always verify the file compiles before committing.
 
 ## Development Guidelines
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4319,6 +4319,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.warn(`Error loading usage analysis for ${sessionFile}: ${usageError}`);
 		}
 
+		const sessionCache = this.getCachedSessionData(sessionFile);
+
 		return {
 			file: details.file,
 			title: details.title || null,
@@ -4331,7 +4333,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			firstInteraction: details.firstInteraction,
 			lastInteraction: details.lastInteraction,
 			turns,
-			usageAnalysis
+			usageAnalysis,
+			actualTokens: sessionCache?.actualTokens || 0
 		};
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -71,6 +71,7 @@ import {
   getTotalTokensFromModelUsage as _getTotalTokensFromModelUsage,
   reconstructJsonlStateAsync as _reconstructJsonlStateAsync,
   extractSubAgentData as _extractSubAgentData,
+  buildReasoningEffortTimeline as _buildReasoningEffortTimeline,
 } from './tokenEstimation';
 import { SessionDiscovery } from './sessionDiscovery';
 import { CacheManager } from './cacheManager';
@@ -167,7 +168,7 @@ type RepoPrStatsResult = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 36; // Add first-user-message fallback title for untitled Copilot CLI sessions
+	private static readonly CACHE_VERSION = 37; // Add thinking effort (reasoning effort) tracking
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -4034,6 +4035,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 					// blocking the extension host event loop on large files.
 					const { sessionState } = await _reconstructJsonlStateAsync(lines);
 
+					// Build per-request effort map from delta lines
+					const { effortByRequestId } = _buildReasoningEffortTimeline(lines);
+
 					// Extract session-level info
 					let sessionMode: 'ask' | 'edit' | 'agent' | 'plan' | 'customAgent' = 'ask';
 					let currentModel: string | null = null;
@@ -4119,7 +4123,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 						inputTokensEstimate: this.estimateTokensFromText(userMessage, requestModel),
 						outputTokensEstimate: this.estimateTokensFromText(responseText, requestModel),
 						thinkingTokensEstimate: this.estimateTokensFromText(thinkingText, requestModel),
-						actualUsage
+						actualUsage,
+						thinkingEffort: effortByRequestId.get(request.requestId)
 					};
 
 					turns.push(turn);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+﻿import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -4132,6 +4132,20 @@ class CopilotTokenTracker implements vscode.Disposable {
 			} else {
 			// Non-delta JSONL (Copilot CLI format)
 			let turnNumber = 0;
+			let cliSessionModel = 'gpt-4o';
+			let cliSessionEffort: string | undefined;
+
+			// Pre-scan for session.start to extract default model and effort
+			for (const line of lines) {
+				try {
+					const ev = JSON.parse(line);
+					if (ev.type === 'session.start' && ev.data) {
+						if (typeof ev.data.selectedModel === 'string') { cliSessionModel = ev.data.selectedModel; }
+						if (typeof ev.data.reasoningEffort === 'string') { cliSessionEffort = ev.data.reasoningEffort; }
+						break;
+					}
+				} catch { /* skip */ }
+			}
 
 			for (const line of lines) {
 				try {
@@ -4143,19 +4157,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 						const contextRefs = this.createEmptyContextRefs();
 						const userMessage = event.data.content;
 						this.analyzeContextReferences(userMessage, contextRefs);
+						const turnModel = event.model || event.data?.model || cliSessionModel;
+						const turnEffort: string | undefined = typeof event.data?.reasoningEffort === 'string'
+							? event.data.reasoningEffort
+							: cliSessionEffort;
 						const turn: ChatTurn = {
 							turnNumber,
 							timestamp: event.timestamp ? new Date(event.timestamp).toISOString() : null,
 							mode: 'agent', // CLI is typically agent mode
 							userMessage,
 							assistantResponse: '',
-							model: event.model || 'gpt-4o',
+							model: turnModel,
 							toolCalls: [],
 							contextReferences: contextRefs,
 							mcpTools: [],
-							inputTokensEstimate: this.estimateTokensFromText(userMessage, event.model || 'gpt-4o'),
+							inputTokensEstimate: this.estimateTokensFromText(userMessage, turnModel),
 							outputTokensEstimate: 0,
-							thinkingTokensEstimate: 0
+							thinkingTokensEstimate: 0,
+							thinkingEffort: turnEffort
 						};
 						turns.push(turn);
 					}

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -244,7 +244,85 @@ export async function reconstructJsonlStateAsync(lines: string[], yieldInterval 
 }
 
 /**
- * Extract per-request actual token usage from raw JSONL lines using regex.
+ * Build a map from requestId → reasoning effort level by scanning delta-based JSONL lines.
+ *
+ * The effort level is taken from `configurationSchema.properties.reasoningEffort.default`
+ * on the active selectedModel at the time each request is added to the session.
+ *
+ * Returns: Map<requestId, effort> plus the default effort at session start.
+ */
+export function buildReasoningEffortTimeline(lines: string[]): {
+  effortByRequestId: Map<string, string>;
+  defaultEffort: string | null;
+  switchCount: number;
+} {
+  const effortByRequestId = new Map<string, string>();
+  let currentEffort: string | null = null;
+  let defaultEffort: string | null = null;
+  let switchCount = 0;
+
+  function extractEffortFromModel(model: unknown): string | null {
+    if (!model || typeof model !== 'object') { return null; }
+    const m = model as Record<string, unknown>;
+    const metadata = m['metadata'];
+    if (!metadata || typeof metadata !== 'object') { return null; }
+    const meta = metadata as Record<string, unknown>;
+    const schema = meta['configurationSchema'];
+    if (!schema || typeof schema !== 'object') { return null; }
+    const s = schema as Record<string, unknown>;
+    const props = s['properties'];
+    if (!props || typeof props !== 'object') { return null; }
+    const p = props as Record<string, unknown>;
+    const re = p['reasoningEffort'];
+    if (!re || typeof re !== 'object') { return null; }
+    const r = re as Record<string, unknown>;
+    return typeof r['default'] === 'string' ? r['default'] : null;
+  }
+
+  for (const line of lines) {
+    if (!line.trim()) { continue; }
+    let delta: any;
+    try { delta = JSON.parse(line); } catch { continue; }
+    if (typeof delta.kind !== 'number') { continue; }
+
+    if (delta.kind === 0) {
+      // Initial state: extract model from inputState.selectedModel
+      const model = delta.v?.inputState?.selectedModel;
+      const effort = extractEffortFromModel(model);
+      if (effort !== null) {
+        currentEffort = effort;
+        defaultEffort = effort;
+      }
+    } else if (delta.kind === 1) {
+      const k = delta.k;
+      // Update to inputState.selectedModel — two-element path
+      if (Array.isArray(k) && k[0] === 'inputState' && k[1] === 'selectedModel') {
+        const effort = extractEffortFromModel(delta.v);
+        if (effort !== null && effort !== currentEffort) {
+          if (currentEffort !== null) { switchCount++; }
+          currentEffort = effort;
+        }
+      }
+    } else if (delta.kind === 2) {
+      const k = delta.k;
+      // New request being added: k = ["requests", <index>]
+      if (Array.isArray(k) && k[0] === 'requests' && typeof k[1] === 'number' && currentEffort !== null) {
+        const req = delta.v;
+        if (req && typeof req === 'object') {
+          const r = req as Record<string, unknown>;
+          const requestId = typeof r['requestId'] === 'string' ? r['requestId'] : null;
+          if (requestId) {
+            effortByRequestId.set(requestId, currentEffort);
+          }
+        }
+      }
+    }
+  }
+
+  return { effortByRequestId, defaultEffort, switchCount };
+}
+
+
  * Handles cases where lines with result data fail JSON.parse due to bad escape characters.
  * Supports both old format (usage.promptTokens/completionTokens) and new format (promptTokens/outputTokens).
  */

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -322,7 +322,8 @@ export function buildReasoningEffortTimeline(lines: string[]): {
   return { effortByRequestId, defaultEffort, switchCount };
 }
 
-
+/**
+ * Extract per-request actual token usage from raw JSONL lines using regex.
  * Handles cases where lines with result data fail JSON.parse due to bad escape characters.
  * Supports both old format (usage.promptTokens/completionTokens) and new format (promptTokens/outputTokens).
  */

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -372,6 +372,8 @@ export interface SessionLogData {
   lastInteraction: string | null;
   turns: ChatTurn[];
   usageAnalysis?: SessionUsageAnalysis;
+  /** Session-level actual token count from LLM API (e.g. session.shutdown in CLI format). 0 when unavailable. */
+  actualTokens?: number;
 }
 
 // Local summary type for customization files (mirrors webview/shared/contextRefUtils.ts)

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -122,6 +122,16 @@ category?: 'copilot' | 'non-copilot';
 }
 
 // New interfaces for usage analysis
+/** Per-level request counts for thinking effort (reasoning effort) tracking. */
+export interface ThinkingEffortUsage {
+  /** Number of requests submitted at each effort level, keyed by level name (e.g. "low", "medium", "high"). */
+  byEffort: { [effort: string]: number };
+  /** Number of times the effort level changed within this session. */
+  switchCount: number;
+  /** The effort level active at the start of the session, or null if not available. */
+  defaultEffort: string | null;
+}
+
 export interface SessionUsageAnalysis {
   toolCalls: ToolCallUsage;
   modeUsage: ModeUsage;
@@ -138,6 +148,7 @@ export interface SessionUsageAnalysis {
     unknownRequests: number;
     totalRequests: number;
   };
+  thinkingEffort?: ThinkingEffortUsage;
   editScope?: EditScopeUsage;
   applyUsage?: ApplyButtonUsage;
   sessionDuration?: SessionDurationData;
@@ -289,6 +300,12 @@ export interface UsageAnalysisPeriod {
   sessionDuration: SessionDurationData;
   conversationPatterns: ConversationPatterns;
   agentTypes: AgentTypeUsage;
+  /** Aggregated thinking effort (reasoning effort) usage across all sessions in this period. */
+  thinkingEffortUsage?: {
+    byEffort: { [effort: string]: number };
+    sessionCount: number; // sessions with effort data
+    switchCount: number;  // total effort switches across all sessions
+  };
 }
 
 // Detailed session file information for diagnostics view
@@ -337,6 +354,8 @@ export interface ChatTurn {
   outputTokensEstimate: number;
   thinkingTokensEstimate: number;
   actualUsage?: ActualUsage;
+  /** Thinking effort level active when this turn was submitted (e.g. "low", "medium", "high"). */
+  thinkingEffort?: string;
 }
 
 // Full session log data for the log viewer

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -29,6 +29,7 @@ import {
 	extractPerRequestUsageFromRawLines,
 	createEmptyContextRefs,
 	extractSubAgentData,
+	buildReasoningEffortTimeline,
 } from './tokenEstimation';
 import {
 	getModeType,
@@ -238,6 +239,17 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 		period.agentTypes.defaultAgent += analysis.agentTypes.defaultAgent;
 		period.agentTypes.workspaceAgent += analysis.agentTypes.workspaceAgent;
 		period.agentTypes.other += analysis.agentTypes.other;
+	}
+
+	if (analysis.thinkingEffort) {
+		if (!period.thinkingEffortUsage) {
+			period.thinkingEffortUsage = { byEffort: {}, sessionCount: 0, switchCount: 0 };
+		}
+		period.thinkingEffortUsage.sessionCount++;
+		period.thinkingEffortUsage.switchCount += analysis.thinkingEffort.switchCount;
+		for (const [effort, count] of Object.entries(analysis.thinkingEffort.byEffort)) {
+			period.thinkingEffortUsage.byEffort[effort] = (period.thinkingEffortUsage.byEffort[effort] || 0) + count;
+		}
 	}
 }
 
@@ -1360,6 +1372,22 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 					}
 					analysis.modelSwitching.switchCount = switchCount;
 					applyModelTierClassification(deps, uniqueModels, models, analysis);
+				}
+
+				// Extract thinking effort (reasoning effort) from delta lines
+				{
+					const { effortByRequestId, defaultEffort, switchCount: effortSwitchCount } = buildReasoningEffortTimeline(lines);
+					if (defaultEffort !== null || effortByRequestId.size > 0) {
+						const byEffort: { [effort: string]: number } = {};
+						for (const [, effort] of effortByRequestId) {
+							byEffort[effort] = (byEffort[effort] || 0) + 1;
+						}
+						// If we have a defaultEffort but no per-request data, record it as the session default
+						if (effortByRequestId.size === 0 && defaultEffort !== null) {
+							byEffort[defaultEffort] = requests.length;
+						}
+						analysis.thinkingEffort = { byEffort, switchCount: effortSwitchCount, defaultEffort };
+					}
 				}
 
 				// Derive conversation patterns from mode usage before returning

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1398,10 +1398,35 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 
 			// Non-delta JSONL (Copilot CLI format) - process line-by-line
 			let sessionMode = 'ask';
+			let cliDefaultModel = 'gpt-4o';
+			let cliDefaultEffort: string | null = null;
+			let cliRequestCount = 0;
+			const cliEffortByRequest: { [effort: string]: number } = {};
 			for (const line of lines) {
 				if (!line.trim()) { continue; }
 				try {
 					const event = JSON.parse(line);
+
+					// Copilot CLI session.start carries model + reasoningEffort
+					if (event.type === 'session.start' && event.data) {
+						if (typeof event.data.selectedModel === 'string') {
+							cliDefaultModel = event.data.selectedModel;
+						}
+						if (typeof event.data.reasoningEffort === 'string') {
+							cliDefaultEffort = event.data.reasoningEffort;
+						}
+					}
+
+					// Count user.message requests and accumulate effort counts
+					if (event.type === 'user.message') {
+						cliRequestCount++;
+						const effort = typeof event.data?.reasoningEffort === 'string'
+							? event.data.reasoningEffort
+							: cliDefaultEffort;
+						if (effort) {
+							cliEffortByRequest[effort] = (cliEffortByRequest[effort] || 0) + 1;
+						}
+					}
 
 					// Handle VS Code incremental format - detect mode from session header
 					if (event.kind === 0 && event.v?.inputState?.mode) {
@@ -1545,6 +1570,15 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 					// Skip malformed lines
 				}
 			}
+
+			// Store CLI thinking effort data if available
+			if (cliDefaultEffort !== null || Object.keys(cliEffortByRequest).length > 0) {
+				const byEffort = Object.keys(cliEffortByRequest).length > 0
+					? cliEffortByRequest
+					: (cliDefaultEffort !== null ? { [cliDefaultEffort]: cliRequestCount } : {});
+				analysis.thinkingEffort = { byEffort, switchCount: 0, defaultEffort: cliDefaultEffort };
+			}
+
 			// Calculate model switching for JSONL files before returning
 			await calculateModelSwitching(deps, sessionFile, analysis, fileContent);
 
@@ -1718,6 +1752,11 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 					if (typeof event.kind === 'number') {
 						isDeltaBased = true;
 						sessionState = applyDelta(sessionState, event);
+					}
+
+					// Copilot CLI session.start carries the selected model
+					if (event.type === 'session.start' && typeof event.data?.selectedModel === 'string') {
+						defaultModel = event.data.selectedModel;
 					}
 
 					// Handle VS Code incremental format - extract model from session header (kind: 0)

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -32,16 +32,19 @@ type ChatTurn = {
 	outputTokensEstimate: number;
 	thinkingTokensEstimate: number;
 	actualUsage?: ActualUsage;
+	thinkingEffort?: string;
 };
 
 type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
 type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number };
 type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
+type ThinkingEffortUsage = { byEffort: { [effort: string]: number }; switchCount: number; defaultEffort: string | null };
 type SessionUsageAnalysis = {
 	toolCalls: ToolCallUsage;
 	modeUsage: ModeUsage;
 	contextReferences: ContextReferenceUsage;
 	mcpTools: McpToolUsage;
+	thinkingEffort?: ThinkingEffortUsage;
 };
 
 type SessionLogData = {
@@ -499,6 +502,7 @@ function renderTurnCard(turn: ChatTurn): string {
 					<span class="turn-number">#${turn.turnNumber}</span>
 					<span class="turn-mode" style="background: ${getModeColor(turn.mode)};">${getModeIcon(turn.mode)} ${turn.mode}</span>
 					${turn.model ? `<span class="turn-model">🎯 ${escapeHtml(turn.model)}</span>` : ''}
+					${turn.thinkingEffort ? `<span class="turn-effort">💡 ${escapeHtml(turn.thinkingEffort)}</span>` : ''}
 				<span class="turn-tokens">📊 ${formatCompact(totalTokens)} tokens (↑${turn.inputTokensEstimate} ↓${turn.outputTokensEstimate})</span>
 				${hasThinking ? `<span class="turn-tokens" style="color: #a78bfa;">🧠 ${formatCompact(turn.thinkingTokensEstimate)} thinking</span>` : ''}
 				${hasActualUsage ? `<span class="turn-tokens" style="color: #22c55e;">✓ ${formatCompact(turn.actualUsage!.promptTokens + turn.actualUsage!.completionTokens)} actual</span>` : ''}
@@ -540,6 +544,7 @@ function renderLayout(data: SessionLogData): void {
 	const turnsWithThinking = data.turns.filter(t => t.thinkingTokensEstimate > 0).length;
 	const totalRefs = getTotalContextRefs(data.contextReferences);
 	const usage = data.usageAnalysis;
+	const sessionEffort = usage?.thinkingEffort;
 	const usageMode = usage?.modeUsage || { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 };
 	const usageToolTotal = usage?.toolCalls?.total ?? totalToolCalls;
 	const usageTopTools = usage ? getTopEntries(usage.toolCalls.byTool, 3) : [];
@@ -628,6 +633,11 @@ function renderLayout(data: SessionLogData): void {
 					<div class="summary-label">🧠 Thinking Tokens</div>
 					<div class="summary-value">${formatCompact(totalThinkingTokens)}</div>
 					<div class="summary-sub">${turnsWithThinking} of ${data.turns.length} turns used thinking</div>
+				</div>` : ''}
+				${sessionEffort ? `<div class="summary-card">
+					<div class="summary-label">💡 Thinking Effort</div>
+					<div class="summary-value">${sessionEffort.defaultEffort ?? Object.keys(sessionEffort.byEffort)[0] ?? '—'}</div>
+					<div class="summary-sub">${Object.entries(sessionEffort.byEffort).map(([k, v]) => `${k}: ${v}`).join(', ')}${sessionEffort.switchCount > 0 ? ` · ${sessionEffort.switchCount} switch${sessionEffort.switchCount !== 1 ? 'es' : ''}` : ''}</div>
 				</div>` : ''}
 				${totalSubAgentCalls > 0 ? `<div class="summary-card">
 					<div class="summary-label">🤖 Sub-Agent Calls</div>

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,4 +1,4 @@
-// Log Viewer webview - displays session file details and chat turns
+﻿// Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 // CSS imported as text via esbuild
@@ -60,6 +60,8 @@ type SessionLogData = {
 	lastInteraction: string | null;
 	turns: ChatTurn[];
 	usageAnalysis?: SessionUsageAnalysis;
+	/** Session-level actual token count from LLM API (e.g. CLI session.shutdown). 0 when unavailable. */
+	actualTokens?: number;
 	compactNumbers?: boolean;
 };
 
@@ -561,6 +563,10 @@ function renderLayout(data: SessionLogData): void {
 	const actualPromptTotal = turnsWithActual.reduce((s, t) => s + (t.actualUsage?.promptTokens || 0), 0);
 	const actualCompletionTotal = turnsWithActual.reduce((s, t) => s + (t.actualUsage?.completionTokens || 0), 0);
 	const actualTotal = actualPromptTotal + actualCompletionTotal;
+
+	// Session-level actual tokens (from session.shutdown in CLI sessions) when no per-turn data
+	const sessionActualTokens = data.actualTokens || 0;
+	const hasSessionActualOnly = !hasAnyActualUsage && sessionActualTokens > 0;
 	
 	// Aggregate prompt breakdown across all turns
 	const aggregatedBreakdown: { [key: string]: { category: string; label: string; totalTokens: number; totalPct: number; count: number } } = {};
@@ -624,9 +630,15 @@ function renderLayout(data: SessionLogData): void {
 				</div>
 				${hasAnyActualUsage ? `
 				<div class="summary-card actual-usage-card">
-					<div class="summary-label">📊 Actual Tokens</div>
+					<div class="summary-label">✅ Actual Tokens</div>
 					<div class="summary-value">${formatCompact(actualTotal)}</div>
 					<div class="summary-sub">↑${formatCompact(actualPromptTotal)} prompt, ↓${formatCompact(actualCompletionTotal)} completion</div>
+				</div>
+				` : hasSessionActualOnly ? `
+				<div class="summary-card actual-usage-card">
+					<div class="summary-label">✅ Actual Tokens</div>
+					<div class="summary-value">${formatCompact(sessionActualTokens)}</div>
+					<div class="summary-sub">Total from session shutdown event</div>
 				</div>
 				` : ''}
 				${totalThinkingTokens > 0 ? `<div class="summary-card">

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -245,13 +245,13 @@ body {
 }
 
 .turn-effort {
-	font-size: 11px;
-	color: var(--link-color);
-	background: color-mix(in srgb, var(--link-color) 10%, transparent);
-	padding: 3px 8px;
+	font-size: 12px;
+	color: #93c5fd;
+	background: rgba(59, 130, 246, 0.15);
+	padding: 4px 10px;
 	border-radius: 6px;
 	font-weight: 600;
-	border: 1px solid color-mix(in srgb, var(--link-color) 30%, transparent);
+	border: 1px solid rgba(59, 130, 246, 0.35);
 	flex-shrink: 0;
 	white-space: nowrap;
 	text-transform: capitalize;

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -244,6 +244,19 @@ body {
 	max-width: 200px;
 }
 
+.turn-effort {
+	font-size: 11px;
+	color: var(--link-color);
+	background: color-mix(in srgb, var(--link-color) 10%, transparent);
+	padding: 3px 8px;
+	border-radius: 6px;
+	font-weight: 600;
+	border: 1px solid color-mix(in srgb, var(--link-color) 30%, transparent);
+	flex-shrink: 0;
+	white-space: nowrap;
+	text-transform: capitalize;
+}
+
 .turn-tokens {
 	font-size: 12px;
 	color: var(--text-secondary);

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -35,6 +35,11 @@ type UsageAnalysisPeriod = {
 	contextReferences: ContextReferenceUsage;
 	mcpTools: McpToolUsage;
 	modelSwitching: ModelSwitchingAnalysis;
+	thinkingEffortUsage?: {
+		byEffort: { [effort: string]: number };
+		sessionCount: number;
+		switchCount: number;
+	};
 };
 
 type UsageAnalysisStats = {
@@ -397,6 +402,7 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 			unknownRequests: 0,
 			totalRequests: 0,
 		},
+		thinkingEffortUsage: period?.thinkingEffortUsage,
 	});
 
 	try {
@@ -937,6 +943,53 @@ function renderLayout(stats: UsageAnalysisStats): void {
 				</div>
 			</div>`;
 
+	// Build thinking effort section if we have data for any period
+	const effortData = stats.last30Days.thinkingEffortUsage || stats.today.thinkingEffortUsage || stats.month.thinkingEffortUsage;
+	const thinkingEffortHtml = effortData ? (() => {
+		const EFFORT_ORDER = ['minimal', 'low', 'medium', 'high', 'max', 'xhigh'];
+		const renderEffortPeriod = (teu: { byEffort: { [effort: string]: number }; sessionCount: number; switchCount: number } | undefined) => {
+			if (!teu || teu.sessionCount === 0) { return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>'; }
+			const total = Object.values(teu.byEffort).reduce((s, v) => s + v, 0);
+			const sorted = EFFORT_ORDER
+				.filter(k => teu.byEffort[k] > 0)
+				.concat(Object.keys(teu.byEffort).filter(k => !EFFORT_ORDER.includes(k) && teu.byEffort[k] > 0));
+			return `
+				${sorted.map(level => {
+					const count = teu.byEffort[level] || 0;
+					const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+					return `<div style="display: flex; align-items: center; gap: 6px; margin-bottom: 6px;">
+						<span style="width: 52px; font-size: 11px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${escapeHtml(level)}</span>
+						<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 10px; overflow: hidden;">
+							<div style="width: ${pct}%; background: var(--link-color); height: 100%; border-radius: 4px;"></div>
+						</div>
+						<span style="font-size: 10px; color: var(--text-muted); width: 36px; text-align: right;">${count} (${pct}%)</span>
+					</div>`;
+				}).join('')}
+				<div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">${teu.sessionCount} session${teu.sessionCount !== 1 ? 's' : ''} · ${teu.switchCount} effort switch${teu.switchCount !== 1 ? 'es' : ''}</div>
+			`;
+		};
+		return `
+			<!-- Thinking Effort Section -->
+			<div class="section">
+				<div class="section-title"><span>💡</span><span>Thinking Effort (Reasoning)</span></div>
+				<div class="section-subtitle">How often each reasoning effort level was used (requests per level)</div>
+				<div class="three-column">
+					<div>
+						<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📅 Today</h4>
+						${renderEffortPeriod(stats.today.thinkingEffortUsage)}
+					</div>
+					<div>
+						<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📆 Last 30 Days</h4>
+						${renderEffortPeriod(stats.last30Days.thinkingEffortUsage)}
+					</div>
+					<div>
+						<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📅 Previous Month</h4>
+						${renderEffortPeriod(stats.month.thinkingEffortUsage)}
+					</div>
+				</div>
+			</div>`;
+	})() : '';
+
 	const sessionsSummaryHtml = `
 			<!-- Summary Section -->
 			<div class="section">
@@ -1090,6 +1143,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 				</div>
 
 				${multiModelHtml}
+				${thinkingEffortHtml}
 			</div>
 
 			<div id="tab-panel-tools" class="tab-panel"${activeTab !== 'tools' ? ' style="display:none"' : ''}>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -957,15 +957,15 @@ function renderLayout(stats: UsageAnalysisStats): void {
 				${sorted.map(level => {
 					const count = teu.byEffort[level] || 0;
 					const pct = total > 0 ? Math.round((count / total) * 100) : 0;
-					return `<div style="display: flex; align-items: center; gap: 6px; margin-bottom: 6px;">
-						<span style="width: 52px; font-size: 11px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${escapeHtml(level)}</span>
-						<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 10px; overflow: hidden;">
+					return `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+						<span style="width: 56px; font-size: 12px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${escapeHtml(level)}</span>
+						<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 12px; overflow: hidden;">
 							<div style="width: ${pct}%; background: var(--link-color); height: 100%; border-radius: 4px;"></div>
 						</div>
-						<span style="font-size: 10px; color: var(--text-muted); width: 36px; text-align: right;">${count} (${pct}%)</span>
+						<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${count} <span style="color: var(--text-secondary); font-weight: 400;">(${pct}%)</span></span>
 					</div>`;
 				}).join('')}
-				<div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">${teu.sessionCount} session${teu.sessionCount !== 1 ? 's' : ''} · ${teu.switchCount} effort switch${teu.switchCount !== 1 ? 'es' : ''}</div>
+				<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${teu.sessionCount} session${teu.sessionCount !== 1 ? 's' : ''} · ${teu.switchCount} effort switch${teu.switchCount !== 1 ? 'es' : ''}</div>
 			`;
 		};
 		return `


### PR DESCRIPTION
## Summary

Tracks the thinking/reasoning effort level (low/medium/high/max/xhigh) users select per request in VS Code Copilot Chat sessions and surfaces it across the extension's views.

## What's tracked

The effort level comes from `configurationSchema.properties.reasoningEffort.default` on the active `selectedModel` in VS Code delta-based JSONL session files. This value changes dynamically when the user switches effort in the UI.

## Changes

### Backend (`vscode-extension/src/`)
- **`types.ts`** — New `ThinkingEffortUsage` interface; `thinkingEffort?` on `SessionUsageAnalysis` and `ChatTurn`; `thinkingEffortUsage?` on `UsageAnalysisPeriod`
- **`tokenEstimation.ts`** — New `buildReasoningEffortTimeline()` helper: single pass over delta lines → `Map<requestId, effort>` + default effort + switch count
- **`usageAnalysis.ts`** — Uses the helper in the delta-based `analyzeSessionUsage` path; merges effort data into period stats in `mergeUsageAnalysis`
- **`extension.ts`** — Imports the helper; attaches `thinkingEffort` to each `ChatTurn` in the log viewer; bumps `CACHE_VERSION` 36→37

### Webviews
- **Log viewer** — 💡 effort badge per turn (next to model badge); session summary card showing effort breakdown + switch count
- **Usage analysis** — New "💡 Thinking Effort (Reasoning)" section with per-level bar charts for Today / Last 30 Days / Previous Month

## Notes
- Only VS Code delta-based JSONL sessions have per-request effort data; CLI sessions do not
- Missing effort (`null`) means the model doesn't support reasoning or data isn't available — not surfaced as "unknown"
- Effort level names vary by model family: Claude uses `low/medium/high/max`; GPT-5.4 uses `low/medium/high/xhigh`; Gemini 3 Pro uses `low/high`