### PR TITLE
Add Windsurf integration with accurate token, turn, and cost tracking

### DIFF
--- a/scripts/repo-stats.ps1
+++ b/scripts/repo-stats.ps1
@@ -1,0 +1,201 @@
+<#
+.SYNOPSIS
+    Calculates repository statistics: file counts, lines of code, file sizes, and disk usage.
+
+.DESCRIPTION
+    Scans the repository (excluding common build/dependency directories) and reports:
+    - Total number of tracked files
+    - Number of code files vs documentation files
+    - Lines of actual code (docs excluded)
+    - Average and max code file size in lines
+    - Size on disk (total and code-only)
+
+    Documentation files (markdown, txt, license files) are counted separately from code.
+
+.PARAMETER Path
+    Root path of the repository. Defaults to the parent of the script's directory.
+
+.EXAMPLE
+    ./scripts/repo-stats.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$Path = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Directories to exclude from the scan (build artifacts, deps, VCS internals).
+$excludeDirs = @(
+    'node_modules', 'dist', 'out', 'bin', 'obj', '.git', '.vs', '.vscode-test',
+    'coverage', '.nyc_output', 'packages', '.next', '.turbo', 'TestResults'
+)
+
+# Relative path fragments to exclude (generated/bundled webview output committed to the repo).
+$excludePathFragments = @(
+    'visualstudio-extension/src/CopilotTokenTracker/webview',
+    'visualstudio-extension\src\CopilotTokenTracker\webview'
+)
+
+# File names to exclude (lockfiles etc. that aren't hand-written code).
+$excludeFileNames = @('package-lock.json', 'yarn.lock', 'pnpm-lock.yaml')
+
+# File extensions considered "documentation" (excluded from code stats).
+$docExtensions = @('.md', '.markdown', '.txt', '.rst', '.adoc')
+
+# Files considered documentation by name (no extension or generic names).
+$docFileNames = @('LICENSE', 'NOTICE', 'COPYING', 'AUTHORS', 'CHANGELOG')
+
+# Directories whose contents are always treated as documentation.
+$docDirs = @('docs', 'doc', 'documentation')
+
+# File extensions considered "code" for LOC counting.
+$codeExtensions = @(
+    '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+    '.cs', '.csx', '.vb', '.fs',
+    '.ps1', '.psm1', '.psd1',
+    '.py', '.rb', '.go', '.rs', '.java', '.kt',
+    '.c', '.cpp', '.cc', '.h', '.hpp',
+    '.html', '.css', '.scss', '.less',
+    '.json', '.yaml', '.yml', '.xml',
+    '.sh', '.bash',
+    '.sql'
+)
+
+function Test-ExcludedPath {
+    param([string]$FullPath, [string]$Root)
+    $rel = $FullPath.Substring($Root.Length).TrimStart('\','/')
+    $parts = $rel -split '[\\/]'
+    foreach ($p in $parts) {
+        if ($excludeDirs -contains $p) { return $true }
+    }
+    $relNorm = $rel -replace '\\','/'
+    foreach ($frag in $excludePathFragments) {
+        $fragNorm = $frag -replace '\\','/'
+        if ($relNorm -like "$fragNorm*") { return $true }
+    }
+    return $false
+}
+
+# Detects minified / bundled files by sampling avg line length.
+# Minified JS/CSS typically has very long lines (few line breaks).
+function Test-IsMinified {
+    param([System.IO.FileInfo]$File)
+    if ($File.Name -match '\.min\.(js|css|mjs)$') { return $true }
+    if ($File.Length -lt 10KB) { return $false }
+    $ext = $File.Extension.ToLowerInvariant()
+    if ($ext -notin '.js', '.mjs', '.cjs', '.css') { return $false }
+    try {
+        $content = Get-Content -LiteralPath $File.FullName -Raw -ErrorAction Stop
+        $lineCount = ($content -split "`n").Count
+        if ($lineCount -le 0) { return $false }
+        $avgLineLen = $content.Length / $lineCount
+        return ($avgLineLen -gt 500)
+    } catch {
+        return $false
+    }
+}
+
+function Get-FileCategory {
+    param([System.IO.FileInfo]$File, [string]$Root)
+    $ext = $File.Extension.ToLowerInvariant()
+    $base = $File.BaseName.ToUpperInvariant()
+    $nameUpper = $File.Name.ToUpperInvariant()
+
+    $rel = $File.FullName.Substring($Root.Length).TrimStart('\','/')
+    $firstSeg = ($rel -split '[\\/]')[0].ToLowerInvariant()
+    if ($docDirs -contains $firstSeg) { return 'doc' }
+
+    if ($excludeFileNames -contains $File.Name) { return 'other' }
+    if (Test-IsMinified -File $File) { return 'other' }
+
+    if ($docExtensions -contains $ext) { return 'doc' }
+    if ($docFileNames -contains $base) { return 'doc' }
+    if ($docFileNames -contains $nameUpper) { return 'doc' }
+    if ($codeExtensions -contains $ext) { return 'code' }
+    return 'other'
+}
+
+Write-Host "Scanning: $Path" -ForegroundColor Cyan
+
+$allFiles = Get-ChildItem -Path $Path -Recurse -File -Force |
+    Where-Object { -not (Test-ExcludedPath -FullPath $_.FullName -Root $Path) }
+
+$codeFiles = @()
+$docFiles = @()
+$otherFiles = @()
+
+foreach ($f in $allFiles) {
+    switch (Get-FileCategory -File $f -Root $Path) {
+        'code' { $codeFiles += $f }
+        'doc'  { $docFiles += $f }
+        default { $otherFiles += $f }
+    }
+}
+
+# Count lines of code per file (non-empty lines).
+$codeStats = foreach ($f in $codeFiles) {
+    $lines = 0
+    try {
+        $lines = (Get-Content -LiteralPath $f.FullName -ErrorAction Stop | Measure-Object -Line).Lines
+    } catch {
+        $lines = 0
+    }
+    [PSCustomObject]@{
+        Path  = $f.FullName
+        Lines = $lines
+        Size  = $f.Length
+    }
+}
+
+$totalLoc    = ($codeStats | Measure-Object -Property Lines -Sum).Sum
+$avgLoc      = if ($codeStats.Count -gt 0) { [math]::Round($totalLoc / $codeStats.Count, 1) } else { 0 }
+$maxFile     = $codeStats | Sort-Object Lines -Descending | Select-Object -First 1
+$sizeBytes   = ($allFiles | Measure-Object -Property Length -Sum).Sum
+$codeBytes   = ($codeFiles | Measure-Object -Property Length -Sum).Sum
+
+function Format-Size {
+    param([long]$Bytes)
+    if ($Bytes -ge 1GB) { return "{0:N2} GB" -f ($Bytes / 1GB) }
+    if ($Bytes -ge 1MB) { return "{0:N2} MB" -f ($Bytes / 1MB) }
+    if ($Bytes -ge 1KB) { return "{0:N2} KB" -f ($Bytes / 1KB) }
+    return "$Bytes B"
+}
+
+Write-Host ""
+Write-Host "=== Repository Stats ===" -ForegroundColor Green
+Write-Host ("Root:              {0}" -f $Path)
+Write-Host ("Total files:       {0}" -f $allFiles.Count)
+Write-Host ("  Code files:      {0}" -f $codeFiles.Count)
+Write-Host ("  Doc files:       {0}" -f $docFiles.Count)
+Write-Host ("  Other files:     {0}" -f $otherFiles.Count)
+Write-Host ""
+Write-Host ("Lines of code:     {0:N0}" -f $totalLoc)
+Write-Host ("Avg lines/file:    {0}" -f $avgLoc)
+if ($maxFile) {
+    $relMax = $maxFile.Path.Substring($Path.Length).TrimStart('\','/')
+    Write-Host ("Largest file:      {0} ({1:N0} lines)" -f $relMax, $maxFile.Lines)
+}
+Write-Host ""
+Write-Host ("Size on disk:      {0}" -f (Format-Size $sizeBytes))
+Write-Host ("Code-only size:    {0}" -f (Format-Size $codeBytes))
+Write-Host ""
+Write-Host "Top 5 largest code files by lines:" -ForegroundColor Yellow
+$codeStats | Sort-Object Lines -Descending | Select-Object -First 5 | ForEach-Object {
+    $rel = $_.Path.Substring($Path.Length).TrimStart('\','/')
+    Write-Host ("  {0,6:N0}  {1}" -f $_.Lines, $rel)
+}
+
+# Return an object for scripting scenarios.
+[PSCustomObject]@{
+    TotalFiles    = $allFiles.Count
+    CodeFiles     = $codeFiles.Count
+    DocFiles      = $docFiles.Count
+    OtherFiles    = $otherFiles.Count
+    LinesOfCode   = $totalLoc
+    AvgLinesPerCodeFile = $avgLoc
+    MaxFileLines  = if ($maxFile) { $maxFile.Lines } else { 0 }
+    MaxFilePath   = if ($maxFile) { $maxFile.Path } else { $null }
+    SizeOnDiskBytes = $sizeBytes
+    CodeSizeBytes = $codeBytes
+} | Out-Null

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -80,6 +80,7 @@ Supported editors shown in the chart:
 - `Cursor` — Cursor editor
 - `OpenCode` — Terminal-based coding agent
 - `Crush` — Terminal-based coding agent
+- `Windsurf` — Windsurf editor; session data is only available when the extension runs **inside Windsurf** (via the Windsurf API). See [Known Issues](#known-issues) for details.
 - `Visual Studio` — Visual Studio IDE (2022+); token counts are **estimated** from prompt and response text length
 
 ---
@@ -262,6 +263,7 @@ The extension uses intelligent caching to improve performance:
 
 ## Known Issues
 
+- **Windsurf sessions when running in VS Code**: Windsurf stores its conversation sessions as encrypted binary protobuf (`.pb`) files in `~/.codeium/windsurf/cascade/`. These files are encrypted and contain no extractable text — no chat messages, no model names, no token counts. Session data (turns, tokens, models) is only accessible through the Windsurf internal API, which is only available when the extension runs *inside* Windsurf itself. When running in VS Code with Windsurf installed, Windsurf sessions cannot be shown.
 - Numbers shown use **actual token counts** from the LLM API when available (e.g. Copilot Chat JSONL sessions and OpenCode sessions). When actual token data is not available, the extension falls back to **estimates** computed from text in the session logs.
 - If you use multiple machines (or multiple VS Code profiles/windows), local-only mode will only reflect what's on the current machine. The cloud backend improves cross-device coverage.
 - Premium Requests are not tracked.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -82,6 +82,7 @@ Supported editors shown in the chart:
 - `Crush` — Terminal-based coding agent
 - `Claude Code` — Anthropic CLI/IDE extension (actual API token counts, no estimation)
 - `Gemini CLI` — Google's CLI coding agent (actual token counts from session JSONL)
+- `Windsurf` — Windsurf editor (running sessions discovered via Windsurf integration; file fallback available from local Cascade data)
 - `Visual Studio` — Visual Studio IDE (2022+); token counts are **estimated** from prompt and response text length
 
 ---
@@ -269,6 +270,7 @@ The extension uses intelligent caching to improve performance:
 - Premium Requests are not tracked.
 - Dev Containers: Copilot Chat session logs are written to the host machine's user profile (outside the container). The extension currently does not read from host paths, so token tracking will not work inside a Dev Container. Run VS Code locally (outside the container) or mount the host user data directories into the container at the expected locations.
 - Windows with WSL: The extension can only show information when VS Code, Copilot CLI, and OpenCode run in the same environment as the VS Code host. To track usage properly, either run VS Code from within WSL using the [Remote - WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) (recommended), or run all tools natively on Windows. See the [VS Code WSL documentation](https://code.visualstudio.com/docs/remote/wsl) for setup instructions.
+- Windsurf sessions are surfaced as virtual `windsurf://trajectory/...` entries. Their underlying `.pb` Cascade files are binary protobuf data, so the text log viewer reveals the backing file instead of rendering the session as plain text.
 
 > **⚠️ Warning**
 >

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -134,6 +134,11 @@
         "command": "copilot-token-tracker.signOutGitHub",
         "title": "Disconnect GitHub",
         "category": "AI Engineering Fluency"
+      },
+      {
+        "command": "copilot-token-tracker.checkWindsurfStatus",
+        "title": "Check Windsurf Status",
+        "category": "AI Engineering Fluency"
       }
     ],
     "configuration": {
@@ -293,6 +298,21 @@
           },
           "default": [],
           "description": "List of tool names to suppress from the 'Unknown Tools Found' section in the Usage Analysis dashboard. Useful for tools you are testing that don't yet have friendly display names."
+        },
+        "copilotTokenTracker.windsurf.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Windsurf session tracking when running inside Windsurf editor."
+        },
+        "copilotTokenTracker.windsurf.includeCascadeDetails": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include detailed Cascade trajectory information in Windsurf session analysis."
+        },
+        "copilotTokenTracker.windsurf.cacheCredentials": {
+          "type": "boolean",
+          "default": true,
+          "description": "Cache Windsurf API credentials to reduce authentication overhead. Credentials are automatically invalidated when Windsurf restarts."
         }
       }
     }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -139,6 +139,11 @@
         "command": "aiEngineeringFluency.signOutGitHub",
         "title": "Disconnect GitHub",
         "category": "AI Engineering Fluency"
+      },
+      {
+        "command": "copilot-token-tracker.checkWindsurfStatus",
+        "title": "Check Windsurf Status",
+        "category": "AI Engineering Fluency"
       }
     ],
     "configuration": {
@@ -366,6 +371,21 @@
           },
           "default": [],
           "description": "List of tool names to suppress from the 'Unknown Tools Found' section in the Usage Analysis dashboard. Useful for tools you are testing that don't yet have friendly display names."
+        },
+        "copilotTokenTracker.windsurf.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Windsurf session tracking when running inside Windsurf editor."
+        },
+        "copilotTokenTracker.windsurf.includeCascadeDetails": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include detailed Cascade trajectory information in Windsurf session analysis."
+        },
+        "copilotTokenTracker.windsurf.cacheCredentials": {
+          "type": "boolean",
+          "default": true,
+          "description": "Cache Windsurf API credentials to reduce authentication overhead. Credentials are automatically invalidated when Windsurf restarts."
         }
       }
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -57,6 +57,7 @@ import { VisualStudioDataAccess } from './visualstudio';
 import { ContinueDataAccess } from './continue';
 import { ClaudeCodeDataAccess } from './claudecode';
 import { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
+import { WindsurfDataAccess } from './windsurf';
 import {
   estimateTokensFromText as _estimateTokensFromText,
   estimateTokensFromJsonlSession as _estimateTokensFromJsonlSession,
@@ -186,6 +187,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private continue_: ContinueDataAccess;
 	private claudeCode: ClaudeCodeDataAccess;
 	private claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
+	public windsurf: WindsurfDataAccess;
 	private cacheManager: CacheManager;
 
 	private get usageAnalysisDeps(): UsageAnalysisDeps {
@@ -341,6 +343,26 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 		if (this.crush.isCrushSessionFile(sessionFile)) {
 			return this.crush.statSessionFile(sessionFile);
+		}
+		if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+			// For Windsurf sessions, resolve via API (in Windsurf) or .pb file metadata (in VS Code)
+			const session = await this.windsurf.resolveSession(sessionFile);
+			if (session) {
+				// Get stats from the extension's package.json as a base
+				const baseStats = await fs.promises.stat(__filename);
+				// Modify the properties we need
+				Object.defineProperty(baseStats, 'mtime', {
+					value: new Date(session.modified),
+					writable: false
+				});
+				Object.defineProperty(baseStats, 'size', {
+					value: session.size,
+					writable: false
+				});
+				return baseStats;
+			}
+			// Fallback if session not found - use extension file stats
+			return fs.promises.stat(__filename);
 		}
 		return this.openCode.statSessionFile(sessionFile);
 	}
@@ -853,6 +875,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.visualStudio = new VisualStudioDataAccess();
 		this.claudeCode = new ClaudeCodeDataAccess();
 		this.claudeDesktopCowork = new ClaudeDesktopCoworkDataAccess();
+		this.windsurf = new WindsurfDataAccess(extensionUri);
 		this.cacheManager = new CacheManager(context, { log: (m: string) => this.log(m), warn: (m: string) => this.warn(m), error: (m: string) => this.error(m) }, CopilotTokenTracker.CACHE_VERSION);
 		this.sessionDiscovery = new SessionDiscovery({
 			log: (m) => this.log(m),
@@ -864,6 +887,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			continue_: this.continue_,
 			claudeCode: this.claudeCode,
 			claudeDesktopCowork: this.claudeDesktopCowork,
+			windsurf: this.windsurf,
 			sampleDataDirectoryOverride: () => this.localRegressionSampleDataDir,
 		});
 		this.context = context;
@@ -2588,6 +2612,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return this.claudeCode.countClaudeCodeInteractions(sessionFile);
 			}
 
+			// Handle Windsurf sessions - API-based with interaction count, file-based fallback
+			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+				const session = await this.windsurf.resolveSession(sessionFile);
+				return session?.interactions ?? 0;
+			}
+
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 
 			// Check if this is a UUID-only file (new Copilot CLI format)
@@ -2839,6 +2869,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 				};
 			}
 
+			// Handle Windsurf virtual sessions
+			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+				const session = await this.windsurf.resolveSession(sessionFile);
+				return {
+					title: session?.title,
+					firstInteraction: session?.firstInteraction ?? null,
+					lastInteraction: session?.lastInteraction ?? null,
+				};
+			}
+
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 
 			// Check if this is a UUID-only file (new Copilot CLI format)
@@ -2953,7 +2993,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.crush.isCrushSessionFile(sessionFilePath) ||
 			this.continue_.isContinueSessionFile(sessionFilePath) ||
 			this.claudeDesktopCowork.isCoworkSessionFile(sessionFilePath) ||
-			this.claudeCode.isClaudeCodeSessionFile(sessionFilePath);
+			this.claudeCode.isClaudeCodeSessionFile(sessionFilePath) ||
+			this.windsurf.isWindsurfSessionFile(sessionFilePath);
 		if (!isSpecialSession) {
 			preloadedContent = await fs.promises.readFile(sessionFilePath, 'utf8');
 		}
@@ -3074,6 +3115,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (this.claudeCode.isClaudeCodeSessionFile(sessionFile)) {
 			details.editorRoot = this.claudeCode.getClaudeCodeProjectsDir();
 			details.editorName = 'Claude Code';
+			return;
+		}
+		if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+			details.editorName = 'Windsurf';
 			return;
 		}
 		try {
@@ -3361,6 +3406,21 @@ class CopilotTokenTracker implements vscode.Disposable {
 				details.interactions = this.claudeDesktopCowork.countCoworkInteractions(sessionFile);
 				details.editorRoot = this.claudeDesktopCowork.getCoworkBaseDir();
 				details.editorName = 'Claude Desktop Cowork';
+				await this.updateCacheWithSessionDetails(sessionFile, stat, details);
+				return details;
+			}
+
+			// Handle Windsurf virtual sessions — resolve via API or .pb file metadata
+			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+				const session = await this.windsurf.resolveSession(sessionFile);
+				if (session) {
+					details.title = session.title;
+					details.interactions = session.interactions;
+					details.editorSource = 'windsurf';
+					details.editorName = 'Windsurf';
+					details.firstInteraction = session.firstInteraction ?? stat.mtime.toISOString();
+					details.lastInteraction = session.lastInteraction ?? stat.mtime.toISOString();
+				}
 				await this.updateCacheWithSessionDetails(sessionFile, stat, details);
 				return details;
 			}
@@ -4478,6 +4538,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return { ...result, actualTokens: result.tokens };
 			}
 
+			// Handle Windsurf sessions - API-based with actual token counts, file-based fallback
+			if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
+				const session = await this.windsurf.resolveSession(sessionFilePath);
+				const tokens = session?.tokens ?? 0;
+				return { tokens, thinkingTokens: 0, actualTokens: tokens };
+			}
+
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFilePath, 'utf8');
 
 			// Check if this is a UUID-only file (new Copilot CLI format)
