### PR TITLE
Publish extension to Open VSX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,6 +424,22 @@ jobs:
           --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
           --pat "$VSCE_PAT"
 
+    - name: Publish to Open VSX Registry
+      id: publish_open_vsx
+      env:
+        OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+      run: |
+        if [ -z "$OPEN_VSX_TOKEN" ]; then
+          echo "❌ OPEN_VSX_TOKEN secret is not configured."
+          echo "   Create a token at https://open-vsx.org/user-settings/tokens"
+          exit 1
+        fi
+
+        echo "Publishing ${{ steps.download_vsix.outputs.vsix_file }} to Open VSX Registry..."
+        npx --yes ovsx publish \
+          --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
+          -p "$OPEN_VSX_TOKEN"
+
     - name: Publish Summary
       if: always()
       run: |
@@ -441,6 +457,18 @@ jobs:
             echo ""
             echo "Ensure the \`VSCE_PAT\` secret is configured with a valid Azure DevOps PAT"
             echo "with the \`Marketplace (Publish)\` scope for all accessible organizations."
+          fi
+          echo ""
+          echo "# 🌐 Open VSX Registry"
+          echo ""
+          if [ "${{ steps.publish_open_vsx.outcome }}" == "success" ]; then
+            echo "✅ Extension v${{ needs.release.outputs.version }} published to the [Open VSX Registry](https://open-vsx.org/extension/RobBos/copilot-token-tracker)"
+          elif [ "${{ steps.publish_open_vsx.outcome }}" == "skipped" ]; then
+            echo "⏭️ Open VSX publish skipped."
+          else
+            echo "❌ Failed to publish v${{ needs.release.outputs.version }} to the Open VSX Registry."
+            echo ""
+            echo "Ensure the \`OPEN_VSX_TOKEN\` secret is configured with a valid Open VSX token."
           fi
         } >> "$GITHUB_STEP_SUMMARY"
 
@@ -657,5 +685,4 @@ jobs:
         } else {
           "## ❌ Build failed — no .vsix produced" >> $env:GITHUB_STEP_SUMMARY
         }
-
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,7 +415,7 @@ The project uses a fully automated release pipeline via GitHub Actions.
 
 The workflow inputs:
 - `create_tag` — Creates a git tag from the `package.json` version (default: true)
-- `publish_marketplace` — Publishes to the VS Code Marketplace (default: true)
+- `publish_marketplace` — Publishes to the VS Code Marketplace and Open VSX (default: true)
 
 The workflow automatically:
 
@@ -425,13 +425,14 @@ The workflow automatically:
 4. Runs the full build pipeline (lint, type-check, compile, test)
 5. Creates a GitHub Release with the VSIX attached
 6. Publishes to the VS Code Marketplace (using the `VSCE_PAT` secret)
-7. Opens a PR to sync `CHANGELOG.md` in the repository
+7. Publishes to the Open VSX Registry (using the `OPEN_VSX_TOKEN` secret)
+8. Opens a PR to sync `CHANGELOG.md` in the repository
 
-> **Security:** Only users with repository write access can trigger the `workflow_dispatch`. The `VSCE_PAT` secret must be configured in repository settings (Settings → Secrets and variables → Actions). Create a PAT at https://dev.azure.com with the "Marketplace (Publish)" scope.
+> **Security:** Only users with repository write access can trigger the `workflow_dispatch`. The `VSCE_PAT` secret must be configured in repository settings (Settings → Secrets and variables → Actions). Create a PAT at https://dev.azure.com with the "Marketplace (Publish)" scope. The `OPEN_VSX_TOKEN` secret must also be configured; create a token at https://open-vsx.org/user-settings/tokens.
 
 ### Tag-Based Release (Build Only)
 
-Pushing a version tag (e.g., `git push origin v0.0.19`) triggers the build and creates a GitHub release, but does **not** publish to the marketplace. Use the workflow dispatch for the full pipeline.
+Pushing a version tag (e.g., `git push origin v0.0.19`) triggers the build and creates a GitHub release, but does **not** publish to the marketplaces. Use the workflow dispatch for the full pipeline.
 
 ### Manual Changelog Sync
 


### PR DESCRIPTION
We want the VS Code extension to be available on Open VSX whenever we publish to the VS Code Marketplace, so users on alternative stores can install the same release.

This adds an Open VSX publish step to the Release workflow that uses the existing VSIX and updates the release docs to mention the new token requirement.

Note: this requires the `OPEN_VSX_TOKEN` Actions secret (create a token at https://open-vsx.org/user-settings/tokens).