### PR TITLE
fix: use absolute URLs for logo image in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Token Tracker
 
-![AI Engineering Fluency](assets/AI%20Engineering%20Fluency%20-%20Transparent.png)
+![AI Engineering Fluency](https://raw.githubusercontent.com/rajbos/github-copilot-token-usage/main/assets/AI%20Engineering%20Fluency%20-%20Transparent.png)
 
 Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Studio, and the command line. All data is read from local session logs — nothing leaves your machine unless you opt in to cloud sync.
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # AI Engineering Fluency — VS Code Extension
 
-![AI Engineering Fluency](../assets/AI%20Engineering%20Fluency%20-%20Transparent.png)
+![AI Engineering Fluency](https://raw.githubusercontent.com/rajbos/github-copilot-token-usage/main/assets/AI%20Engineering%20Fluency%20-%20Transparent.png)
 
 Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and productivity insights directly inside VS Code. Reads local session logs and displays today's and monthly usage in the status bar, with rich detail views and optional cloud sync.
 


### PR DESCRIPTION
## Problem

The AI Engineering Fluency logo at the top of the README was not loading on:
- [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker)
- [Open VSX](https://open-vsx.org/extension/RobBos/copilot-token-tracker)

All other images (badges, screenshots) loaded fine because they already used absolute URLs.

## Root Cause

Both README files used relative paths for the logo:
- \README.md\: \ssets/AI%20Engineering%20Fluency%20-%20Transparent.png\
- \scode-extension/README.md\: \../assets/AI%20Engineering%20Fluency%20-%20Transparent.png\

Marketplace renderers don't resolve relative paths (especially ones traversing \../\), so the image returned a 404.

## Fix

Replace both relative paths with the absolute \aw.githubusercontent.com\ URL.