### PR TITLE
chore: bump versions for release (vscode-extension, visualstudio-extension)

### DIFF
--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.7"
+              Version="1.0.8"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {
@@ -369,5 +369,3 @@
     "serialize-javascript": ">=7.0.3"
   }
 }
-
-


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.1.3 | v0.1.4 |
| Visual Studio extension | v1.0.7 | v1.0.8 |

### After merging, run these workflows:

- **Extensions - Release** (\elease.yml\) — publishes VS Code extension v0.1.4
- **Visual Studio Extension - Build & Package** (\isualstudio-build.yml\) — set \publish_marketplace: true\ to publish VS extension v1.0.8