### PR TITLE
feat: add token count column to diagnostics session files tab

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3144,6 +3144,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			size: cached.size || stat.size,
 			modified: stat.mtime.toISOString(),
 			interactions: cached.interactions,
+			tokens: cached.tokens || 0,
 			contextReferences: cached.usageAnalysis.contextReferences,
 			firstInteraction: cached.firstInteraction || null,
 			lastInteraction: lastInteraction,
@@ -3169,6 +3170,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 	): Promise<void> {
 		// Get existing cache entry if available
 		const existingCache = this.getCachedSessionData(sessionFile);
+
+		// Enrich details with token count from existing cache (populated by main stats calculation)
+		details.tokens = existingCache?.tokens || 0;
 
 		// Create or update cache entry
 		const cacheEntry: SessionFileCache = {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4141,13 +4141,25 @@ class CopilotTokenTracker implements vscode.Disposable {
 			let cliSessionModel = 'gpt-4o';
 			let cliSessionEffort: string | undefined;
 
-			// Pre-scan for session.start to extract default model and effort
+			// Pre-scan for model and effort:
+			// 1. session.start.data.selectedModel (older CLI format)
+			// 2. First tool.execution_complete.data.model (newer CLI format — session.start has no selectedModel)
+			let cliModelFound = false;
 			for (const line of lines) {
 				try {
 					const ev = JSON.parse(line);
 					if (ev.type === 'session.start' && ev.data) {
-						if (typeof ev.data.selectedModel === 'string') { cliSessionModel = ev.data.selectedModel; }
+						if (typeof ev.data.selectedModel === 'string') {
+							cliSessionModel = ev.data.selectedModel;
+							cliModelFound = true;
+						}
 						if (typeof ev.data.reasoningEffort === 'string') { cliSessionEffort = ev.data.reasoningEffort; }
+						if (cliModelFound) { break; }
+						// No model in session.start — continue scanning for tool.execution_complete
+					}
+					// Newer format: model stored per tool call result
+					if (ev.type === 'tool.execution_complete' && typeof ev.data?.model === 'string') {
+						cliSessionModel = ev.data.model;
 						break;
 					}
 				} catch { /* skip */ }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3138,13 +3138,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 			lastInteraction = stat.mtime.toISOString();
 		}
 
-		// Reconstruct SessionFileDetails from cache
+		// Reconstruct SessionFileDetails from cache.
+		// Prefer actualTokens (real API count) when available; fall back to estimated tokens.
 		const details: SessionFileDetails = {
 			file: sessionFile,
 			size: cached.size || stat.size,
 			modified: stat.mtime.toISOString(),
 			interactions: cached.interactions,
-			tokens: cached.tokens || 0,
+			tokens: cached.actualTokens || cached.tokens || 0,
 			contextReferences: cached.usageAnalysis.contextReferences,
 			firstInteraction: cached.firstInteraction || null,
 			lastInteraction: lastInteraction,
@@ -3171,8 +3172,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Get existing cache entry if available
 		const existingCache = this.getCachedSessionData(sessionFile);
 
-		// Enrich details with token count from existing cache (populated by main stats calculation)
-		details.tokens = existingCache?.tokens || 0;
+		// Enrich details with token count from existing cache (populated by main stats calculation).
+		// Prefer actualTokens (real API count) when available; fall back to estimated tokens.
+		details.tokens = existingCache?.actualTokens || existingCache?.tokens || 0;
 
 		// Create or update cache entry
 		const cacheEntry: SessionFileCache = {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -314,6 +314,7 @@ export interface SessionFileDetails {
   size: number;
   modified: string;
   interactions: number;
+  tokens?: number; // estimated token count for the session
   contextReferences: ContextReferenceUsage;
   firstInteraction: string | null;
   lastInteraction: string | null;

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -103,7 +103,7 @@ const vscode = acquireVsCodeApi<DiagnosticsViewState>();
 const initialData = window.__INITIAL_DIAGNOSTICS__;
 
 // Sorting and filtering state
-let currentSortColumn: "lastInteraction" = "lastInteraction";
+let currentSortColumn: "lastInteraction" | "size" | "tokens" | "interactions" | "contextRefs" = "lastInteraction";
 let currentSortDirection: "asc" | "desc" = "desc";
 let currentEditorFilter: string | null = null; // null = show all
 let currentContextRefFilter: keyof ContextReferenceUsage | null = null; // null = show all
@@ -418,28 +418,38 @@ function getEditorIcon(editor: string): string {
 
 function sortSessionFiles(files: SessionFileDetails[]): SessionFileDetails[] {
   return [...files].sort((a, b) => {
-    const aVal = a.lastInteraction;
-    const bVal = b.lastInteraction;
+    let aNum: number;
+    let bNum: number;
 
-    // Handle null values - push them to the end
-    if (!aVal && !bVal) {
+    if (currentSortColumn === "lastInteraction") {
+      const aVal = a.lastInteraction;
+      const bVal = b.lastInteraction;
+      if (!aVal && !bVal) { return 0; }
+      if (!aVal) { return 1; }
+      if (!bVal) { return -1; }
+      aNum = new Date(aVal).getTime();
+      bNum = new Date(bVal).getTime();
+    } else if (currentSortColumn === "size") {
+      aNum = a.size || 0;
+      bNum = b.size || 0;
+    } else if (currentSortColumn === "tokens") {
+      aNum = a.tokens || 0;
+      bNum = b.tokens || 0;
+    } else if (currentSortColumn === "interactions") {
+      aNum = a.interactions || 0;
+      bNum = b.interactions || 0;
+    } else if (currentSortColumn === "contextRefs") {
+      aNum = getTotalContextRefs(a.contextReferences);
+      bNum = getTotalContextRefs(b.contextReferences);
+    } else {
       return 0;
     }
-    if (!aVal) {
-      return 1;
-    }
-    if (!bVal) {
-      return -1;
-    }
 
-    const aTime = new Date(aVal).getTime();
-    const bTime = new Date(bVal).getTime();
-
-    return currentSortDirection === "desc" ? bTime - aTime : aTime - bTime;
+    return currentSortDirection === "desc" ? bNum - aNum : aNum - bNum;
   });
 }
 
-function getSortIndicator(column: "lastInteraction"): string {
+function getSortIndicator(column: typeof currentSortColumn): string {
   if (currentSortColumn !== column) {
     return "";
   }
@@ -634,10 +644,10 @@ function renderSessionTable(
 						<th>Editor</th>
 						<th>Title</th>
 						<th>Repository</th>
-						<th>Size</th>
-						<th>Tokens</th>
-						<th>Interactions</th>
-						<th>Context Refs</th>
+						<th class="sortable" data-sort="size">Size${getSortIndicator("size")}</th>
+						<th class="sortable" data-sort="tokens">Tokens${getSortIndicator("tokens")}</th>
+						<th class="sortable" data-sort="interactions">Interactions${getSortIndicator("interactions")}</th>
+						<th class="sortable" data-sort="contextRefs">Context Refs${getSortIndicator("contextRefs")}</th>
 						<th class="sortable" data-sort="lastInteraction">Last Interaction${getSortIndicator("lastInteraction")}</th>
 						<th>Actions</th>
 					</tr>
@@ -1575,7 +1585,7 @@ function renderLayout(data: DiagnosticsData): void {
       header.addEventListener("click", () => {
         const sortColumn = (header as HTMLElement).getAttribute(
           "data-sort",
-        ) as "lastInteraction";
+        ) as typeof currentSortColumn;
         if (sortColumn) {
           // Toggle direction if same column, otherwise default to desc
           if (currentSortColumn === sortColumn) {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -24,6 +24,7 @@ type SessionFileDetails = {
   size: number;
   modified: string;
   interactions: number;
+  tokens?: number;
   contextReferences: ContextReferenceUsage;
   firstInteraction: string | null;
   lastInteraction: string | null;
@@ -185,6 +186,14 @@ function sanitizeNumber(value: number | undefined | null): string {
   if (!Number.isFinite(n)) {
     return "0";
   }
+  return Math.floor(n).toString();
+}
+
+function formatTokenCount(value: number | undefined | null): string {
+  const n = Number(value ?? 0);
+  if (!Number.isFinite(n) || n === 0) { return "0"; }
+  if (n >= 1_000_000) { return `${(n / 1_000_000).toFixed(1)}M`; }
+  if (n >= 1_000) { return `${(n / 1_000).toFixed(1)}K`; }
   return Math.floor(n).toString();
 }
 
@@ -509,6 +518,10 @@ function renderSessionTable(
     (sum, sf) => sum + Number(sf.interactions || 0),
     0,
   );
+  const totalTokens = filteredFiles.reduce(
+    (sum, sf) => sum + Number(sf.tokens || 0),
+    0,
+  );
   const totalContextRefs = filteredFiles.reduce(
     (sum, sf) => sum + getTotalContextRefs(sf.contextReferences),
     0,
@@ -582,6 +595,10 @@ function renderSessionTable(
 				<div class="summary-value">${totalInteractions}</div>
 			</div>
 			<div class="summary-card">
+				<div class="summary-label">🪙 Tokens</div>
+				<div class="summary-value" title="${totalTokens.toLocaleString()} tokens">${formatTokenCount(totalTokens)}</div>
+			</div>
+			<div class="summary-card">
 				<div class="summary-label">🔗 Context References</div>
 				<div class="summary-value">${safeText(totalContextRefs)}</div>
 				<div class="summary-sub">
@@ -618,6 +635,7 @@ function renderSessionTable(
 						<th>Title</th>
 						<th>Repository</th>
 						<th>Size</th>
+						<th>Tokens</th>
 						<th>Interactions</th>
 						<th>Context Refs</th>
 						<th class="sortable" data-sort="lastInteraction">Last Interaction${getSortIndicator("lastInteraction")}</th>
@@ -636,6 +654,7 @@ function renderSessionTable(
 							</td>
 							<td class="repository-cell" title="${sf.repository ? escapeHtml(sf.repository) : "No repository detected"}">${sf.repository ? escapeHtml(getRepoDisplayName(sf.repository)) : '<span style="color: #666;">—</span>'}</td>
 							<td>${formatFileSize(sf.size)}</td>
+							<td title="${Number(sf.tokens || 0).toLocaleString()} tokens">${formatTokenCount(sf.tokens)}</td>
 							<td>${sanitizeNumber(sf.interactions)}</td>
 							<td title="${escapeHtml(getContextRefsSummary(sf.contextReferences))}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td>
 							<td>${formatDate(sf.lastInteraction)}</td>


### PR DESCRIPTION
## Summary

Adds a **Tokens** column to the Session Files tab in the Diagnostics view, so you can see the estimated token count per session at a glance.

## Changes

### `vscode-extension/src/types.ts`
- Added `tokens?: number` field to the `SessionFileDetails` interface

### `vscode-extension/src/extension.ts`
- `getSessionFileDetailsFromCache()`: populates `details.tokens` from the cached token count
- `updateCacheWithSessionDetails()`: enriches `details.tokens` from the existing cache entry — covers all non-cache-hit code paths (OpenCode, VS, Crush, Continue, Claude Desktop, JSONL, JSON)

### `vscode-extension/src/webview/diagnostics/main.ts`
- Added `tokens?` field to the local `SessionFileDetails` type
- Added `formatTokenCount()` helper: compact K/M display (e.g. `12.3K`, `1.2M`) with full count in the tooltip
- Added **🪙 Tokens** summary card (total across filtered sessions) alongside the existing Interactions card
- Added **Tokens** column between Size and Interactions in the session table; tooltip shows the exact locale-formatted count

## Notes
- Token counts are populated from the extension's session cache. Sessions that haven't been processed by the main stats calculation yet will show `0` until the cache is warmed.