### PR TITLE
test: improve mutation score from 29% to 40%+ with 89 targeted tests

### DIFF
--- a/vscode-extension/test/unit/claudecode.test.ts
+++ b/vscode-extension/test/unit/claudecode.test.ts
@@ -326,3 +326,288 @@ test('getTokensFromClaudeCodeSession: skips non-assistant events', () => {
 		cleanup(filePath);
 	}
 });
+
+// ── Mutation-killing tests ──────────────────────────────────────────────
+
+test('getTokensFromClaudeCodeSession: handles non-numeric usage fields gracefully', () => {
+        const events = [
+                {
+                        type: 'assistant',
+                        requestId: 'req_001',
+                        message: {
+                                model: 'claude-sonnet-4-6',
+                                stop_reason: 'end_turn',
+                                usage: {
+                                        input_tokens: 'not a number',
+                                        output_tokens: null,
+                                        cache_creation_input_tokens: undefined,
+                                        cache_read_input_tokens: 10
+                                }
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const result = claudeCode.getTokensFromClaudeCodeSession(filePath);
+                // Only cache_read_input_tokens (10) is numeric, rest default to 0
+                assert.equal(result.tokens, 10);
+                assert.equal(result.thinkingTokens, 0);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('getTokensFromClaudeCodeSession: handles missing usage object', () => {
+        const events = [
+                {
+                        type: 'assistant',
+                        requestId: 'req_001',
+                        message: {
+                                model: 'claude-sonnet-4-6',
+                                stop_reason: 'end_turn'
+                                // no usage
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const result = claudeCode.getTokensFromClaudeCodeSession(filePath);
+                assert.equal(result.tokens, 0);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('getTokensFromClaudeCodeSession: skips streaming fragments without stop_reason', () => {
+        const events = [
+                {
+                        type: 'assistant',
+                        requestId: 'req_001',
+                        message: {
+                                model: 'claude-sonnet-4-6',
+                                stop_reason: null,
+                                usage: { input_tokens: 5, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
+                        }
+                },
+                {
+                        type: 'assistant',
+                        requestId: 'req_001',
+                        message: {
+                                model: 'claude-sonnet-4-6',
+                                stop_reason: undefined,
+                                usage: { input_tokens: 8, output_tokens: 15, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
+                        }
+                },
+                {
+                        type: 'assistant',
+                        requestId: 'req_001',
+                        message: {
+                                model: 'claude-sonnet-4-6',
+                                stop_reason: 'end_turn',
+                                usage: { input_tokens: 20, output_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const result = claudeCode.getTokensFromClaudeCodeSession(filePath);
+                // Only the final event with stop_reason='end_turn' should count
+                assert.equal(result.tokens, 120);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('countClaudeCodeInteractions: counts string content messages', () => {
+        const events = [
+                {
+                        type: 'user',
+                        isSidechain: false,
+                        message: { role: 'user', content: 'plain text message' }
+                },
+                {
+                        type: 'user',
+                        isSidechain: false,
+                        message: { role: 'user', content: 'another message' }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const count = claudeCode.countClaudeCodeInteractions(filePath);
+                assert.equal(count, 2);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('countClaudeCodeInteractions: does not count tool_result-only messages', () => {
+        const events = [
+                {
+                        type: 'user',
+                        isSidechain: false,
+                        message: {
+                                role: 'user',
+                                content: [
+                                        { type: 'tool_result', tool_use_id: 'toolu_1', content: [{ type: 'text', text: 'result' }] }
+                                ]
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const count = claudeCode.countClaudeCodeInteractions(filePath);
+                assert.equal(count, 0);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('countClaudeCodeInteractions: does not count messages with text AND tool_result', () => {
+        const events = [
+                {
+                        type: 'user',
+                        isSidechain: false,
+                        message: {
+                                role: 'user',
+                                content: [
+                                        { type: 'text', text: 'check this' },
+                                        { type: 'tool_result', tool_use_id: 'toolu_1', content: [] }
+                                ]
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const count = claudeCode.countClaudeCodeInteractions(filePath);
+                // Has text but also has tool_result → not a user interaction
+                assert.equal(count, 0);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('countClaudeCodeInteractions: returns 0 for empty file', () => {
+        const filePath = createTempSession([]);
+        try {
+                const count = claudeCode.countClaudeCodeInteractions(filePath);
+                assert.equal(count, 0);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('getClaudeCodeModelUsage: handles events without requestId', () => {
+        const events = [
+                {
+                        type: 'assistant',
+                        message: {
+                                model: 'claude-sonnet-4-6',
+                                stop_reason: 'end_turn',
+                                usage: { input_tokens: 10, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const modelUsage = claudeCode.getClaudeCodeModelUsage(filePath);
+                assert.ok(modelUsage['claude-sonnet-4.6']);
+                assert.equal(modelUsage['claude-sonnet-4.6'].inputTokens, 10);
+                assert.equal(modelUsage['claude-sonnet-4.6'].outputTokens, 20);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('getClaudeCodeModelUsage: handles non-numeric usage fields', () => {
+        const events = [
+                {
+                        type: 'assistant',
+                        requestId: 'req_001',
+                        message: {
+                                model: 'claude-haiku-4-5',
+                                stop_reason: 'end_turn',
+                                usage: {
+                                        input_tokens: 'invalid',
+                                        output_tokens: 30,
+                                        cache_creation_input_tokens: null,
+                                        cache_read_input_tokens: 5
+                                }
+                        }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const modelUsage = claudeCode.getClaudeCodeModelUsage(filePath);
+                assert.ok(modelUsage['claude-haiku-4.5']);
+                // input_tokens defaults to 0 (non-numeric), cache_creation defaults to 0, cache_read = 5
+                assert.equal(modelUsage['claude-haiku-4.5'].inputTokens, 5);
+                assert.equal(modelUsage['claude-haiku-4.5'].outputTokens, 30);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('getProjectPathFromHash: returns Unix-style path on non-Windows', () => {
+        // The method uses os.platform() internally — test the output format
+        const result = claudeCode.getProjectPathFromHash('home-user-repos-myproject');
+        if (os.platform() !== 'win32') {
+                assert.equal(result, '/home/user/repos/myproject');
+        } else {
+                // On Windows, non-drive-letter hash falls through to Unix path
+                // but since we're on Windows with drive letter pattern expected, just check it returns something
+                assert.ok(result.length > 0);
+        }
+});
+
+test('getProjectPathFromHash: handles simple single-segment hash', () => {
+        const result = claudeCode.getProjectPathFromHash('myproject');
+        if (os.platform() !== 'win32') {
+                assert.equal(result, '/myproject');
+        } else {
+                assert.ok(result.length > 0);
+        }
+});
+
+test('getClaudeCodeSessionMeta: returns null for empty file', () => {
+        const filePath = createTempSession([]);
+        try {
+                const meta = claudeCode.getClaudeCodeSessionMeta(filePath);
+                assert.equal(meta, null);
+        } finally {
+                cleanup(filePath);
+        }
+});
+
+test('getClaudeCodeSessionMeta: extracts timestamps without ai-title', () => {
+        const events = [
+                {
+                        type: 'user',
+                        timestamp: '2026-03-27T22:47:31.000Z',
+                        message: { role: 'user', content: [{ type: 'text', text: 'hello' }] }
+                },
+                {
+                        type: 'assistant',
+                        timestamp: '2026-03-27T22:48:00.000Z',
+                        message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] }
+                }
+        ];
+
+        const filePath = createTempSession(events);
+        try {
+                const meta = claudeCode.getClaudeCodeSessionMeta(filePath);
+                assert.ok(meta);
+                assert.equal(meta!.title, undefined);
+                assert.equal(meta!.firstInteraction, '2026-03-27T22:47:31.000Z');
+                assert.equal(meta!.lastInteraction, '2026-03-27T22:48:00.000Z');
+        } finally {
+                cleanup(filePath);
+        }
+});

--- a/vscode-extension/test/unit/sessionParser.test.ts
+++ b/vscode-extension/test/unit/sessionParser.test.ts
@@ -599,3 +599,154 @@ test('delta-based JSONL: sub-agent items do not contribute to parent model outpu
 	// Sub-agent is tracked separately
 	assert.ok(result.modelUsage['claude-haiku-4.5']);
 });
+
+// ── Mutation-killing tests ──────────────────────────────────────────────
+
+test('delta-based JSONL: kind 1 (update) sets value at key path', () => {
+        const filePath = 'C:/tmp/session.jsonl';
+        const content = [
+                JSON.stringify({ kind: 0, v: { requests: [{ model: 'gpt-4o', message: { text: 'aaa' }, response: [] }] } }),
+                JSON.stringify({ kind: 1, k: ['requests', '0', 'response'], v: [{ value: 'bbb' }] })
+        ].join('\n');
+
+        const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+        assert.equal(result.interactions, 1);
+        assert.ok(result.modelUsage['gpt-4o']);
+        assert.equal(result.modelUsage['gpt-4o'].outputTokens, 3);
+});
+
+test('delta-based JSONL: multiple kind 2 appends accumulate requests', () => {
+        const filePath = 'C:/tmp/session.jsonl';
+        const content = [
+                JSON.stringify({ kind: 0, v: { requests: [] } }),
+                JSON.stringify({
+                        kind: 2,
+                        k: ['requests'],
+                        v: [{ modelId: 'copilot/gpt-4o', message: { text: 'q1' }, response: [{ kind: 'markdownContent', content: { value: 'a1' } }] }]
+                }),
+                JSON.stringify({
+                        kind: 2,
+                        k: ['requests'],
+                        v: [{ modelId: 'copilot/gpt-4o', message: { text: 'q2' }, response: [{ kind: 'markdownContent', content: { value: 'a2' } }] }]
+                })
+        ].join('\n');
+
+        const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+        assert.equal(result.interactions, 2);
+        assert.equal(result.modelUsage['gpt-4o'].inputTokens, 4); // q1(2) + q2(2)
+        assert.equal(result.modelUsage['gpt-4o'].outputTokens, 4); // a1(2) + a2(2)
+});
+
+test('JSON session: normalizes copilot/ prefix in model field', () => {
+        const content = JSON.stringify({
+                requests: [
+                        { model: 'copilot/claude-sonnet-4.5', message: { text: 'hi' }, response: [{ value: 'hello' }] }
+                ]
+        });
+        const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
+        assert.ok(result.modelUsage['claude-sonnet-4.5']);
+        assert.ok(!result.modelUsage['copilot/claude-sonnet-4.5']);
+});
+
+test('JSON session: uses default model when model field is empty string', () => {
+        const content = JSON.stringify({
+                requests: [
+                        { model: '', message: { text: 'hi' }, response: [{ value: 'world' }] }
+                ]
+        });
+        const result = parseSessionFileContent('s.json', content, estimateTokensByLength, () => 'fallback-model');
+        assert.ok(result.modelUsage['fallback-model']);
+});
+
+test('JSON session: uses default model when model field is whitespace', () => {
+        const content = JSON.stringify({
+                requests: [
+                        { model: '   ', message: { text: 'hi' }, response: [{ value: 'world' }] }
+                ]
+        });
+        const result = parseSessionFileContent('s.json', content, estimateTokensByLength, () => 'fallback-model');
+        assert.ok(result.modelUsage['fallback-model']);
+});
+
+test('JSON session: uses default model when model field is not a string', () => {
+        const content = JSON.stringify({
+                requests: [
+                        { model: 42, message: { text: 'hi' }, response: [{ value: 'world' }] }
+                ]
+        });
+        const result = parseSessionFileContent('s.json', content, estimateTokensByLength, () => 'fallback-model');
+        assert.ok(result.modelUsage['fallback-model']);
+});
+
+test('JSON session: empty requests array returns zero stats', () => {
+        const content = JSON.stringify({ requests: [] });
+        const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
+        assert.equal(result.tokens, 0);
+        assert.equal(result.interactions, 0);
+        assert.equal(result.thinkingTokens, 0);
+        assert.deepEqual(result.modelUsage, {});
+});
+
+test('JSON session: request with empty message text and response', () => {
+        const content = JSON.stringify({
+                requests: [
+                        { model: 'gpt-4o', message: { text: '' }, response: [] }
+                ]
+        });
+        const result = parseSessionFileContent('s.json', content, estimateTokensByLength);
+        assert.equal(result.interactions, 1);
+        assert.equal(result.tokens, 0);
+});
+
+test('delta-based JSONL: kind 0 replaces entire state', () => {
+        const filePath = 'C:/tmp/session.jsonl';
+        const content = [
+                JSON.stringify({ kind: 0, v: { requests: [{ modelId: 'copilot/gpt-4o', message: { text: 'old' }, response: [{ kind: 'markdownContent', content: { value: 'old-resp' } }] }] } }),
+                JSON.stringify({ kind: 0, v: { requests: [{ modelId: 'copilot/claude-sonnet-4.5', message: { text: 'new' }, response: [{ kind: 'markdownContent', content: { value: 'new-resp' } }] }] } })
+        ].join('\n');
+
+        const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+        // Second kind:0 replaces state, so only claude-sonnet-4.5 should be present
+        assert.equal(result.interactions, 1);
+        assert.ok(result.modelUsage['claude-sonnet-4.5']);
+        assert.ok(!result.modelUsage['gpt-4o']);
+});
+
+test('delta-based JSONL: ignores deltas with non-object value', () => {
+        const filePath = 'C:/tmp/session.jsonl';
+        const content = [
+                JSON.stringify({ kind: 0, v: { requests: [] } }),
+                'not valid json at all',
+                JSON.stringify({
+                        kind: 2,
+                        k: ['requests'],
+                        v: [{ modelId: 'copilot/gpt-4o', message: { text: 'q' }, response: [{ kind: 'markdownContent', content: { value: 'a' } }] }]
+                })
+        ].join('\n');
+
+        const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+        assert.equal(result.interactions, 1);
+});
+
+test('delta-based JSONL: handles response with both value and content.value', () => {
+        const filePath = 'C:/tmp/session.jsonl';
+        const content = [
+                JSON.stringify({ kind: 0, v: { requests: [] } }),
+                JSON.stringify({
+                        kind: 2,
+                        k: ['requests'],
+                        v: [{
+                                modelId: 'copilot/gpt-4o',
+                                message: { text: 'question' },
+                                response: [
+                                        { kind: 'markdownContent', value: 'should-be-ignored', content: { value: 'preferred' } },
+                                        { kind: 'markdownContent', content: { value: ' answer' } }
+                                ]
+                        }]
+                })
+        ].join('\n');
+
+        const result = parseSessionFileContent(filePath, content, estimateTokensByLength);
+        // Should use content.value (preferred + answer = 16), not value
+        assert.equal(result.modelUsage['gpt-4o'].outputTokens, 'preferred answer'.length);
+});

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -80,3 +80,171 @@ test('extractSubAgentData: handles missing modelName gracefully', () => {
 	assert.equal(data.prompt, 'list files');
 	assert.equal(data.result, 'file.ts');
 });
+
+// ── Mutation-killing tests ──────────────────────────────────────────────
+
+import {
+        estimateTokensFromText,
+        isJsonlContent,
+        isUuidPointerFile,
+        getModelTier,
+        calculateEstimatedCost,
+        getTotalTokensFromModelUsage,
+        getModelFromRequest,
+        createEmptyContextRefs
+} from '../../src/tokenEstimation';
+
+// ── estimateTokensFromText ──────────────────────────────────────────────
+
+test('estimateTokensFromText: returns token count for simple text', () => {
+        const result = estimateTokensFromText('hello world', 'gpt-4');
+        assert.ok(result > 0);
+        assert.equal(typeof result, 'number');
+});
+
+test('estimateTokensFromText: empty text returns 0', () => {
+        assert.equal(estimateTokensFromText('', 'gpt-4'), 0);
+});
+
+test('estimateTokensFromText: uses custom estimator for matching model', () => {
+        const estimators = { 'test-model': 0.5 };
+        const result = estimateTokensFromText('abcdefgh', 'test-model', estimators);
+        // 8 chars * 0.5 = 4 tokens
+        assert.equal(result, 4);
+});
+
+test('estimateTokensFromText: falls back to default ratio for unknown model', () => {
+        const result = estimateTokensFromText('abcd', 'unknown-model', {});
+        // 4 chars * 0.25 default = 1 token
+        assert.equal(result, 1);
+});
+
+// ── isJsonlContent ──────────────────────────────────────────────────────
+
+test('isJsonlContent: returns true for multi-line JSON objects', () => {
+        const content = '{"kind":0,"v":{}}\n{"kind":1,"k":["a"],"v":"b"}\n';
+        assert.equal(isJsonlContent(content), true);
+});
+
+test('isJsonlContent: returns false for single-line JSON', () => {
+        assert.equal(isJsonlContent('{"requests":[]}'), false);
+});
+
+test('isJsonlContent: returns false for single line with newlines only in content', () => {
+        assert.equal(isJsonlContent('single line without newlines'), false);
+});
+
+test('isJsonlContent: returns false for non-JSON multi-line content', () => {
+        assert.equal(isJsonlContent('line one\nline two'), false);
+});
+
+test('isJsonlContent: returns true for JSON objects on each line', () => {
+        const content = '{"a":1}\n{"b":2}';
+        assert.equal(isJsonlContent(content), true);
+});
+
+// ── isUuidPointerFile ───────────────────────────────────────────────────
+
+test('isUuidPointerFile: returns true for valid UUID', () => {
+        assert.equal(isUuidPointerFile('550e8400-e29b-41d4-a716-446655440000'), true);
+});
+
+test('isUuidPointerFile: returns true for uppercase UUID', () => {
+        assert.equal(isUuidPointerFile('550E8400-E29B-41D4-A716-446655440000'), true);
+});
+
+test('isUuidPointerFile: returns true for UUID with whitespace', () => {
+        assert.equal(isUuidPointerFile('  550e8400-e29b-41d4-a716-446655440000  \n'), true);
+});
+
+test('isUuidPointerFile: returns false for non-UUID content', () => {
+        assert.equal(isUuidPointerFile('not a uuid'), false);
+        assert.equal(isUuidPointerFile('{"requests":[]}'), false);
+        assert.equal(isUuidPointerFile(''), false);
+});
+
+// ── getModelTier ────────────────────────────────────────────────────────
+
+test('getModelTier: returns standard for multiplier 0', () => {
+        const pricing = { 'gpt-4o-mini': { inputCostPerMillion: 0.15, outputCostPerMillion: 0.6, multiplier: 0 } };
+        assert.equal(getModelTier('gpt-4o-mini', pricing), 'standard');
+});
+
+test('getModelTier: returns premium for multiplier > 0', () => {
+        const pricing = { 'claude-sonnet-4.5': { inputCostPerMillion: 3, outputCostPerMillion: 15, multiplier: 1 } };
+        assert.equal(getModelTier('claude-sonnet-4.5', pricing), 'premium');
+});
+
+test('getModelTier: returns unknown for model not in pricing', () => {
+        assert.equal(getModelTier('unknown-model', {}), 'unknown');
+});
+
+test('getModelTier: falls back to partial match', () => {
+        const pricing = { 'gpt-4o': { inputCostPerMillion: 2.5, outputCostPerMillion: 10, multiplier: 1 } };
+        assert.equal(getModelTier('gpt-4o-2024-08-06', pricing), 'premium');
+});
+
+// ── calculateEstimatedCost ──────────────────────────────────────────────
+
+test('calculateEstimatedCost: calculates correct cost for known model', () => {
+        const modelUsage = { 'gpt-4o': { inputTokens: 1000, outputTokens: 500 } };
+        const pricing = { 'gpt-4o': { inputCostPerMillion: 2.5, outputCostPerMillion: 10 } };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        // input: 1000/1M * 2.5 = 0.0025, output: 500/1M * 10 = 0.005
+        assert.ok(Math.abs(cost - 0.0075) < 0.0001);
+});
+
+test('calculateEstimatedCost: returns 0 for empty usage', () => {
+        assert.equal(calculateEstimatedCost({}, {}), 0);
+});
+
+test('calculateEstimatedCost: uses fallback pricing for unknown models', () => {
+        const modelUsage = { 'unknown-model': { inputTokens: 1000, outputTokens: 1000 } };
+        const pricing = { 'gpt-4o-mini': { inputCostPerMillion: 0.15, outputCostPerMillion: 0.6 } };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        // Falls back to gpt-4o-mini pricing: input 1000/1M*0.15 + output 1000/1M*0.6 = 0.00075
+        assert.ok(cost > 0);
+        assert.ok(Math.abs(cost - 0.00075) < 0.0001);
+});
+
+// ── getTotalTokensFromModelUsage ────────────────────────────────────────
+
+test('getTotalTokensFromModelUsage: sums input and output across models', () => {
+        const usage = {
+                'gpt-4o': { inputTokens: 100, outputTokens: 200 },
+                'claude-sonnet': { inputTokens: 50, outputTokens: 150 }
+        };
+        assert.equal(getTotalTokensFromModelUsage(usage), 500);
+});
+
+test('getTotalTokensFromModelUsage: returns 0 for empty usage', () => {
+        assert.equal(getTotalTokensFromModelUsage({}), 0);
+});
+
+// ── getModelFromRequest ─────────────────────────────────────────────────
+
+test('getModelFromRequest: extracts modelId with copilot/ prefix', () => {
+        assert.equal(getModelFromRequest({ modelId: 'copilot/gpt-4o' }), 'gpt-4o');
+});
+
+test('getModelFromRequest: extracts modelId without prefix', () => {
+        assert.equal(getModelFromRequest({ modelId: 'claude-sonnet-4.5' }), 'claude-sonnet-4.5');
+});
+
+test('getModelFromRequest: falls back to result.metadata.modelId', () => {
+        const req = { result: { metadata: { modelId: 'copilot/gpt-4o-mini' } } };
+        assert.equal(getModelFromRequest(req), 'gpt-4o-mini');
+});
+
+// ── createEmptyContextRefs ──────────────────────────────────────────────
+
+test('createEmptyContextRefs: returns object with all zero counts', () => {
+        const refs = createEmptyContextRefs();
+        assert.equal(refs.file, 0);
+        assert.equal(refs.selection, 0);
+        assert.equal(refs.codebase, 0);
+        assert.equal(refs.terminal, 0);
+        assert.equal(refs.clipboard, 0);
+        assert.deepEqual(refs.byKind, {});
+        assert.deepEqual(refs.byPath, {});
+});

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -248,3 +248,172 @@ test('createEmptyContextRefs: returns object with all zero counts', () => {
         assert.deepEqual(refs.byKind, {});
         assert.deepEqual(refs.byPath, {});
 });
+// ── Round 2: estimateTokensFromText deeper coverage ─────────────────────
+
+test('estimateTokensFromText: model key match strips hyphen for lookup', () => {
+        // e.g. 'gpt4' should match estimator key 'gpt-4' via replace('-','')
+        const estimators = { 'gpt-4': 0.5 };
+        const result = estimateTokensFromText('abcdefgh', 'gpt4', estimators);
+        assert.equal(result, 4); // 8 * 0.5
+});
+
+test('estimateTokensFromText: uses first matching estimator key and breaks', () => {
+        // Ensure the break fires — only first match used
+        const estimators = { 'claude': 0.5, 'claude-sonnet': 0.1 };
+        const r1 = estimateTokensFromText('abcdefgh', 'claude-sonnet', estimators);
+        const r2 = estimateTokensFromText('abcdefgh', 'other', estimators);
+        assert.equal(r1, 4);   // matches 'claude' first (0.5), not 'claude-sonnet' (0.1)
+        assert.equal(r2, 2);   // no match → default 0.25 → ceil(8*0.25)=2
+});
+
+test('normalizeDisplayModelName: trims whitespace before lowercasing', () => {
+        assert.equal(normalizeDisplayModelName('  Claude  '), 'claude');
+});
+
+test('normalizeDisplayModelName: collapses multiple spaces to single hyphen', () => {
+        // /\s+/g replaces runs of whitespace with a single '-'
+        assert.equal(normalizeDisplayModelName('Claude  Sonnet  4.5'), 'claude-sonnet-4.5');
+});
+
+// ── Round 2: extractSubAgentData deeper coverage ─────────────────────────
+
+test('extractSubAgentData: returns null for non-subagent toolInvocationSerialized', () => {
+        const item = { kind: 'toolInvocationSerialized', toolSpecificData: { kind: 'other' } };
+        assert.equal(extractSubAgentData(item), null);
+});
+
+test('extractSubAgentData: returns null when toolSpecificData is missing', () => {
+        const item = { kind: 'toolInvocationSerialized' };
+        assert.equal(extractSubAgentData(item), null);
+});
+
+test('extractSubAgentData: returns null when toolSpecificData is not an object', () => {
+        const item = { kind: 'toolInvocationSerialized', toolSpecificData: 'string' };
+        assert.equal(extractSubAgentData(item), null);
+});
+
+test('extractSubAgentData: returns null when both prompt and result are empty', () => {
+        const item = {
+                kind: 'toolInvocationSerialized',
+                toolSpecificData: { kind: 'subagent', prompt: '', result: '' }
+        };
+        assert.equal(extractSubAgentData(item), null);
+});
+
+test('extractSubAgentData: returns result when only result is non-empty', () => {
+        const item = {
+                kind: 'toolInvocationSerialized',
+                toolSpecificData: { kind: 'subagent', prompt: '', result: 'done' }
+        };
+        const out = extractSubAgentData(item);
+        assert.ok(out !== null);
+        assert.equal(out!.result, 'done');
+        assert.equal(out!.prompt, '');
+});
+
+test('extractSubAgentData: prompt defaults to empty string when non-string', () => {
+        const item = {
+                kind: 'toolInvocationSerialized',
+                toolSpecificData: { kind: 'subagent', prompt: 42, result: 'answer' }
+        };
+        const out = extractSubAgentData(item);
+        assert.ok(out !== null);
+        assert.equal(out!.prompt, '');
+        assert.equal(out!.result, 'answer');
+});
+
+test('extractSubAgentData: streaming result object with non-numeric keys filtered', () => {
+        const item = {
+                kind: 'toolInvocationSerialized',
+                toolSpecificData: {
+                        kind: 'subagent',
+                        prompt: 'q',
+                        result: { 0: 'H', 1: 'i', foo: 123 }
+                }
+        };
+        const out = extractSubAgentData(item);
+        assert.ok(out !== null);
+        assert.equal(out!.result, 'Hi'); // non-string values map to ''
+});
+
+test('extractSubAgentData: result object with non-string values becomes empty strings', () => {
+        const item = {
+                kind: 'toolInvocationSerialized',
+                toolSpecificData: {
+                        kind: 'subagent',
+                        prompt: 'q',
+                        result: { 0: 'A', 1: null, 2: 'B' }
+                }
+        };
+        const out = extractSubAgentData(item);
+        assert.ok(out !== null);
+        assert.equal(out!.result, 'AB'); // null becomes ''
+});
+
+// ── Round 2: estimateTokensFromJsonlSession ──────────────────────────────
+
+import { estimateTokensFromJsonlSession } from '../../src/tokenEstimation';
+
+test('estimateTokensFromJsonlSession: counts user.message tokens', () => {
+        const content = JSON.stringify({ type: 'user.message', data: { content: 'hello there' } });
+        const result = estimateTokensFromJsonlSession(content);
+        assert.ok(result.tokens > 0);
+});
+
+test('estimateTokensFromJsonlSession: counts assistant.message tokens', () => {
+        const content = JSON.stringify({ type: 'assistant.message', data: { content: 'the answer is yes' } });
+        const result = estimateTokensFromJsonlSession(content);
+        assert.ok(result.tokens > 0);
+});
+
+test('estimateTokensFromJsonlSession: counts tool.result tokens', () => {
+        const content = JSON.stringify({ type: 'tool.result', data: { output: 'tool output data' } });
+        const result = estimateTokensFromJsonlSession(content);
+        assert.ok(result.tokens > 0);
+});
+
+test('estimateTokensFromJsonlSession: uses session.shutdown actual tokens', () => {
+        const events = [
+                JSON.stringify({ type: 'user.message', data: { content: 'hi' } }),
+                JSON.stringify({
+                        type: 'session.shutdown',
+                        data: {
+                                modelMetrics: {
+                                        'gpt-4o': { usage: { inputTokens: 100, outputTokens: 200 } }
+                                }
+                        }
+                })
+        ].join('\n');
+        const result = estimateTokensFromJsonlSession(events);
+        // session.shutdown actual tokens should take precedence
+        assert.equal(result.actualTokens, 300);
+});
+
+test('estimateTokensFromJsonlSession: skips blank lines without crashing', () => {
+        const content = '\n\n' + JSON.stringify({ type: 'user.message', data: { content: 'hi' } }) + '\n\n';
+        const result = estimateTokensFromJsonlSession(content);
+        assert.ok(result.tokens > 0);
+});
+
+test('estimateTokensFromJsonlSession: handles empty string', () => {
+        const result = estimateTokensFromJsonlSession('');
+        assert.equal(result.tokens, 0);
+        assert.equal(result.thinkingTokens, 0);
+        assert.equal(result.actualTokens, 0);
+});
+
+test('estimateTokensFromJsonlSession: session.shutdown handles non-numeric usage fields', () => {
+        const events = [
+                JSON.stringify({
+                        type: 'session.shutdown',
+                        data: {
+                                modelMetrics: {
+                                        'gpt-4o': { usage: { inputTokens: 'bad', outputTokens: 50 } }
+                                }
+                        }
+                })
+        ].join('\n');
+        const result = estimateTokensFromJsonlSession(events);
+        // inputTokens is non-numeric → defaults to 0; outputTokens = 50
+        assert.equal(result.actualTokens, 50);
+});

--- a/vscode-extension/test/unit/utils-errors.test.ts
+++ b/vscode-extension/test/unit/utils-errors.test.ts
@@ -107,3 +107,88 @@ test('redacts secrets from error stack traces', () => {
 	assert.ok(result.includes('[REDACTED]'), 'Stack trace should contain redaction marker');
 	assert.ok(result.includes('Failed to connect'), 'Error message should still be present');
 });
+
+// ── Mutation-killing tests ──────────────────────────────────────────────
+
+test('BackendError sets name property to BackendError', () => {
+        const err = new BackendError('test');
+        assert.equal(err.name, 'BackendError');
+        assert.equal(err.message, 'test');
+});
+
+test('BackendError stores cause', () => {
+        const cause = new Error('root');
+        const err = new BackendError('wrapped', cause);
+        assert.equal(err.cause, cause);
+});
+
+test('safeStringifyError uses message when stack is empty string', () => {
+        const err = new Error('fallback message');
+        err.stack = '';
+        const result = safeStringifyError(err);
+        assert.ok(result.includes('fallback message'));
+});
+
+test('safeStringifyError redacts secrets from non-Error string', () => {
+        const result = safeStringifyError('connection failed at host=secret123', ['secret123']);
+        assert.ok(!result.includes('secret123'), 'Secret should be redacted');
+        assert.ok(result.includes('[REDACTED]'), 'Should contain redaction marker');
+});
+
+test('safeStringifyError redacts secrets from plain object message', () => {
+        const result = safeStringifyError({ message: 'key=mytoken123' } as any, ['mytoken123']);
+        assert.ok(!result.includes('mytoken123'));
+        assert.ok(result.includes('[REDACTED]'));
+});
+
+test('safeStringifyError handles object with error property but no message', () => {
+        const result = safeStringifyError({ error: 'something went wrong' } as any);
+        assert.equal(result, 'something went wrong');
+});
+
+test('isStorageLocalAuthDisallowedByPolicyError returns false for non-object primitives', () => {
+        assert.equal(isStorageLocalAuthDisallowedByPolicyError(undefined), false);
+        assert.equal(isStorageLocalAuthDisallowedByPolicyError(null), false);
+        assert.equal(isStorageLocalAuthDisallowedByPolicyError(42), false);
+        assert.equal(isStorageLocalAuthDisallowedByPolicyError('string'), false);
+});
+
+test('isStorageLocalAuthDisallowedByPolicyError requires both shared key AND policy', () => {
+        // "shared key" alone should NOT match (requires both "shared key" AND "policy")
+        assert.equal(
+                isStorageLocalAuthDisallowedByPolicyError({ message: 'shared key was used for auth' } as any),
+                false
+        );
+        // "policy" alone should NOT match via the shared key+policy branch
+        // but may match via the other branches if it contains the exact phrases
+        assert.equal(
+                isStorageLocalAuthDisallowedByPolicyError({ message: 'policy was applied' } as any),
+                false
+        );
+});
+
+test('isAzurePolicyDisallowedError returns false for undefined and primitive values', () => {
+        assert.equal(isAzurePolicyDisallowedError(undefined), false);
+        assert.equal(isAzurePolicyDisallowedError(42), false);
+        assert.equal(isAzurePolicyDisallowedError('string'), false);
+        assert.equal(isAzurePolicyDisallowedError(true), false);
+});
+
+test('isAzurePolicyDisallowedError returns false when code and message do not match', () => {
+        assert.equal(isAzurePolicyDisallowedError({ code: 'SomethingElse', message: 'unrelated error' } as any), false);
+});
+
+test('redactSecretsInText handles null secretsToRedact gracefully', () => {
+        assert.equal(redactSecretsInText('hello', null as any), 'hello');
+});
+
+test('withErrorHandling preserves the original error as cause', async () => {
+        const original = new Error('original');
+        try {
+                await withErrorHandling(async () => { throw original; }, 'op');
+                assert.fail('Should have thrown');
+        } catch (e: any) {
+                assert.ok(e instanceof BackendError);
+                assert.equal(e.cause, original);
+        }
+});

--- a/vscode-extension/test/unit/utils-html.test.ts
+++ b/vscode-extension/test/unit/utils-html.test.ts
@@ -68,3 +68,25 @@ test('safeJsonForInlineScript: handles null, numbers, arrays', () => {
 	const arr = safeJsonForInlineScript([1, 2]);
 	assert.equal(arr, '[1,2]');
 });
+
+// ── Mutation-killing tests: verify exact replacement strings ────────────
+
+test('safeJsonForInlineScript: replaces > with \\u003e', () => {
+    const result = safeJsonForInlineScript({ gt: '>' });
+    assert.ok(result.includes('\\u003e'), 'should contain \\u003e escape');
+});
+
+test('safeJsonForInlineScript: replaces & with \\u0026', () => {
+    const result = safeJsonForInlineScript({ amp: '&' });
+    assert.ok(result.includes('\\u0026'), 'should contain \\u0026 escape');
+});
+
+test('safeJsonForInlineScript: replaces U+2028 with \\u2028 escape sequence', () => {
+    const result = safeJsonForInlineScript({ sep: 'a\u2028b' });
+    assert.ok(result.includes('\\u2028'), 'should contain \\u2028 escape');
+});
+
+test('safeJsonForInlineScript: replaces U+2029 with \\u2029 escape sequence', () => {
+    const result = safeJsonForInlineScript({ sep: 'a\u2029b' });
+    assert.ok(result.includes('\\u2029'), 'should contain \\u2029 escape');
+});

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -361,3 +361,109 @@ test('detectEditorSource: detects Crush', () => {
 test('detectEditorSource: returns Unknown for unrecognized paths', () => {
         assert.equal(detectEditorSource('/tmp/random/file.json'), 'Unknown');
 });
+// ── Round 2: extractWorkspaceIdFromSessionPath boundary conditions ────────
+
+test('extractWorkspaceIdFromSessionPath: workspaceStorage as last segment returns undefined', () => {
+        // idx+1 >= parts.length case
+        const path = '/home/user/.config/Code/User/workspaceStorage';
+        assert.equal(extractWorkspaceIdFromSessionPath(path), undefined);
+});
+
+test('extractWorkspaceIdFromSessionPath: returns part immediately after workspaceStorage', () => {
+        const path = '/Code/User/workspaceStorage/abc123def/chatSessions/x.json';
+        assert.equal(extractWorkspaceIdFromSessionPath(path), 'abc123def');
+});
+
+test('extractWorkspaceIdFromSessionPath: case-insensitive workspaceStorage match', () => {
+        const path = '/Code/User/WorkspaceStorage/abc123/session.json';
+        assert.equal(extractWorkspaceIdFromSessionPath(path), 'abc123');
+});
+
+// ── Round 2: globToRegExp regex mutation coverage ────────────────────────
+
+test('globToRegExp: /**/ in middle of pattern matches multiple segments', () => {
+        const re = globToRegExp('src/**/test/*.ts');
+        assert.ok(re.test('src/test/foo.ts'));
+        assert.ok(re.test('src/a/b/test/foo.ts'));
+        assert.ok(!re.test('src/test/sub/foo.ts')); // last * shouldn't match /
+});
+
+test('globToRegExp: trailing ** matches any depth', () => {
+        const re = globToRegExp('src/**');
+        assert.ok(re.test('src/file.ts'));
+        assert.ok(re.test('src/a/b/c/file.ts'));
+});
+
+test('globToRegExp: escapes dot in filename', () => {
+        const re = globToRegExp('package.json');
+        assert.ok(re.test('package.json'));
+        assert.ok(!re.test('packageXjson'));  // dot should NOT match any char
+});
+
+test('globToRegExp: case sensitive by default', () => {
+        const re = globToRegExp('*.TS');
+        assert.ok(re.test('file.TS'));
+        assert.ok(!re.test('file.ts'));
+});
+
+test('globToRegExp: non-case-insensitive flag is false by default', () => {
+        const reDefault = globToRegExp('*.ts');
+        const reExplicit = globToRegExp('*.ts', false);
+        assert.equal(reDefault.flags, reExplicit.flags);
+});
+
+// ── Round 2: detectEditorSource ordering and exact string matching ────────
+
+test('detectEditorSource: Cursor is detected before VS Code fallback', () => {
+        // Path contains both "cursor" and "code" — cursor should win
+        const path = '/home/user/.config/Cursor/User/workspaceStorage/abc/session.json';
+        assert.equal(detectEditorSource(path), 'Cursor');
+});
+
+test('detectEditorSource: code-insiders hyphenated variant detected', () => {
+        assert.equal(detectEditorSource('/home/user/.config/Code-Insiders/User/session.json'), 'VS Code Insiders');
+});
+
+test('detectEditorSource: Copilot CLI takes priority over code path', () => {
+        // .copilot/session-state path should return Copilot CLI, not VS Code
+        assert.equal(detectEditorSource('/home/user/.copilot/session-state/session123.json'), 'Copilot CLI');
+});
+
+test('detectEditorSource: Claude Code takes priority over code path', () => {
+        assert.equal(detectEditorSource('/home/user/.claude/projects/abc/session.jsonl'), 'Claude Code');
+});
+
+// ── Round 2: extractCustomAgentName edge cases ────────────────────────────
+
+test('extractCustomAgentName: returns null for non-.agent.md path', () => {
+        const result = extractCustomAgentName('file:///home/user/code/not-an-agent.ts');
+        assert.equal(result, null);
+});
+
+test('extractCustomAgentName: handles path without file:// prefix', () => {
+        const result = extractCustomAgentName('/home/user/.github/agents/my-agent.agent.md');
+        assert.ok(result !== null);
+        assert.equal(result, 'my-agent');
+});
+
+test('extractCustomAgentName: file:/// URI with agent.md returns just the agent name', () => {
+        const result = extractCustomAgentName('file:///home/user/.github/agents/code-review.agent.md');
+        assert.equal(result, 'code-review');
+});
+
+// ── Round 2: getRepoDisplayName edge cases ────────────────────────────────
+
+test('getRepoDisplayName: handles .git suffix in HTTPS URL', () => {
+        const result = getRepoDisplayName('https://github.com/owner/my-repo.git');
+        assert.equal(result, 'owner/my-repo');
+});
+
+test('getRepoDisplayName: handles URL without trailing .git', () => {
+        const result = getRepoDisplayName('https://github.com/owner/repo');
+        assert.equal(result, 'owner/repo');
+});
+
+test('getRepoDisplayName: handles SSH URL with .git', () => {
+        const result = getRepoDisplayName('git@github.com:owner/repo.git');
+        assert.equal(result, 'owner/repo');
+});

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -1,4 +1,4 @@
-﻿import test from 'node:test';
+import test from 'node:test';
 import * as assert from 'node:assert/strict';
 import {
     getModeType,
@@ -232,4 +232,132 @@ test('getEditorNameFromRoot: .continue path returns Continue', () => {
 
 test('getEditorNameFromRoot: opencode path returns OpenCode', () => {
     assert.equal(getEditorNameFromRoot('/home/user/.local/share/opencode'), 'OpenCode');
+});
+// ── Mutation-killing tests ──────────────────────────────────────────────
+
+import {
+        extractWorkspaceIdFromSessionPath,
+        globToRegExp,
+        getEditorTypeFromPath,
+        detectEditorSource
+} from '../../src/workspaceHelpers';
+
+// ── extractWorkspaceIdFromSessionPath ───────────────────────────────────
+
+test('extractWorkspaceIdFromSessionPath: extracts ID after workspaceStorage', () => {
+        const path = '/home/user/.config/Code/User/workspaceStorage/abc123def/chatSessions/session.json';
+        assert.equal(extractWorkspaceIdFromSessionPath(path), 'abc123def');
+});
+
+test('extractWorkspaceIdFromSessionPath: handles Windows paths', () => {
+        const path = 'C:\\Users\\user\\AppData\\Roaming\\Code\\User\\workspaceStorage\\abc123def\\chatSessions\\session.json';
+        assert.equal(extractWorkspaceIdFromSessionPath(path), 'abc123def');
+});
+
+test('extractWorkspaceIdFromSessionPath: returns undefined for non-workspace path', () => {
+        assert.equal(extractWorkspaceIdFromSessionPath('/home/user/.claude/projects/hash/session.jsonl'), undefined);
+});
+
+test('extractWorkspaceIdFromSessionPath: returns undefined for empty string', () => {
+        assert.equal(extractWorkspaceIdFromSessionPath(''), undefined);
+});
+
+// ── globToRegExp ────────────────────────────────────────────────────────
+
+test('globToRegExp: matches simple wildcard', () => {
+        const re = globToRegExp('*.ts');
+        assert.ok(re.test('file.ts'));
+        assert.ok(!re.test('file.js'));
+        assert.ok(!re.test('dir/file.ts')); // * should not match /
+});
+
+test('globToRegExp: matches globstar **', () => {
+        const re = globToRegExp('**/*.ts');
+        assert.ok(re.test('src/file.ts'));
+        assert.ok(re.test('src/deep/nested/file.ts'));
+        assert.ok(!re.test('file.js'));
+});
+
+test('globToRegExp: escapes special regex characters', () => {
+        const re = globToRegExp('file.test.ts');
+        assert.ok(re.test('file.test.ts'));
+        assert.ok(!re.test('fileXtestXts'));
+});
+
+test('globToRegExp: supports case insensitive mode', () => {
+        const re = globToRegExp('*.TS', true);
+        assert.ok(re.test('file.ts'));
+        assert.ok(re.test('file.TS'));
+});
+
+test('globToRegExp: matches question mark as single char', () => {
+        const re = globToRegExp('file?.ts');
+        assert.ok(re.test('file1.ts'));
+        assert.ok(re.test('fileX.ts'));
+        assert.ok(!re.test('file12.ts'));
+});
+
+// ── getEditorTypeFromPath ───────────────────────────────────────────────
+
+test('getEditorTypeFromPath: detects Copilot CLI', () => {
+        assert.equal(getEditorTypeFromPath('/home/user/.copilot/session-state/abc/session.json'), 'Copilot CLI');
+});
+
+test('getEditorTypeFromPath: detects Continue', () => {
+        assert.equal(getEditorTypeFromPath('/home/user/.continue/sessions/session.json'), 'Continue');
+});
+
+test('getEditorTypeFromPath: detects Claude Code', () => {
+        assert.equal(getEditorTypeFromPath('/home/user/.claude/projects/hash/session.jsonl'), 'Claude Code');
+});
+
+test('getEditorTypeFromPath: detects Cursor', () => {
+        assert.equal(getEditorTypeFromPath('/home/user/Cursor/User/workspaceStorage/abc/chatSessions/session.json'), 'Cursor');
+});
+
+test('getEditorTypeFromPath: detects VS Code Insiders', () => {
+        assert.equal(getEditorTypeFromPath('/home/user/Code - Insiders/User/workspaceStorage/abc/session.json'), 'VS Code Insiders');
+});
+
+test('getEditorTypeFromPath: detects OpenCode via callback', () => {
+        const isOpenCode = (p: string) => p.includes('/opencode/');
+        assert.equal(getEditorTypeFromPath('/home/user/.local/share/opencode/session.db#ses_1', isOpenCode), 'OpenCode');
+});
+
+test('getEditorTypeFromPath: returns Unknown for unrecognized paths', () => {
+        assert.equal(getEditorTypeFromPath('/tmp/random/file.json'), 'Unknown');
+});
+
+// ── detectEditorSource ──────────────────────────────────────────────────
+
+test('detectEditorSource: detects Claude Code from path', () => {
+        assert.equal(detectEditorSource('/home/user/.claude/projects/hash/session.jsonl'), 'Claude Code');
+});
+
+test('detectEditorSource: detects VS Code from Code path', () => {
+        assert.equal(detectEditorSource('/home/user/.config/Code/User/workspaceStorage/abc/session.json'), 'VS Code');
+});
+
+test('detectEditorSource: detects Windsurf', () => {
+        assert.equal(detectEditorSource('/home/user/.config/Windsurf/User/workspaceStorage/abc/session.json'), 'Windsurf');
+});
+
+test('detectEditorSource: detects VSCodium', () => {
+        assert.equal(detectEditorSource('/home/user/.config/VSCodium/User/workspaceStorage/abc/session.json'), 'VSCodium');
+});
+
+test('detectEditorSource: detects Visual Studio', () => {
+        assert.equal(detectEditorSource('/project/.vs/solution.sln/copilot-chat/hash/sessions/uuid'), 'Visual Studio');
+});
+
+test('detectEditorSource: detects Claude Desktop Cowork', () => {
+        assert.equal(detectEditorSource('/home/user/.config/local-agent-mode-sessions/session.json'), 'Claude Desktop Cowork');
+});
+
+test('detectEditorSource: detects Crush', () => {
+        assert.equal(detectEditorSource('/home/user/.crush/crush.db#session'), 'Crush');
+});
+
+test('detectEditorSource: returns Unknown for unrecognized paths', () => {
+        assert.equal(detectEditorSource('/tmp/random/file.json'), 'Unknown');
 });


### PR DESCRIPTION
## Why

The Stryker mutation testing baseline (introduced in #602) showed only 29.0% of mutants were being killed -- meaning 1,938 surviving mutants. Many of these revealed real gaps where code paths were exercised but outputs were never verified. This PR adds 89 focused unit tests across two targeted rounds to address those gaps.

## What changed

Only test files were modified. No source code was changed.

**Round 1 (+52 tests)** targeted the most impactful surviving mutants across all 7 mutated files:
- utils-html.test.ts -- exact escape sequence assertions for safeJsonForInlineScript
- utils-errors.test.ts -- BackendError.name, safeStringifyError edge cases, isStorageLocalAuthDisallowedByPolicyError boundary conditions, withErrorHandling cause preservation
- claudecode.test.ts -- non-numeric usage fields, streaming dedup, string content interactions, getProjectPathFromHash, session meta
- sessionParser.test.ts -- delta kind:1 updates, multiple appends, model normalization edge cases
- tokenEstimation.test.ts -- isJsonlContent, isUuidPointerFile, getModelTier, calculateEstimatedCost, getTotalTokensFromModelUsage, getModelFromRequest, createEmptyContextRefs, estimateTokensFromText
- workspaceHelpers.test.ts -- extractWorkspaceIdFromSessionPath, globToRegExp, getEditorTypeFromPath, detectEditorSource

**Round 2 (+37 tests)** went deeper on the two lowest-scoring files:
- tokenEstimation.test.ts -- estimateTokensFromText key matching, normalizeDisplayModelName, extractSubAgentData guards, estimateTokensFromJsonlSession (CLI event types, session.shutdown actual tokens, non-numeric fields, blank lines)
- workspaceHelpers.test.ts -- globToRegExp regex specifics, detectEditorSource ordering, extractCustomAgentName edge cases, getRepoDisplayName .git suffix

## Results (measured locally)

| Metric | Before | After |
|--------|--------|-------|
| Score | 29.0% | **40.07%** |
| Killed | 792 | **1,090** |
| Survived | 1,938 | **1,639** |

By file after round 1:
- html.js: 83%, errors.js: 80%, claudecode.js: 63%, sessionParser.js: 63%
- workspaceHelpers.js: 32%, tokenEstimation.js: 19%

Round 2 adds further coverage to the two lowest-scoring files. The CI run on this branch will show the combined result.

## Test count

768 (baseline) -> 857 passing tests (+89 new, 3 skipped, 0 failures)