### PR TITLE
feat: add Day/Week/Month period toggle to chart view

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -239,6 +239,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private outputChannel: vscode.OutputChannel;
 	private lastDetailedStats: DetailedStats | undefined;
 	private lastDailyStats: DailyTokenStats[] | undefined;
+	/** Full-year daily stats (up to 365 days) for the chart Week/Month period views. */
+	private lastFullDailyStats: DailyTokenStats[] | undefined;
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private lastDashboardData: any | undefined;
 	private tokenEstimators: { [key: string]: number } = tokenEstimatorsData.estimators;
@@ -565,6 +567,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.sessionDiscovery.clearCache();
 		this.lastDetailedStats = undefined;
 		this.lastDailyStats = undefined;
+		this.lastFullDailyStats = undefined;
 		this.lastUsageAnalysisStats = undefined;
 
 		const results: LocalViewRegressionResult[] = [];
@@ -722,6 +725,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.sessionDiscovery.clearCache();
 			this.lastDetailedStats = undefined;
 			this.lastDailyStats = undefined;
+			this.lastFullDailyStats = undefined;
 			this.lastUsageAnalysisStats = undefined;
 			this.lastDashboardData = undefined;
 		}
@@ -822,6 +826,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			// Clear cached computed stats so details panel doesn't show stale data
 			this.lastDetailedStats = undefined;
 			this.lastDailyStats = undefined;
+			this.lastFullDailyStats = undefined;
 			this.lastUsageAnalysisStats = undefined;
 			this.lastDashboardData = undefined;
 
@@ -1464,14 +1469,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 				}
 			}
 
-			// If the chart panel is open, update its content (daily stats were computed in calculateDetailedStats)
-			if (this.chartPanel && this.lastDailyStats) {
-				const dailyStats = this.lastDailyStats;
+			// If the chart panel is open, update its content (prefer full-year stats for week/month views)
+			if (this.chartPanel && (this.lastFullDailyStats || this.lastDailyStats)) {
+				const chartStats = this.lastFullDailyStats ?? this.lastDailyStats!;
 				if (silent) {
 					// Background update: send data via postMessage to preserve the active chart view toggle
-					void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: { ...this.buildChartData(dailyStats), compactNumbers: this.getCompactNumbersSetting() } });
+					void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: { ...this.buildChartData(chartStats), compactNumbers: this.getCompactNumbersSetting() } });
 				} else {
-					this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, dailyStats);
+					this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, chartStats);
 				}
 			}
 
@@ -1952,48 +1957,55 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (this.environmentalPanel) {
 			this.environmentalPanel.webview.html = this.getEnvironmentalHtml(this.environmentalPanel.webview, stats);
 		}
-		if (this.chartPanel && this.lastDailyStats) {
-			this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, this.lastDailyStats);
+		if (this.chartPanel && (this.lastFullDailyStats || this.lastDailyStats)) {
+			this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, this.lastFullDailyStats ?? this.lastDailyStats!);
 		}
 	}
 
