### PR TITLE
docs: add Windsurf/Open VSX install badges and Windsurf details

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ windsurf --install-extension RobBos.copilot-token-tracker
 ```
 
 <details>
-<summary><img src="https://open-vsx.org/static/img/logo.svg" width="16"> <b>Windsurf (Open VSX)</b></summary>
+<summary><img src="assets/open-vsx-logo.svg" width="16"> <b>Windsurf (Open VSX)</b></summary>
 
 ```bash
 # Install in Windsurf (Open VSX)

--- a/README.md
+++ b/README.md
@@ -21,32 +21,41 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 
 ## Pick your tool
 
-### 🖥️ VS Code Extension
+### 🖥️ VS Code Extension (Chromium)
 
-Real-time token usage in the status bar, fluency score dashboard, usage analysis, cloud sync, and more.
+Real-time token usage in the status bar, fluency score dashboard, usage analysis, cloud sync, and more. Works with all Chromium-based VS Code forks — VS Code, Windsurf, Cursor, VSCodium, Trae, Kiro, Void, and more.
 
 [![Install - VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker) [![Install - Windsurf (Open VSX)](https://img.shields.io/badge/Install-Windsurf-00B4D8?logo=open-vsx)](https://open-vsx.org/extension/RobBos/copilot-token-tracker) [![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/copilot-token-tracker?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/copilot-token-tracker)
 
 ```bash
 # Install from the VS Code Marketplace
 ext install RobBos.copilot-token-tracker
-
-# Install from Open VSX (VSCodium)
-codium --install-extension RobBos.copilot-token-tracker
-
-# Install from Open VSX (Code OSS)
-code --install-extension RobBos.copilot-token-tracker
-
-# Install in Windsurf (Open VSX)
-windsurf --install-extension RobBos.copilot-token-tracker
 ```
 
 <details>
-<summary><img src="assets/open-vsx-logo.svg" width="16"> <b>Windsurf (Open VSX)</b></summary>
+<summary>📦 Install in other Chromium-based editors (Open VSX)</summary>
 
 ```bash
-# Install in Windsurf (Open VSX)
+# VSCodium
+codium --install-extension RobBos.copilot-token-tracker
+
+# Code OSS
+code --install-extension RobBos.copilot-token-tracker
+
+# Windsurf
 windsurf --install-extension RobBos.copilot-token-tracker
+
+# Cursor
+cursor --install-extension RobBos.copilot-token-tracker
+
+# Trae (ByteDance)
+trae --install-extension RobBos.copilot-token-tracker
+
+# Kiro (AWS)
+kiro --install-extension RobBos.copilot-token-tracker
+
+# Void
+void --install-extension RobBos.copilot-token-tracker
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 
 Real-time token usage in the status bar, fluency score dashboard, usage analysis, cloud sync, and more. Works with all Chromium-based VS Code forks — VS Code, Windsurf, Cursor, VSCodium, Trae, Kiro, Void, and more.
 
-[![Install - VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker) [![Install - Windsurf (Open VSX)](https://img.shields.io/badge/Install-Windsurf-00B4D8?logo=open-vsx)](https://open-vsx.org/extension/RobBos/copilot-token-tracker) [![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/copilot-token-tracker?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/copilot-token-tracker)
+[![Install - VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker) [![VS Code installs](https://vsmarketplacebadges.dev/installs-short/RobBos.copilot-token-tracker.svg?label=VS%20Code%20installs)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker) [![Install - Windsurf (Open VSX)](https://img.shields.io/badge/Install-Windsurf-00B4D8?logo=open-vsx)](https://open-vsx.org/extension/RobBos/copilot-token-tracker) [![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/copilot-token-tracker?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/copilot-token-tracker)
 
 ```bash
 # Install from the VS Code Marketplace

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 
 Real-time token usage in the status bar, fluency score dashboard, usage analysis, cloud sync, and more.
 
-[![VS Code installs](https://vsmarketplacebadges.dev/installs-short/RobBos.copilot-token-tracker.svg?label=VS%20Code%20installs)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker)
-
-[![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/copilot-token-tracker?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/copilot-token-tracker)
+[![Install - VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker) [![Install - Windsurf (Open VSX)](https://img.shields.io/badge/Install-Windsurf-00B4D8?logo=open-vsx)](https://open-vsx.org/extension/RobBos/copilot-token-tracker) [![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/copilot-token-tracker?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/copilot-token-tracker)
 
 ```bash
 # Install from the VS Code Marketplace
@@ -38,7 +36,20 @@ codium --install-extension RobBos.copilot-token-tracker
 
 # Install from Open VSX (Code OSS)
 code --install-extension RobBos.copilot-token-tracker
+
+# Install in Windsurf (Open VSX)
+windsurf --install-extension RobBos.copilot-token-tracker
 ```
+
+<details>
+<summary><img src="https://open-vsx.org/static/img/logo.svg" width="16"> <b>Windsurf (Open VSX)</b></summary>
+
+```bash
+# Install in Windsurf (Open VSX)
+windsurf --install-extension RobBos.copilot-token-tracker
+```
+
+</details>
 
 📖 [Full VS Code extension documentation](docs/vscode-extension/README.md)
 

--- a/assets/open-vsx-logo.svg
+++ b/assets/open-vsx-logo.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect rx="10" ry="10" width="64" height="64" fill="#00B4D8"/>
+  <g fill="#ffffff" font-family="Arial, Helvetica, sans-serif" font-weight="700" font-size="30">
+    <text x="32" y="40" text-anchor="middle">VSX</text>
+  </g>
+</svg>


### PR DESCRIPTION
Adds clickable install badges and a collapsible Windsurf (Open VSX) install snippet to the README.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>