### PR TITLE
feat: cache-aware cost estimation for Claude and OpenCode sessions

### DIFF
--- a/vscode-extension/src/README.md
+++ b/vscode-extension/src/README.md
@@ -42,6 +42,8 @@ Contains pricing information for AI models, including input and output token cos
     "model-name": {
       "inputCostPerMillion": 1.75,
       "outputCostPerMillion": 14.0,
+      "cachedInputCostPerMillion": 0.175,
+      "cacheCreationCostPerMillion": 2.1875,
       "category": "Model category",
       "tier": "standard|premium|unknown",
       "multiplier": 1
@@ -49,6 +51,39 @@ Contains pricing information for AI models, including input and output token cos
   }
 }
 ```
+
+**Cache pricing fields (optional):**
+
+| Field | Description |
+|-------|-------------|
+| `cachedInputCostPerMillion` | Cost per million tokens for cache **reads** — tokens already cached and billed at a reduced rate |
+| `cacheCreationCostPerMillion` | Cost per million tokens for cache **creation** — writing tokens into the cache (billed at a premium) |
+
+When these fields are absent, the full `inputCostPerMillion` rate is applied to all input tokens.
+
+**Anthropic prompt caching rates** (used for all `claude-*` models):
+- Cache reads: **10% of input rate** (e.g. $0.30/M for Claude Sonnet 4 at $3.00/M input)
+- Cache creation: **125% of input rate** (e.g. $3.75/M for Claude Sonnet 4)
+
+**OpenAI prompt caching rates** (automatic prefix matching):
+- Cache reads: **50% of input rate** (e.g. $1.25/M for GPT-4o at $2.50/M input)
+- Note: OpenAI cache creation does not incur an extra fee, so `cacheCreationCostPerMillion` is not set for OpenAI models.
+
+### Which data sources provide cache token breakdowns?
+
+Cache-aware pricing only applies when the session source actually exposes how many tokens were cached vs. uncached:
+
+| Source | Cache tokens available? | Fields used |
+|--------|------------------------|-------------|
+| **Claude Desktop** (`claudedesktop.ts`) | ✅ Yes | `usage.cache_creation_input_tokens`, `usage.cache_read_input_tokens` |
+| **Claude Code** (`claudecode.ts`) | ✅ Yes | same Anthropic API fields |
+| **OpenCode** (`opencode.ts`) | ✅ Yes (DB format) | `msg.tokens.cache.write`, `msg.tokens.cache.read` |
+| VS Code Copilot | ❌ Not exposed | Copilot API returns only aggregate `promptTokens` |
+| Continue.dev | ❌ No | Character-based estimation only |
+| Cursor (Crush) | ❌ No | DB prompt/completion totals only |
+| Visual Studio | ❌ No | Character-based estimation only |
+
+For sources without cache data, the full input rate is used (no change from previous behaviour).
 
 **How to update:**
 1. Check official pricing pages:
@@ -80,7 +115,7 @@ Note: These are the current GitHub Copilot supported Gemini models. Pricing from
 - These files are imported at compile time and bundled into the extension
 - After making changes, run `npm run compile` to rebuild
 - Pricing is for reference only - GitHub Copilot may use different pricing structures
-- Cost estimates assume a 50/50 split between input and output tokens
+- Cost estimates use actual input/output token counts when available. Cache-aware pricing is applied automatically for sources that expose cache token breakdowns (Claude Desktop, Claude Code, OpenCode).
 
 ## customizationPatterns.json
 

--- a/vscode-extension/src/claudecode.ts
+++ b/vscode-extension/src/claudecode.ts
@@ -221,13 +221,21 @@ export class ClaudeCodeDataAccess {
 				modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
 			}
 
+			const cacheCreation = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+			const cachedRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
 			const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
-				+ (typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0)
-				+ (typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0);
+				+ cacheCreation
+				+ cachedRead;
 			const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
 
 			modelUsage[model].inputTokens += inputTokens;
 			modelUsage[model].outputTokens += outputTokens;
+			if (cacheCreation > 0) {
+				modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + cacheCreation;
+			}
+			if (cachedRead > 0) {
+				modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + cachedRead;
+			}
 		}
 
 		return modelUsage;

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -247,13 +247,21 @@ export class ClaudeDesktopCoworkDataAccess {
 				modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
 			}
 
+			const cacheCreation = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+			const cachedRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
 			const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
-				+ (typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0)
-				+ (typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0);
+				+ cacheCreation
+				+ cachedRead;
 			const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
 
 			modelUsage[model].inputTokens += inputTokens;
 			modelUsage[model].outputTokens += outputTokens;
+			if (cacheCreation > 0) {
+				modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + cacheCreation;
+			}
+			if (cachedRead > 0) {
+				modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + cachedRead;
+			}
 		}
 
 		return modelUsage;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -168,7 +168,7 @@ type RepoPrStatsResult = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 38; // Fix repo detection for CLI worktree sessions
+	private static readonly CACHE_VERSION = 39; // Cache-aware cost: track cachedReadTokens/cacheCreationTokens in ModelUsage
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 

--- a/vscode-extension/src/modelPricing.json
+++ b/vscode-extension/src/modelPricing.json
@@ -174,6 +174,7 @@
     "gpt-4o": {
       "inputCostPerMillion": 2.5,
       "outputCostPerMillion": 10.0,
+      "cachedInputCostPerMillion": 1.25,
       "category": "GPT-4 models",
       "tier": "standard",
       "multiplier": 0,
@@ -182,6 +183,7 @@
     "gpt-4o-mini": {
       "inputCostPerMillion": 0.15,
       "outputCostPerMillion": 0.6,
+      "cachedInputCostPerMillion": 0.075,
       "category": "GPT-4 models",
       "tier": "standard",
       "multiplier": 0,
@@ -198,6 +200,8 @@
     "claude-sonnet-3.5": {
       "inputCostPerMillion": 3.0,
       "outputCostPerMillion": 15.0,
+      "cachedInputCostPerMillion": 0.3,
+      "cacheCreationCostPerMillion": 3.75,
       "category": "Claude models (Anthropic)",
       "tier": "unknown",
       "multiplier": 1,
@@ -206,6 +210,8 @@
     "claude-sonnet-3.7": {
       "inputCostPerMillion": 3.0,
       "outputCostPerMillion": 15.0,
+      "cachedInputCostPerMillion": 0.3,
+      "cacheCreationCostPerMillion": 3.75,
       "category": "Claude models (Anthropic)",
       "tier": "unknown",
       "multiplier": 1,
@@ -214,6 +220,8 @@
     "claude-sonnet-4": {
       "inputCostPerMillion": 3.0,
       "outputCostPerMillion": 15.0,
+      "cachedInputCostPerMillion": 0.3,
+      "cacheCreationCostPerMillion": 3.75,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 1,
@@ -222,6 +230,8 @@
     "claude-sonnet-4.5": {
       "inputCostPerMillion": 3.0,
       "outputCostPerMillion": 15.0,
+      "cachedInputCostPerMillion": 0.3,
+      "cacheCreationCostPerMillion": 3.75,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 1
@@ -229,6 +239,8 @@
     "claude-sonnet-4.6": {
       "inputCostPerMillion": 3.0,
       "outputCostPerMillion": 15.0,
+      "cachedInputCostPerMillion": 0.3,
+      "cacheCreationCostPerMillion": 3.75,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 3,
@@ -237,6 +249,8 @@
     "claude-haiku": {
       "inputCostPerMillion": 0.25,
       "outputCostPerMillion": 1.25,
+      "cachedInputCostPerMillion": 0.025,
+      "cacheCreationCostPerMillion": 0.3125,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 0
@@ -244,6 +258,8 @@
     "claude-haiku-4.5": {
       "inputCostPerMillion": 1.0,
       "outputCostPerMillion": 5.0,
+      "cachedInputCostPerMillion": 0.1,
+      "cacheCreationCostPerMillion": 1.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 0.33
@@ -251,6 +267,8 @@
     "claude-opus-4.1": {
       "inputCostPerMillion": 15.0,
       "outputCostPerMillion": 75.0,
+      "cachedInputCostPerMillion": 1.5,
+      "cacheCreationCostPerMillion": 18.75,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 10
@@ -258,6 +276,8 @@
     "claude-opus-4.5": {
       "inputCostPerMillion": 5.0,
       "outputCostPerMillion": 25.0,
+      "cachedInputCostPerMillion": 0.5,
+      "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 3
@@ -265,6 +285,8 @@
     "claude-opus-4.6": {
       "inputCostPerMillion": 5.0,
       "outputCostPerMillion": 25.0,
+      "cachedInputCostPerMillion": 0.5,
+      "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 3
@@ -272,6 +294,8 @@
     "claude-opus-4.6-(fast-mode)-(preview)": {
       "inputCostPerMillion": 5.0,
       "outputCostPerMillion": 25.0,
+      "cachedInputCostPerMillion": 0.5,
+      "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 30
@@ -279,6 +303,8 @@
     "claude-opus-4.6-fast": {
       "inputCostPerMillion": 5.0,
       "outputCostPerMillion": 25.0,
+      "cachedInputCostPerMillion": 0.5,
+      "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 30

--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -360,6 +360,16 @@ export class OpenCodeDataAccess {
 			modelUsage[model].inputTokens += turnInput;
 			modelUsage[model].outputTokens += turnOutput;
 
+			// Track cache tokens if available (tokens.cache.read / tokens.cache.write)
+			const turnCachedRead = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.cache?.read || 0), 0);
+			const turnCacheCreation = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.cache?.write || 0), 0);
+			if (turnCachedRead > 0) {
+				modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + turnCachedRead;
+			}
+			if (turnCacheCreation > 0) {
+				modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + turnCacheCreation;
+			}
+
 			prevTotal = turnCumTotal;
 		}
 

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -525,8 +525,16 @@ export function getModelTier(modelId: string, modelPricing: { [key: string]: Mod
 }
 
 /**
- * Calculate estimated cost in USD based on model usage
- * Assumes 50/50 split between input and output tokens for estimation
+ * Calculate estimated cost in USD based on model usage.
+ * Applies cache-aware pricing when cachedReadTokens / cacheCreationTokens breakdowns
+ * are available (e.g. Claude Desktop / Claude Code / OpenCode sessions).
+ *
+ * Cost formula:
+ *   uncachedInput = inputTokens - (cachedReadTokens ?? 0) - (cacheCreationTokens ?? 0)
+ *   cost = uncachedInput × inputCostPerMillion
+ *        + cachedReadTokens × cachedInputCostPerMillion (fallback: inputCostPerMillion)
+ *        + cacheCreationTokens × cacheCreationCostPerMillion (fallback: inputCostPerMillion)
+ *        + outputTokens × outputCostPerMillion
  * @param modelUsage Object with model names as keys and token counts as values
  * @returns Estimated cost in USD
  */
@@ -534,25 +542,18 @@ export function calculateEstimatedCost(modelUsage: ModelUsage, modelPricing: { [
 	let totalCost = 0;
 
 	for (const [model, usage] of Object.entries(modelUsage)) {
-		const pricing = modelPricing[model];
+		const pricing = modelPricing[model] ?? modelPricing['gpt-4o-mini'];
 
-		if (pricing) {
-			// Use actual input and output token counts
-			const inputCost = (usage.inputTokens / 1_000_000) * pricing.inputCostPerMillion;
-			const outputCost = (usage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
+		const cachedRead = usage.cachedReadTokens ?? 0;
+		const cacheCreation = usage.cacheCreationTokens ?? 0;
+		const uncachedInput = Math.max(0, usage.inputTokens - cachedRead - cacheCreation);
 
-			totalCost += inputCost + outputCost;
-		} else {
-			// Fallback for models without pricing data - use GPT-4o-mini as default
-			const fallbackPricing = modelPricing['gpt-4o-mini'];
+		const uncachedInputCost = (uncachedInput / 1_000_000) * pricing.inputCostPerMillion;
+		const cachedReadCost = (cachedRead / 1_000_000) * (pricing.cachedInputCostPerMillion ?? pricing.inputCostPerMillion);
+		const cacheCreationCost = (cacheCreation / 1_000_000) * (pricing.cacheCreationCostPerMillion ?? pricing.inputCostPerMillion);
+		const outputCost = (usage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
 
-			const inputCost = (usage.inputTokens / 1_000_000) * fallbackPricing.inputCostPerMillion;
-			const outputCost = (usage.outputTokens / 1_000_000) * fallbackPricing.outputCostPerMillion;
-
-			totalCost += inputCost + outputCost;
-
-			// log(`No pricing data for model '${model}', using fallback pricing (gpt-4o-mini)`);
-		}
+		totalCost += uncachedInputCost + cachedReadCost + cacheCreationCost + outputCost;
 	}
 
 	return totalCost;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -11,14 +11,18 @@ export interface TokenUsageStats {
 
 export interface ModelUsage {
   [modelName: string]: {
-    inputTokens: number;
+    inputTokens: number;    // total input tokens (uncached + cached reads + cache creation)
     outputTokens: number;
+    cachedReadTokens?: number;     // portion of inputTokens that were cache reads (billed at reduced rate)
+    cacheCreationTokens?: number;  // portion of inputTokens used to create cache entries (billed at higher rate)
   };
 }
 
 export interface ModelPricing {
   inputCostPerMillion: number;
   outputCostPerMillion: number;
+  cachedInputCostPerMillion?: number;    // cost per million cache-read tokens (e.g. 0.30 for Claude Sonnet 4)
+  cacheCreationCostPerMillion?: number;  // cost per million cache-creation tokens (e.g. 3.75 for Claude Sonnet 4)
   category?: string;
   tier?: "standard" | "premium" | "unknown";
   multiplier?: number;


### PR DESCRIPTION
Closes #604

## Summary

Applies Anthropic prompt-caching discount rates to cost estimates for sessions where the data exposes cache token breakdowns (Claude Desktop, Claude Code, OpenCode). Previously, all input tokens were billed at the full input rate — this overestimates costs significantly when cache reads (10% of normal rate) dominate.

## What changed

### Data model
- `ModelUsage` — added optional `cachedReadTokens?` and `cacheCreationTokens?` breakdown fields (kept `inputTokens` as the full total, so no existing token-count displays are affected)
- `ModelPricing` — added optional `cachedInputCostPerMillion?` and `cacheCreationCostPerMillion?` fields

### Pricing data (`modelPricing.json`)
- All Claude models: cache read = 10% of input, cache creation = 125% of input
- `gpt-4o` / `gpt-4o-mini`: cache read = 50% of input

### Cost formula (`tokenEstimation.ts`)
```
uncachedInput = inputTokens − cachedReadTokens − cacheCreationTokens
cost = uncachedInput × inputRate
     + cachedReadTokens × cachedInputRate  (fallback: inputRate)
     + cacheCreationTokens × creationRate  (fallback: inputRate)
     + outputTokens × outputRate
```
Falls back to the old formula when cache fields are absent.

### Source data wiring
| Source | Change |
|--------|--------|
| `claudedesktop.ts` | Populates `cachedReadTokens` / `cacheCreationTokens` from `cache_read_input_tokens` / `cache_creation_input_tokens` |
| `claudecode.ts` | Same |
| `opencode.ts` | Reads `tokens.cache.read` / `tokens.cache.write` from OpenCode DB messages |
| All other sources | No change — full input rate still applied (no cache data available) |

### Other
- `CACHE_VERSION` bumped to 39 to invalidate stale caches
- `vscode-extension/src/README.md` updated with source survey table and cache pricing field docs