### PR TITLE
chore: bump versions for release (vscode-extension, cli, visualstudio-extension)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.6"
+              Version="1.0.7"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.1.2 | v0.1.3 |
| CLI | v0.0.8 | v0.0.9 |
| Visual Studio extension | v1.0.6 | v1.0.7 |

### After merging, run these workflows:

1. **Extensions - Release** (
Release.yml) — Actions → _Extensions - Release_ → Run workflow (on main)
   Publishes VS Code extension **v0.1.3** to the VS Code Marketplace

2. **CLI - Publish to npm and GitHub** (cli-publish.yml) — Actions → _CLI - Publish to npm and GitHub_ → Run workflow (on main)
   Publishes **@rajbos/ai-engineering-fluency@0.0.9** to npm

3. **Visual Studio Extension - Build & Package** (Visualstudio-build.yml) — Actions → _Visual Studio Extension - Build & Package_ → Run workflow (on main)
   Set publish_marketplace: true to publish **v1.0.7** to the Visual Studio Marketplace