-	private async calculateDailyStats(): Promise<DailyTokenStats[]> {
+	/** Compute daily token stats for up to `daysBack` days, using the same token preference
+	 *  (actualTokens > estimatedTokens) and date assignment (lastInteraction || mtime) as
+	 *  calculateDetailedStats so all chart period views are consistent. Stores the result in
+	 *  `lastFullDailyStats` and returns it. Zero-fill is handled per-period in buildChartData. */
+	private async calculateDailyStats(daysBack = 365): Promise<DailyTokenStats[]> {
 		const now = new Date();
-		// Use last 30 days instead of current month for better chart visibility
-		const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+		const cutoffDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack);
 
-		// Map to store daily stats by date string (YYYY-MM-DD)
 		const dailyStatsMap = new Map<string, DailyTokenStats>();
 
 		try {
 			const sessionFiles = await this.sessionDiscovery.getCopilotSessionFiles();
-			this.log(`📈 Preparing chart data from ${sessionFiles.length} session file(s)...`);
+			this.log(`📈 Preparing chart data (${daysBack}d) from ${sessionFiles.length} session file(s)...`);
 
 			const dailyResults = await this.runWithConcurrency(sessionFiles, async (sessionFile) => {
 				const fileStats = await this.statSessionFile(sessionFile);
 				const mtime = fileStats.mtime.getTime();
 				const fileSize = fileStats.size;
-				if (mtime < thirtyDaysAgo.getTime()) { return null; }
+				if (mtime < cutoffDate.getTime()) { return null; }
 				const sessionData = await this.getSessionFileDataCached(sessionFile, mtime, fileSize);
-				return { sessionFile, sessionData, mtime };
+				const details = await this.getSessionFileDetails(sessionFile);
+				return { sessionFile, sessionData, mtime, details };
 			});
 
 			for (const r of dailyResults) {
 				if (!r) { continue; }
-				const { sessionFile, sessionData, mtime } = r;
+				const { sessionFile, sessionData, mtime, details } = r;
 				try {
-					const tokens = sessionData.tokens;
+					// Prefer actualTokens when available (same as calculateDetailedStats)
+					const estimatedTokens = sessionData.tokens;
+					const actualTokens = sessionData.actualTokens || 0;
+					const tokens = actualTokens > 0 ? actualTokens : estimatedTokens;
+
 					const interactions = sessionData.interactions;
 					const modelUsage = sessionData.modelUsage;
 					const editorType = this.getEditorTypeFromPath(sessionFile);
-
-					// Get repository from cached session data
 					const repository = sessionData.repository || 'Unknown';
 
-					// Get the date in YYYY-MM-DD format
-					const dateKey = this.formatDateKey(new Date(mtime));
+					// Use lastInteraction for date (same as calculateDetailedStats)
+					const lastActivity = details.lastInteraction
+						? new Date(details.lastInteraction)
+						: new Date(mtime);
+					const dateKey = this.formatDateKey(lastActivity);
 
-					// Initialize or update the daily stats
 					if (!dailyStatsMap.has(dateKey)) {
 						dailyStatsMap.set(dateKey, {
 							date: dateKey,
@@ -2006,32 +2018,29 @@ class CopilotTokenTracker implements vscode.Disposable {
 						});
 					}
 
-					const dailyStats = dailyStatsMap.get(dateKey)!;
-					dailyStats.tokens += tokens;
-					dailyStats.sessions += 1;
-					dailyStats.interactions += interactions;
+					const dailyEntry = dailyStatsMap.get(dateKey)!;
+					dailyEntry.tokens += tokens;
+					dailyEntry.sessions += 1;
+					dailyEntry.interactions += interactions;
 
-					// Merge editor usage
-					if (!dailyStats.editorUsage[editorType]) {
-						dailyStats.editorUsage[editorType] = { tokens: 0, sessions: 0 };
+					if (!dailyEntry.editorUsage[editorType]) {
+						dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 };
 					}
-					dailyStats.editorUsage[editorType].tokens += tokens;
-					dailyStats.editorUsage[editorType].sessions += 1;
+					dailyEntry.editorUsage[editorType].tokens += tokens;
+					dailyEntry.editorUsage[editorType].sessions += 1;
 
-					// Merge repository usage
-					if (!dailyStats.repositoryUsage[repository]) {
-						dailyStats.repositoryUsage[repository] = { tokens: 0, sessions: 0 };
+					if (!dailyEntry.repositoryUsage[repository]) {
+						dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 };
 					}
-					dailyStats.repositoryUsage[repository].tokens += tokens;
-					dailyStats.repositoryUsage[repository].sessions += 1;
+					dailyEntry.repositoryUsage[repository].tokens += tokens;
+					dailyEntry.repositoryUsage[repository].sessions += 1;
 
-					// Merge model usage
 					for (const [model, usage] of Object.entries(modelUsage)) {
-						if (!dailyStats.modelUsage[model]) {
-							dailyStats.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+						if (!dailyEntry.modelUsage[model]) {
+							dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
 						}
-						dailyStats.modelUsage[model].inputTokens += usage.inputTokens;
-						dailyStats.modelUsage[model].outputTokens += usage.outputTokens;
+						dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
+						dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
 					}
 				} catch (fileError) {
 					this.warn(`Error processing session file ${sessionFile} for daily stats: ${fileError}`);
@@ -2041,44 +2050,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.error('Error calculating daily stats:', error);
 		}
 
-		// Convert map to array and sort by date
-		let dailyStatsArray = Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
-
-		// Always fill in all 30 days to show complete chart
-		const today = new Date();
-
-		// Create a set of existing dates for quick lookup
-		const existingDates = new Set(dailyStatsArray.map(s => s.date));
-
-		// Generate all dates from 30 days ago to today
-		const allDates: string[] = [];
-		const currentDate = new Date(thirtyDaysAgo);
-
-		while (currentDate <= today) {
-			const dateKey = this.formatDateKey(currentDate);
-			allDates.push(dateKey);
-			currentDate.setDate(currentDate.getDate() + 1);
-		}
-
-		// Add missing dates with zero values
-		for (const dateKey of allDates) {
-			if (!existingDates.has(dateKey)) {
-				dailyStatsMap.set(dateKey, {
-					date: dateKey,
-					tokens: 0,
-					sessions: 0,
-					interactions: 0,
-					modelUsage: {},
-					editorUsage: {},
-					repositoryUsage: {}
-				});
-			}
-		}
-
-		// Re-convert map to array and sort by date
-		dailyStatsArray = Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
-
-		return dailyStatsArray;
+		const result = Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+		this.lastFullDailyStats = result;
+		return result;
 	}
 
 	private detectMissedPotential(
@@ -4758,8 +4732,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return;
 		}
 
-		// Use daily stats computed by calculateDetailedStats if available, otherwise compute them
-		const dailyStats = this.lastDailyStats ?? await this.calculateDailyStats();
+		// Use full-year daily stats for week/month period views; compute if not yet cached
+		const dailyStats = this.lastFullDailyStats ?? await this.calculateDailyStats();
 
 		// Create webview panel
 		this.chartPanel = vscode.window.createWebviewPanel(
@@ -5451,6 +5425,8 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 		}
 
 		this.log('🔄 Refreshing Chart view');
+		// Refresh the full-year daily stats so week/month period views are up to date
+		await this.calculateDailyStats();
 		// Refresh all stats so the status bar and tooltip stay in sync
 		await this.updateTokenStats();
 		this.log('✅ Chart view refreshed');
@@ -7948,17 +7924,8 @@ ${hashtag}`;
 		</html>`;
   }
 
-  private buildChartData(dailyStats: DailyTokenStats[]): ChartDataPayload {
-    // Transform dailyStats into the structure expected by the webview
-    const labels = dailyStats.map((d) => d.date);
-    const tokensData = dailyStats.map((d) => d.tokens);
-    const sessionsData = dailyStats.map((d) => d.sessions);
-
-    // Aggregate model usage across all days
-    const allModels = new Set<string>();
-    dailyStats.forEach((d) =>
-      Object.keys(d.modelUsage).forEach((m) => allModels.add(m)),
-    );
+  private buildChartData(fullDailyStats: DailyTokenStats[]): ChartDataPayload {
+    const now = new Date();
 
     const modelColors = [
       { bg: "rgba(54, 162, 235, 0.6)", border: "rgba(54, 162, 235, 1)" },
@@ -7971,94 +7938,187 @@ ${hashtag}`;
       { bg: "rgba(100, 181, 246, 0.6)", border: "rgba(100, 181, 246, 1)" },
     ];
 
-    const modelDatasets = Array.from(allModels).map((model, idx) => {
-      const color = modelColors[idx % modelColors.length];
-      return {
-        label: getModelDisplayName(model),
-        data: dailyStats.map((d) => {
-          const usage = d.modelUsage[model];
-          return usage ? usage.inputTokens + usage.outputTokens : 0;
-        }),
-        backgroundColor: color.bg,
-        borderColor: color.border,
-        borderWidth: 1,
-      };
+    const fmtKey = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+    const emptyEntry = (date: string): DailyTokenStats => ({
+      date, tokens: 0, sessions: 0, interactions: 0,
+      modelUsage: {}, editorUsage: {}, repositoryUsage: {},
     });
 
-    // Aggregate editor usage across all days
-    const allEditors = new Set<string>();
-    dailyStats.forEach((d) =>
-      Object.keys(d.editorUsage).forEach((e) => allEditors.add(e)),
-    );
+    const mergeInto = (target: DailyTokenStats, src: DailyTokenStats) => {
+      target.tokens += src.tokens;
+      target.sessions += src.sessions;
+      target.interactions += src.interactions;
+      for (const [m, u] of Object.entries(src.modelUsage)) {
+        if (!target.modelUsage[m]) { target.modelUsage[m] = { inputTokens: 0, outputTokens: 0 }; }
+        target.modelUsage[m].inputTokens += u.inputTokens;
+        target.modelUsage[m].outputTokens += u.outputTokens;
+      }
+      for (const [e, u] of Object.entries(src.editorUsage)) {
+        if (!target.editorUsage[e]) { target.editorUsage[e] = { tokens: 0, sessions: 0 }; }
+        target.editorUsage[e].tokens += u.tokens;
+        target.editorUsage[e].sessions += u.sessions;
+      }
+      for (const [r, u] of Object.entries(src.repositoryUsage)) {
+        if (!target.repositoryUsage[r]) { target.repositoryUsage[r] = { tokens: 0, sessions: 0 }; }
+        target.repositoryUsage[r].tokens += u.tokens;
+        target.repositoryUsage[r].sessions += u.sessions;
+      }
+    };
 
-    const editorDatasets = Array.from(allEditors).map((editor, idx) => {
-      const color = modelColors[idx % modelColors.length];
-      return {
-        label: editor,
-        data: dailyStats.map((d) => d.editorUsage[editor]?.tokens || 0),
-        backgroundColor: color.bg,
-        borderColor: color.border,
-        borderWidth: 1,
-      };
-    });
+    type BucketEntry = { label: string; key: string; stats: DailyTokenStats };
 
-    // Aggregate repository usage across all days
-    const allRepositories = new Set<string>();
-    dailyStats.forEach((d) =>
-      Object.keys(d.repositoryUsage).forEach((r) => allRepositories.add(r)),
-    );
+    const buildPeriodData = (buckets: BucketEntry[]) => {
+      const entries = buckets.map(b => b.stats);
+      const labels = buckets.map(b => b.label);
+      const tokensData = entries.map(e => e.tokens);
+      const sessionsData = entries.map(e => e.sessions);
 
-    const repositoryDatasets = Array.from(allRepositories).map((repo, idx) => {
-      const color = modelColors[idx % modelColors.length];
-      const label = this.getRepoDisplayName(repo);
-      return {
-        label,
-        fullRepo: repo,
-        data: dailyStats.map((d) => d.repositoryUsage[repo]?.tokens || 0),
-        backgroundColor: color.bg,
-        borderColor: color.border,
-        borderWidth: 1,
-      };
-    });
-
-    // Calculate repository totals for summary
-    const repositoryTotalsMap: Record<string, number> = {};
-    dailyStats.forEach((d) => {
-      Object.entries(d.repositoryUsage).forEach(([repo, usage]) => {
-        const displayName = this.getRepoDisplayName(repo);
-        repositoryTotalsMap[displayName] =
-          (repositoryTotalsMap[displayName] || 0) + usage.tokens;
+      const allModels = new Set<string>();
+      entries.forEach(e => Object.keys(e.modelUsage).forEach(m => allModels.add(m)));
+      const modelDatasets = Array.from(allModels).map((model, idx) => {
+        const color = modelColors[idx % modelColors.length];
+        return {
+          label: getModelDisplayName(model),
+          data: entries.map(e => { const u = e.modelUsage[model]; return u ? u.inputTokens + u.outputTokens : 0; }),
+          backgroundColor: color.bg, borderColor: color.border, borderWidth: 1,
+        };
       });
-    });
 
-    // Calculate editor totals for summary cards
+      const allEditors = new Set<string>();
+      entries.forEach(e => Object.keys(e.editorUsage).forEach(ed => allEditors.add(ed)));
+      const editorDatasets = Array.from(allEditors).map((editor, idx) => {
+        const color = modelColors[idx % modelColors.length];
+        return {
+          label: editor,
+          data: entries.map(e => e.editorUsage[editor]?.tokens || 0),
+          backgroundColor: color.bg, borderColor: color.border, borderWidth: 1,
+        };
+      });
+
+      const allRepos = new Set<string>();
+      entries.forEach(e => Object.keys(e.repositoryUsage).forEach(r => allRepos.add(r)));
+      const repositoryDatasets = Array.from(allRepos).map((repo, idx) => {
+        const color = modelColors[idx % modelColors.length];
+        return {
+          label: this.getRepoDisplayName(repo),
+          fullRepo: repo,
+          data: entries.map(e => e.repositoryUsage[repo]?.tokens || 0),
+          backgroundColor: color.bg, borderColor: color.border, borderWidth: 1,
+        };
+      });
+
+      const totalTokens = tokensData.reduce((a, b) => a + b, 0);
+      const totalSessions = sessionsData.reduce((a, b) => a + b, 0);
+      const periodCount = buckets.length;
+      return {
+        labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets,
+        periodCount, totalTokens, totalSessions,
+        avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0,
+      };
+    };
+
+    // ── Daily period: last 30 days with zero-fill ─────────────────────
+    const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+    const thirtyDaysAgoStr = fmtKey(thirtyDaysAgo);
+    const todayStr = fmtKey(now);
+    const dailyBucketMap = new Map<string, BucketEntry>();
+    for (let cursor = new Date(thirtyDaysAgo); cursor <= now; cursor.setDate(cursor.getDate() + 1)) {
+      const key = fmtKey(new Date(cursor));
+      dailyBucketMap.set(key, { key, label: key, stats: emptyEntry(key) });
+    }
+    for (const day of fullDailyStats) {
+      if (day.date >= thirtyDaysAgoStr && day.date <= todayStr) {
+        const bucket = dailyBucketMap.get(day.date);
+        if (bucket) { mergeInto(bucket.stats, day); }
+      }
+    }
+    const dailyBuckets = Array.from(dailyBucketMap.values()).sort((a, b) => a.key.localeCompare(b.key));
+    const dailyPeriod = buildPeriodData(dailyBuckets);
+
+    // ── Weekly period: last 6 calendar weeks with zero-fill ──────────
+    const getMondayOfWeek = (d: Date): Date => {
+      const copy = new Date(d); copy.setHours(0, 0, 0, 0);
+      const day = copy.getDay();
+      copy.setDate(copy.getDate() - (day === 0 ? 6 : day - 1));
+      return copy;
+    };
+    const fmtWeekLabel = (monday: Date): string => {
+      const sunday = new Date(monday); sunday.setDate(monday.getDate() + 6);
+      if (monday.getMonth() === sunday.getMonth()) {
+        return `${monday.toLocaleDateString("en-US", { month: "short" })} ${monday.getDate()}–${sunday.getDate()}`;
+      }
+      return `${monday.toLocaleDateString("en-US", { month: "short", day: "numeric" })}–${sunday.toLocaleDateString("en-US", { month: "short", day: "numeric" })}`;
+    };
+    const thisMonday = getMondayOfWeek(now);
+    const weekBucketMap = new Map<string, BucketEntry>();
+    for (let w = 5; w >= 0; w--) {
+      const monday = new Date(thisMonday); monday.setDate(thisMonday.getDate() - w * 7);
+      const key = fmtKey(monday);
+      weekBucketMap.set(key, { key, label: fmtWeekLabel(monday), stats: emptyEntry(key) });
+    }
+    for (const day of fullDailyStats) {
+      const monday = getMondayOfWeek(new Date(day.date + "T00:00:00"));
+      const bucket = weekBucketMap.get(fmtKey(monday));
+      if (bucket) { mergeInto(bucket.stats, day); }
+    }
+    const weeklyBuckets = Array.from(weekBucketMap.values()).sort((a, b) => a.key.localeCompare(b.key));
+    const weeklyPeriod = buildPeriodData(weeklyBuckets);
+
+    // ── Monthly period: last 12 calendar months with zero-fill ───────
+    const monthBucketMap = new Map<string, BucketEntry>();
+    for (let m = 11; m >= 0; m--) {
+      const monthDate = new Date(now.getFullYear(), now.getMonth() - m, 1);
+      const key = `${monthDate.getFullYear()}-${String(monthDate.getMonth() + 1).padStart(2, "0")}`;
+      const label = monthDate.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+      monthBucketMap.set(key, { key, label, stats: emptyEntry(key) });
+    }
+    for (const day of fullDailyStats) {
+      const monthKey = day.date.slice(0, 7);
+      const bucket = monthBucketMap.get(monthKey);
+      if (bucket) { mergeInto(bucket.stats, day); }
+    }
+    const monthlyBuckets = Array.from(monthBucketMap.values()).sort((a, b) => a.key.localeCompare(b.key));
+    const monthlyPeriod = buildPeriodData(monthlyBuckets);
+
+    // ── Summary totals from the daily period (last 30 days) ──────────
     const editorTotalsMap: Record<string, number> = {};
-    dailyStats.forEach((d) => {
-      Object.entries(d.editorUsage).forEach(([editor, usage]) => {
+    dailyBuckets.forEach(b => {
+      Object.entries(b.stats.editorUsage).forEach(([editor, usage]) => {
         editorTotalsMap[editor] = (editorTotalsMap[editor] || 0) + usage.tokens;
       });
     });
-
-    const totalTokens = tokensData.reduce((a, b) => a + b, 0);
-    const totalSessions = sessionsData.reduce((a, b) => a + b, 0);
+    const repositoryTotalsMap: Record<string, number> = {};
+    dailyBuckets.forEach(b => {
+      Object.entries(b.stats.repositoryUsage).forEach(([repo, usage]) => {
+        const displayName = this.getRepoDisplayName(repo);
+        repositoryTotalsMap[displayName] = (repositoryTotalsMap[displayName] || 0) + usage.tokens;
+      });
+    });
 
     return {
-      labels,
-      tokensData,
-      sessionsData,
-      modelDatasets,
-      editorDatasets,
+      // Backward-compat flat fields (daily period)
+      labels: dailyPeriod.labels,
+      tokensData: dailyPeriod.tokensData,
+      sessionsData: dailyPeriod.sessionsData,
+      modelDatasets: dailyPeriod.modelDatasets,
+      editorDatasets: dailyPeriod.editorDatasets,
+      repositoryDatasets: dailyPeriod.repositoryDatasets,
       editorTotalsMap,
-      repositoryDatasets,
       repositoryTotalsMap,
-      dailyCount: dailyStats.length,
-      totalTokens,
-      avgTokensPerDay:
-        dailyStats.length > 0 ? Math.round(totalTokens / dailyStats.length) : 0,
-      totalSessions,
+      dailyCount: dailyPeriod.periodCount,
+      totalTokens: dailyPeriod.totalTokens,
+      avgTokensPerDay: dailyPeriod.avgPerPeriod,
+      totalSessions: dailyPeriod.totalSessions,
       lastUpdated: new Date().toISOString(),
       backendConfigured: this.isBackendConfigured(),
       compactNumbers: this.getCompactNumbersSetting(),
+      periods: {
+        daily: dailyPeriod,
+        weekly: weeklyPeriod,
+        monthly: monthlyPeriod,
+      },
     };
   }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1546,6 +1546,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.warn(`Failed to save cache: ${err}`);
 			});
 
+			// Pre-warm full-year chart data in background so the chart opens without delay.
+			// Only kick off when not already computed and the chart panel isn't open (showChart handles that case).
+			if (!this.lastFullDailyStats && !this.chartPanel) {
+				void this.calculateDailyStats();
+			}
+
 			return detailedStats;
 		} catch (error) {
 			this.error('Error updating token stats:', error);
@@ -1981,14 +1987,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const mtime = fileStats.mtime.getTime();
 				const fileSize = fileStats.size;
 				if (mtime < cutoffDate.getTime()) { return null; }
+				// getSessionFileDataCached already stores lastInteraction in its cache entry;
+				// calling getSessionFileDetails() would be a redundant second stat + cache lookup.
 				const sessionData = await this.getSessionFileDataCached(sessionFile, mtime, fileSize);
-				const details = await this.getSessionFileDetails(sessionFile);
-				return { sessionFile, sessionData, mtime, details };
+				return { sessionFile, sessionData, mtime };
 			});
 
 			for (const r of dailyResults) {
 				if (!r) { continue; }
-				const { sessionFile, sessionData, mtime, details } = r;
+				const { sessionFile, sessionData, mtime } = r;
 				try {
 					// Prefer actualTokens when available (same as calculateDetailedStats)
 					const estimatedTokens = sessionData.tokens;
@@ -2000,9 +2007,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 					const editorType = this.getEditorTypeFromPath(sessionFile);
 					const repository = sessionData.repository || 'Unknown';
 
-					// Use lastInteraction for date (same as calculateDetailedStats)
-					const lastActivity = details.lastInteraction
-						? new Date(details.lastInteraction)
+					// Use lastInteraction for date (same as calculateDetailedStats), falling back to mtime
+					const lastActivity = sessionData.lastInteraction
+						? new Date(sessionData.lastInteraction)
 						: new Date(mtime);
 					const dateKey = this.formatDateKey(lastActivity);
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8135,9 +8135,9 @@ ${hashtag}`;
       backendConfigured: this.isBackendConfigured(),
       compactNumbers: this.getCompactNumbersSetting(),
       periods: {
-        daily: dailyPeriod,
-        weekly: weeklyPeriod,
-        monthly: monthlyPeriod,
+        day: dailyPeriod,
+        week: weeklyPeriod,
+        month: monthlyPeriod,
       },
     };
   }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4739,10 +4739,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return;
 		}
 
-		// Use full-year daily stats for week/month period views; compute if not yet cached
-		const dailyStats = this.lastFullDailyStats ?? await this.calculateDailyStats();
+		// Open the panel IMMEDIATELY with whatever daily stats are already in memory.
+		// Full-year data (needed for Week/Month views) is computed in the background below.
+		const hasFullData = !!this.lastFullDailyStats;
+		const initialStats = this.lastFullDailyStats ?? this.lastDailyStats ?? [];
 
-		// Create webview panel
+		// Create webview panel now so the tab appears without waiting for I/O
 		this.chartPanel = vscode.window.createWebviewPanel(
 			'copilotTokenChart',
 			'Token Usage Over Time',
@@ -4768,14 +4770,25 @@ class CopilotTokenTracker implements vscode.Disposable {
 			}
 		});
 
-		// Set the HTML content
-		this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, dailyStats);
+		// Render immediately; Week/Month buttons are shown as loading if full-year data isn't ready
+		this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, initialStats, hasFullData);
 
 		// Handle panel disposal
 		this.chartPanel.onDidDispose(() => {
 			this.log('📈 Chart view closed');
 			this.chartPanel = undefined;
 		});
