### PR TITLE
ci: update workflows to Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         
     - name: Upload build artifacts
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
+      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '24.x'
       with:
         name: build-artifacts
         path: |

--- a/.github/workflows/check-models.yml
+++ b/.github/workflows/check-models.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Authenticate GitHub CLI
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,14 @@ jobs:
         exit "$status"
 
     - name: Publish test results to step summary
-      if: always() && matrix.node-version == '22.x'
+      if: always() && matrix.node-version == '24.x'
       shell: bash
       run: node scripts/parse-test-output.js "$RUNNER_TEMP/test-output.txt" >> "$GITHUB_STEP_SUMMARY"
       
     - name: Run tests
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:
         run: cd vscode-extension && npm test
         options: -screen 0 1024x768x24
@@ -92,7 +94,7 @@ jobs:
       
     - name: Upload build artifacts
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      if: matrix.node-version == '22.x'
+      if: matrix.node-version == '24.x'
       with:
         name: extension-build
         path: |
@@ -117,7 +119,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         cache: 'npm'
         cache-dependency-path: vscode-extension/package-lock.json
         

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -58,7 +58,7 @@ jobs:
     if: needs.check-changes.outputs.cli-relevant == 'true'
     runs-on: ubuntu-latest
     env:
-        node-version: 22
+        node-version: 24
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         cache: 'npm'
         cache-dependency-path: vscode-extension/package-lock.json
 
@@ -389,7 +389,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         cache: 'npm'
         cache-dependency-path: vscode-extension/package-lock.json
 
@@ -499,7 +499,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: '22.x'
+        node-version: '24.x'
 
     # ── Install dependencies ────────────────────────────────────────────────
 

--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         
     - name: Sync GitHub release notes to CHANGELOG.md
       env:

--- a/.github/workflows/sync-toolnames.yml
+++ b/.github/workflows/sync-toolnames.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: '20.x'
+        node-version: '24.x'
 
     - name: Authenticate GitHub CLI
       env:

--- a/.github/workflows/visualstudio-build.yml
+++ b/.github/workflows/visualstudio-build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
 
       # ── Install dependencies ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Updates all GitHub Actions workflows to use Node.js 24, addressing the Node.js 20 deprecation warnings.

### Changes

| File | Change |
|---|---|
| `ci.yml` | `20.x` → `24.x` (package job); matrix conditionals `22.x` → `24.x`; add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to `coactions/setup-xvfb` step |
| `build.yml` | Matrix artifact conditional `22.x` → `24.x` |
| `check-models.yml` | `20.x` → `24.x` |
| `cli-build.yml` | `22` → `24` |
| `copilot-setup-steps.yml` | `"20"` → `"24"` |
| `release.yml` | Three places: `20.x`/`22.x` → `24.x` |
| `sync-release-notes.yml` | `20.x` → `24.x` |
| `sync-toolnames.yml` | `20.x` → `24.x` |
| `visualstudio-build.yml` | `22.x` → `24.x` |

### Notes

- The build/CI matrix (`[22.x, 24.x]`) is intentionally kept to verify compatibility across both supported LTS versions.
- `coactions/setup-xvfb` has no newer version available; the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var opts it into Node.js 24 now and silences the deprecation warning.