### PR TITLE
chore: bump Visual Studio extension version to 1.0.5

### DIFF
--- a/visualstudio-extension/CHANGELOG.md
+++ b/visualstudio-extension/CHANGELOG.md
@@ -6,6 +6,33 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-04-11
+
+### ✨ Features & Improvements
+- Add thinking effort (reasoning effort) tracking — shows actual vs estimated tokens for Claude models using extended thinking
+- Display 'xhigh' reasoning effort as 'Extra High' in the UI
+- GitHub authentication support — sign in with your GitHub account to view Copilot Cloud Agent and Review Agent usage
+- Add Claude Desktop Cowork session support
+- Show actual tokens in log viewer header for CLI sessions
+- Fix: track token usage from sub-agent calls in Copilot agent mode
+- Fix: wrap long MCP tool names in session viewer
+- Add per-tool suppression for unknown tool name notifications
+- Add friendly display names for 14 additional tools
+- Security fix: sanitize user-provided values in Repository PRs panel
+
+## [1.0.4] - 2026-04-08
+
+### ✨ Features & Improvements
+- Updated webview bundles with latest features from VS Code extension (v0.0.27)
+- Add AI Engineering Fluency icon to the extension
+
+## [1.0.3] - 2026-03-31
+
+### ✨ Features & Improvements
+- Updated webview bundles with latest features from VS Code extension (v0.0.26)
+- Performance: batch all CLI calls into a single `all --json` invocation for faster panel loading
+- Add support for Claude Code sessions
+
 ## [1.0.2] - 2026-03-28
 
 ### ✨ Features & Improvements

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.4"
+              Version="1.0.5"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>


### PR DESCRIPTION
## Visual Studio Extension v1.0.5

Bumps the Visual Studio extension version from `1.0.4` → `1.0.5` and backfills the CHANGELOG with missing 1.0.3 and 1.0.4 entries.

### Changes
- `source.extension.vsixmanifest`: version `1.0.4` → `1.0.5`
- `CHANGELOG.md`: add entries for 1.0.3, 1.0.4, and 1.0.5

### What's new in 1.0.5 (via updated webview bundles)
- Thinking effort (reasoning effort) tracking for Claude models
- Display 'xhigh' reasoning effort as 'Extra High'
- GitHub authentication support — sign in to view Copilot Cloud Agent & Review Agent usage
- Claude Desktop Cowork session support
- Show actual tokens in log viewer header for CLI sessions
- Fix: track token usage from sub-agent calls in Copilot agent mode
- Fix: wrap long MCP tool names in session viewer
- Per-tool suppression for unknown tool name notifications
- 14 additional friendly tool display names
- Security fix: sanitize user-provided values in Repository PRs panel

### After merging
Trigger the **Extensions - Release** workflow with:
- `vs_only: true`
- `publish_marketplace: true`

This will build the VSIX using the current webview bundles and publish to the Visual Studio Marketplace.