@@ -5199,6 +5266,21 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 	}
 
 	public async showLogViewer(sessionFilePath: string): Promise<void> {
+		// Windsurf sessions are binary protobuf files — cannot show as log viewer
+		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
+			const trajectoryId = sessionFilePath.replace('windsurf://trajectory/', '');
+			const pbPath = path.join(os.homedir(), '.codeium', 'windsurf', 'cascade', `${trajectoryId}.pb`);
+			vscode.window.showInformationMessage(
+				`Windsurf sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
+				'Reveal in Explorer'
+			).then(choice => {
+				if (choice === 'Reveal in Explorer') {
+					vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(pbPath));
+				}
+			});
+			return;
+		}
+
 		// Close existing log viewer panel if open
 		if (this.logViewerPanel) {
 			this.logViewerPanel.dispose();
@@ -5371,6 +5453,21 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 	 * Does not modify the original file.
 	 */
 	public async showFormattedJsonlFile(sessionFilePath: string): Promise<void> {
+		// Windsurf sessions are binary protobuf files — open the real .pb file in the OS
+		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
+			const trajectoryId = sessionFilePath.replace('windsurf://trajectory/', '');
+			const pbPath = path.join(os.homedir(), '.codeium', 'windsurf', 'cascade', `${trajectoryId}.pb`);
+			vscode.window.showInformationMessage(
+				`Windsurf sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
+				'Reveal in Explorer'
+			).then(choice => {
+				if (choice === 'Reveal in Explorer') {
+					vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(pbPath));
+				}
+			});
+			return;
+		}
+
 		try {
 			// Read the file content
 			const fileContent = await fs.promises.readFile(sessionFilePath, 'utf-8');
@@ -8546,15 +8643,65 @@ export function activate(context: vscode.ExtensionContext) {
     },
   );
 
-  // Register the GitHub sign out command
-  const signOutGitHubCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.signOutGitHub",
+  
+  // Register the Windsurf diagnostics command
+  const windsurfDiagnosticsCommand = vscode.commands.registerCommand(
+    "copilot-token-tracker.windsurfDiagnostics",
     async () => {
-      tokenTracker.log("GitHub sign out command called");
-      await tokenTracker.signOutFromGitHub();
+      tokenTracker.log("Windsurf diagnostics command called");
+      try {
+        const diagnostics = await tokenTracker.windsurf.runDiagnostics();
+        
+        // Create a new document to show the diagnostics
+        const doc = await vscode.workspace.openTextDocument({
+          content: `# Windsurf Diagnostics Report
+
+Generated: ${new Date().toISOString()}
+
+## Environment
+- Running in Windsurf: ${diagnostics.environment.isRunningInWindsurf}
+- App Name: ${diagnostics.environment.appName}
+
+## Extension Status
+- Extension Found: ${diagnostics.extension.found}
+- Extension Active: ${diagnostics.extension.active}
+- Extension Version: ${diagnostics.extension.packageJSON}
+
+## Credentials
+- Available: ${diagnostics.credentials.available}
+- Port: ${diagnostics.credentials.port}
+- CSRF Token Length: ${diagnostics.credentials.csrfLength}
+
+## API Connectivity Test
+- Success: ${diagnostics.apiTest.success}
+- Status Code: ${diagnostics.apiTest.statusCode}
+- Error: ${diagnostics.apiTest.error || 'None'}
+
+## Configuration
+- Windsurf Integration Enabled: ${diagnostics.configuration.enabled}
+
+## Sessions
+- Available: ${diagnostics.sessions.available}
+- Count: ${diagnostics.sessions.count}
+- Error: ${diagnostics.sessions.error || 'None'}
+
+## Recommendations
+
+${!diagnostics.extension.found ? '- Install the Windsurf extension\n' : ''}
+${!diagnostics.extension.active ? '- Activate the Windsurf extension or restart Windsurf\n' : ''}
+${!diagnostics.credentials.available ? '- Check if Windsurf language server is running\n' : ''}
+${!diagnostics.apiTest.success ? `- API connectivity issue: ${diagnostics.apiTest.error}\n` : ''}
+${diagnostics.sessions.count === 0 && diagnostics.apiTest.success ? '- Windsurf is working correctly, but no chat sessions have been created yet. Try starting a chat session in Windsurf and then refresh the token tracker.\n' : ''}
+`,
+          language: 'markdown'
+        });
+        
+        await vscode.window.showTextDocument(doc);
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to run Windsurf diagnostics: ${error instanceof Error ? error.message : String(error)}`);
+      }
     },
   );
-
   // Add to subscriptions for proper cleanup
   context.subscriptions.push(
     refreshCommand,
@@ -8569,11 +8716,12 @@ export function activate(context: vscode.ExtensionContext) {
     generateDiagnosticReportCommand,
     clearCacheCommand,
     authenticateGitHubCommand,
-    signOutGitHubCommand,
-    tokenTracker,
+    windsurfDiagnosticsCommand,
+    tokenTracker
   );
-
+  
   tokenTracker.log("Extension activation complete");
+
 }
 
 export function deactivate() {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -66,6 +66,7 @@ import type { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
 import type { MistralVibeDataAccess } from './mistralvibe';
 import type { GeminiCliDataAccess } from './geminicli';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
+import { WindsurfDataAccess } from './windsurf';
 import { getEcosystemDisplayName } from './ecosystemAdapter';
 import { buildAdapterRegistry, createDataAccessInstances } from './adapters';
 import { CopilotAppDataAccess } from './copilotAppData';
@@ -289,6 +290,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private claudeDesktopCowork!: ClaudeDesktopCoworkDataAccess;
 	private mistralVibe!: MistralVibeDataAccess;
 	private geminiCli!: GeminiCliDataAccess;
+	public windsurf!: WindsurfDataAccess;
 	private ecosystems!: IEcosystemAdapter[];
 	private cacheManager!: CacheManager;
 	private readonly copilotAppData = new CopilotAppDataAccess();
@@ -470,6 +472,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 	public async statSessionFile(sessionFile: string): Promise<import('fs').Stats> {
 		const eco = this.findEcosystem(sessionFile);
 		if (eco) { return eco.stat(sessionFile); }
+		if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+			const session = await this.windsurf.resolveSession(sessionFile);
+			if (session) {
+				const baseStats = await fs.promises.stat(__filename);
+				Object.defineProperty(baseStats, 'mtime', { value: new Date(session.modified), writable: false });
+				Object.defineProperty(baseStats, 'size', { value: session.size, writable: false });
+				return baseStats;
+			}
+			return fs.promises.stat(__filename);
+		}
 		return fs.promises.stat(sessionFile);
 	}
 
@@ -914,6 +926,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.claudeDesktopCowork = dataAccess.claudeDesktopCowork;
 		this.mistralVibe = dataAccess.mistralVibe;
 		this.geminiCli = dataAccess.geminiCli;
+		this.windsurf = new WindsurfDataAccess(extensionUri);
 		this.ecosystems = buildAdapterRegistry({
 			...dataAccess,
 			estimateTokens: (t, m) => this.estimateTokensFromText(t, m),
@@ -926,6 +939,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			warn: (m) => this.warn(m),
 			error: (m, e) => this.error(m, e),
 			ecosystems: this.ecosystems,
+			windsurf: this.windsurf,
 			sampleDataDirectoryOverride: () => this.localRegressionSampleDataDir,
 		});
 	}
@@ -3047,6 +3061,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const eco = this.findEcosystem(sessionFile);
 			if (eco) { return eco.countInteractions(sessionFile); }
 
+			// Handle Windsurf sessions - API-based with interaction count, file-based fallback
+			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+				const session = await this.windsurf.resolveSession(sessionFile);
+				return session?.interactions ?? 0;
+			}
+
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 			if (this.isUuidPointerFile(fileContent)) { return 0; }
 
@@ -3176,6 +3196,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (eco) {
 				const meta = await eco.getMeta(sessionFile);
 				return { ...meta, dailyInteractions: {} };
+			}
+
+			// Handle Windsurf virtual sessions
+			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+				const session = await this.windsurf.resolveSession(sessionFile);
+				return {
+					title: session?.title,
+					firstInteraction: session?.firstInteraction ?? null,
+					lastInteraction: session?.lastInteraction ?? null,
+					dailyInteractions: {},
+				};
 			}
 
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
@@ -3565,6 +3596,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 			details.editorName = getEcosystemDisplayName(eco, sessionFile);
 			return;
 		}
+		if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+			details.editorName = 'Windsurf';
+			return;
+		}
 		try {
 			const parts = sessionFile.split(/[/\\]/);
 			const userIdx = parts.findIndex(p => p.toLowerCase() === 'user');
@@ -3738,6 +3773,21 @@ class CopilotTokenTracker implements vscode.Disposable {
 		try {
 			const eco = this.findEcosystem(sessionFile);
 			if (eco) { return this.processEcosystemSessionDetails(eco, sessionFile, stat, details); }
+
+			// Handle Windsurf virtual sessions — resolve via API or .pb file metadata
+			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
+				const session = await this.windsurf.resolveSession(sessionFile);
+				if (session) {
+					details.title = session.title;
+					details.interactions = session.interactions;
+					details.editorSource = 'windsurf';
+					details.editorName = 'Windsurf';
+					details.firstInteraction = session.firstInteraction ?? stat.mtime.toISOString();
+					details.lastInteraction = session.lastInteraction ?? stat.mtime.toISOString();
+				}
+				await this.updateCacheWithSessionDetails(sessionFile, stat, details);
+				return details;
+			}
 
 			const fileContent = await fs.promises.readFile(sessionFile, 'utf8');
 			if (this.isUuidPointerFile(fileContent)) {
@@ -4367,6 +4417,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		try {
 			const eco = this.findEcosystem(sessionFilePath);
 			if (eco) { return eco.getTokens(sessionFilePath); }
+			if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
+				const session = await this.windsurf.resolveSession(sessionFilePath);
+				const tokens = session?.tokens ?? 0;
+				return { tokens, thinkingTokens: 0, actualTokens: tokens };
+			}
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFilePath, 'utf8');
 			if (this.isUuidPointerFile(fileContent)) { return { tokens: 0, thinkingTokens: 0, actualTokens: 0 }; }
 			if (sessionFilePath.endsWith('.jsonl') || this.isJsonlContent(fileContent)) {
@@ -5103,6 +5158,19 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 	}
 
 	public async showLogViewer(sessionFilePath: string): Promise<void> {
+		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
+			const trajectoryId = sessionFilePath.replace('windsurf://trajectory/', '');
+			const pbPath = path.join(os.homedir(), '.codeium', 'windsurf', 'cascade', `${trajectoryId}.pb`);
+			vscode.window.showInformationMessage(
+				`Windsurf sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
+				'Reveal in Explorer'
+			).then(choice => {
+				if (choice === 'Reveal in Explorer') {
+					vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(pbPath));
+				}
+			});
+			return;
+		}
 		if (this.logViewerPanel) { this.logViewerPanel.dispose(); this.logViewerPanel = undefined; }
 		const logData = await this.getSessionLogData(sessionFilePath);
 		this.logViewerPanel = vscode.window.createWebviewPanel(
@@ -5208,6 +5276,21 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 	 * Does not modify the original file.
 	 */
 	public async showFormattedJsonlFile(sessionFilePath: string): Promise<void> {
+		// Windsurf sessions are binary protobuf files — open the real .pb file in the OS
+		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
+			const trajectoryId = sessionFilePath.replace('windsurf://trajectory/', '');
+			const pbPath = path.join(os.homedir(), '.codeium', 'windsurf', 'cascade', `${trajectoryId}.pb`);
+			vscode.window.showInformationMessage(
+				`Windsurf sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
+				'Reveal in Explorer'
+			).then(choice => {
+				if (choice === 'Reveal in Explorer') {
+					vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(pbPath));
+				}
+			});
+			return;
+		}
+
 		try {
 			// Read the file content
 			const fileContent = await fs.promises.readFile(sessionFilePath, 'utf-8');
@@ -7869,12 +7952,68 @@ function registerDiagnosticAndAuthCommands(context: vscode.ExtensionContext, tok
     },
   );
 
-  // Register the GitHub sign out command
   const signOutGitHubCommand = vscode.commands.registerCommand(
     "aiEngineeringFluency.signOutGitHub",
     async () => {
       tokenTracker.log("GitHub sign out command called");
       await tokenTracker.signOutFromGitHub();
+    },
+  );
+
+  const windsurfDiagnosticsCommand = vscode.commands.registerCommand(
+    "copilot-token-tracker.checkWindsurfStatus",
+    async () => {
+      tokenTracker.log("Windsurf diagnostics command called");
+      try {
+        const diagnostics = await tokenTracker.windsurf.runDiagnostics();
+
+        const doc = await vscode.workspace.openTextDocument({
+          content: `# Windsurf Diagnostics Report
+
+Generated: ${new Date().toISOString()}
+
+## Environment
+- Running in Windsurf: ${diagnostics.environment.isRunningInWindsurf}
+- App Name: ${diagnostics.environment.appName}
+
+## Extension Status
+- Extension Found: ${diagnostics.extension.found}
+- Extension Active: ${diagnostics.extension.active}
+- Extension Version: ${diagnostics.extension.packageJSON}
+
+## Credentials
+- Available: ${diagnostics.credentials.available}
+- Port: ${diagnostics.credentials.port}
+- CSRF Token Length: ${diagnostics.credentials.csrfLength}
+
+## API Connectivity Test
+- Success: ${diagnostics.apiTest.success}
+- Status Code: ${diagnostics.apiTest.statusCode}
+- Error: ${diagnostics.apiTest.error || 'None'}
+
+## Configuration
+- Windsurf Integration Enabled: ${diagnostics.configuration.enabled}
+
+## Sessions
+- Available: ${diagnostics.sessions.available}
+- Count: ${diagnostics.sessions.count}
+- Error: ${diagnostics.sessions.error || 'None'}
+
+## Recommendations
+
+${!diagnostics.extension.found ? '- Install the Windsurf extension\n' : ''}
+${!diagnostics.extension.active ? '- Activate the Windsurf extension or restart Windsurf\n' : ''}
+${!diagnostics.credentials.available ? '- Check if Windsurf language server is running\n' : ''}
+${!diagnostics.apiTest.success ? `- API connectivity issue: ${diagnostics.apiTest.error}\n` : ''}
+${diagnostics.sessions.count === 0 && diagnostics.apiTest.success ? '- Windsurf is working correctly, but no chat sessions have been created yet. Try starting a chat session in Windsurf and then refresh the token tracker.\n' : ''}
+`,
+          language: 'markdown'
+        });
+
+        await vscode.window.showTextDocument(doc);
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to run Windsurf diagnostics: ${error instanceof Error ? error.message : String(error)}`);
+      }
     },
   );
 
@@ -7885,6 +8024,7 @@ function registerDiagnosticAndAuthCommands(context: vscode.ExtensionContext, tok
     clearCacheCommand,
     authenticateGitHubCommand,
     signOutGitHubCommand,
+    windsurfDiagnosticsCommand,
   );
 }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3367,9 +3367,40 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const debugLogTokens = await this.readTokensFromDebugLog(sessionFilePath);
 		const { resolvedActualTokens, finalCacheReadTokens, resolvedModelUsage } = this.resolveAndApplyDebugLog(tokenResult, debugLogTokens, modelUsage, dailyRollups, totalInteractions);
 
+		await this.applyWindsurfBreakdown(sessionFilePath, resolvedModelUsage, dailyRollups, usageAnalysis);
+
 		const sessionData = this.buildSessionDataObject(tokenResult, interactions, resolvedModelUsage, mtime, fileSize, usageAnalysis, sessionMeta, resolvedActualTokens, finalCacheReadTokens, debugLogTokens, dailyRollups);
 		this.setCachedSessionData(sessionFilePath, sessionData, fileSize);
 		return sessionData;
+	}
+
+	/**
+	 * Windsurf sessions are discovered via the gRPC API (not a re-parseable file), so the
+	 * data layer pre-builds a ModelUsage map and tool-call breakdown. Fold those into the
+	 * resolved model usage / daily rollups / analysis so Today's Sessions shows real
+	 * input/output/cached tokens, models and cost instead of zeros.
+	 */
+	private async applyWindsurfBreakdown(
+		sessionFilePath: string,
+		resolvedModelUsage: ModelUsage,
+		dailyRollups: { [utcDayKey: string]: DailyRollupEntry },
+		usageAnalysis: SessionUsageAnalysis
+	): Promise<void> {
+		if (!this.windsurf.isWindsurfSessionFile(sessionFilePath)) { return; }
+		const session = await this.windsurf.resolveSession(sessionFilePath);
+		if (!session) { return; }
+		if (session.modelUsage && Object.keys(session.modelUsage).length > 0) {
+			for (const [model, usage] of Object.entries(session.modelUsage)) {
+				resolvedModelUsage[model] = { ...usage };
+			}
+			// Windsurf has a single activity day; mirror the model usage onto its rollup
+			// so per-day model/cost aggregation matches the session totals.
+			for (const day of Object.keys(dailyRollups)) {
+				dailyRollups[day].modelUsage = session.modelUsage;
+				if (session.cachedTokens) { dailyRollups[day].cachedReadTokens = session.cachedTokens; }
+			}
+		}
+		if (session.toolCalls) { usageAnalysis.toolCalls = session.toolCalls; }
 	}
 
 	private async preloadSessionFileContent(sessionFilePath: string): Promise<{ preloadedContent: string | undefined; preloadedParsedJson: any | undefined }> {
@@ -4435,7 +4466,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
 				const session = await this.windsurf.resolveSession(sessionFilePath);
 				const tokens = session?.tokens ?? 0;
-				return { tokens, thinkingTokens: 0, actualTokens: tokens };
+				return { tokens, thinkingTokens: 0, actualTokens: tokens, cacheReadTokens: session?.cachedTokens };
 			}
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFilePath, 'utf8');
 			if (this.isUuidPointerFile(fileContent)) { return { tokens: 0, thinkingTokens: 0, actualTokens: 0 }; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -926,7 +926,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.claudeDesktopCowork = dataAccess.claudeDesktopCowork;
 		this.mistralVibe = dataAccess.mistralVibe;
 		this.geminiCli = dataAccess.geminiCli;
-		this.windsurf = new WindsurfDataAccess(extensionUri);
+		this.windsurf = new WindsurfDataAccess(extensionUri, (m) => this.log(m));
 		this.ecosystems = buildAdapterRegistry({
 			...dataAccess,
 			estimateTokens: (t, m) => this.estimateTokensFromText(t, m),
@@ -3201,11 +3201,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 			// Handle Windsurf virtual sessions
 			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
 				const session = await this.windsurf.resolveSession(sessionFile);
+				const lastInteraction = session?.lastInteraction ?? null;
+				// Windsurf's API gives no per-day breakdown, so attribute the session's
+				// activity to its last-activity day. Without this, computeDailyRollups
+				// falls back to firstInteraction (the trajectory's createdTime, which can
+				// be months old for a long-lived session) and computeLastActivityKey then
+				// buckets the session by creation date instead of recent activity.
+				const dailyInteractions: { [utcDayKey: string]: number } = {};
+				if (lastInteraction) {
+					const d = new Date(lastInteraction);
+					if (!isNaN(d.getTime())) {
+						dailyInteractions[d.toISOString().slice(0, 10)] = Math.max(1, session?.interactions ?? 1);
+					}
+				}
 				return {
 					title: session?.title,
 					firstInteraction: session?.firstInteraction ?? null,
-					lastInteraction: session?.lastInteraction ?? null,
-					dailyInteractions: {},
+					lastInteraction,
+					dailyInteractions,
 				};
 			}
 
@@ -3362,6 +3375,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private async preloadSessionFileContent(sessionFilePath: string): Promise<{ preloadedContent: string | undefined; preloadedParsedJson: any | undefined }> {
 		const isSpecialSession = this.findEcosystem(sessionFilePath) !== null;
 		if (isSpecialSession) { return { preloadedContent: undefined, preloadedParsedJson: undefined }; }
+		// Windsurf sessions use virtual paths (windsurf://trajectory/...) — no file to read
+		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) { return { preloadedContent: undefined, preloadedParsedJson: undefined }; }
 		const preloadedContent = await fs.promises.readFile(sessionFilePath, 'utf8');
 		let preloadedParsedJson: any | undefined;
 		const isPlainJson = !sessionFilePath.endsWith('.jsonl') && !_isJsonlContent(preloadedContent) && !_isUuidPointerFile(preloadedContent);

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -11,6 +11,8 @@ import type { ContinueDataAccess } from './continue';
 import type { VisualStudioDataAccess } from "./visualstudio";
 import type { ClaudeCodeDataAccess } from './claudecode';
 import type { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
+import type { WindsurfDataAccess } from './windsurf';
+import type { SessionFileDetails } from './types';
 
 export interface SessionDiscoveryDeps {
 	log: (message: string) => void;
@@ -22,6 +24,7 @@ export interface SessionDiscoveryDeps {
 	visualStudio: VisualStudioDataAccess;
 	claudeCode: ClaudeCodeDataAccess;
 	claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
+	windsurf: WindsurfDataAccess;
 	sampleDataDirectoryOverride?: () => string | undefined;
 }
 
@@ -200,6 +203,13 @@ export class SessionDiscovery {
 			try { coworkExists = fs.existsSync(coworkBaseDir); } catch { /* ignore */ }
 			candidates.push({ path: coworkBaseDir, exists: coworkExists, source: 'Claude Desktop (Cowork)' });
 		}
+
+		// Windsurf (file-based when in VS Code, API-based when in Windsurf)
+		const windsurfInstalled = this.deps.windsurf.isWindsurfInstalled();
+		const windsurfPath = windsurfInstalled
+			? this.deps.windsurf.getCascadeDir()
+			: 'Not installed (~/.codeium/windsurf/cascade)';
+		candidates.push({ path: windsurfPath, exists: windsurfInstalled, source: 'Windsurf' });
 
 		return candidates;
 	}
@@ -522,6 +532,52 @@ export class SessionDiscovery {
 				}
 			} catch (coworkError) {
 				this.deps.warn(`Could not read Claude Desktop Cowork session files: ${coworkError}`);
+			}
+
+			// Check for Windsurf sessions (API-based when in Windsurf, file-based otherwise)
+			try {
+				if (this.deps.windsurf.isRunningInWindsurf()) {
+					this.deps.log('Windsurf detected - fetching sessions via API...');
+					let windsurfSessions: SessionFileDetails[] = [];
+					try {
+						windsurfSessions = await (this.deps.windsurf as any).getWindsurfSessionsV2();
+						this.deps.log(`Windsurf API returned ${windsurfSessions.length} sessions`);
+					} catch (sessionError) {
+						this.deps.error(`Exception in getWindsurfSessionsV2(): ${sessionError instanceof Error ? sessionError.message : String(sessionError)}`, sessionError);
+					}
+					if (windsurfSessions.length > 0) {
+						this.deps.log(`Found ${windsurfSessions.length} session(s) in Windsurf`);
+						sessionFiles.push(...windsurfSessions.map(s => s.file));
+					} else {
+						this.deps.log('No Windsurf sessions found via API - running diagnostics...');
+						const diagnostics = await this.deps.windsurf.runDiagnostics();
+						this.deps.log(`Windsurf diagnostics: ${JSON.stringify(diagnostics, null, 2)}`);
+						if (!diagnostics.extension.found) {
+							this.deps.warn('Windsurf extension not found - make sure Windsurf is installed and active');
+						} else if (!diagnostics.extension.active) {
+							this.deps.warn('Windsurf extension found but not active - try restarting Windsurf');
+						} else if (!diagnostics.credentials.available) {
+							this.deps.warn('Windsurf credentials not available - this could indicate a connection issue');
+						} else if (!diagnostics.apiTest.success) {
+							this.deps.warn(`Windsurf API test failed: ${diagnostics.apiTest.error}`);
+						} else if (diagnostics.sessions.count === 0) {
+							this.deps.log('Windsurf is working correctly, but no chat sessions have been created yet');
+						}
+					}
+				} else if (this.deps.windsurf.isWindsurfInstalled()) {
+					this.deps.log('Windsurf installed (not active editor) - discovering sessions from local files...');
+					const fileSessions = await this.deps.windsurf.getWindsurfCascadeSessionFiles();
+					if (fileSessions.length > 0) {
+						this.deps.log(`Found ${fileSessions.length} Windsurf session file(s) in ~/.codeium/windsurf/cascade`);
+						sessionFiles.push(...fileSessions.map(s => s.file));
+					} else {
+						this.deps.log('No Windsurf cascade session files found in ~/.codeium/windsurf/cascade');
+					}
+				} else {
+					this.deps.log('Windsurf not detected - skipping Windsurf session discovery');
+				}
+			} catch (windsurfError) {
+				this.deps.warn(`Could not read Windsurf sessions: ${windsurfError}`);
 			}
 
 			// Log summary

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -24,12 +24,14 @@ import * as path from 'path';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { isDiscoverable } from './ecosystemAdapter';
 import { normalizePathForDedup } from './workspaceHelpers';
+import type { WindsurfDataAccess } from './windsurf';
 
 export interface SessionDiscoveryDeps {
 	log: (message: string) => void;
 	warn: (message: string) => void;
 	error: (message: string, error?: any) => void;
 	ecosystems: IEcosystemAdapter[];
+	windsurf?: WindsurfDataAccess;
 	sampleDataDirectoryOverride?: () => string | undefined;
 }
 
@@ -101,6 +103,15 @@ export class SessionDiscovery {
 					candidates.push({ path: cp.path, exists, source: cp.source });
 				}
 			} catch { /* ignore individual adapter errors */ }
+		}
+
+		if (this.deps.windsurf) {
+			const cascadeDir = this.deps.windsurf.getCascadeDir();
+			candidates.push({
+				path: cascadeDir,
+				exists: this.pathExistsWithLogging(cascadeDir, 'Windsurf Cascade'),
+				source: 'Windsurf Cascade',
+			});
 		}
 
 		return candidates;
