### PR TITLE
fix: skip VS filesystem scan on macOS/Linux to prevent extension hang (#611)

### DIFF
--- a/vscode-extension/src/visualstudio.ts
+++ b/vscode-extension/src/visualstudio.ts
@@ -117,8 +117,12 @@ results.push(sessionPath);
  * for `.vs/<solution>/copilot-chat/<hash>/sessions/<uuid>` paths.
  * Scans: user home dir, and common named dev roots (C:\repos, C:\code, etc.).
  * Depth-limited and skips known heavy directories to stay fast.
+ *
+ * Visual Studio only runs on Windows — skip entirely on macOS/Linux to avoid
+ * a deep recursive home-directory walk that causes the extension to hang.
  */
 private _discoverFromFilesystem(seen: Set<string>, results: string[]): void {
+if (os.platform() !== 'win32') { return; }
 const home = os.homedir();
 // Drive letter(s): default to C, also try D if it exists
 const drives = ['C', 'D'];


### PR DESCRIPTION
## Problem

Fixes #611 (related: #493)

On macOS and Linux, the extension was **hanging on startup** from version 0.0.22 onwards. The last log entry before the hang was:

```
[1:19:57 PM] 📁 Crush: found 0 project(s) in projects.json
```

## Root Cause

`VisualStudioDataAccess._discoverFromFilesystem()` performs a recursive filesystem scan of the user's **home directory at depth 7**, looking for `.vs/copilot-chat/sessions/` paths (Visual Studio project directories).

On **macOS and Linux**, Visual Studio doesn't exist — `.vs/` directories are never created. However, the scan still walked through all subdirectories of `~/` synchronously using `readdirSync`, which on a typical developer machine (with many workspaces and deeply nested project trees) caused the extension to appear completely frozen.

## Fix

Add an early-exit guard at the top of `_discoverFromFilesystem()`:

```typescript
if (os.platform() !== 'win32') { return; }
```

Visual Studio is a Windows-only application (Visual Studio for Mac was discontinued). There are no `.vs/` session directories to find on macOS or Linux, so the scan is skipped entirely on those platforms. The log-based discovery path (`_discoverFromLogs`) is unaffected — it already exits early when the `%LOCALAPPDATA%\Temp\VSGitHubCopilotLogs` directory doesn't exist.

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` — 0 errors)
- Extension bundles cleanly (`node esbuild.js`)
- On Windows: behaviour unchanged — full filesystem scan still runs