### PR TITLE
fix: add node types to CLI tsconfig

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "lib": ["ES2022"],
+    "types": ["node"],
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "dist",


### PR DESCRIPTION
## Summary

Adds `"types": ["node"]` to `cli/tsconfig.json` to resolve TypeScript compile errors for `console` and `process` globals in `cli/src/commands/environmental.ts`.

`@types/node` was already a dev dependency in `cli/package.json` but wasn't being picked up because the `types` array wasn't specified in the compiler options.