@@ -182,6 +193,24 @@ export class SessionDiscovery {
 				seen.add(key); batch.push(f);
 			}
 			if (batch.length > 0) { allDeduped.push(...batch); if (onBatch) { onBatch(batch); } }
+		}
+		if (this.deps.windsurf) {
+			try {
+				const windsurfFiles = (await this.deps.windsurf.getWindsurfSessions()).map(session => session.file);
+				const batch = windsurfFiles.filter(f => {
+					const key = normalizePathForDedup(f);
+					if (seen.has(key)) { return false; }
+					seen.add(key);
+					return true;
+				});
+				if (batch.length > 0) {
+					allDeduped.push(...batch);
+					if (onBatch) { onBatch(batch); }
+				}
+			} catch (error) {
+				this.deps.warn(`Could not discover Windsurf sessions: ${error}`);
+				this._lastDiscoveryHadError = true;
+			}
 		}
 		const dupCount = results.reduce((n, r) => n + (r.status === 'fulfilled' ? r.value.sessionFiles.length : 0), 0) - allDeduped.length;
 		if (dupCount > 0) { this.deps.log(`🧹 Deduplicated ${dupCount} duplicate session path(s)`); }

--- a/vscode-extension/src/toolNames.json
+++ b/vscode-extension/src/toolNames.json
@@ -1,5 +1,12 @@
 {
   "unknown": "Unknown"
+  ,"windsurf_cascade": "Windsurf Cascade"
+  ,"windsurf_file_edit": "Windsurf: File Edit"
+  ,"windsurf_file_create": "Windsurf: File Create"
+  ,"windsurf_file_read": "Windsurf: File Read"
+  ,"windsurf_terminal": "Windsurf: Terminal"
+  ,"windsurf_search": "Windsurf: Search"
+  ,"windsurf_browser": "Windsurf: Browser"
   ,"run_in_terminal": "Run In Terminal"
   ,"run_build": "Run Build"
   ,"run_command_in_terminal": "Run Command In Terminal"

--- a/vscode-extension/src/toolNames.json
+++ b/vscode-extension/src/toolNames.json
@@ -1,5 +1,12 @@
 {
   "unknown": "Unknown"
+  ,"windsurf_cascade": "Windsurf Cascade"
+  ,"windsurf_file_edit": "Windsurf: File Edit"
+  ,"windsurf_file_create": "Windsurf: File Create"
+  ,"windsurf_file_read": "Windsurf: File Read"
+  ,"windsurf_terminal": "Windsurf: Terminal"
+  ,"windsurf_search": "Windsurf: Search"
+  ,"windsurf_browser": "Windsurf: Browser"
   ,"run_in_terminal": "Run In Terminal"
   ,"run_shell_command": "Run Shell Command"
   ,"send_to_terminal": "Send To Terminal"

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -480,6 +480,12 @@ export interface SessionFileDetails {
    * children fall outside the loaded 14-day diagnostic window.
    */
   totalChildCount?: number;
+  // Windsurf-only: pre-built token/model/tool breakdown derived from the
+  // trajectory steps (the gRPC API gives no per-day file we can re-parse later,
+  // so the data layer maps it into the extension's standard shapes up front).
+  modelUsage?: ModelUsage; // per-model input/output/cached token breakdown
+  cachedTokens?: number;   // session-level cache-read tokens
+  toolCalls?: { total: number; byTool: { [tool: string]: number } }; // tool invocation breakdown
 }
 
 // Prompt token detail from actual LLM usage data

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1194,6 +1194,11 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 			return analysis;
 		}
 
+		// Handle Windsurf virtual sessions — no file content to analyze
+		if (sessionFile.startsWith('windsurf://')) {
+			return analysis;
+		}
+
 		// Handle Claude Code sessions
 		if (deps.claudeCode?.isClaudeCodeSessionFile(sessionFile)) {
 			// Claude Code has actual token counts; usage analysis extracts tool calls and modes
@@ -1716,6 +1721,11 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 	// Handle Claude Code sessions
 	if (deps.claudeCode?.isClaudeCodeSessionFile(sessionFile)) {
 		return deps.claudeCode.getClaudeCodeModelUsage(sessionFile);
+	}
+
+	// Handle Windsurf virtual sessions — no file content to analyze
+	if (sessionFile.startsWith('windsurf://')) {
+		return modelUsage;
 	}
 
 	const fileName = sessionFile.split(/[/\\]/).pop() || sessionFile;

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1778,6 +1778,9 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 		if (eco && isAnalyzable(eco)) {
 			return eco.analyzeUsage(sessionFile, { modelPricing: deps.modelPricing, toolNameMap: deps.toolNameMap });
 		}
+		if (sessionFile.startsWith('windsurf://')) {
+			return analysis;
+		}
 
 		const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 		const isJsonl = sessionFile.endsWith('.jsonl') || isJsonlContent(fileContent);
@@ -2110,6 +2113,9 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 	if (deps.ecosystems) {
 		const eco = deps.ecosystems.find(e => e.handles(sessionFile));
 		if (eco) { return eco.getModelUsage(sessionFile); }
+	}
+	if (sessionFile.startsWith('windsurf://')) {
+		return modelUsage;
 	}
 	try {
 		const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');

--- a/vscode-extension/src/windsurf.ts
+++ b/vscode-extension/src/windsurf.ts
@@ -1,0 +1,936 @@
+/**
+ * Windsurf data access layer.
+ * Handles reading session data from Windsurf's local language server API.
+ * Uses gRPC-over-HTTP/1.1 to query Cascade trajectories and extract token usage.
+ * Falls back to file-based discovery (~/.codeium/windsurf/cascade/*.pb) when running in VS Code.
+ */
+import * as vscode from 'vscode';
+import * as http from 'http';
+import * as https from 'https';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { ModelUsage, SessionFileDetails, DailyTokenStats } from './types';
+
+interface WindsurfCredentials {
+	csrf: string;
+	port: number;
+}
+
+interface CascadeTrajectorySummary {
+	summary: string;
+	stepCount: number;
+	createdTime: string;
+	lastModifiedTime: string;
+	trajectoryId: string;
+	status: string;
+	lastGeneratorModelUid: string;
+	trajectoryType: string;
+	lastUserInputTime?: string;
+	workspaces?: Array<{
+		workspaceFolderAbsoluteUri?: string;
+		branchName?: string;
+		repository?: { computedName?: string };
+	}>;
+}
+
+interface GetAllCascadeTrajectoriesResponse {
+	trajectorySummaries: {
+		[cascadeId: string]: CascadeTrajectorySummary;
+	};
+}
+
+interface CascadeTrajectoryStep {
+	type: string;
+	metadata?: {
+		requestedModelUid?: string;
+		responseDimensionGroups?: Array<{
+			title: string;
+			dimensions: Array<{
+				uid: string;
+				cumulativeMetric?: {
+					value: number;
+				};
+			}>;
+		}>;
+	};
+}
+
+interface GetCascadeTrajectoryStepsResponse {
+	steps: CascadeTrajectoryStep[];
+}
+
+export class WindsurfDataAccess {
+	private credentials: WindsurfCredentials | null = null;
+	private readonly extensionUri: vscode.Uri;
+
+	constructor(extensionUri: vscode.Uri) {
+		this.extensionUri = extensionUri;
+	}
+
+	/**
+	 * Check if the extension is running inside Windsurf.
+	 */
+	isRunningInWindsurf(): boolean {
+		return vscode.env.appName.toLowerCase().includes('windsurf');
+	}
+
+	/**
+	 * Check if a session file is a Windsurf session file.
+	 * Windsurf uses virtual windsurf://trajectory/{id} paths.
+	 */
+	isWindsurfSessionFile(filePath: string): boolean {
+		return filePath.startsWith('windsurf://trajectory/');
+	}
+
+	/**
+	 * Get the path to Windsurf's Cascade session directory.
+	 * Returns ~/.codeium/windsurf/cascade on all platforms.
+	 */
+	getCascadeDir(): string {
+		return path.join(os.homedir(), '.codeium', 'windsurf', 'cascade');
+	}
+
+	/**
+	 * Check whether Windsurf is installed by looking for its Cascade directory.
+	 * Works regardless of whether we are running inside Windsurf or VS Code.
+	 */
+	isWindsurfInstalled(): boolean {
+		try {
+			return fs.existsSync(this.getCascadeDir());
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Discover Windsurf Cascade sessions from local .pb files.
+	 * Used as a fallback when the extension is running in VS Code (not Windsurf).
+	 * Returns basic metadata — token counts are not available without the API.
+	 */
+	async getWindsurfCascadeSessionFiles(): Promise<SessionFileDetails[]> {
+		const cascadeDir = this.getCascadeDir();
+		try {
+			const entries = await fs.promises.readdir(cascadeDir);
+			const pbFiles = entries.filter(f => f.endsWith('.pb'));
+
+			const sessions: SessionFileDetails[] = [];
+			for (const pbFile of pbFiles) {
+				const trajectoryId = pbFile.slice(0, -3); // strip .pb
+				const filePath = path.join(cascadeDir, pbFile);
+				let stat: fs.Stats;
+				try {
+					stat = await fs.promises.stat(filePath);
+				} catch {
+					continue;
+				}
+
+				sessions.push({
+					file: `windsurf://trajectory/${trajectoryId}`,
+					modified: stat.mtime.toISOString(),
+					size: stat.size,
+					interactions: 1,
+					tokens: 0,
+					contextReferences: {
+						file: 0, selection: 0, implicitSelection: 0, symbol: 0,
+						codebase: 0, workspace: 0, terminal: 0, vscode: 0,
+						terminalLastCommand: 0, terminalSelection: 0, clipboard: 0,
+						changes: 0, outputPanel: 0, problemsPanel: 0,
+						byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {},
+					},
+					firstInteraction: stat.birthtime.toISOString(),
+					lastInteraction: stat.mtime.toISOString(),
+					editorSource: 'windsurf',
+					editorName: 'Windsurf',
+					title: `Windsurf Session`,
+				});
+			}
+			return sessions;
+		} catch (error) {
+			console.warn('[Windsurf] Could not read cascade directory:', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Get Windsurf credentials by intercepting HTTP requests from the Windsurf extension.
+	 */
+	async getCredentials(): Promise<WindsurfCredentials | null> {
+		if (!this.isRunningInWindsurf()) {
+			console.log('[Windsurf] Not running in Windsurf environment');
+			return null;
+		}
+
+		// Return cached credentials if available
+		if (this.credentials) {
+			console.log('[Windsurf] Using cached credentials');
+			// Validate credentials before returning
+			if (await this.validateCredentials(this.credentials)) {
+				return this.credentials;
+			} else {
+				console.log('[Windsurf] Cached credentials invalid, clearing...');
+				// Clear invalid credentials
+				this.credentials = null;
+			}
+		}
+
+		// Try multiple credential capture methods
+		console.log('[Windsurf] Attempting credential capture...');
+		this.credentials = await this.captureCredentials();
+		
+		// Fallback: try alternative methods if primary fails
+		if (!this.credentials) {
+			console.log('[Windsurf] Primary capture failed, trying alternative methods...');
+			this.credentials = await this.captureCredentialsAlternative();
+		}
+		
+		return this.credentials;
+	}
+
+	/**
+	 * Validate credentials with a health check.
+	 */
+	private async validateCredentials(credentials: WindsurfCredentials): Promise<boolean> {
+		try {
+			const response = await this.makeApiCall('GetProcesses', {}, credentials);
+			return response.statusCode === 200;
+		} catch (error) {
+			return false;
+		}
+	}
+
+	/**
+	 * Capture credentials by monkey-patching http.ClientRequest.
+	 */
+	private async captureCredentials(): Promise<WindsurfCredentials | null> {
+		console.log('[Windsurf] Starting credentials capture...');
+		
+		// 1. Get reference to Windsurf extension
+		const ext = vscode.extensions.getExtension('codeium.windsurf');
+		console.log(`[Windsurf] Extension found: ${!!ext}, active: ${ext?.isActive}`);
+		if (!ext?.isActive) {
+			console.warn('Windsurf extension not found or not active');
+			return null;
+		}
+
+		const exports = ext.exports;
+		console.log(`[Windsurf] Extension exports available: ${!!exports}`);
+		if (!exports || typeof exports.devClient !== 'function') {
+			console.warn('Windsurf extension devClient not available');
+			return null;
+		}
+
+		// 2. Wait for devClient to be ready
+		let devClient: any = null;
+		console.log('[Windsurf] Waiting for devClient to be ready...');
+		for (let attempt = 0; attempt < 10; attempt++) {
+			devClient = exports.devClient();
+			console.log(`[Windsurf] DevClient attempt ${attempt + 1}: ${!!devClient}`);
+			if (devClient) {break;}
+			await new Promise(resolve => setTimeout(resolve, 2000));
+		}
+		if (!devClient) {
+			console.warn('Windsurf devClient not ready after timeout');
+			return null;
+		}
+		
+		console.log(`[Windsurf] DevClient ready, available methods: ${Object.keys(devClient).filter(k => typeof devClient[k] === 'function').join(', ')}`);
+
+		// 3. Patch ClientRequest to intercept headers
+		let csrf = '';
+		let port = 0;
+		const origEnd = http.ClientRequest.prototype.end;
+		const origWrite = http.ClientRequest.prototype.write;
+
+		const capture = function (this: http.ClientRequest) {
+			const token = this.getHeader('x-codeium-csrf-token');
+			const host = this.getHeader('host');
+			console.log(`[Windsurf] HTTP Request intercepted - CSRF token: ${!!token}, Host: ${host}`);
+			if (token && !csrf) {
+				csrf = String(token);
+				console.log(`[Windsurf] Captured CSRF token: ${csrf.substring(0, 10)}...`);
+				if (host) {
+					const m = String(host).match(/:(\d+)/);
+					if (m) {
+						port = Number(m[1]);
+						console.log(`[Windsurf] Captured port: ${port}`);
+					}
+				}
+			}
+		};
+
+		http.ClientRequest.prototype.end = function (this: any, ...a: any[]) {
+			capture.call(this);
+			return origEnd.apply(this, a as any);
+		};
+		http.ClientRequest.prototype.write = function (this: any, ...a: any[]) {
+			capture.call(this);
+			return origWrite.apply(this, a as any);
+		};
+
+		try {
+			// 4. Trigger devClient method to cause HTTP request
+			console.log('[Windsurf] Triggering devClient methods to capture credentials...');
+			for (const method of Object.keys(devClient)) {
+				if (typeof devClient[method] !== 'function') {continue;}
+				console.log(`[Windsurf] Trying method: ${method}`);
+				try {
+					await Promise.race([
+						devClient[method]({}),
+						new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), 5000)),
+					]);
+				} catch (error) {
+					console.log(`[Windsurf] Method ${method} failed (expected): ${error instanceof Error ? error.message : String(error)}`);
+					// Expected - we only need the headers
+				}
+				if (csrf) {
+					console.log('[Windsurf] Credentials captured successfully!');
+					break;
+				}
+			}
+		} finally {
+			// Always restore originals
+			http.ClientRequest.prototype.end = origEnd;
+			http.ClientRequest.prototype.write = origWrite;
+		}
+
+		const result = csrf && port ? { csrf, port } : null;
+		console.log(`[Windsurf] Credential capture result: ${result ? `CSRF=${result.csrf.substring(0, 10)}..., Port=${result.port}` : 'null'}`);
+		return result;
+	}
+
+	/**
+	 * Alternative credential capture method - tries different approaches.
+	 */
+	private async captureCredentialsAlternative(): Promise<WindsurfCredentials | null> {
+		console.log('[Windsurf] Trying alternative credential capture methods...');
+		
+		// Method 1: Try to get credentials from environment variables or configuration
+		const envPort = process.env.WINDSURF_PORT || process.env.CODEIUM_PORT;
+		const envToken = process.env.WINDSURF_TOKEN || process.env.CODEIUM_TOKEN;
+		
+		if (envPort && envToken) {
+			console.log('[Windsurf] Found credentials in environment variables');
+			return { csrf: envToken, port: parseInt(envPort) };
+		}
+		
+		// Method 2: Try common ports for Windsurf language server
+		const commonPorts = [6060, 6061, 6062, 6063, 8080, 8081, 9090, 9091];
+		console.log('[Windsurf] Trying common ports for Windsurf language server...');
+		
+		for (const port of commonPorts) {
+			try {
+				// Try to make a simple health check to each port
+				const response = await this.makeApiCall('GetProcesses', {}, { csrf: 'dummy', port });
+				if (response.statusCode === 400 || response.statusCode === 401) {
+					// Port is alive but needs proper CSRF - this is likely the right port
+					console.log(`[Windsurf] Found active Windsurf server on port ${port}, but need proper CSRF`);
+					// We can't proceed without CSRF, but at least we know the port
+					// Return null to let the main method handle it
+					return null;
+				}
+			} catch (error) {
+				// Expected for most ports - continue trying
+				continue;
+			}
+		}
+		
+		// Method 3: Try to access Windsurf's internal state directly
+		try {
+			const ext = vscode.extensions.getExtension('codeium.windsurf');
+			if (ext?.isActive && ext.exports) {
+				// Try to access internal configuration or state
+				const exports = ext.exports;
+				console.log('[Windsurf] Checking Windsurf extension exports for alternative access...');
+				
+				// Look for any configuration or state objects
+				for (const key of Object.keys(exports)) {
+					const value = exports[key];
+					if (value && typeof value === 'object') {
+						// Look for port or token in nested objects
+						if (value.port || value.token || value.csrf) {
+							console.log(`[Windsurf] Found potential credentials in exports.${key}`);
+							const port = value.port || value.serverPort || value.languageServerPort;
+							const csrf = value.token || value.csrf || value.authToken;
+							if (port && csrf) {
+								return { csrf: String(csrf), port: Number(port) };
+							}
+						}
+					}
+				}
+			}
+		} catch (error) {
+			console.log('[Windsurf] Alternative access failed:', error);
+		}
+		
+		console.log('[Windsurf] All alternative methods failed');
+		return null;
+	}
+
+	/**
+	 * Make an API call to the Windsurf language server.
+	 */
+	private async makeApiCall(
+		methodName: string,
+		body: any,
+		credentials?: WindsurfCredentials
+	): Promise<http.IncomingMessage> {
+		const creds = credentials || this.credentials;
+		if (!creds) {
+			throw new Error('No Windsurf credentials available');
+		}
+
+		return new Promise((resolve, reject) => {
+			const data = JSON.stringify(body);
+			const options = {
+				hostname: '127.0.0.1',
+				port: creds.port,
+				path: `/exa.language_server_pb.LanguageServerService/${methodName}`,
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Connect-Protocol-Version': '1',
+					'x-codeium-csrf-token': creds.csrf,
+					'Content-Length': Buffer.byteLength(data),
+				},
+			};
+
+			const req = http.request(options, (res) => {
+				resolve(res);
+			});
+
+			req.on('error', (error) => {
+				reject(error);
+			});
+
+			req.write(data);
+			req.end();
+		});
+	}
+
+	/**
+	 * Get all Cascade trajectory summaries.
+	 */
+	async getAllCascadeTrajectories(): Promise<GetAllCascadeTrajectoriesResponse | null> {
+		console.log('[Windsurf] Getting all Cascade trajectories...');
+		const credentials = await this.getCredentials();
+		if (!credentials) {
+			console.warn('Windsurf: No credentials available for API call');
+			return null;
+		}
+
+		console.log(`[Windsurf] Making API call to GetAllCascadeTrajectories with credentials: CSRF=${credentials.csrf.substring(0, 10)}..., Port=${credentials.port}`);
+		try {
+			const response = await this.makeApiCall('GetAllCascadeTrajectories', { include_user_inputs: false }, credentials);
+			
+			console.log(`[Windsurf] API response status: ${response.statusCode}`);
+			if (response.statusCode !== 200) {
+				throw new Error(`API call failed with status ${response.statusCode}`);
+			}
+
+			const data = await this.readResponseData(response);
+			console.log(`[Windsurf] Raw API response data: ${data.substring(0, 200)}${data.length > 200 ? '...' : ''}`);
+			const result = JSON.parse(data) as GetAllCascadeTrajectoriesResponse;
+			
+			// Validate response structure
+			if (!result || typeof result !== 'object' || !('trajectorySummaries' in result)) {
+				console.error('[Windsurf] Invalid response structure:', result);
+				throw new Error('Invalid response structure from GetAllCascadeTrajectories');
+			}
+			
+			const trajectoryCount = Object.keys(result.trajectorySummaries).length;
+			console.log(`[Windsurf] Successfully retrieved ${trajectoryCount} trajectories`);
+			// Log details of each trajectory for debugging
+			for (const [cascadeId, summary] of Object.entries(result.trajectorySummaries)) {
+				console.log(`[Windsurf] Trajectory ${cascadeId}: status=${summary.status}, type=${summary.trajectoryType}, steps=${summary.stepCount}`);
+			}
+			return result;
+		} catch (error) {
+			console.error('[Windsurf] Failed to get Cascade trajectories:', error);
+			// Clear credentials on error
+			this.credentials = null;
+			return null;
+		}
+	}
+
+	/**
+	 * Get detailed steps for a specific Cascade trajectory.
+	 */
+	async getCascadeTrajectorySteps(cascadeId: string): Promise<GetCascadeTrajectoryStepsResponse | null> {
+		const credentials = await this.getCredentials();
+		if (!credentials) {return null;}
+
+		try {
+			const response = await this.makeApiCall('GetCascadeTrajectorySteps', { cascade_id: cascadeId }, credentials);
+			
+			if (response.statusCode !== 200) {
+				throw new Error(`API call failed with status ${response.statusCode}`);
+			}
+
+			const data = await this.readResponseData(response);
+			return JSON.parse(data) as GetCascadeTrajectoryStepsResponse;
+		} catch (error) {
+			console.error(`Failed to get Cascade trajectory steps for ${cascadeId}:`, error);
+			// Clear credentials on error
+			this.credentials = null;
+			return null;
+		}
+	}
+
+	/**
+	 * Read response data from HTTP response.
+	 */
+	private async readResponseData(response: http.IncomingMessage): Promise<string> {
+		return new Promise((resolve, reject) => {
+			let data = '';
+			response.on('data', (chunk) => {
+				data += chunk;
+			});
+			response.on('end', () => {
+				resolve(data);
+			});
+			response.on('error', (error) => {
+				reject(error);
+			});
+		});
+	}
+
+	/**
+	 * Extract token usage from Cascade trajectory steps.
+	 */
+	extractTokenUsage(steps: CascadeTrajectoryStep[]): { inputTokens: number; outputTokens: number; cachedTokens: number } {
+		let inputTokens = 0;
+		let outputTokens = 0;
+		let cachedTokens = 0;
+
+		for (const step of steps) {
+			if (step.type !== 'CORTEX_STEP_TYPE_USER_INPUT') {continue;}
+			
+			for (const group of step.metadata?.responseDimensionGroups ?? []) {
+				if (group.title !== 'Token Usage') {continue;}
+				
+				for (const dim of group.dimensions) {
+					const value = dim.cumulativeMetric?.value ?? 0;
+					if (dim.uid === 'input_tokens') {
+						inputTokens += value;
+					} else if (dim.uid === 'output_tokens') {
+						outputTokens += value;
+					} else if (dim.uid === 'cached_input_tokens') {
+						cachedTokens += value;
+					}
+				}
+			}
+		}
+
+		return { inputTokens, outputTokens, cachedTokens };
+	}
+
+	/**
+	 * Get model display name from Windsurf model UID.
+	 */
+	getModelDisplayName(modelUid: string): string {
+		// Map Windsurf model UIDs to display names
+		const modelMap: { [key: string]: string } = {
+			'claude-sonnet-4': 'Claude Sonnet 4',
+			'gpt-4o': 'GPT-4o',
+			'gpt-4o-mini': 'GPT-4o Mini',
+			'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
+			'claude-3-haiku-20240307': 'Claude 3 Haiku',
+		};
+		
+		return modelMap[modelUid] || modelUid;
+	}
+
+	/**
+	 * Resolve a windsurf://trajectory/{id} session file to its SessionFileDetails.
+	 * Tries the API first (only works inside Windsurf), then falls back to .pb file metadata.
+	 * Returns null if the session cannot be found by either method.
+	 */
+	async resolveSession(sessionFile: string): Promise<SessionFileDetails | null> {
+		// Try API-based sessions first (available when running inside Windsurf)
+		try {
+			const apiSessions = await this.getWindsurfSessions();
+			const found = apiSessions.find(s => s.file === sessionFile);
+			if (found) { return found; }
+		} catch {
+			// API unavailable - fall through to file-based
+		}
+
+		// Fall back to .pb file metadata
+		const trajectoryId = sessionFile.replace('windsurf://trajectory/', '');
+		const cascadeDir = this.getCascadeDir();
+		const pbPath = path.join(cascadeDir, `${trajectoryId}.pb`);
+		try {
+			const stat = await fs.promises.stat(pbPath);
+			return {
+				file: sessionFile,
+				modified: stat.mtime.toISOString(),
+				size: stat.size,
+				interactions: 1,
+				tokens: 0,
+				contextReferences: {
+					file: 0, selection: 0, implicitSelection: 0, symbol: 0,
+					codebase: 0, workspace: 0, terminal: 0, vscode: 0,
+					terminalLastCommand: 0, terminalSelection: 0, clipboard: 0,
+					changes: 0, outputPanel: 0, problemsPanel: 0,
+					byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {},
+				},
+				firstInteraction: stat.birthtime.toISOString(),
+				lastInteraction: stat.mtime.toISOString(),
+				editorSource: 'windsurf',
+				editorName: 'Windsurf',
+				title: 'Windsurf Session',
+			};
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Simple test method to verify basic functionality
+	 */
+	async testMethod(): Promise<string> {
+		console.log('[Windsurf] testMethod() called');
+		return 'test-method-works';
+	}
+
+	/**
+	 * New method to test if there's a binding issue with getWindsurfSessions
+	 */
+	async getWindsurfSessionsV2(): Promise<SessionFileDetails[]> {
+		// Add logging to confirm method is reached
+		console.log('[Windsurf] getWindsurfSessionsV2() ENTRY POINT');
+		
+		try {
+			console.log('[Windsurf] getWindsurfSessionsV2() called');
+			console.log('[Windsurf] === STARTING SESSION DISCOVERY ===');
+			const sessions: SessionFileDetails[] = [];
+			
+			// Check if Windsurf is enabled in configuration
+			console.log('[Windsurf] About to get configuration...');
+			const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+			console.log('[Windsurf] Got configuration object');
+			const windsurfEnabled = config.get<boolean>('windsurf.enabled', true);
+			console.log(`[Windsurf] Configuration check - enabled: ${windsurfEnabled}`);
+			
+			if (!windsurfEnabled) {
+				console.log('[Windsurf] Windsurf integration disabled in configuration');
+				return [];
+			}
+			
+			console.log('[Windsurf] Fetching trajectories...');
+			const trajectories = await this.getAllCascadeTrajectories();
+			console.log(`[Windsurf] Got trajectories: ${trajectories ? 'YES' : 'NO'}`);
+			
+			if (!trajectories || !trajectories.trajectorySummaries) {
+				console.log('[Windsurf] No trajectories available');
+				return [];
+			}
+			
+			const trajectoryIds = Object.keys(trajectories.trajectorySummaries);
+			console.log(`[Windsurf] Found ${trajectoryIds.length} trajectory summaries`);
+			
+			// Process each trajectory
+			for (const trajectoryId of trajectoryIds) {
+				console.log(`[Windsurf] Processing trajectory: ${trajectoryId}`);
+				const summary = trajectories.trajectorySummaries[trajectoryId];
+				
+				// For now, use stepCount as a proxy for activity (since we don't have token data in the summary)
+				const activityScore = summary.stepCount || 0;
+				console.log(`[Windsurf] Trajectory ${trajectoryId}: ${activityScore} steps`);
+				
+				if (activityScore === 0) {
+					console.log(`[Windsurf] Skipping trajectory ${trajectoryId} - no steps`);
+					continue;
+				}
+				
+				// Create a session file details object for Windsurf sessions
+				const sessionFile: SessionFileDetails = {
+					file: `windsurf://trajectory/${trajectoryId}`,
+					modified: summary.lastModifiedTime || new Date().toISOString(),
+					size: activityScore, // Use stepCount as size proxy
+					interactions: activityScore, // Use stepCount as interactions
+					tokens: activityScore * 100, // Rough token estimate
+					contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} }, // Default values
+					firstInteraction: summary.createdTime,
+					lastInteraction: summary.lastUserInputTime || summary.lastModifiedTime,
+					editorSource: 'windsurf',
+					editorName: 'Windsurf',
+					title: summary.summary || `Windsurf Session ${trajectoryId}`
+				};
+				
+				console.log(`[Windsurf] Added session: ${sessionFile.file} (${activityScore} steps)`);
+				sessions.push(sessionFile);
+			}
+			
+			console.log(`[Windsurf] === SESSION DISCOVERY COMPLETE ===`);
+			console.log(`[Windsurf] Returning ${sessions.length} sessions`);
+			return sessions;
+			
+		} catch (error) {
+			console.error('[Windsurf] Exception in getWindsurfSessionsV2():', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Process all Windurf trajectories and return session details.
+	 */
+	async getWindsurfSessions(): Promise<SessionFileDetails[]> {
+		// Minimal version to isolate the issue
+		console.log('[Windsurf] MINIMAL VERSION - ENTRY POINT');
+		
+		try {
+			console.log('[Windsurf] MINIMAL VERSION - IN TRY BLOCK');
+			
+			// Try the simplest possible operation
+			const sessions: SessionFileDetails[] = [];
+			console.log('[Windsurf] MINIMAL VERSION - CREATED EMPTY ARRAY');
+			
+			// Just return the empty array for now
+			console.log('[Windsurf] MINIMAL VERSION - ABOUT TO RETURN');
+			return sessions;
+			
+		} catch (error) {
+			console.error('[Windsurf] MINIMAL VERSION - CATCH BLOCK:', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Original version (commented out for debugging)
+	 */
+	async getWindsurfSessionsOriginal(): Promise<SessionFileDetails[]> {
+		// Add logging outside try-catch to see if method is even reached
+		console.log('[Windsurf] getWindsurfSessions() ENTRY POINT');
+		
+		try {
+			console.log('[Windsurf] getWindsurfSessions() called');
+			console.log('[Windsurf] === STARTING SESSION DISCOVERY ===');
+			const sessions: SessionFileDetails[] = [];
+			
+			// Check if Windsurf is enabled in configuration
+			console.log('[Windsurf] About to get configuration...');
+			const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+			console.log('[Windsurf] Got configuration object');
+			const windsurfEnabled = config.get<boolean>('windsurf.enabled', true);
+			console.log(`[Windsurf] Configuration check - enabled: ${windsurfEnabled}`);
+			if (!windsurfEnabled) {
+				console.log('[Windsurf] Integration is disabled in configuration');
+				return sessions;
+			}
+		
+		console.log('[Windsurf] Fetching trajectories...');
+		const trajectories = await this.getAllCascadeTrajectories();
+		if (!trajectories || !trajectories.trajectorySummaries) {
+			console.log('[Windsurf] No Cascade trajectories found or invalid response');
+			console.log('[Windsurf] This could mean:');
+			console.log('[Windsurf] 1. No chat sessions have been created yet');
+			console.log('[Windsurf] 2. The Windsurf language server is not running');
+			console.log('[Windsurf] 3. Credential capture failed');
+			console.log('[Windsurf] 4. API endpoints have changed');
+			return sessions;
+		}
+
+		console.log(`[Windsurf] Processing ${Object.keys(trajectories.trajectorySummaries).length} trajectories...`);
+		for (const [cascadeId, summary] of Object.entries(trajectories.trajectorySummaries)) {
+			console.log(`[Windsurf] Processing trajectory ${cascadeId}...`);
+			try {
+				// Validate summary data
+				if (!summary || typeof summary !== 'object') {
+					console.warn(`[Windsurf] Invalid trajectory summary for ${cascadeId}, skipping`);
+					continue;
+				}
+
+				console.log(`[Windsurf] Getting steps for trajectory ${cascadeId}...`);
+				const steps = await this.getCascadeTrajectorySteps(cascadeId);
+				if (!steps || !steps.steps) {
+					console.warn(`[Windsurf] No steps found for trajectory ${cascadeId}, skipping`);
+					continue;
+				}
+
+				console.log(`[Windsurf] Found ${steps.steps.length} steps for trajectory ${cascadeId}`);
+				const tokenUsage = this.extractTokenUsage(steps.steps);
+				const totalTokens = tokenUsage.inputTokens + tokenUsage.outputTokens;
+				console.log(`[Windsurf] Token usage for ${cascadeId}: input=${tokenUsage.inputTokens}, output=${tokenUsage.outputTokens}, total=${totalTokens}`);
+				
+				if (totalTokens === 0) {
+					console.log(`[Windsurf] Skipping trajectory ${cascadeId} - no tokens found`);
+					continue;
+				} // Skip sessions with no tokens
+
+				// Validate and parse dates
+				let createdDate: Date;
+				try {
+					createdDate = new Date(summary.createdTime);
+					if (isNaN(createdDate.getTime())) {
+						console.warn(`Invalid createdTime for trajectory ${cascadeId}: ${summary.createdTime}`);
+						continue;
+					}
+				} catch (error) {
+					console.warn(`Failed to parse createdTime for trajectory ${cascadeId}: ${error}`);
+					continue;
+				}
+				
+				const dateStr = createdDate.toISOString().split('T')[0]; // YYYY-MM-DD
+
+				// Extract workspace/repository info
+				let workspaceName = 'Unknown';
+				let repositoryName = 'Unknown';
+				
+				if (summary.workspaces && Array.isArray(summary.workspaces) && summary.workspaces.length > 0) {
+					const workspace = summary.workspaces[0];
+					if (workspace && typeof workspace === 'object') {
+						if (workspace.workspaceFolderAbsoluteUri && typeof workspace.workspaceFolderAbsoluteUri === 'string') {
+							const uriParts = workspace.workspaceFolderAbsoluteUri.split('/');
+							workspaceName = uriParts[uriParts.length - 1] || workspaceName;
+						}
+						if (workspace.repository && typeof workspace.repository === 'object' && workspace.repository.computedName) {
+							repositoryName = String(workspace.repository.computedName);
+						}
+					}
+				}
+
+				const session = {
+					file: `windsurf://${cascadeId}`,
+					size: 0, // API-based, no file size
+					modified: summary.lastModifiedTime,
+					interactions: summary.stepCount,
+					tokens: totalTokens,
+					contextReferences: {
+						file: 0,
+						selection: 0,
+						implicitSelection: 0,
+						symbol: 0,
+						codebase: 0,
+						workspace: 0,
+						terminal: 0,
+						vscode: 0,
+						terminalLastCommand: 0,
+						terminalSelection: 0,
+						clipboard: 0,
+						changes: 0,
+						outputPanel: 0,
+						problemsPanel: 0,
+						byKind: {},
+						copilotInstructions: 0,
+						agentsMd: 0,
+						byPath: {},
+					},
+					firstInteraction: summary.createdTime,
+					lastInteraction: summary.lastUserInputTime || summary.lastModifiedTime,
+					editorSource: 'windsurf',
+					editorName: 'Windsurf',
+					title: summary.summary || `Cascade ${cascadeId}`,
+					repository: repositoryName,
+				};
+				console.log(`[Windsurf] Successfully processed session ${cascadeId}: ${session.title} (${totalTokens} tokens)`);
+				sessions.push(session);
+			} catch (error) {
+				console.error(`Failed to process Windsurf trajectory ${cascadeId}:`, error);
+			}
+		}
+
+		console.log(`[Windsurf] Session processing complete. Returning ${sessions.length} sessions.`);
+		return sessions;
+		} catch (error) {
+			console.error('[Windsurf] Error in getWindsurfSessions:', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Clear cached credentials (useful for testing or when Windsurf restarts).
+	 */
+	clearCredentialsCache(): void {
+		this.credentials = null;
+	}
+
+	/**
+	 * Run diagnostics to help troubleshoot Windsurf session detection issues.
+	 */
+	async runDiagnostics(): Promise<{ [key: string]: any }> {
+		console.log('[Windsurf] Running diagnostics...');
+		const diagnostics: { [key: string]: any } = {};
+
+		// Basic environment checks
+		diagnostics.environment = {
+			isRunningInWindsurf: this.isRunningInWindsurf(),
+			appName: vscode.env.appName,
+		};
+
+		// Extension checks
+		const ext = vscode.extensions.getExtension('codeium.windsurf');
+		diagnostics.extension = {
+			found: !!ext,
+			active: ext?.isActive,
+			packageJSON: ext?.packageJSON?.version || 'unknown',
+		};
+
+		// Credential checks
+		const credentials = await this.getCredentials();
+		diagnostics.credentials = {
+			available: !!credentials,
+			port: credentials?.port || null,
+			csrfLength: credentials?.csrf?.length || 0,
+		};
+
+		// API connectivity test
+		if (credentials) {
+			try {
+				const response = await this.makeApiCall('GetProcesses', {}, credentials);
+				diagnostics.apiTest = {
+					success: true,
+					statusCode: response.statusCode,
+				};
+			} catch (error) {
+				diagnostics.apiTest = {
+					success: false,
+					error: error instanceof Error ? error.message : String(error),
+				};
+			}
+		} else {
+			diagnostics.apiTest = {
+				success: false,
+				error: 'No credentials available',
+			};
+		}
+
+		// Configuration checks
+		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		diagnostics.configuration = {
+			enabled: config.get<boolean>('windsurf.enabled', true),
+		};
+
+		// Try to get actual session count
+		try {
+			const trajectories = await this.getAllCascadeTrajectories();
+			diagnostics.sessions = {
+				available: !!trajectories,
+				count: trajectories ? Object.keys(trajectories.trajectorySummaries).length : 0,
+			};
+		} catch (error) {
+			diagnostics.sessions = {
+				available: false,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+
+		console.log('[Windsurf] Diagnostics complete:', diagnostics);
+		return diagnostics;
+	}
+}
+
+// Extend SessionFileDetails interface to include Windsurf-specific data
+declare module './types' {
+	interface SessionFileDetails {
+		windsurfData?: {
+			cascadeId: string;
+			trajectoryType: string;
+			status: string;
+			inputTokens: number;
+			outputTokens: number;
+			cachedTokens: number;
+		};
+	}
+}

--- a/vscode-extension/src/windsurf.ts
+++ b/vscode-extension/src/windsurf.ts
@@ -1,0 +1,920 @@
+/**
+ * Windsurf data access layer.
+ * Handles reading session data from Windsurf's local language server API.
+ * Uses gRPC-over-HTTP/1.1 to query Cascade trajectories and extract token usage.
+ * Falls back to file-based discovery (~/.codeium/windsurf/cascade/*.pb) when running in VS Code.
+ */
+import * as vscode from 'vscode';
+import * as http from 'http';
+import * as https from 'https';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { ModelUsage, SessionFileDetails, DailyTokenStats } from './types';
+
+interface WindsurfCredentials {
+	csrf: string;
+	port: number;
+}
+
+interface CascadeTrajectorySummary {
+	summary: string;
+	stepCount: number;
+	createdTime: string;
+	lastModifiedTime: string;
+	trajectoryId: string;
+	status: string;
+	lastGeneratorModelUid: string;
+	trajectoryType: string;
+	lastUserInputTime?: string;
+	workspaces?: Array<{
+		workspaceFolderAbsoluteUri?: string;
+		branchName?: string;
+		repository?: { computedName?: string };
+	}>;
+}
+
+interface GetAllCascadeTrajectoriesResponse {
+	trajectorySummaries: {
+		[cascadeId: string]: CascadeTrajectorySummary;
+	};
+}
+
+interface CascadeTrajectoryStep {
+	type: string;
+	metadata?: {
+		requestedModelUid?: string;
+		responseDimensionGroups?: Array<{
+			title: string;
+			dimensions: Array<{
+				uid: string;
+				cumulativeMetric?: {
+					value: number;
+				};
+			}>;
+		}>;
+	};
+}
+
+interface GetCascadeTrajectoryStepsResponse {
+	steps: CascadeTrajectoryStep[];
+}
+
+export class WindsurfDataAccess {
+	private credentials: WindsurfCredentials | null = null;
+	private readonly extensionUri: vscode.Uri;
+
+	constructor(extensionUri: vscode.Uri) {
+		this.extensionUri = extensionUri;
+	}
+
+	/**
+	 * Check if the extension is running inside Windsurf.
+	 */
+	isRunningInWindsurf(): boolean {
+		return vscode.env.appName.toLowerCase().includes('windsurf');
+	}
+
+	/**
+	 * Check if a session file is a Windsurf session file.
+	 * Windsurf uses virtual windsurf://trajectory/{id} paths.
+	 */
+	isWindsurfSessionFile(filePath: string): boolean {
+		return filePath.startsWith('windsurf://trajectory/');
+	}
+
+	/**
+	 * Get the path to Windsurf's Cascade session directory.
+	 * Returns ~/.codeium/windsurf/cascade on all platforms.
+	 */
+	getCascadeDir(): string {
+		return path.join(os.homedir(), '.codeium', 'windsurf', 'cascade');
+	}
+
+	/**
+	 * Check whether Windsurf is installed by looking for its Cascade directory.
+	 * Works regardless of whether we are running inside Windsurf or VS Code.
+	 */
+	isWindsurfInstalled(): boolean {
+		try {
+			return fs.existsSync(this.getCascadeDir());
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Discover Windsurf Cascade sessions from local .pb files.
+	 * Used as a fallback when the extension is running in VS Code (not Windsurf).
+	 * Returns basic metadata — token counts are not available without the API.
+	 */
+	async getWindsurfCascadeSessionFiles(): Promise<SessionFileDetails[]> {
+		const cascadeDir = this.getCascadeDir();
+		try {
+			const entries = await fs.promises.readdir(cascadeDir);
+			const pbFiles = entries.filter(f => f.endsWith('.pb'));
+
+			const sessions: SessionFileDetails[] = [];
+			for (const pbFile of pbFiles) {
+				const trajectoryId = pbFile.slice(0, -3); // strip .pb
+				const filePath = path.join(cascadeDir, pbFile);
+				let stat: fs.Stats;
+				try {
+					stat = await fs.promises.stat(filePath);
+				} catch {
+					continue;
+				}
+
+				sessions.push({
+					file: `windsurf://trajectory/${trajectoryId}`,
+					modified: stat.mtime.toISOString(),
+					size: stat.size,
+					interactions: 1,
+					tokens: 0,
+					contextReferences: {
+						file: 0, selection: 0, implicitSelection: 0, symbol: 0,
+						codebase: 0, workspace: 0, terminal: 0, vscode: 0,
+						terminalLastCommand: 0, terminalSelection: 0, clipboard: 0,
+						changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0,
+						byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {},
+					},
+					firstInteraction: stat.birthtime.toISOString(),
+					lastInteraction: stat.mtime.toISOString(),
+					editorSource: 'windsurf',
+					editorName: 'Windsurf',
+					title: `Windsurf Session`,
+				});
+			}
+			return sessions;
+		} catch (error) {
+			console.warn('[Windsurf] Could not read cascade directory:', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Get Windsurf credentials by intercepting HTTP requests from the Windsurf extension.
+	 */
+	async getCredentials(): Promise<WindsurfCredentials | null> {
+		if (!this.isRunningInWindsurf()) {
+			console.log('[Windsurf] Not running in Windsurf environment');
+			return null;
+		}
+
+		// Return cached credentials if available
+		if (this.credentials) {
+			console.log('[Windsurf] Using cached credentials');
+			// Validate credentials before returning
+			if (await this.validateCredentials(this.credentials)) {
+				return this.credentials;
+			} else {
+				console.log('[Windsurf] Cached credentials invalid, clearing...');
+				// Clear invalid credentials
+				this.credentials = null;
+			}
+		}
+
+		// Try multiple credential capture methods
+		console.log('[Windsurf] Attempting credential capture...');
+		this.credentials = await this.captureCredentials();
+		
+		// Fallback: try alternative methods if primary fails
+		if (!this.credentials) {
+			console.log('[Windsurf] Primary capture failed, trying alternative methods...');
+			this.credentials = await this.captureCredentialsAlternative();
+		}
+		
+		return this.credentials;
+	}
+
+	/**
+	 * Validate credentials with a health check.
+	 */
+	private async validateCredentials(credentials: WindsurfCredentials): Promise<boolean> {
+		try {
+			const response = await this.makeApiCall('GetProcesses', {}, credentials);
+			return response.statusCode === 200;
+		} catch (error) {
+			return false;
+		}
+	}
+
+	/**
+	 * Capture credentials by monkey-patching http.ClientRequest.
+	 */
+	private async captureCredentials(): Promise<WindsurfCredentials | null> {
+		console.log('[Windsurf] Starting credentials capture...');
+		
+		// 1. Get reference to Windsurf extension
+		const ext = vscode.extensions.getExtension('codeium.windsurf');
+		console.log(`[Windsurf] Extension found: ${!!ext}, active: ${ext?.isActive}`);
+		if (!ext?.isActive) {
+			console.warn('Windsurf extension not found or not active');
+			return null;
+		}
+
+		const exports = ext.exports;
+		console.log(`[Windsurf] Extension exports available: ${!!exports}`);
+		if (!exports || typeof exports.devClient !== 'function') {
+			console.warn('Windsurf extension devClient not available');
+			return null;
+		}
+
+		// 2. Wait for devClient to be ready
+		let devClient: any = null;
+		console.log('[Windsurf] Waiting for devClient to be ready...');
+		for (let attempt = 0; attempt < 10; attempt++) {
+			devClient = exports.devClient();
+			console.log(`[Windsurf] DevClient attempt ${attempt + 1}: ${!!devClient}`);
+			if (devClient) {break;}
+			await new Promise(resolve => setTimeout(resolve, 2000));
+		}
+		if (!devClient) {
+			console.warn('Windsurf devClient not ready after timeout');
+			return null;
+		}
+		
+		console.log(`[Windsurf] DevClient ready, available methods: ${Object.keys(devClient).filter(k => typeof devClient[k] === 'function').join(', ')}`);
+
+		// 3. Patch ClientRequest to intercept headers
+		let csrf = '';
+		let port = 0;
+		const origEnd = http.ClientRequest.prototype.end;
+		const origWrite = http.ClientRequest.prototype.write;
+
+		const capture = function (this: http.ClientRequest) {
+			const token = this.getHeader('x-codeium-csrf-token');
+			const host = this.getHeader('host');
+			console.log(`[Windsurf] HTTP Request intercepted - CSRF token: ${!!token}, Host: ${host}`);
+			if (token && !csrf) {
+				csrf = String(token);
+				console.log(`[Windsurf] Captured CSRF token: ${csrf.substring(0, 10)}...`);
+				if (host) {
+					const m = String(host).match(/:(\d+)/);
+					if (m) {
+						port = Number(m[1]);
+						console.log(`[Windsurf] Captured port: ${port}`);
+					}
+				}
+			}
+		};
+
+		http.ClientRequest.prototype.end = function (this: any, ...a: any[]) {
+			capture.call(this);
+			return origEnd.apply(this, a as any);
+		};
+		http.ClientRequest.prototype.write = function (this: any, ...a: any[]) {
+			capture.call(this);
+			return origWrite.apply(this, a as any);
+		};
+
+		try {
+			// 4. Trigger devClient method to cause HTTP request
+			console.log('[Windsurf] Triggering devClient methods to capture credentials...');
+			for (const method of Object.keys(devClient)) {
+				if (typeof devClient[method] !== 'function') {continue;}
+				console.log(`[Windsurf] Trying method: ${method}`);
+				try {
+					await Promise.race([
+						devClient[method]({}),
+						new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), 5000)),
+					]);
+				} catch (error) {
+					console.log(`[Windsurf] Method ${method} failed (expected): ${error instanceof Error ? error.message : String(error)}`);
+					// Expected - we only need the headers
+				}
+				if (csrf) {
+					console.log('[Windsurf] Credentials captured successfully!');
+					break;
+				}
+			}
+		} finally {
+			// Always restore originals
+			http.ClientRequest.prototype.end = origEnd;
+			http.ClientRequest.prototype.write = origWrite;
+		}
+
+		const result = csrf && port ? { csrf, port } : null;
+		console.log(`[Windsurf] Credential capture result: ${result ? `CSRF=${result.csrf.substring(0, 10)}..., Port=${result.port}` : 'null'}`);
+		return result;
+	}
+
+	/**
+	 * Alternative credential capture method - tries different approaches.
+	 */
+	private async captureCredentialsAlternative(): Promise<WindsurfCredentials | null> {
+		console.log('[Windsurf] Trying alternative credential capture methods...');
+		
+		// Method 1: Try to get credentials from environment variables or configuration
+		const envPort = process.env.WINDSURF_PORT || process.env.CODEIUM_PORT;
+		const envToken = process.env.WINDSURF_TOKEN || process.env.CODEIUM_TOKEN;
+		
+		if (envPort && envToken) {
+			console.log('[Windsurf] Found credentials in environment variables');
+			return { csrf: envToken, port: parseInt(envPort) };
+		}
+		
+		// Method 2: Try common ports for Windsurf language server
+		const commonPorts = [6060, 6061, 6062, 6063, 8080, 8081, 9090, 9091];
+		console.log('[Windsurf] Trying common ports for Windsurf language server...');
+		
+		for (const port of commonPorts) {
+			try {
+				// Try to make a simple health check to each port
+				const response = await this.makeApiCall('GetProcesses', {}, { csrf: 'dummy', port });
+				if (response.statusCode === 400 || response.statusCode === 401) {
+					// Port is alive but needs proper CSRF - this is likely the right port
+					console.log(`[Windsurf] Found active Windsurf server on port ${port}, but need proper CSRF`);
+					// We can't proceed without CSRF, but at least we know the port
+					// Return null to let the main method handle it
+					return null;
+				}
+			} catch (error) {
+				// Expected for most ports - continue trying
+				continue;
+			}
+		}
+		
+		// Method 3: Try to access Windsurf's internal state directly
+		try {
+			const ext = vscode.extensions.getExtension('codeium.windsurf');
+			if (ext?.isActive && ext.exports) {
+				// Try to access internal configuration or state
+				const exports = ext.exports;
+				console.log('[Windsurf] Checking Windsurf extension exports for alternative access...');
+				
+				// Look for any configuration or state objects
+				for (const key of Object.keys(exports)) {
+					const value = exports[key];
+					if (value && typeof value === 'object') {
+						// Look for port or token in nested objects
+						if (value.port || value.token || value.csrf) {
+							console.log(`[Windsurf] Found potential credentials in exports.${key}`);
+							const port = value.port || value.serverPort || value.languageServerPort;
+							const csrf = value.token || value.csrf || value.authToken;
+							if (port && csrf) {
+								return { csrf: String(csrf), port: Number(port) };
+							}
+						}
+					}
+				}
+			}
+		} catch (error) {
+			console.log('[Windsurf] Alternative access failed:', error);
+		}
+		
+		console.log('[Windsurf] All alternative methods failed');
+		return null;
+	}
+
+	/**
+	 * Make an API call to the Windsurf language server.
+	 */
+	private async makeApiCall(
+		methodName: string,
+		body: any,
+		credentials?: WindsurfCredentials
+	): Promise<http.IncomingMessage> {
+		const creds = credentials || this.credentials;
+		if (!creds) {
+			throw new Error('No Windsurf credentials available');
+		}
+
+		return new Promise((resolve, reject) => {
+			const data = JSON.stringify(body);
+			const options = {
+				hostname: '127.0.0.1',
+				port: creds.port,
+				path: `/exa.language_server_pb.LanguageServerService/${methodName}`,
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Connect-Protocol-Version': '1',
+					'x-codeium-csrf-token': creds.csrf,
+					'Content-Length': Buffer.byteLength(data),
+				},
+			};
+
+			const req = http.request(options, (res) => {
+				resolve(res);
+			});
+
+			req.on('error', (error) => {
+				reject(error);
+			});
+
+			req.write(data);
+			req.end();
+		});
+	}
+
+	/**
+	 * Get all Cascade trajectory summaries.
+	 */
+	async getAllCascadeTrajectories(): Promise<GetAllCascadeTrajectoriesResponse | null> {
+		console.log('[Windsurf] Getting all Cascade trajectories...');
+		const credentials = await this.getCredentials();
+		if (!credentials) {
+			console.warn('Windsurf: No credentials available for API call');
+			return null;
+		}
+
+		console.log(`[Windsurf] Making API call to GetAllCascadeTrajectories with credentials: CSRF=${credentials.csrf.substring(0, 10)}..., Port=${credentials.port}`);
+		try {
+			const response = await this.makeApiCall('GetAllCascadeTrajectories', { include_user_inputs: false }, credentials);
+			
+			console.log(`[Windsurf] API response status: ${response.statusCode}`);
+			if (response.statusCode !== 200) {
+				throw new Error(`API call failed with status ${response.statusCode}`);
+			}
+
+			const data = await this.readResponseData(response);
+			console.log(`[Windsurf] Raw API response data: ${data.substring(0, 200)}${data.length > 200 ? '...' : ''}`);
+			const result = JSON.parse(data) as GetAllCascadeTrajectoriesResponse;
+			
+			// Validate response structure
+			if (!result || typeof result !== 'object' || !('trajectorySummaries' in result)) {
+				console.error('[Windsurf] Invalid response structure:', result);
+				throw new Error('Invalid response structure from GetAllCascadeTrajectories');
+			}
+			
+			const trajectoryCount = Object.keys(result.trajectorySummaries).length;
+			console.log(`[Windsurf] Successfully retrieved ${trajectoryCount} trajectories`);
+			// Log details of each trajectory for debugging
+			for (const [cascadeId, summary] of Object.entries(result.trajectorySummaries)) {
+				console.log(`[Windsurf] Trajectory ${cascadeId}: status=${summary.status}, type=${summary.trajectoryType}, steps=${summary.stepCount}`);
+			}
+			return result;
+		} catch (error) {
+			console.error('[Windsurf] Failed to get Cascade trajectories:', error);
+			// Clear credentials on error
+			this.credentials = null;
+			return null;
+		}
+	}
+
+	/**
+	 * Get detailed steps for a specific Cascade trajectory.
+	 */
+	async getCascadeTrajectorySteps(cascadeId: string): Promise<GetCascadeTrajectoryStepsResponse | null> {
+		const credentials = await this.getCredentials();
+		if (!credentials) {return null;}
+
+		try {
+			const response = await this.makeApiCall('GetCascadeTrajectorySteps', { cascade_id: cascadeId }, credentials);
+			
+			if (response.statusCode !== 200) {
+				throw new Error(`API call failed with status ${response.statusCode}`);
+			}
+
+			const data = await this.readResponseData(response);
+			return JSON.parse(data) as GetCascadeTrajectoryStepsResponse;
+		} catch (error) {
+			console.error(`Failed to get Cascade trajectory steps for ${cascadeId}:`, error);
+			// Clear credentials on error
+			this.credentials = null;
+			return null;
+		}
+	}
+
+	/**
+	 * Read response data from HTTP response.
+	 */
+	private async readResponseData(response: http.IncomingMessage): Promise<string> {
+		return new Promise((resolve, reject) => {
+			let data = '';
+			response.on('data', (chunk) => {
+				data += chunk;
+			});
+			response.on('end', () => {
+				resolve(data);
+			});
+			response.on('error', (error) => {
+				reject(error);
+			});
+		});
+	}
+
+	/**
+	 * Extract token usage from Cascade trajectory steps.
+	 */
+	extractTokenUsage(steps: CascadeTrajectoryStep[]): { inputTokens: number; outputTokens: number; cachedTokens: number } {
+		let inputTokens = 0;
+		let outputTokens = 0;
+		let cachedTokens = 0;
+
+		for (const step of steps) {
+			if (step.type !== 'CORTEX_STEP_TYPE_USER_INPUT') {continue;}
+			
+			for (const group of step.metadata?.responseDimensionGroups ?? []) {
+				if (group.title !== 'Token Usage') {continue;}
+				
+				for (const dim of group.dimensions) {
+					const value = dim.cumulativeMetric?.value ?? 0;
+					if (dim.uid === 'input_tokens') {
+						inputTokens += value;
+					} else if (dim.uid === 'output_tokens') {
+						outputTokens += value;
+					} else if (dim.uid === 'cached_input_tokens') {
+						cachedTokens += value;
+					}
+				}
+			}
+		}
+
+		return { inputTokens, outputTokens, cachedTokens };
+	}
+
+	/**
+	 * Get model display name from Windsurf model UID.
+	 */
+	getModelDisplayName(modelUid: string): string {
+		// Map Windsurf model UIDs to display names
+		const modelMap: { [key: string]: string } = {
+			'claude-sonnet-4': 'Claude Sonnet 4',
+			'gpt-4o': 'GPT-4o',
+			'gpt-4o-mini': 'GPT-4o Mini',
+			'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
+			'claude-3-haiku-20240307': 'Claude 3 Haiku',
+		};
+		
+		return modelMap[modelUid] || modelUid;
+	}
+
+	/**
+	 * Resolve a windsurf://trajectory/{id} session file to its SessionFileDetails.
+	 * Tries the API first (only works inside Windsurf), then falls back to .pb file metadata.
+	 * Returns null if the session cannot be found by either method.
+	 */
+	async resolveSession(sessionFile: string): Promise<SessionFileDetails | null> {
+		// Try API-based sessions first (available when running inside Windsurf)
+		try {
+			const apiSessions = await this.getWindsurfSessions();
+			const found = apiSessions.find(s => s.file === sessionFile);
+			if (found) { return found; }
+		} catch {
+			// API unavailable - fall through to file-based
+		}
+
+		// Fall back to .pb file metadata
+		const trajectoryId = sessionFile.replace('windsurf://trajectory/', '');
+		const cascadeDir = this.getCascadeDir();
+		const pbPath = path.join(cascadeDir, `${trajectoryId}.pb`);
+		try {
+			const stat = await fs.promises.stat(pbPath);
+			return {
+				file: sessionFile,
+				modified: stat.mtime.toISOString(),
+				size: stat.size,
+				interactions: 1,
+				tokens: 0,
+				contextReferences: {
+					file: 0, selection: 0, implicitSelection: 0, symbol: 0,
+					codebase: 0, workspace: 0, terminal: 0, vscode: 0,
+					terminalLastCommand: 0, terminalSelection: 0, clipboard: 0,
+					changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0,
+					byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {},
+				},
+				firstInteraction: stat.birthtime.toISOString(),
+				lastInteraction: stat.mtime.toISOString(),
+				editorSource: 'windsurf',
+				editorName: 'Windsurf',
+				title: 'Windsurf Session',
+			};
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Simple test method to verify basic functionality
+	 */
+	async testMethod(): Promise<string> {
+		console.log('[Windsurf] testMethod() called');
+		return 'test-method-works';
+	}
+
+	/**
+	 * New method to test if there's a binding issue with getWindsurfSessions
+	 */
+	async getWindsurfSessionsV2(): Promise<SessionFileDetails[]> {
+		// Add logging to confirm method is reached
+		console.log('[Windsurf] getWindsurfSessionsV2() ENTRY POINT');
+		
+		try {
+			console.log('[Windsurf] getWindsurfSessionsV2() called');
+			console.log('[Windsurf] === STARTING SESSION DISCOVERY ===');
+			const sessions: SessionFileDetails[] = [];
+			
+			// Check if Windsurf is enabled in configuration
+			console.log('[Windsurf] About to get configuration...');
+			const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+			console.log('[Windsurf] Got configuration object');
+			const windsurfEnabled = config.get<boolean>('windsurf.enabled', true);
+			console.log(`[Windsurf] Configuration check - enabled: ${windsurfEnabled}`);
+			
+			if (!windsurfEnabled) {
+				console.log('[Windsurf] Windsurf integration disabled in configuration');
+				return [];
+			}
+			
+			console.log('[Windsurf] Fetching trajectories...');
+			const trajectories = await this.getAllCascadeTrajectories();
+			console.log(`[Windsurf] Got trajectories: ${trajectories ? 'YES' : 'NO'}`);
+			
+			if (!trajectories || !trajectories.trajectorySummaries) {
+				console.log('[Windsurf] No trajectories available');
+				return [];
+			}
+			
+			const trajectoryIds = Object.keys(trajectories.trajectorySummaries);
+			console.log(`[Windsurf] Found ${trajectoryIds.length} trajectory summaries`);
+			
+			// Process each trajectory
+			for (const trajectoryId of trajectoryIds) {
+				console.log(`[Windsurf] Processing trajectory: ${trajectoryId}`);
+				const summary = trajectories.trajectorySummaries[trajectoryId];
+				
+				// For now, use stepCount as a proxy for activity (since we don't have token data in the summary)
+				const activityScore = summary.stepCount || 0;
+				console.log(`[Windsurf] Trajectory ${trajectoryId}: ${activityScore} steps`);
+				
+				if (activityScore === 0) {
+					console.log(`[Windsurf] Skipping trajectory ${trajectoryId} - no steps`);
+					continue;
+				}
+				
+				// Create a session file details object for Windsurf sessions
+				const sessionFile: SessionFileDetails = {
+					file: `windsurf://trajectory/${trajectoryId}`,
+					modified: summary.lastModifiedTime || new Date().toISOString(),
+					size: activityScore, // Use stepCount as size proxy
+					interactions: activityScore, // Use stepCount as interactions
+					tokens: activityScore * 100, // Rough token estimate
+					contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} }, // Default values
+					firstInteraction: summary.createdTime,
+					lastInteraction: summary.lastUserInputTime || summary.lastModifiedTime,
+					editorSource: 'windsurf',
+					editorName: 'Windsurf',
+					title: summary.summary || `Windsurf Session ${trajectoryId}`
+				};
+				
+				console.log(`[Windsurf] Added session: ${sessionFile.file} (${activityScore} steps)`);
+				sessions.push(sessionFile);
+			}
+			
+			console.log(`[Windsurf] === SESSION DISCOVERY COMPLETE ===`);
+			console.log(`[Windsurf] Returning ${sessions.length} sessions`);
+			return sessions;
+			
+		} catch (error) {
+			console.error('[Windsurf] Exception in getWindsurfSessionsV2():', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Process all Windurf trajectories and return session details.
+	 */
+	async getWindsurfSessions(): Promise<SessionFileDetails[]> {
+		return this.getWindsurfSessionsV2();
+	}
+
+	/**
+	 * Original version (commented out for debugging)
+	 */
+	async getWindsurfSessionsOriginal(): Promise<SessionFileDetails[]> {
+		// Add logging outside try-catch to see if method is even reached
+		console.log('[Windsurf] getWindsurfSessions() ENTRY POINT');
+		
+		try {
+			console.log('[Windsurf] getWindsurfSessions() called');
+			console.log('[Windsurf] === STARTING SESSION DISCOVERY ===');
+			const sessions: SessionFileDetails[] = [];
+			
+			// Check if Windsurf is enabled in configuration
+			console.log('[Windsurf] About to get configuration...');
+			const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+			console.log('[Windsurf] Got configuration object');
+			const windsurfEnabled = config.get<boolean>('windsurf.enabled', true);
+			console.log(`[Windsurf] Configuration check - enabled: ${windsurfEnabled}`);
+			if (!windsurfEnabled) {
+				console.log('[Windsurf] Integration is disabled in configuration');
+				return sessions;
+			}
+		
+		console.log('[Windsurf] Fetching trajectories...');
+		const trajectories = await this.getAllCascadeTrajectories();
+		if (!trajectories || !trajectories.trajectorySummaries) {
+			console.log('[Windsurf] No Cascade trajectories found or invalid response');
+			console.log('[Windsurf] This could mean:');
+			console.log('[Windsurf] 1. No chat sessions have been created yet');
+			console.log('[Windsurf] 2. The Windsurf language server is not running');
+			console.log('[Windsurf] 3. Credential capture failed');
+			console.log('[Windsurf] 4. API endpoints have changed');
+			return sessions;
+		}
+
+		console.log(`[Windsurf] Processing ${Object.keys(trajectories.trajectorySummaries).length} trajectories...`);
+		for (const [cascadeId, summary] of Object.entries(trajectories.trajectorySummaries)) {
+			console.log(`[Windsurf] Processing trajectory ${cascadeId}...`);
+			try {
+				// Validate summary data
+				if (!summary || typeof summary !== 'object') {
+					console.warn(`[Windsurf] Invalid trajectory summary for ${cascadeId}, skipping`);
+					continue;
+				}
+
+				console.log(`[Windsurf] Getting steps for trajectory ${cascadeId}...`);
+				const steps = await this.getCascadeTrajectorySteps(cascadeId);
+				if (!steps || !steps.steps) {
+					console.warn(`[Windsurf] No steps found for trajectory ${cascadeId}, skipping`);
+					continue;
+				}
+
+				console.log(`[Windsurf] Found ${steps.steps.length} steps for trajectory ${cascadeId}`);
+				const tokenUsage = this.extractTokenUsage(steps.steps);
+				const totalTokens = tokenUsage.inputTokens + tokenUsage.outputTokens;
+				console.log(`[Windsurf] Token usage for ${cascadeId}: input=${tokenUsage.inputTokens}, output=${tokenUsage.outputTokens}, total=${totalTokens}`);
+				
+				if (totalTokens === 0) {
+					console.log(`[Windsurf] Skipping trajectory ${cascadeId} - no tokens found`);
+					continue;
+				} // Skip sessions with no tokens
+
+				// Validate and parse dates
+				let createdDate: Date;
+				try {
+					createdDate = new Date(summary.createdTime);
+					if (isNaN(createdDate.getTime())) {
+						console.warn(`Invalid createdTime for trajectory ${cascadeId}: ${summary.createdTime}`);
+						continue;
+					}
+				} catch (error) {
+					console.warn(`Failed to parse createdTime for trajectory ${cascadeId}: ${error}`);
+					continue;
+				}
+				
+				const dateStr = createdDate.toISOString().split('T')[0]; // YYYY-MM-DD
+
+				// Extract workspace/repository info
+				let workspaceName = 'Unknown';
+				let repositoryName = 'Unknown';
+				
+				if (summary.workspaces && Array.isArray(summary.workspaces) && summary.workspaces.length > 0) {
+					const workspace = summary.workspaces[0];
+					if (workspace && typeof workspace === 'object') {
+						if (workspace.workspaceFolderAbsoluteUri && typeof workspace.workspaceFolderAbsoluteUri === 'string') {
+							const uriParts = workspace.workspaceFolderAbsoluteUri.split('/');
+							workspaceName = uriParts[uriParts.length - 1] || workspaceName;
+						}
+						if (workspace.repository && typeof workspace.repository === 'object' && workspace.repository.computedName) {
+							repositoryName = String(workspace.repository.computedName);
+						}
+					}
+				}
+
+				const session = {
+					file: `windsurf://${cascadeId}`,
+					size: 0, // API-based, no file size
+					modified: summary.lastModifiedTime,
+					interactions: summary.stepCount,
+					tokens: totalTokens,
+					contextReferences: {
+						file: 0,
+						selection: 0,
+						implicitSelection: 0,
+						symbol: 0,
+						codebase: 0,
+						workspace: 0,
+						terminal: 0,
+						vscode: 0,
+						terminalLastCommand: 0,
+						terminalSelection: 0,
+						clipboard: 0,
+						changes: 0,
+						outputPanel: 0,
+						problemsPanel: 0,
+						pullRequest: 0,
+						byKind: {},
+						copilotInstructions: 0,
+						agentsMd: 0,
+						byPath: {},
+					},
+					firstInteraction: summary.createdTime,
+					lastInteraction: summary.lastUserInputTime || summary.lastModifiedTime,
+					editorSource: 'windsurf',
+					editorName: 'Windsurf',
+					title: summary.summary || `Cascade ${cascadeId}`,
+					repository: repositoryName,
+				};
+				console.log(`[Windsurf] Successfully processed session ${cascadeId}: ${session.title} (${totalTokens} tokens)`);
+				sessions.push(session);
+			} catch (error) {
+				console.error(`Failed to process Windsurf trajectory ${cascadeId}:`, error);
+			}
+		}
+
+		console.log(`[Windsurf] Session processing complete. Returning ${sessions.length} sessions.`);
+		return sessions;
+		} catch (error) {
+			console.error('[Windsurf] Error in getWindsurfSessions:', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Clear cached credentials (useful for testing or when Windsurf restarts).
+	 */
+	clearCredentialsCache(): void {
+		this.credentials = null;
+	}
+
+	/**
+	 * Run diagnostics to help troubleshoot Windsurf session detection issues.
+	 */
+	async runDiagnostics(): Promise<{ [key: string]: any }> {
+		console.log('[Windsurf] Running diagnostics...');
+		const diagnostics: { [key: string]: any } = {};
+
+		// Basic environment checks
+		diagnostics.environment = {
+			isRunningInWindsurf: this.isRunningInWindsurf(),
+			appName: vscode.env.appName,
+		};
+
+		// Extension checks
+		const ext = vscode.extensions.getExtension('codeium.windsurf');
+		diagnostics.extension = {
+			found: !!ext,
+			active: ext?.isActive,
+			packageJSON: ext?.packageJSON?.version || 'unknown',
+		};
+
+		// Credential checks
+		const credentials = await this.getCredentials();
+		diagnostics.credentials = {
+			available: !!credentials,
+			port: credentials?.port || null,
+			csrfLength: credentials?.csrf?.length || 0,
+		};
+
+		// API connectivity test
+		if (credentials) {
+			try {
+				const response = await this.makeApiCall('GetProcesses', {}, credentials);
+				diagnostics.apiTest = {
+					success: true,
+					statusCode: response.statusCode,
+				};
+			} catch (error) {
+				diagnostics.apiTest = {
+					success: false,
+					error: error instanceof Error ? error.message : String(error),
+				};
+			}
+		} else {
+			diagnostics.apiTest = {
+				success: false,
+				error: 'No credentials available',
+			};
+		}
+
+		// Configuration checks
+		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		diagnostics.configuration = {
+			enabled: config.get<boolean>('windsurf.enabled', true),
+		};
+
+		// Try to get actual session count
+		try {
+			const trajectories = await this.getAllCascadeTrajectories();
+			diagnostics.sessions = {
+				available: !!trajectories,
+				count: trajectories ? Object.keys(trajectories.trajectorySummaries).length : 0,
+			};
+		} catch (error) {
+			diagnostics.sessions = {
+				available: false,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+
+		console.log('[Windsurf] Diagnostics complete:', diagnostics);
+		return diagnostics;
+	}
+}
+
+// Extend SessionFileDetails interface to include Windsurf-specific data
+declare module './types' {
+	interface SessionFileDetails {
+		windsurfData?: {
+			cascadeId: string;
+			trajectoryType: string;
+			status: string;
+			inputTokens: number;
+			outputTokens: number;
+			cachedTokens: number;
+		};
+	}
+}

--- a/vscode-extension/src/windsurf.ts
+++ b/vscode-extension/src/windsurf.ts
@@ -462,14 +462,16 @@ export class WindsurfDataAccess {
 	}
 
 	/**
-	 * Get detailed steps for a specific Cascade trajectory.
+	 * Get a single (size-capped) page of steps for a Cascade trajectory, starting at
+	 * `stepOffset`. The server caps each response by payload size (not a fixed count),
+	 * so callers must page through with `getAllTrajectorySteps` to get the full list.
 	 */
-	async getCascadeTrajectorySteps(cascadeId: string): Promise<GetCascadeTrajectoryStepsResponse | null> {
+	async getCascadeTrajectorySteps(cascadeId: string, stepOffset = 0): Promise<GetCascadeTrajectoryStepsResponse | null> {
 		const credentials = await this.getCredentials();
 		if (!credentials) {return null;}
 
 		try {
-			const response = await this.makeApiCall('GetCascadeTrajectorySteps', { cascade_id: cascadeId }, credentials);
+			const response = await this.makeApiCall('GetCascadeTrajectorySteps', { cascade_id: cascadeId, step_offset: stepOffset }, credentials);
 			
 			if (response.statusCode !== 200) {
 				throw new Error(`API call failed with status ${response.statusCode}`);
@@ -483,6 +485,35 @@ export class WindsurfDataAccess {
 			this.credentials = null;
 			return null;
 		}
+	}
+
+	/**
+	 * Fetch ALL steps for a trajectory by paging through `step_offset`.
+	 *
+	 * GetCascadeTrajectorySteps caps each response by payload size (e.g. 75 of 665 steps
+	 * for a large session), which would otherwise undercount user turns and tokens. The
+	 * request supports a `step_offset` field (see GetCascadeTrajectoryStepsRequest in the
+	 * Windsurf language-server proto), so we accumulate pages until we have `expectedCount`
+	 * steps or a page comes back empty.
+	 */
+	async getAllTrajectorySteps(cascadeId: string, expectedCount: number): Promise<CascadeTrajectoryStep[]> {
+		const all: CascadeTrajectoryStep[] = [];
+		const maxPages = 100; // safety valve against an unexpected non-advancing server
+		let prevFirstSignature: string | undefined;
+		for (let page = 0; page < maxPages; page++) {
+			const response = await this.getCascadeTrajectorySteps(cascadeId, all.length);
+			const batch = response?.steps;
+			if (!batch || batch.length === 0) { break; }
+			// Guard: if step_offset were ignored, every page would repeat the same first step.
+			// Detect that and stop rather than accumulating duplicates (which would inflate
+			// the user-turn / token counts).
+			const firstSignature = JSON.stringify(batch[0]).slice(0, 200);
+			if (page > 0 && firstSignature === prevFirstSignature) { break; }
+			prevFirstSignature = firstSignature;
+			all.push(...batch);
+			if (expectedCount > 0 && all.length >= expectedCount) { break; }
+		}
+		return all;
 	}
 
 	/**
@@ -676,25 +707,26 @@ export class WindsurfDataAccess {
 					continue;
 				}
 
-				// Fetch the trajectory steps to derive REAL token counts and user-turn
-				// counts. `stepCount` counts every internal agent step, and tokens were
-				// previously a rough `stepCount * 100` estimate — both massively overstate
-				// reality. The steps API exposes per-turn token usage and the actual user
-				// messages (CORTEX_STEP_TYPE_USER_INPUT).
+				// Derive REAL token counts and user-turn counts. `stepCount` counts every
+				// internal agent step (model calls, tool runs), and tokens were previously a
+				// rough `stepCount * 100` estimate — both massively overstate reality.
+				//
+				// Turn counting uses CORTEX_STEP_TYPE_USER_INPUT steps. We page through the full
+				// step list via step_offset so large sessions are not undercounted by the
+				// per-response size cap.
 				let interactions = 1;
 				let tokens = 0;
 				let usedRealData = false;
 				try {
-					const stepsResponse = await this.getCascadeTrajectorySteps(trajectoryId);
-					const steps = stepsResponse?.steps;
-					if (steps && steps.length > 0) {
+					const steps = await this.getAllTrajectorySteps(trajectoryId, activityScore);
+					if (steps.length > 0) {
 						const usage = this.extractTokenUsage(steps);
-						const userTurns = this.countUserTurns(steps);
-						interactions = Math.max(1, userTurns);
+						const stepTurns = this.countUserTurns(steps);
+						interactions = Math.max(1, stepTurns);
 						tokens = usage.totalTokens;
 						usedRealData = true;
 						const partial = steps.length < activityScore;
-						this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} stepsReturned=${steps.length}${partial ? ' (PARTIAL — token/turn counts are a lower bound)' : ''} userTurns=${userTurns} tokens(total=${usage.totalTokens}, input=${usage.inputTokens}, cached=${usage.cachedTokens}) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
+						this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} stepsFetched=${steps.length}${partial ? ' (PARTIAL steps)' : ''} userTurns=${stepTurns} tokens(total=${usage.totalTokens}, input=${usage.inputTokens}, cached=${usage.cachedTokens}) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
 					}
 				} catch (stepError) {
 					this.log(`[Windsurf] trajectory ${trajectoryId}: failed to fetch steps (${stepError}); no token data`);

--- a/vscode-extension/src/windsurf.ts
+++ b/vscode-extension/src/windsurf.ts
@@ -587,6 +587,7 @@ export class WindsurfDataAccess {
 		// Map Windsurf model UIDs to display names
 		const modelMap: { [key: string]: string } = {
 			'claude-sonnet-4': 'Claude Sonnet 4',
+			'claude-sonnet-4-5': 'Claude Sonnet 4.5',
 			'gpt-4o': 'GPT-4o',
 			'gpt-4o-mini': 'GPT-4o Mini',
 			'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
@@ -594,6 +595,65 @@ export class WindsurfDataAccess {
 		};
 		
 		return modelMap[modelUid] || modelUid;
+	}
+
+	/**
+	 * Build a standard ModelUsage map for a Windsurf trajectory so the rest of the
+	 * extension (Today's Sessions breakdown, cost, model column) can treat it like
+	 * any other editor.
+	 *
+	 * Windsurf reports `inputTokens` (uncached input) and `cacheReadTokens` separately,
+	 * whereas the extension's ModelUsage.inputTokens means TOTAL input INCLUDING cache
+	 * reads — so the two are combined here and cachedReadTokens carries the cache portion.
+	 *
+	 * Output tokens are not reported directly. `cumulativeTokensAtStep` (the session
+	 * total) excludes cache reads (it is orders of magnitude smaller than the summed
+	 * cacheReadTokens), so it represents cumulative (uncached input + output). Output is
+	 * therefore derived as totalTokens - inputTokens, clamped at 0 to stay safe if that
+	 * assumption ever breaks.
+	 */
+	buildModelUsage(usage: { totalTokens: number; inputTokens: number; cachedTokens: number }, modelUid: string | undefined): ModelUsage {
+		const model = (modelUid ? this.getModelDisplayName(modelUid) : '') || 'Windsurf';
+		const outputTokens = Math.max(0, usage.totalTokens - usage.inputTokens);
+		return {
+			[model]: {
+				inputTokens: usage.inputTokens + usage.cachedTokens,
+				outputTokens,
+				cachedReadTokens: usage.cachedTokens,
+			},
+		};
+	}
+
+	/**
+	 * Map a Cascade step type to a friendly tool label, or undefined if the step is
+	 * not a tool invocation (planner responses, user inputs, checkpoints, etc.).
+	 */
+	private static readonly TOOL_STEP_LABELS: { [type: string]: string } = {
+		CORTEX_STEP_TYPE_CODE_ACTION: 'Edit file',
+		CORTEX_STEP_TYPE_RUN_COMMAND: 'Run command',
+		CORTEX_STEP_TYPE_VIEW_FILE: 'View file',
+		CORTEX_STEP_TYPE_GREP_SEARCH: 'Grep search',
+		CORTEX_STEP_TYPE_FIND: 'Find',
+		CORTEX_STEP_TYPE_LIST_DIRECTORY: 'List directory',
+		CORTEX_STEP_TYPE_TODO_LIST: 'Todo list',
+		CORTEX_STEP_TYPE_RETRIEVE_MEMORY: 'Retrieve memory',
+	};
+
+	/**
+	 * Count tool invocations in a trajectory, grouped by friendly tool name. Only
+	 * action steps (edits, commands, searches, etc.) are counted — planner responses,
+	 * user inputs, checkpoints and errors are not tools.
+	 */
+	countToolCalls(steps: CascadeTrajectoryStep[]): { total: number; byTool: { [tool: string]: number } } {
+		const byTool: { [tool: string]: number } = {};
+		let total = 0;
+		for (const step of steps) {
+			const label = WindsurfDataAccess.TOOL_STEP_LABELS[step.type];
+			if (!label) { continue; }
+			byTool[label] = (byTool[label] || 0) + 1;
+			total++;
+		}
+		return { total, byTool };
 	}
 
 	/**
@@ -699,55 +759,8 @@ export class WindsurfDataAccess {
 
 			for (const trajectoryId of trajectoryIds) {
 				const summary = trajectories.trajectorySummaries[trajectoryId];
-				const activityScore = summary.stepCount || 0;
-				const lastInteraction = this.pickLatestTimestamp(summary.lastUserInputTime, summary.lastModifiedTime);
-				const utcDayKey = lastInteraction ? lastInteraction.slice(0, 10) : '(none)';
-				if (activityScore === 0) {
-					this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=0 → SKIPPED`);
-					continue;
-				}
-
-				// Derive REAL token counts and user-turn counts. `stepCount` counts every
-				// internal agent step (model calls, tool runs), and tokens were previously a
-				// rough `stepCount * 100` estimate — both massively overstate reality.
-				//
-				// Turn counting uses CORTEX_STEP_TYPE_USER_INPUT steps. We page through the full
-				// step list via step_offset so large sessions are not undercounted by the
-				// per-response size cap.
-				let interactions = 1;
-				let tokens = 0;
-				let usedRealData = false;
-				try {
-					const steps = await this.getAllTrajectorySteps(trajectoryId, activityScore);
-					if (steps.length > 0) {
-						const usage = this.extractTokenUsage(steps);
-						const stepTurns = this.countUserTurns(steps);
-						interactions = Math.max(1, stepTurns);
-						tokens = usage.totalTokens;
-						usedRealData = true;
-						const partial = steps.length < activityScore;
-						this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} stepsFetched=${steps.length}${partial ? ' (PARTIAL steps)' : ''} userTurns=${stepTurns} tokens(total=${usage.totalTokens}, input=${usage.inputTokens}, cached=${usage.cachedTokens}) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
-					}
-				} catch (stepError) {
-					this.log(`[Windsurf] trajectory ${trajectoryId}: failed to fetch steps (${stepError}); no token data`);
-				}
-				if (!usedRealData) {
-					this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} (no steps returned) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
-				}
-
-				sessions.push({
-					file: `windsurf://trajectory/${trajectoryId}`,
-					modified: summary.lastModifiedTime || new Date().toISOString(),
-					size: activityScore,
-					interactions,
-					tokens,
-					contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} },
-					firstInteraction: summary.createdTime,
-					lastInteraction: lastInteraction || summary.lastModifiedTime,
-					editorSource: 'windsurf',
-					editorName: 'Windsurf',
-					title: summary.summary || `Windsurf Session ${trajectoryId}`
-				});
+				const session = await this.buildSessionFromTrajectory(trajectoryId, summary);
+				if (session) { sessions.push(session); }
 			}
 
 			this.log(`[Windsurf] === API DISCOVERY COMPLETE — ${sessions.length} sessions ===`);
@@ -756,6 +769,75 @@ export class WindsurfDataAccess {
 			this.log(`[Windsurf] Exception in getWindsurfSessionsV2(): ${error}`);
 			return [];
 		}
+	}
+
+	/**
+	 * Build a SessionFileDetails for a single Cascade trajectory: fetch its steps,
+	 * derive real token/turn/tool/model breakdowns, and shape it like any other editor's
+	 * session. Returns null for empty (stepCount=0) trajectories.
+	 */
+	private async buildSessionFromTrajectory(trajectoryId: string, summary: CascadeTrajectorySummary): Promise<SessionFileDetails | null> {
+		const activityScore = summary.stepCount || 0;
+		const lastInteraction = this.pickLatestTimestamp(summary.lastUserInputTime, summary.lastModifiedTime);
+		const utcDayKey = lastInteraction ? lastInteraction.slice(0, 10) : '(none)';
+		if (activityScore === 0) {
+			this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=0 → SKIPPED`);
+			return null;
+		}
+
+		// Derive REAL token counts and user-turn counts. `stepCount` counts every
+		// internal agent step (model calls, tool runs), and tokens were previously a
+		// rough `stepCount * 100` estimate — both massively overstate reality.
+		//
+		// Turn counting uses CORTEX_STEP_TYPE_USER_INPUT steps. We page through the full
+		// step list via step_offset so large sessions are not undercounted by the
+		// per-response size cap.
+		let interactions = 1;
+		let tokens = 0;
+		let usedRealData = false;
+		let modelUsage: ModelUsage | undefined;
+		let cachedTokens = 0;
+		let toolCalls: { total: number; byTool: { [tool: string]: number } } | undefined;
+		try {
+			const steps = await this.getAllTrajectorySteps(trajectoryId, activityScore);
+			if (steps.length > 0) {
+				const usage = this.extractTokenUsage(steps);
+				const stepTurns = this.countUserTurns(steps);
+				interactions = Math.max(1, stepTurns);
+				tokens = usage.totalTokens;
+				cachedTokens = usage.cachedTokens;
+				modelUsage = this.buildModelUsage(usage, summary.lastGeneratorModelUid);
+				toolCalls = this.countToolCalls(steps);
+				usedRealData = true;
+				const partial = steps.length < activityScore;
+				if (usage.inputTokens > usage.totalTokens) {
+					this.log(`[Windsurf] trajectory ${trajectoryId}: inputTokens(${usage.inputTokens}) > totalTokens(${usage.totalTokens}) — output clamped to 0 (cumulative-token assumption may have changed)`);
+				}
+				this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} stepsFetched=${steps.length}${partial ? ' (PARTIAL steps)' : ''} userTurns=${stepTurns} tokens(total=${usage.totalTokens}, input=${usage.inputTokens}, cached=${usage.cachedTokens}) tools=${toolCalls.total} → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
+			}
+		} catch (stepError) {
+			this.log(`[Windsurf] trajectory ${trajectoryId}: failed to fetch steps (${stepError}); no token data`);
+		}
+		if (!usedRealData) {
+			this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} (no steps returned) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
+		}
+
+		return {
+			file: `windsurf://trajectory/${trajectoryId}`,
+			modified: summary.lastModifiedTime || new Date().toISOString(),
+			size: activityScore,
+			interactions,
+			tokens,
+			...(modelUsage ? { modelUsage } : {}),
+			...(cachedTokens ? { cachedTokens } : {}),
+			...(toolCalls ? { toolCalls } : {}),
+			contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} },
+			firstInteraction: summary.createdTime,
+			lastInteraction: lastInteraction || summary.lastModifiedTime,
+			editorSource: 'windsurf',
+			editorName: 'Windsurf',
+			title: summary.summary || `Windsurf Session ${trajectoryId}`
+		};
 	}
 
 	/**

--- a/vscode-extension/src/windsurf.ts
+++ b/vscode-extension/src/windsurf.ts
@@ -44,6 +44,12 @@ interface CascadeTrajectoryStep {
 	type: string;
 	metadata?: {
 		requestedModelUid?: string;
+		// Token usage lives on CORTEX_STEP_TYPE_PLANNER_RESPONSE steps (string-encoded ints).
+		// cumulativeTokensAtStep is the running total for the trajectory, so the maximum
+		// across planner responses is the session's total token count.
+		cumulativeTokensAtStep?: string;
+		inputTokens?: string;
+		cacheReadTokens?: string;
 		responseDimensionGroups?: Array<{
 			title: string;
 			dimensions: Array<{
@@ -63,16 +69,22 @@ interface GetCascadeTrajectoryStepsResponse {
 export class WindsurfDataAccess {
 	private credentials: WindsurfCredentials | null = null;
 	private readonly extensionUri: vscode.Uri;
+	private log: (msg: string) => void = (msg) => console.log(msg);
+	private sessionCache: { sessions: SessionFileDetails[]; expiresAt: number } | null = null;
+	private static readonly SESSION_CACHE_TTL_MS = 15_000;
 
-	constructor(extensionUri: vscode.Uri) {
+	constructor(extensionUri: vscode.Uri, log?: (msg: string) => void) {
 		this.extensionUri = extensionUri;
+		if (log) { this.log = log; }
 	}
 
 	/**
 	 * Check if the extension is running inside Windsurf.
 	 */
 	isRunningInWindsurf(): boolean {
-		return vscode.env.appName.toLowerCase().includes('windsurf');
+		const appName = vscode.env.appName.toLowerCase();
+		this.log(`[Windsurf] appName="${vscode.env.appName}" → isWindsurf=${appName.includes('windsurf')}`);
+		return appName.includes('windsurf');
 	}
 
 	/**
@@ -157,33 +169,29 @@ export class WindsurfDataAccess {
 	 */
 	async getCredentials(): Promise<WindsurfCredentials | null> {
 		if (!this.isRunningInWindsurf()) {
-			console.log('[Windsurf] Not running in Windsurf environment');
+			this.log('[Windsurf] Not running in Windsurf environment — skipping credential capture');
 			return null;
 		}
 
 		// Return cached credentials if available
 		if (this.credentials) {
-			console.log('[Windsurf] Using cached credentials');
-			// Validate credentials before returning
 			if (await this.validateCredentials(this.credentials)) {
 				return this.credentials;
 			} else {
-				console.log('[Windsurf] Cached credentials invalid, clearing...');
-				// Clear invalid credentials
+				this.log('[Windsurf] Cached credentials invalid, clearing...');
 				this.credentials = null;
 			}
 		}
 
-		// Try multiple credential capture methods
-		console.log('[Windsurf] Attempting credential capture...');
+		this.log('[Windsurf] Attempting credential capture...');
 		this.credentials = await this.captureCredentials();
-		
-		// Fallback: try alternative methods if primary fails
+
 		if (!this.credentials) {
-			console.log('[Windsurf] Primary capture failed, trying alternative methods...');
+			this.log('[Windsurf] Primary capture failed, trying alternative methods...');
 			this.credentials = await this.captureCredentialsAlternative();
 		}
-		
+
+		this.log(`[Windsurf] Credential capture result: ${this.credentials ? `port=${this.credentials.port}` : 'failed'}`);
 		return this.credentials;
 	}
 
@@ -496,33 +504,49 @@ export class WindsurfDataAccess {
 	}
 
 	/**
-	 * Extract token usage from Cascade trajectory steps.
+	 * Count the number of real user turns in a trajectory. Windsurf's `stepCount`
+	 * counts every internal agent step (model calls, tool runs, etc.); the actual
+	 * number of user messages is the count of CORTEX_STEP_TYPE_USER_INPUT steps.
 	 */
-	extractTokenUsage(steps: CascadeTrajectoryStep[]): { inputTokens: number; outputTokens: number; cachedTokens: number } {
+	countUserTurns(steps: CascadeTrajectoryStep[]): number {
+		return steps.reduce((n, s) => n + (s.type === 'CORTEX_STEP_TYPE_USER_INPUT' ? 1 : 0), 0);
+	}
+
+	/**
+	 * Extract token usage from Cascade trajectory steps.
+	 *
+	 * Token usage is reported on CORTEX_STEP_TYPE_PLANNER_RESPONSE steps via
+	 * string-encoded `metadata.cumulativeTokensAtStep` / `inputTokens` /
+	 * `cacheReadTokens` fields (NOT on USER_INPUT steps, and NOT in the
+	 * 'Token Usage' dimension group, which Windsurf no longer emits).
+	 *
+	 * `cumulativeTokensAtStep` is the running total for the whole trajectory, so the
+	 * maximum across planner responses is the session's total token count. `inputTokens`
+	 * and `cacheReadTokens` are per-step, so they are summed for an input breakdown.
+	 */
+	extractTokenUsage(steps: CascadeTrajectoryStep[]): { totalTokens: number; inputTokens: number; cachedTokens: number } {
+		let totalTokens = 0;
 		let inputTokens = 0;
-		let outputTokens = 0;
 		let cachedTokens = 0;
 
+		const parse = (value: string | undefined): number => {
+			if (!value || !/^\d+$/.test(value)) { return 0; }
+			const n = Number(value);
+			return Number.isSafeInteger(n) ? n : 0;
+		};
+
 		for (const step of steps) {
-			if (step.type !== 'CORTEX_STEP_TYPE_USER_INPUT') {continue;}
-			
-			for (const group of step.metadata?.responseDimensionGroups ?? []) {
-				if (group.title !== 'Token Usage') {continue;}
-				
-				for (const dim of group.dimensions) {
-					const value = dim.cumulativeMetric?.value ?? 0;
-					if (dim.uid === 'input_tokens') {
-						inputTokens += value;
-					} else if (dim.uid === 'output_tokens') {
-						outputTokens += value;
-					} else if (dim.uid === 'cached_input_tokens') {
-						cachedTokens += value;
-					}
-				}
-			}
+			if (step.type !== 'CORTEX_STEP_TYPE_PLANNER_RESPONSE') { continue; }
+			const meta = step.metadata;
+			if (!meta) { continue; }
+
+			const cumulative = parse(meta.cumulativeTokensAtStep);
+			if (cumulative > totalTokens) { totalTokens = cumulative; }
+			inputTokens += parse(meta.inputTokens);
+			cachedTokens += parse(meta.cacheReadTokens);
 		}
 
-		return { inputTokens, outputTokens, cachedTokens };
+		return { totalTokens, inputTokens, cachedTokens };
 	}
 
 	/**
@@ -595,89 +619,139 @@ export class WindsurfDataAccess {
 	}
 
 	/**
-	 * New method to test if there's a binding issue with getWindsurfSessions
+	 * Returns the later of two ISO timestamps, ignoring missing/unparseable values.
+	 * Used so an actively-running session is bucketed by its most recent activity
+	 * (lastModifiedTime advances as the agent works, even when lastUserInputTime is stale).
+	 */
+	private pickLatestTimestamp(...candidates: Array<string | undefined>): string | undefined {
+		let best: string | undefined;
+		let bestMs = -Infinity;
+		for (const c of candidates) {
+			if (!c) { continue; }
+			const ms = Date.parse(c);
+			if (Number.isNaN(ms)) { continue; }
+			if (ms > bestMs) { bestMs = ms; best = c; }
+		}
+		return best;
+	}
+
+	/**
+	 * API-based session discovery (requires running inside Windsurf with credentials).
 	 */
 	async getWindsurfSessionsV2(): Promise<SessionFileDetails[]> {
-		// Add logging to confirm method is reached
-		console.log('[Windsurf] getWindsurfSessionsV2() ENTRY POINT');
-		
+		this.log('[Windsurf] getWindsurfSessionsV2() ENTRY POINT');
+
 		try {
-			console.log('[Windsurf] getWindsurfSessionsV2() called');
-			console.log('[Windsurf] === STARTING SESSION DISCOVERY ===');
+			this.log('[Windsurf] === STARTING API SESSION DISCOVERY ===');
 			const sessions: SessionFileDetails[] = [];
-			
-			// Check if Windsurf is enabled in configuration
-			console.log('[Windsurf] About to get configuration...');
-			const config = vscode.workspace.getConfiguration('copilotTokenTracker');
-			console.log('[Windsurf] Got configuration object');
+
+			const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 			const windsurfEnabled = config.get<boolean>('windsurf.enabled', true);
-			console.log(`[Windsurf] Configuration check - enabled: ${windsurfEnabled}`);
-			
+			this.log(`[Windsurf] enabled=${windsurfEnabled}, isRunningInWindsurf=${this.isRunningInWindsurf()}`);
+
 			if (!windsurfEnabled) {
-				console.log('[Windsurf] Windsurf integration disabled in configuration');
+				this.log('[Windsurf] Windsurf integration disabled in configuration');
 				return [];
 			}
-			
-			console.log('[Windsurf] Fetching trajectories...');
+
+			this.log('[Windsurf] Fetching trajectories via API...');
 			const trajectories = await this.getAllCascadeTrajectories();
-			console.log(`[Windsurf] Got trajectories: ${trajectories ? 'YES' : 'NO'}`);
-			
+			this.log(`[Windsurf] Got trajectories: ${trajectories ? 'YES' : 'NO'}`);
+
 			if (!trajectories || !trajectories.trajectorySummaries) {
-				console.log('[Windsurf] No trajectories available');
+				this.log('[Windsurf] No trajectories available from API');
 				return [];
 			}
-			
+
 			const trajectoryIds = Object.keys(trajectories.trajectorySummaries);
-			console.log(`[Windsurf] Found ${trajectoryIds.length} trajectory summaries`);
-			
-			// Process each trajectory
+			this.log(`[Windsurf] Found ${trajectoryIds.length} trajectory summaries`);
+
 			for (const trajectoryId of trajectoryIds) {
-				console.log(`[Windsurf] Processing trajectory: ${trajectoryId}`);
 				const summary = trajectories.trajectorySummaries[trajectoryId];
-				
-				// For now, use stepCount as a proxy for activity (since we don't have token data in the summary)
 				const activityScore = summary.stepCount || 0;
-				console.log(`[Windsurf] Trajectory ${trajectoryId}: ${activityScore} steps`);
-				
+				const lastInteraction = this.pickLatestTimestamp(summary.lastUserInputTime, summary.lastModifiedTime);
+				const utcDayKey = lastInteraction ? lastInteraction.slice(0, 10) : '(none)';
 				if (activityScore === 0) {
-					console.log(`[Windsurf] Skipping trajectory ${trajectoryId} - no steps`);
+					this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=0 → SKIPPED`);
 					continue;
 				}
-				
-				// Create a session file details object for Windsurf sessions
-				const sessionFile: SessionFileDetails = {
+
+				// Fetch the trajectory steps to derive REAL token counts and user-turn
+				// counts. `stepCount` counts every internal agent step, and tokens were
+				// previously a rough `stepCount * 100` estimate — both massively overstate
+				// reality. The steps API exposes per-turn token usage and the actual user
+				// messages (CORTEX_STEP_TYPE_USER_INPUT).
+				let interactions = 1;
+				let tokens = 0;
+				let usedRealData = false;
+				try {
+					const stepsResponse = await this.getCascadeTrajectorySteps(trajectoryId);
+					const steps = stepsResponse?.steps;
+					if (steps && steps.length > 0) {
+						const usage = this.extractTokenUsage(steps);
+						const userTurns = this.countUserTurns(steps);
+						interactions = Math.max(1, userTurns);
+						tokens = usage.totalTokens;
+						usedRealData = true;
+						const partial = steps.length < activityScore;
+						this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} stepsReturned=${steps.length}${partial ? ' (PARTIAL — token/turn counts are a lower bound)' : ''} userTurns=${userTurns} tokens(total=${usage.totalTokens}, input=${usage.inputTokens}, cached=${usage.cachedTokens}) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
+					}
+				} catch (stepError) {
+					this.log(`[Windsurf] trajectory ${trajectoryId}: failed to fetch steps (${stepError}); no token data`);
+				}
+				if (!usedRealData) {
+					this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} (no steps returned) → interactions=${interactions} tokens=${tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
+				}
+
+				sessions.push({
 					file: `windsurf://trajectory/${trajectoryId}`,
 					modified: summary.lastModifiedTime || new Date().toISOString(),
-					size: activityScore, // Use stepCount as size proxy
-					interactions: activityScore, // Use stepCount as interactions
-					tokens: activityScore * 100, // Rough token estimate
-					contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} }, // Default values
+					size: activityScore,
+					interactions,
+					tokens,
+					contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} },
 					firstInteraction: summary.createdTime,
-					lastInteraction: summary.lastUserInputTime || summary.lastModifiedTime,
+					lastInteraction: lastInteraction || summary.lastModifiedTime,
 					editorSource: 'windsurf',
 					editorName: 'Windsurf',
 					title: summary.summary || `Windsurf Session ${trajectoryId}`
-				};
-				
-				console.log(`[Windsurf] Added session: ${sessionFile.file} (${activityScore} steps)`);
-				sessions.push(sessionFile);
+				});
 			}
-			
-			console.log(`[Windsurf] === SESSION DISCOVERY COMPLETE ===`);
-			console.log(`[Windsurf] Returning ${sessions.length} sessions`);
+
+			this.log(`[Windsurf] === API DISCOVERY COMPLETE — ${sessions.length} sessions ===`);
 			return sessions;
-			
 		} catch (error) {
-			console.error('[Windsurf] Exception in getWindsurfSessionsV2():', error);
+			this.log(`[Windsurf] Exception in getWindsurfSessionsV2(): ${error}`);
 			return [];
 		}
 	}
 
 	/**
-	 * Process all Windurf trajectories and return session details.
+	 * Process all Windsurf trajectories and return session details.
+	 * Tries the API first (full token data), falls back to .pb file metadata when API is unavailable.
 	 */
 	async getWindsurfSessions(): Promise<SessionFileDetails[]> {
-		return this.getWindsurfSessionsV2();
+		this.log('[Windsurf] getWindsurfSessions() called');
+		const now = Date.now();
+		if (this.sessionCache && this.sessionCache.expiresAt > now) {
+			this.log(`[Windsurf] Returning ${this.sessionCache.sessions.length} cached session(s)`);
+			return this.sessionCache.sessions;
+		}
+		const sessions = await this.discoverWindsurfSessions();
+		this.sessionCache = { sessions, expiresAt: now + WindsurfDataAccess.SESSION_CACHE_TTL_MS };
+		return sessions;
+	}
+
+	private async discoverWindsurfSessions(): Promise<SessionFileDetails[]> {
+		const apiSessions = await this.getWindsurfSessionsV2();
+		if (apiSessions.length > 0) {
+			this.log(`[Windsurf] API returned ${apiSessions.length} session(s)`);
+			return apiSessions;
+		}
+		this.log('[Windsurf] API returned no sessions — falling back to .pb file discovery');
+		const fileSessions = await this.getWindsurfCascadeSessionFiles();
+		this.log(`[Windsurf] File-based discovery found ${fileSessions.length} session(s)`);
+		return fileSessions;
 	}
 
 	/**
@@ -694,7 +768,7 @@ export class WindsurfDataAccess {
 			
 			// Check if Windsurf is enabled in configuration
 			console.log('[Windsurf] About to get configuration...');
-			const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+			const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 			console.log('[Windsurf] Got configuration object');
 			const windsurfEnabled = config.get<boolean>('windsurf.enabled', true);
 			console.log(`[Windsurf] Configuration check - enabled: ${windsurfEnabled}`);
@@ -734,8 +808,8 @@ export class WindsurfDataAccess {
 
 				console.log(`[Windsurf] Found ${steps.steps.length} steps for trajectory ${cascadeId}`);
 				const tokenUsage = this.extractTokenUsage(steps.steps);
-				const totalTokens = tokenUsage.inputTokens + tokenUsage.outputTokens;
-				console.log(`[Windsurf] Token usage for ${cascadeId}: input=${tokenUsage.inputTokens}, output=${tokenUsage.outputTokens}, total=${totalTokens}`);
+				const totalTokens = tokenUsage.totalTokens;
+				console.log(`[Windsurf] Token usage for ${cascadeId}: total=${totalTokens}, input=${tokenUsage.inputTokens}, cached=${tokenUsage.cachedTokens}`);
 				
 				if (totalTokens === 0) {
 					console.log(`[Windsurf] Skipping trajectory ${cascadeId} - no tokens found`);
@@ -881,7 +955,7 @@ export class WindsurfDataAccess {
 		}
 
 		// Configuration checks
-		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 		diagnostics.configuration = {
 			enabled: config.get<boolean>('windsurf.enabled', true),
 		};

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -710,6 +710,9 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
 	if (normalizedPath.includes('/.claude/projects/')) {
 		return 'Claude Code';
 	}
+	if (normalizedPath.startsWith('windsurf://')) {
+		return 'Windsurf';
+	}
 	if (normalizedPath.includes('/code - insiders/') || normalizedPath.includes('/code%20-%20insiders/')) {
 		return 'VS Code Insiders';
 	}

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -913,6 +913,7 @@ function detectVSCodeVariantFromPath(lowerPath: string): string | undefined {
  */
 export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);
+	if (lowerPath.startsWith('windsurf://')) { return 'Windsurf'; }
 	return detectToolEditorFromPath(filePath, lowerPath, isOpenCodeSessionFile) ??
 		detectVSCodeVariantFromPath(lowerPath) ??
 		'Unknown';
@@ -940,6 +941,7 @@ function detectIDEEditorSource(lowerPath: string): string | undefined {
  */
 export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);
+	if (lowerPath.startsWith('windsurf://')) { return 'Windsurf'; }
 	if (lowerPath.includes('/.copilot/jb/')) { return 'JetBrains'; }
 	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
 	if (lowerPath.includes('/.copilot/session-store.db#')) { return 'Copilot CLI'; }

--- a/vscode-extension/test/unit/windsurf.test.ts
+++ b/vscode-extension/test/unit/windsurf.test.ts
@@ -166,3 +166,55 @@ test('getAllTrajectorySteps: returns empty when the first page is empty', async 
 	assert.equal(all.length, 0);
 });
 
+// ----- buildModelUsage -----
+
+test('buildModelUsage: maps Windsurf input+cache into ModelUsage and derives output', () => {
+	// inputTokens is uncached; cachedTokens is cache reads; total excludes cache.
+	const usage = { totalTokens: 149612, inputTokens: 18141, cachedTokens: 1872656 };
+	const mu = windsurf.buildModelUsage(usage, 'claude-sonnet-4-5');
+	const entry = mu['Claude Sonnet 4.5'];
+	assert.ok(entry, 'expected the model display name as the key');
+	// ModelUsage.inputTokens is TOTAL input incl. cache reads.
+	assert.equal(entry.inputTokens, 18141 + 1872656);
+	assert.equal(entry.cachedReadTokens, 1872656);
+	// output = total - uncached input.
+	assert.equal(entry.outputTokens, 149612 - 18141);
+});
+
+test('buildModelUsage: clamps output to 0 when inputTokens exceeds totalTokens', () => {
+	const usage = { totalTokens: 100, inputTokens: 500, cachedTokens: 0 };
+	const mu = windsurf.buildModelUsage(usage, 'gpt-4o');
+	assert.equal(mu['GPT-4o'].outputTokens, 0);
+});
+
+test('buildModelUsage: falls back to a "Windsurf" key when the model UID is missing', () => {
+	const usage = { totalTokens: 10, inputTokens: 4, cachedTokens: 0 };
+	const mu = windsurf.buildModelUsage(usage, undefined);
+	assert.ok(mu['Windsurf'], 'expected a Windsurf fallback key');
+	assert.equal(mu['Windsurf'].outputTokens, 6);
+});
+
+// ----- countToolCalls -----
+
+test('countToolCalls: counts only action steps, grouped by friendly tool name', () => {
+	const steps = [
+		userStep(),
+		plannerStep({ cumulativeTokensAtStep: '100' }),
+		otherStep('CORTEX_STEP_TYPE_CODE_ACTION'),
+		otherStep('CORTEX_STEP_TYPE_CODE_ACTION'),
+		otherStep('CORTEX_STEP_TYPE_RUN_COMMAND'),
+		otherStep('CORTEX_STEP_TYPE_CHECKPOINT'), // not a tool
+		otherStep('CORTEX_STEP_TYPE_ERROR_MESSAGE'), // not a tool
+		otherStep('CORTEX_STEP_TYPE_GREP_SEARCH'),
+	] as any;
+
+	const result = windsurf.countToolCalls(steps);
+	assert.equal(result.total, 4);
+	assert.deepEqual(result.byTool, { 'Edit file': 2, 'Run command': 1, 'Grep search': 1 });
+});
+
+test('countToolCalls: returns an empty breakdown when there are no tool steps', () => {
+	const steps = [userStep(), plannerStep({ cumulativeTokensAtStep: '100' })] as any;
+	assert.deepEqual(windsurf.countToolCalls(steps), { total: 0, byTool: {} });
+});
+

--- a/vscode-extension/test/unit/windsurf.test.ts
+++ b/vscode-extension/test/unit/windsurf.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for Windsurf (Cascade) token / user-turn extraction
+ * (src/windsurf.ts).
+ *
+ * Token usage lives on CORTEX_STEP_TYPE_PLANNER_RESPONSE steps as string-encoded
+ * integers (cumulativeTokensAtStep / inputTokens / cacheReadTokens). User turns are
+ * the count of CORTEX_STEP_TYPE_USER_INPUT steps. These tests pin that behaviour.
+ */
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+
+import { WindsurfDataAccess } from '../../src/windsurf';
+
+const windsurf = new WindsurfDataAccess(vscode.Uri.file('/mock/ext') as any);
+
+const plannerStep = (meta: Record<string, string>) => ({
+	type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+	metadata: meta,
+});
+const userStep = () => ({ type: 'CORTEX_STEP_TYPE_USER_INPUT', metadata: {} });
+const otherStep = (type: string) => ({ type, metadata: {} });
+
+// ----- extractTokenUsage -----
+
+test('extractTokenUsage: totalTokens is the max cumulativeTokensAtStep across planner steps', () => {
+	const steps = [
+		userStep(),
+		plannerStep({ cumulativeTokensAtStep: '4200', inputTokens: '4000', cacheReadTokens: '100' }),
+		otherStep('CORTEX_STEP_TYPE_TOOL_CALL'),
+		plannerStep({ cumulativeTokensAtStep: '10417', inputTokens: '8717', cacheReadTokens: '1152' }),
+	] as any;
+
+	const usage = windsurf.extractTokenUsage(steps);
+	assert.equal(usage.totalTokens, 10417);
+	assert.equal(usage.inputTokens, 4000 + 8717);
+	assert.equal(usage.cachedTokens, 100 + 1152);
+});
+
+test('extractTokenUsage: ignores non-planner steps entirely', () => {
+	const steps = [
+		userStep(),
+		otherStep('CORTEX_STEP_TYPE_RETRIEVE_MEMORY'),
+		otherStep('CORTEX_STEP_TYPE_USER_INPUT'),
+	] as any;
+
+	const usage = windsurf.extractTokenUsage(steps);
+	assert.deepEqual(usage, { totalTokens: 0, inputTokens: 0, cachedTokens: 0 });
+});
+
+test('extractTokenUsage: tolerates planner steps missing some token fields', () => {
+	const steps = [
+		plannerStep({ cumulativeTokensAtStep: '11027' }), // no inputTokens / cacheReadTokens
+		plannerStep({ inputTokens: '500' }), // no cumulativeTokensAtStep
+	] as any;
+
+	const usage = windsurf.extractTokenUsage(steps);
+	assert.equal(usage.totalTokens, 11027);
+	assert.equal(usage.inputTokens, 500);
+	assert.equal(usage.cachedTokens, 0);
+});
+
+test('extractTokenUsage: rejects malformed / non-integer strings instead of partial-parsing', () => {
+	const steps = [
+		plannerStep({ cumulativeTokensAtStep: '123abc', inputTokens: '1.2e4', cacheReadTokens: '-50' }),
+		plannerStep({ cumulativeTokensAtStep: '9000' }),
+	] as any;
+
+	const usage = windsurf.extractTokenUsage(steps);
+	// '123abc', '1.2e4' and '-50' are all rejected (no silent parseInt truncation / negatives)
+	assert.equal(usage.totalTokens, 9000);
+	assert.equal(usage.inputTokens, 0);
+	assert.equal(usage.cachedTokens, 0);
+});
+
+test('extractTokenUsage: handles missing metadata and empty input', () => {
+	assert.deepEqual(windsurf.extractTokenUsage([]), { totalTokens: 0, inputTokens: 0, cachedTokens: 0 });
+	const steps = [{ type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE' }] as any;
+	assert.deepEqual(windsurf.extractTokenUsage(steps), { totalTokens: 0, inputTokens: 0, cachedTokens: 0 });
+});
+
+// ----- countUserTurns -----
+
+test('countUserTurns: counts only CORTEX_STEP_TYPE_USER_INPUT steps', () => {
+	const steps = [
+		userStep(),
+		plannerStep({ cumulativeTokensAtStep: '100' }),
+		otherStep('CORTEX_STEP_TYPE_TOOL_CALL'),
+		userStep(),
+		userStep(),
+	] as any;
+
+	assert.equal(windsurf.countUserTurns(steps), 3);
+});
+
+test('countUserTurns: returns 0 when there are no user-input steps', () => {
+	const steps = [plannerStep({ cumulativeTokensAtStep: '100' }), otherStep('CORTEX_STEP_TYPE_TOOL_CALL')] as any;
+	assert.equal(windsurf.countUserTurns(steps), 0);
+	assert.equal(windsurf.countUserTurns([]), 0);
+});

--- a/vscode-extension/test/unit/windsurf.test.ts
+++ b/vscode-extension/test/unit/windsurf.test.ts
@@ -98,3 +98,71 @@ test('countUserTurns: returns 0 when there are no user-input steps', () => {
 	assert.equal(windsurf.countUserTurns(steps), 0);
 	assert.equal(windsurf.countUserTurns([]), 0);
 });
+
+// ----- getAllTrajectorySteps (step_offset pagination) -----
+
+/**
+ * Test double that serves canned step pages keyed by offset, recording the offsets
+ * requested. Lets us exercise the pagination loop without a live Windsurf API.
+ */
+class PagingWindsurf extends WindsurfDataAccess {
+	requestedOffsets: number[] = [];
+	constructor(private pages: Array<Array<{ type: string }>>, private ignoreOffset = false) {
+		super(vscode.Uri.file('/mock/ext') as any);
+	}
+	async getCascadeTrajectorySteps(_cascadeId: string, stepOffset = 0): Promise<any> {
+		this.requestedOffsets.push(stepOffset);
+		if (this.ignoreOffset) {
+			// Simulate a server that ignores step_offset and always returns page 0.
+			return { steps: this.pages[0] };
+		}
+		// Find the page whose starting index matches the requested offset.
+		let acc = 0;
+		for (const page of this.pages) {
+			if (acc === stepOffset) { return { steps: page }; }
+			acc += page.length;
+		}
+		return { steps: [] };
+	}
+}
+
+test('getAllTrajectorySteps: accumulates all pages via increasing step_offset', async () => {
+	const pages = [
+		[{ type: 'A' }, { type: 'B' }, { type: 'C' }],
+		[{ type: 'D' }, { type: 'E' }],
+		[{ type: 'F' }],
+	];
+	const wd = new PagingWindsurf(pages);
+	const all = await wd.getAllTrajectorySteps('cid', 6);
+	assert.equal(all.length, 6);
+	assert.deepEqual(all.map((s) => (s as any).type), ['A', 'B', 'C', 'D', 'E', 'F']);
+	assert.deepEqual(wd.requestedOffsets, [0, 3, 5]);
+});
+
+test('getAllTrajectorySteps: stops once expectedCount is reached', async () => {
+	const pages = [
+		[{ type: 'A' }, { type: 'B' }],
+		[{ type: 'C' }, { type: 'D' }],
+	];
+	const wd = new PagingWindsurf(pages);
+	const all = await wd.getAllTrajectorySteps('cid', 2);
+	assert.equal(all.length, 2); // does not fetch the second page
+	assert.deepEqual(wd.requestedOffsets, [0]);
+});
+
+test('getAllTrajectorySteps: guards against a server that ignores step_offset (no duplicate accumulation)', async () => {
+	const pages = [[{ type: 'A' }, { type: 'B' }]];
+	const wd = new PagingWindsurf(pages, /* ignoreOffset */ true);
+	const all = await wd.getAllTrajectorySteps('cid', 10);
+	// Without the guard this would loop to maxPages accumulating duplicates; the
+	// repeated-first-step guard stops after the second identical page.
+	assert.equal(all.length, 2);
+	assert.deepEqual(all.map((s) => (s as any).type), ['A', 'B']);
+});
+
+test('getAllTrajectorySteps: returns empty when the first page is empty', async () => {
+	const wd = new PagingWindsurf([[]]);
+	const all = await wd.getAllTrajectorySteps('cid', 0);
+	assert.equal(all.length, 0);
+});
+


### PR DESCRIPTION
## Why

The extension tracks AI coding token usage across editors, but Windsurf (Cascade) sessions were not surfaced accurately. They either did not appear in the session views, or showed fabricated numbers: a fixed `stepCount x 100` token estimate and `stepCount` (600+) reported as "turns", with the Today's Sessions breakdown columns all empty. This PR makes Windsurf a first-class editor with real, API-sourced usage data.

## What

Windsurf has no re-parseable per-session log file, so the data layer queries Windsurf's local language-server gRPC API and maps the result into the extension's standard shapes up front.

- **Discovery and display.** Windsurf trajectories are discovered via the API and shown everywhere other editors are (session list, details, Today's Sessions, diagnostics). Both editor-detection helpers and session discovery understand the virtual `windsurf://trajectory/{id}` paths.

- **Real token counts.** Token usage is read from `CORTEX_STEP_TYPE_PLANNER_RESPONSE` step metadata (`cumulativeTokensAtStep`, `inputTokens`, `cacheReadTokens`), replacing the old fixed estimate. The session total is the max `cumulativeTokensAtStep` (it is trajectory-cumulative).

- **Real turn counts via pagination.** `GetCascadeTrajectorySteps` caps each response by payload size, so large sessions were truncated and undercounted (e.g. 75 of 665 steps). The step API supports a `step_offset` field (per the Windsurf language-server proto), so `getAllTrajectorySteps` now pages through the full list before counting `CORTEX_STEP_TYPE_USER_INPUT` steps. A 666-step session now reports 26 turns instead of 1.

- **Today's Sessions breakdown.** Windsurf sessions now build a standard `modelUsage` map (model name from `lastGeneratorModelUid`; `inputTokens` = uncached input + cache reads; `cachedReadTokens` = cache reads; `outputTokens` derived as `cumulativeTokens - uncachedInput`), plus session-level cached tokens and a tool-call breakdown counted from action step types. This fills the previously empty Input/Output/Cached/Models/Cost/Tools columns.

- **Correct day attribution.** Windsurf gives no per-day breakdown, so activity is attributed to the session's last-activity day; otherwise long-lived sessions bucketed under their (often months-old) creation date.

## Notes for reviewers

- **Output tokens are inferred**, not reported by Windsurf. The derivation relies on `cumulativeTokensAtStep` excluding cache reads (verified: the summed cache reads are ~12x larger than the cumulative total). Output is clamped at 0 and a warning is logged if `inputTokens > totalTokens`, in case that assumption ever changes. Cost is therefore an estimate, and unknown model UIDs fall back to gpt-4o-mini pricing.
- The "Total" column stays equal to `cumulativeTokensAtStep` and is intentionally not the sum of the Input/Output columns (consistent with how other editors already display a separate billed total).
- Discovery is slightly slower for very large sessions (~13s vs ~7s) because big trajectories page sequentially; the 15s session cache absorbs most of this.
- All numbers above were confirmed against the live Windsurf API during development.

## Testing

- New `windsurf.test.ts` with 16 unit tests covering token extraction, turn counting, `step_offset` pagination (including the offset-ignored dedup guard), model-usage mapping, and tool-call counting.
- Rollup/stats/attribution suites pass (87 tests); full compile clean (0 errors).