+
+		// If we only have 30-day data, compute the full year in the background and push an update
+		if (!hasFullData) {
+			const fullStats = await this.calculateDailyStats();
+			if (this.chartPanel) {
+				void this.chartPanel.webview.postMessage({
+					command: 'updateChartData',
+					data: { ...this.buildChartData(fullStats), periodsReady: true, compactNumbers: this.getCompactNumbersSetting() }
+				});
+			}
+		}
 	}
 
 	public async showUsageAnalysis(): Promise<void> {
@@ -8132,6 +8145,7 @@ ${hashtag}`;
   private getChartHtml(
     webview: vscode.Webview,
     dailyStats: DailyTokenStats[],
+    periodsReady = true,
   ): string {
     const nonce = this.getNonce();
     const scriptUri = webview.asWebviewUri(
@@ -8146,7 +8160,7 @@ ${hashtag}`;
       `script-src 'nonce-${nonce}'`,
     ].join("; ");
 
-    const chartData = this.buildChartData(dailyStats);
+    const chartData = { ...this.buildChartData(dailyStats), periodsReady };
 
     const initialData = JSON.stringify(chartData).replace(/</g, "\\u003c");
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -108,9 +108,9 @@ export interface ChartDataPayload {
   compactNumbers?: boolean;
   /** Pre-computed data for Day / Week / Month period views. */
   periods: {
-    daily: ChartPeriodData;
-    weekly: ChartPeriodData;
-    monthly: ChartPeriodData;
+    day: ChartPeriodData;
+    week: ChartPeriodData;
+    month: ChartPeriodData;
   };
   /**
    * Whether the full-year data needed for Week and Month views is ready.

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -73,6 +73,22 @@ export interface DailyTokenStats {
   repositoryUsage: RepositoryUsage;
 }
 
+/** Aggregated data for one time window (day/week/month) in the chart. */
+export interface ChartPeriodData {
+  labels: string[];
+  tokensData: number[];
+  sessionsData: number[];
+  modelDatasets: object[];
+  editorDatasets: object[];
+  repositoryDatasets: object[];
+  /** Number of bars / data points in this period. */
+  periodCount: number;
+  totalTokens: number;
+  totalSessions: number;
+  /** Average tokens per bar (per day / per week / per month). */
+  avgPerPeriod: number;
+}
+
 /** Shape of the data payload sent to the chart webview (via window.__INITIAL_CHART__ or postMessage). */
 export interface ChartDataPayload {
   labels: string[];
@@ -90,6 +106,12 @@ export interface ChartDataPayload {
   lastUpdated: string;
   backendConfigured: boolean;
   compactNumbers?: boolean;
+  /** Pre-computed data for Day / Week / Month period views. */
+  periods: {
+    daily: ChartPeriodData;
+    weekly: ChartPeriodData;
+    monthly: ChartPeriodData;
+  };
 }
 
 export interface SessionFileCache {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -112,6 +112,11 @@ export interface ChartDataPayload {
     weekly: ChartPeriodData;
     monthly: ChartPeriodData;
   };
+  /**
+   * Whether the full-year data needed for Week and Month views is ready.
+   * When false, the webview should indicate that those views are loading.
+   */
+  periodsReady?: boolean;
 }
 
 export interface SessionFileCache {

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -15,6 +15,21 @@ type ModelDataset = { label: string; data: number[]; backgroundColor: string; bo
 type EditorDataset = ModelDataset;
 type RepositoryDataset = ModelDataset & { fullRepo?: string };
 
+type ChartPeriodData = {
+	labels: string[];
+	tokensData: number[];
+	sessionsData: number[];
+	modelDatasets: ModelDataset[];
+	editorDatasets: EditorDataset[];
+	repositoryDatasets: RepositoryDataset[];
+	periodCount: number;
+	totalTokens: number;
+	totalSessions: number;
+	avgPerPeriod: number;
+};
+
+type ChartPeriod = 'day' | 'week' | 'month';
+
 type InitialChartData = {
 	labels: string[];
 	tokensData: number[];
@@ -31,6 +46,11 @@ type InitialChartData = {
 	lastUpdated: string;
 	backendConfigured?: boolean;
 	compactNumbers?: boolean;
+	periods?: {
+		daily: ChartPeriodData;
+		weekly: ChartPeriodData;
+		monthly: ChartPeriodData;
+	};
 };
 
 // VS Code injects this in the webview environment
@@ -60,8 +80,36 @@ async function loadChartModule(): Promise<void> {
 	Chart = mod.default;
 }
 let currentView: 'total' | 'model' | 'editor' | 'repository' = 'total';
-// Stores the view to restore after a background data update re-initializes the chart
+let currentPeriod: ChartPeriod = 'day';
+// Stores state to restore after a background data update re-initializes the chart
 let pendingView: typeof currentView | null = null;
+let pendingPeriod: ChartPeriod | null = null;
+
+/** Returns period data for the current period, falling back to legacy flat fields. */
+function getActivePeriodData(data: InitialChartData): ChartPeriodData {
+	if (data.periods) {
+		return data.periods[currentPeriod];
+	}
+	// Fallback for backward compat (no periods field)
+	return {
+		labels: data.labels,
+		tokensData: data.tokensData,
+		sessionsData: data.sessionsData,
+		modelDatasets: data.modelDatasets,
+		editorDatasets: data.editorDatasets,
+		repositoryDatasets: data.repositoryDatasets,
+		periodCount: data.dailyCount,
+		totalTokens: data.totalTokens,
+		totalSessions: data.totalSessions,
+		avgPerPeriod: data.avgTokensPerDay,
+	};
+}
+
+const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string }> = {
+	day:   { title: 'Token Usage – Last 30 Days',  footer: 'Day-by-day token usage for the last 30 days',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day'   },
+	week:  { title: 'Token Usage – Last 6 Weeks',  footer: 'Week-by-week token usage for the last 6 weeks', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week'  },
+	month: { title: 'Token Usage – Last 12 Months', footer: 'Monthly token usage for the last 12 months',   countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month' },
+};
 
 function renderLayout(data: InitialChartData): void {
 	setCompactNumbers(data.compactNumbers !== false);
@@ -81,7 +129,8 @@ function renderLayout(data: InitialChartData): void {
 	const header = el('div', 'header');
 	const headerLeft = el('div', 'header-left');
 	const icon = el('span', 'header-icon', '📈');
-	const title = el('span', 'header-title', 'Token Usage - Last 30 Days');
+	const title = el('span', 'header-title', PERIOD_LABELS[currentPeriod].title);
+	title.id = 'chart-title';
 	headerLeft.append(icon, title);
 	const buttons = el('div', 'button-row');
 	buttons.append(
@@ -97,14 +146,18 @@ function renderLayout(data: InitialChartData): void {
 	}
 	header.append(headerLeft, buttons);
 
+	const periodData = getActivePeriodData(data);
+	const periodMeta = PERIOD_LABELS[currentPeriod];
+
 	const summarySection = el('div', 'section');
 	summarySection.append(el('h3', '', '📊 Summary'));
 	const cards = el('div', 'cards');
+	cards.id = 'summary-cards';
 	cards.append(
-		buildCard('Total Days', data.dailyCount.toLocaleString()),
-		buildCard('Total Tokens', formatCompact(data.totalTokens)),
-		buildCard('Avg Tokens / Day', formatCompact(data.avgTokensPerDay)),
-		buildCard('Total Sessions', data.totalSessions.toLocaleString())
+		buildCard('card-period-count',  periodMeta.countLabel,   periodData.periodCount.toLocaleString()),
+		buildCard('card-total-tokens',  'Total Tokens',           formatCompact(periodData.totalTokens)),
+		buildCard('card-avg-tokens',    periodMeta.avgLabel,      formatCompact(periodData.avgPerPeriod)),
+		buildCard('card-total-sessions','Total Sessions',         periodData.totalSessions.toLocaleString())
 	);
 	summarySection.append(cards);
 
@@ -117,14 +170,26 @@ function renderLayout(data: InitialChartData): void {
 	chartSection.append(el('h3', '', '📊 Charts'));
 
 	const chartShell = el('div', 'chart-shell');
+
+	// Period toggle row
+	const periodToggles = el('div', 'chart-controls period-controls');
+	const dayBtn = el('button', `toggle${currentPeriod === 'day' ? ' active' : ''}`, '📅 Day');
+	dayBtn.id = 'period-day';
+	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, '🗓️ Week');
+	weekBtn.id = 'period-week';
+	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, '📆 Month');
+	monthBtn.id = 'period-month';
+	periodToggles.append(dayBtn, weekBtn, monthBtn);
+
+	// Chart view toggle row
 	const toggles = el('div', 'chart-controls');
-	const totalBtn = el('button', 'toggle active', 'Total Tokens');
+	const totalBtn = el('button', `toggle${currentView === 'total' ? ' active' : ''}`, 'Total Tokens');
 	totalBtn.id = 'view-total';
-	const modelBtn = el('button', 'toggle', 'By Model');
+	const modelBtn = el('button', `toggle${currentView === 'model' ? ' active' : ''}`, 'By Model');
 	modelBtn.id = 'view-model';
-	const editorBtn = el('button', 'toggle', 'By Editor');
+	const editorBtn = el('button', `toggle${currentView === 'editor' ? ' active' : ''}`, 'By Editor');
 	editorBtn.id = 'view-editor';
-	const repoBtn = el('button', 'toggle', 'By Repository');
+	const repoBtn = el('button', `toggle${currentView === 'repository' ? ' active' : ''}`, 'By Repository');
 	repoBtn.id = 'view-repository';
 	toggles.append(totalBtn, modelBtn, editorBtn, repoBtn);
 
@@ -133,10 +198,13 @@ function renderLayout(data: InitialChartData): void {
 	canvas.id = 'token-chart';
 	canvasWrap.append(canvas);
 
-	chartShell.append(toggles, canvasWrap);
+	chartShell.append(periodToggles, toggles, canvasWrap);
 	chartSection.append(chartShell);
 
-	const footer = el('div', 'footer', `Day-by-day token usage for the last 30 days\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`);
+	const footer = el('div', 'footer',
+		`${periodMeta.footer}\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`
+	);
+	footer.id = 'chart-footer';
 
 	container.append(header, summarySection, chartSection, footer);
 	root.append(themeStyle, style, container);
@@ -145,8 +213,9 @@ function renderLayout(data: InitialChartData): void {
 	void setupChart(canvas, data);
 }
 
-function buildCard(label: string, value: string): HTMLElement {
+function buildCard(id: string, label: string, value: string): HTMLElement {
 	const card = el('div', 'card');
+	card.id = id;
 	card.append(el('div', 'card-label', label), el('div', 'card-value', value));
 	return card;
 }
@@ -158,9 +227,38 @@ function buildEditorCards(editorTotals: Record<string, number>): HTMLElement | n
 	}
 	const wrap = el('div', 'cards');
 	entries.forEach(([editor, tokens]) => {
-		wrap.append(buildCard(editor, formatCompact(tokens)));
+		wrap.append(buildCard(`editor-${editor}`, editor, formatCompact(tokens)));
 	});
 	return wrap;
+}
+
+function updateSummaryCards(data: InitialChartData): void {
+	const periodData = getActivePeriodData(data);
+	const periodMeta = PERIOD_LABELS[currentPeriod];
+
+	const updateCard = (id: string, label: string | null, value: string) => {
+		const card = document.getElementById(id);
+		if (!card) { return; }
+		if (label !== null) {
+			const labelEl = card.querySelector('.card-label');
+			if (labelEl) { labelEl.textContent = label; }
+		}
+		const valueEl = card.querySelector('.card-value');
+		if (valueEl) { valueEl.textContent = value; }
+	};
+
+	updateCard('card-period-count',   periodMeta.countLabel,  periodData.periodCount.toLocaleString());
+	updateCard('card-total-tokens',   null,                   formatCompact(periodData.totalTokens));
+	updateCard('card-avg-tokens',     periodMeta.avgLabel,    formatCompact(periodData.avgPerPeriod));
+	updateCard('card-total-sessions', null,                   periodData.totalSessions.toLocaleString());
+
+	const title = document.getElementById('chart-title');
+	if (title) { title.textContent = periodMeta.title; }
+
+	const footer = document.getElementById('chart-footer');
+	if (footer) {
+		footer.textContent = `${periodMeta.footer}\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`;
+	}
 }
 
 function wireInteractions(data: InitialChartData): void {
@@ -185,13 +283,24 @@ function wireInteractions(data: InitialChartData): void {
 	const environmental = document.getElementById('btn-environmental');
 	environmental?.addEventListener('click', () => vscode.postMessage({ command: 'showEnvironmental' }));
 
+	// Period toggle buttons
+	const periodButtons: Array<{ id: string; period: ChartPeriod }> = [
+		{ id: 'period-day',   period: 'day'   },
+		{ id: 'period-week',  period: 'week'  },
+		{ id: 'period-month', period: 'month' },
+	];
+	periodButtons.forEach(({ id, period }) => {
+		const btn = document.getElementById(id);
+		btn?.addEventListener('click', () => { void switchPeriod(period, data); });
+	});
+
+	// Chart view toggle buttons
 	const viewButtons = [
-		{ id: 'view-total', view: 'total' as const },
-		{ id: 'view-model', view: 'model' as const },
-		{ id: 'view-editor', view: 'editor' as const },
+		{ id: 'view-total',      view: 'total'      as const },
+		{ id: 'view-model',      view: 'model'      as const },
+		{ id: 'view-editor',     view: 'editor'     as const },
 		{ id: 'view-repository', view: 'repository' as const },
 	];
-
 	viewButtons.forEach(({ id, view }) => {
 		const btn = document.getElementById(id);
 		btn?.addEventListener('click', () => { void switchView(view, data); });
@@ -208,13 +317,44 @@ async function setupChart(canvas: HTMLCanvasElement, data: InitialChartData): Pr
 		return;
 	}
 	chart = new Chart(ctx, createConfig('total', data));
-	// Restore the previously active view if a background update triggered a re-render
-	if (pendingView !== null && pendingView !== 'total') {
+	// Restore the previously active period and view if a background update triggered a re-render
+	if (pendingPeriod !== null && pendingPeriod !== 'day') {
+		const periodToRestore = pendingPeriod;
+		currentPeriod = 'day';
+		await switchPeriod(periodToRestore, data);
+	} else if (pendingView !== null && pendingView !== 'total') {
 		const viewToRestore = pendingView;
-		currentView = 'total'; // Reset so switchView does not short-circuit
+		currentView = 'total';
 		await switchView(viewToRestore, data);
 	}
 	pendingView = null;
+	pendingPeriod = null;
+}
+
+async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promise<void> {
+	if (currentPeriod === period) {
+		return;
+	}
+	currentPeriod = period;
+	setActivePeriod(period);
+	updateSummaryCards(data);
+	if (!chart) {
+		return;
+	}
+	const canvas = chart.canvas as HTMLCanvasElement | null;
+	chart.destroy();
+	if (!canvas) {
+		return;
+	}
+	const ctx = canvas.getContext('2d');
+	if (!ctx) {
+		return;
+	}
+	await loadChartModule();
+	if (!Chart) {
+		return;
+	}
+	chart = new Chart(ctx, createConfig(currentView, data));
 }
 
 async function switchView(view: 'total' | 'model' | 'editor' | 'repository', data: InitialChartData): Promise<void> {
@@ -222,7 +362,7 @@ async function switchView(view: 'total' | 'model' | 'editor' | 'repository', dat
 		return;
 	}
 	currentView = view;
-	setActive(view);
+	setActiveView(view);
 	if (!chart) {
 		return;
 	}
@@ -242,7 +382,15 @@ async function switchView(view: 'total' | 'model' | 'editor' | 'repository', dat
 	chart = new Chart(ctx, createConfig(view, data));
 }
 
-function setActive(view: 'total' | 'model' | 'editor' | 'repository'): void {
+function setActivePeriod(period: ChartPeriod): void {
+	(['period-day', 'period-week', 'period-month'] as const).forEach(id => {
+		const btn = document.getElementById(id);
+		if (!btn) { return; }
+		btn.classList.toggle('active', id === `period-${period}`);
+	});
+}
+
+function setActiveView(view: 'total' | 'model' | 'editor' | 'repository'): void {
 	['view-total', 'view-model', 'view-editor', 'view-repository'].forEach(id => {
 		const btn = document.getElementById(id);
 		if (!btn) {
@@ -253,16 +401,18 @@ function setActive(view: 'total' | 'model' | 'editor' | 'repository'): void {
 }
 
 function createConfig(view: 'total' | 'model' | 'editor' | 'repository', data: InitialChartData): ChartConfig {
+	const period = getActivePeriodData(data);
+
 	// Get CSS variables for theme-aware colors
 	const styles = getComputedStyle(document.body);
 	const textColor = styles.getPropertyValue('--text-primary') || '#e0e0e0';
 	const mutedColor = styles.getPropertyValue('--text-muted') || '#999999';
 	const borderColor = styles.getPropertyValue('--border-subtle') || '#3a3a40';
 	const bgColor = styles.getPropertyValue('--bg-tertiary') || '#1e1e1e';
-	
+
 	// Make grid lines very subtle with low opacity
 	const gridColor = 'rgba(128, 128, 128, 0.15)';
-	
+
 	const baseOptions = {
 		responsive: true,
 		maintainAspectRatio: false,
@@ -288,11 +438,11 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository', data: I
 		return {
 			type: 'bar' as const,
 			data: {
-				labels: data.labels,
+				labels: period.labels,
 				datasets: [
 					{
 						label: 'Tokens',
-						data: data.tokensData,
+						data: period.tokensData,
 						backgroundColor: 'rgba(54, 162, 235, 0.6)',
 						borderColor: 'rgba(54, 162, 235, 1)',
 						borderWidth: 1,
@@ -300,7 +450,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository', data: I
 					},
 					{
 						label: 'Sessions',
-						data: data.sessionsData,
+						data: period.sessionsData,
 						backgroundColor: 'rgba(255, 99, 132, 0.6)',
 						borderColor: 'rgba(255, 99, 132, 1)',
 						borderWidth: 1,
@@ -334,12 +484,12 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository', data: I
 		};
 	}
 
-	const datasets = view === 'model' ? data.modelDatasets : view === 'repository' ? data.repositoryDatasets : data.editorDatasets;
-	
+	const datasets = view === 'model' ? period.modelDatasets : view === 'repository' ? period.repositoryDatasets : period.editorDatasets;
+
 	// Add sessions line as an overlay on all stacked views
 	const sessionsDataset = {
 		label: 'Sessions',
-		data: data.sessionsData,
+		data: period.sessionsData,
 		backgroundColor: 'rgba(255, 99, 132, 0.6)',
 		borderColor: 'rgba(255, 99, 132, 1)',
 		borderWidth: 2,
@@ -347,10 +497,10 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository', data: I
 		yAxisID: 'y1',
 		stack: undefined // Don't stack the line
 	};
-	
+
 	return {
 		type: 'bar' as const,
-		data: { labels: data.labels, datasets: [...datasets, sessionsDataset] },
+		data: { labels: period.labels, datasets: [...datasets, sessionsDataset] },
 		options: {
 			...baseOptions,
 			plugins: {
@@ -359,9 +509,9 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository', data: I
 			},
 			scales: {
 				...baseOptions.scales,
-				y: { 
-					stacked: true, 
-					grid: { color: gridColor }, 
+				y: {
+					stacked: true,
+					grid: { color: gridColor },
 					ticks: { color: textColor, font: { size: 11 }, callback: (value: any) => Number(value).toLocaleString() },
 					title: { display: true, text: 'Tokens', color: textColor, font: { size: 12, weight: 'bold' } }
 				},
@@ -400,7 +550,9 @@ void bootstrap();
 window.addEventListener('message', (event: MessageEvent) => {
 	const message = event.data;
 	if (message.command === 'updateChartData') {
-		pendingView = currentView; // Save current toggle view for restoration after chart re-initializes
+		// Save current toggles for restoration after chart re-initializes
+		pendingView = currentView;
+		pendingPeriod = currentPeriod;
 		renderLayout(message.data as InitialChartData);
 	}
 });

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -48,9 +48,9 @@ type InitialChartData = {
 	compactNumbers?: boolean;
 	periodsReady?: boolean;
 	periods?: {
-		daily: ChartPeriodData;
-		weekly: ChartPeriodData;
-		monthly: ChartPeriodData;
+		day: ChartPeriodData;
+		week: ChartPeriodData;
+		month: ChartPeriodData;
 	};
 };
 

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -46,6 +46,7 @@ type InitialChartData = {
 	lastUpdated: string;
 	backendConfigured?: boolean;
 	compactNumbers?: boolean;
+	periodsReady?: boolean;
 	periods?: {
 		daily: ChartPeriodData;
 		weekly: ChartPeriodData;
@@ -173,12 +174,21 @@ function renderLayout(data: InitialChartData): void {
 
 	// Period toggle row
 	const periodToggles = el('div', 'chart-controls period-controls');
+	const periodsReady = data.periodsReady !== false;
 	const dayBtn = el('button', `toggle${currentPeriod === 'day' ? ' active' : ''}`, '📅 Day');
 	dayBtn.id = 'period-day';
-	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, '🗓️ Week');
+	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, periodsReady ? '🗓️ Week' : '🗓️ Week ⌛');
 	weekBtn.id = 'period-week';
-	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, '📆 Month');
+	if (!periodsReady) {
+		(weekBtn as HTMLButtonElement).disabled = true;
+		weekBtn.title = 'Loading historical data…';
+	}
+	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, periodsReady ? '📆 Month' : '📆 Month ⌛');
 	monthBtn.id = 'period-month';
+	if (!periodsReady) {
+		(monthBtn as HTMLButtonElement).disabled = true;
+		monthBtn.title = 'Loading historical data…';
+	}
 	periodToggles.append(dayBtn, weekBtn, monthBtn);
 
 	// Chart view toggle row

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -151,6 +151,15 @@ body {
 	background: var(--button-hover-bg);
 }
 
+.toggle:disabled {
+	opacity: 0.45;
+	cursor: not-allowed;
+}
+
+.toggle:disabled:hover {
+	background: var(--button-secondary-bg);
+}
+
 .canvas-wrap {
 	position: relative;
 	height: 420px;

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -120,6 +120,12 @@ body {
 	justify-content: center;
 }
 
+.period-controls {
+	margin-bottom: 4px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--border-subtle);
+}
+
 .toggle {
 	background: var(--button-secondary-bg);
 	border: 1px solid var(--border-subtle);


### PR DESCRIPTION
## Summary

Adds a **Day / Week / Month** period toggle to the token usage chart view, allowing users to zoom the time window:

- **Day** — last 30 days (existing behavior, now explicit toggle)
- **Week** — last 6 calendar weeks (Monday–Sunday buckets, labeled "Apr 7–13")
- **Month** — last 12 calendar months (labeled "Apr 2025")

## Changes

### Backend (`extension.ts`)
- Added `lastFullDailyStats` field to cache up to 365 days of raw daily stats
- Rewrote `calculateDailyStats()` to collect up to 365 days using the same consistent pipeline as `calculateDetailedStats()` (uses `lastInteraction`-based date, prefers `actualTokens` over estimated)
- Rewrote `buildChartData()` to produce all three period aggregations (`daily`, `weekly`, `monthly`) in a single pass over the full-year data
- Updated `showChart()`, `refreshChartPanel()`, and auto-refresh to use `lastFullDailyStats`

### Types (`types.ts`)
- Added `ChartPeriodData` interface (labels, token/session/model/editor/repo datasets, period count, totals, avg)
- Added `periods: { daily, weekly, monthly }` field to `ChartDataPayload`

### Webview (`webview/chart/main.ts`)
- Added period toggle row (📅 Day | 🗓️ Week | 📆 Month) above existing view toggles
- Summary cards are period-aware: labels update to "Total Days/Weeks/Months", "Avg Tokens/Day/Week/Month"
- `switchPeriod()` swaps chart data and updates cards without re-rendering the layout
- Selected period is preserved across background chart updates via `pendingPeriod`

### Styles (`webview/chart/styles.css`)
- Added `.period-controls` class with bottom-border separator