### PR TITLE
chore: bump versions for release (CLI npm package 0.0.8)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,34 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-04-11
+
+### ✨ Features & Improvements
+- Added Claude Desktop Cowork session support as a usage analysis data source (#572)
+- Added thinking effort (reasoning effort) tracking for sessions that use reasoning models
+- Added missing friendly display names for 14 tools (#584)
+
+### 🐛 Bug Fixes
+- Fixed token usage tracking from sub-agent calls in Copilot agent mode (#567, #573)
+- Fixed Copilot CLI sessions falling back to first user message as title when no explicit title is set
+- Fixed 0-interaction sessions being shown in diagnostics view; documented CLI session format
+- Fixed potential client-side cross-site scripting vulnerability in usage webview (#579)
+
+## [0.0.7] - 2026-04-08
+
+### ✨ Features & Improvements
+- Added npmjs package link to CLI documentation (#536)
+
+### 🔧 Maintenance
+- Bumped esbuild from 0.27.4 → 0.28.0
+- Bumped @types/node from 25.5.0 → 25.5.2
+
+## [0.0.6] - 2026-04-01
+
+### ✨ Features & Improvements
+- Automatic tools are now annotated and excluded from fluency scoring (#529)
+- Parallelized session discovery and file processing for improved performance
+
 ## [0.0.5] - 2026-03-28
 
 ### ✨ Features & Improvements

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",


### PR DESCRIPTION
## Release prep — CLI version bump

This PR bumps the CLI npm package version and brings the \cli/CHANGELOG.md\ fully up to date.

| Component | Old version | New version |
|-----------|-------------|-------------|
| CLI (\@rajbos/ai-engineering-fluency\) | v0.0.7 | v0.0.8 |

### CHANGELOG catch-up

The changelog was last updated at v0.0.5. This PR adds entries for:
- **v0.0.6** (2026-04-01): automatic tool annotation, parallelized session processing
- **v0.0.7** (2026-04-08): dependency bumps, npmjs docs link
- **v0.0.8** (2026-04-11): see below

### What's new in v0.0.8

#### ✨ Features & Improvements
- Added Claude Desktop Cowork session support as a usage analysis data source (#572)
- Added thinking effort (reasoning effort) tracking for sessions that use reasoning models
- Added missing friendly display names for 14 tools (#584)

#### 🐛 Bug Fixes
- Fixed token usage tracking from sub-agent calls in Copilot agent mode (#567, #573)
- Fixed Copilot CLI sessions falling back to first user message as title when no explicit title is set
- Fixed 0-interaction sessions being shown in diagnostics view; documented CLI session format
- Fixed potential client-side cross-site scripting vulnerability in usage webview (#579)

---

### After merging, run this workflow:

- **CLI - Publish to npm and GitHub** (\cli-publish.yml\)
  - Go to **Actions → CLI - Publish to npm and GitHub → Run workflow** (on \main\)
  - This publishes **\@rajbos/ai-engineering-fluency@0.0.8\** to npm