### PR TITLE
feat: self-hosted sharing server (Phases 1–3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ visualstudio-extension/src/CopilotTokenTracker/obj/project.nuget.cache
 visualstudio-extension/src/CopilotTokenTracker.Tests/bin/
 visualstudio-extension/src/CopilotTokenTracker.Tests/obj/
 visualstudio-extension/TestResults/
+vscode-extension/.session_secret.txt

--- a/README.md
+++ b/README.md
@@ -88,6 +88,48 @@ npx @rajbos/ai-engineering-fluency stats
 
 ---
 
+### 🔗 Self-Hosted Sharing Server
+
+Share usage data with your team without an Azure account. Run a lightweight API server
+on your own infrastructure — team members configure a single endpoint URL and upload
+automatically via their existing GitHub session.
+
+- **Zero Azure required** — SQLite + Docker, runs anywhere
+- **Auth via GitHub** — reuses the session already held by VS Code/Copilot, no API keys
+- **Optional org gating** — restrict uploads to GitHub org members
+- **Web dashboard** — see aggregated usage across your team
+
+```yaml
+# docker-compose.yml
+services:
+  sharing-server:
+    image: ghcr.io/rajbos/copilot-sharing-server:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GITHUB_CLIENT_ID=...
+      - GITHUB_CLIENT_SECRET=...
+      - SESSION_SECRET=...
+      - BASE_URL=https://copilot.example.com
+    volumes:
+      - sharing_data:/data
+volumes:
+  sharing_data:
+```
+
+```json
+// VS Code settings — the only thing team members configure
+{
+  "copilotTokenTracker.backend.enabled": true,
+  "copilotTokenTracker.backend.backend": "sharingServer",
+  "copilotTokenTracker.backend.sharingServer.endpointUrl": "https://copilot.example.com"
+}
+```
+
+📖 [Full sharing server documentation](sharing-server/README.md)
+
+---
+
 ## Contributing
 
 Interested in contributing? Check out our [Contributing Guide](CONTRIBUTING.md) for:

--- a/build.ps1
+++ b/build.ps1
@@ -8,10 +8,11 @@
     Projects:
       vscode-extension  – VS Code extension (TypeScript / Node.js)
       cli               – Command-line tool  (TypeScript / Node.js)
+      sharing           – Self-hosted sharing server (TypeScript / Node.js)
       visualstudio-extension – Visual Studio extension (C# / .NET)   [future]
 
 .PARAMETER Project
-    Which project(s) to build.  Accepts: all | vscode | cli | visualstudio
+    Which project(s) to build.  Accepts: all | vscode | cli | sharing | visualstudio
     Default: all
 
 .PARAMETER Target
@@ -28,7 +29,7 @@
 #>
 
 param(
-    [ValidateSet('all', 'vscode', 'cli', 'visualstudio')]
+    [ValidateSet('all', 'vscode', 'cli', 'visualstudio', 'sharing')]
     [string] $Project = 'all',
 
     [ValidateSet('build', 'package', 'test', 'clean')]
@@ -195,16 +196,34 @@ function Build-VisualStudio {
 }
 
 # ---------------------------------------------------------------------------
-# Entry point
+# Sharing Server
 # ---------------------------------------------------------------------------
+function Build-Sharing {
+    Write-Step "sharing-server: $Target"
+    Push-Location "$PSScriptRoot/sharing-server"
+    try {
+        switch ($Target) {
+            'build'   { npm ci; npm run build }
+            'package' { npm ci; npm run build:production }
+            'test'    { Write-Host "    (no sharing-server tests yet)" }
+            'clean'   { Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue }
+        }
+        Write-Ok "sharing-server done."
+    }
+    finally { Pop-Location }
+}
+
+
 switch ($Project) {
     'all' {
         Build-VsCode
         Build-Cli
+        Build-Sharing
         Build-VisualStudio
     }
     'vscode'      { Build-VsCode }
     'cli'         { Build-Cli }
+    'sharing'     { Build-Sharing }
     'visualstudio'{ Build-VisualStudio }
 }
 

--- a/sharing-server/.env.example
+++ b/sharing-server/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env and fill in the values before running docker-compose
+
+# GitHub OAuth App credentials (create at https://github.com/settings/developers)
+# Set Callback URL to: <BASE_URL>/auth/github/callback
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+
+# Random secret for signing session cookies
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+SESSION_SECRET=change_me_to_a_random_secret
+
+# Public base URL of this server (used in OAuth redirect URI and links)
+BASE_URL=http://localhost:3000
+
+# Optional: restrict to members of a specific GitHub organization
+# Leave empty to allow any GitHub user
+ALLOWED_GITHUB_ORG=

--- a/sharing-server/.gitignore
+++ b/sharing-server/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+data/
+*.db
+.env

--- a/sharing-server/Dockerfile
+++ b/sharing-server/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+
+# ── Build stage ──────────────────────────────────────────────────────────────
+# Uses node:sqlite (built-in, no native compilation needed)
+FROM node:24-slim AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build:production
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+FROM node:24-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the compiled bundle (no node_modules needed — no native deps)
+COPY --from=builder /app/dist ./dist
+
+RUN mkdir -p /data
+
+VOLUME ["/data"]
+
+EXPOSE 3000
+
+ENV NODE_ENV=production \
+    DATA_DIR=/data \
+    PORT=3000
+
+# Use tini as PID 1 for proper signal handling
+ENTRYPOINT ["tini", "--"]
+CMD ["node", "dist/server.js"]

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -95,6 +95,61 @@ npm run build            # development build
 npm run build:production # minified build
 ```
 
+## Running locally (without Docker)
+
+### 1. Install dependencies
+
+```bash
+cd sharing-server
+npm ci
+```
+
+### 2. Create a `.env` file
+
+Copy the example and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Minimum required in `.env`:
+
+```env
+GITHUB_CLIENT_ID=your_github_oauth_app_client_id
+GITHUB_CLIENT_SECRET=your_github_oauth_app_client_secret
+SESSION_SECRET=any_long_random_string_at_least_32_chars
+BASE_URL=http://localhost:3000
+PORT=3000
+DB_PATH=./data/sharing.db
+```
+
+> **GitHub OAuth App callback URL** for local dev: `http://localhost:3000/auth/github/callback`
+
+### 3. Build and start
+
+```bash
+npm run build   # compile TypeScript → dist/server.js
+npm start       # start the server (automatically loads .env via Node --env-file)
+```
+
+Or for **watch mode** (auto-restarts `dist/server.js` whenever it changes):
+
+```bash
+npm run dev
+```
+
+> Run `npm run build` in a separate terminal to rebuild after editing `src/`. The `dev`
+> script uses `node --watch` which restarts automatically when `dist/server.js` changes.
+
+### 4. Verify
+
+```bash
+curl http://localhost:3000/health
+# → {"status":"ok","timestamp":"..."}
+```
+
+Open `http://localhost:3000/dashboard` in your browser to test the OAuth login flow.
+
 ## Environment variables
 
 | Variable | Required | Description |

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -55,7 +55,13 @@ volumes:
   sharing_data:
 ```
 
-> **Tip**: Generate `SESSION_SECRET` with `openssl rand -hex 32`
+> **Tip**: Generate `SESSION_SECRET` with `openssl rand -hex 32` in bash, or in PowerShell:
+``` powershell
+$bytes = New-Object byte[] 32
+[System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+($bytes | ForEach-Object { $_.ToString("x2") }) -join '' | Set-Content -Path .session_secret.txt
+Get-Content .session_secret.txt
+```
 
 ### 3. Start and verify
 

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -1,0 +1,197 @@
+# Copilot Token Usage — Sharing Server
+
+A self-hosted API server + web dashboard that makes sharing Copilot token usage data
+across a team dramatically easier. No Azure account required — anyone with Docker can
+host it in minutes.
+
+## How it works
+
+```
+[VS Code Extension]  ──Bearer token──►  POST /api/upload
+                         (GitHub session)       │
+                                        [Sharing Server]
+                                               │
+                                         SQLite DB (./data/)
+                                               │
+[Web Browser]  ──OAuth login──►  GET /dashboard
+```
+
+**The extension already holds a GitHub OAuth session** (the same one used by Copilot
+and GitHub PR statistics). When you configure a sharing server endpoint URL, the
+extension automatically uses that token for uploads — no API keys, no copy-paste,
+no new consent required.
+
+## Quick start with Docker Compose
+
+### 1. Create a GitHub OAuth App
+
+1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
+2. Fill in:
+   - **Application name**: `Copilot Token Tracker`
+   - **Homepage URL**: `https://your-server.example.com`
+   - **Authorization callback URL**: `https://your-server.example.com/auth/github/callback`
+3. Copy the **Client ID** and generate a **Client Secret**
+
+### 2. Create the compose file
+
+```yaml
+services:
+  sharing-server:
+    image: ghcr.io/rajbos/copilot-sharing-server:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GITHUB_CLIENT_ID=your_client_id
+      - GITHUB_CLIENT_SECRET=your_client_secret
+      - SESSION_SECRET=a_long_random_string_min_32_chars
+      - BASE_URL=https://your-server.example.com
+      # Optional: restrict uploads to members of a specific GitHub org
+      # - ALLOWED_GITHUB_ORG=your-org-name
+    volumes:
+      - sharing_data:/data
+    restart: unless-stopped
+
+volumes:
+  sharing_data:
+```
+
+> **Tip**: Generate `SESSION_SECRET` with `openssl rand -hex 32`
+
+### 3. Start and verify
+
+```bash
+docker compose up -d
+curl https://your-server.example.com/health
+# → {"status":"ok","timestamp":"..."}
+```
+
+### 4. Configure the VS Code extension
+
+In VS Code settings (JSON):
+
+```json
+{
+  "copilotTokenTracker.backend.enabled": true,
+  "copilotTokenTracker.backend.backend": "sharingServer",
+  "copilotTokenTracker.backend.sharingServer.endpointUrl": "https://your-server.example.com"
+}
+```
+
+Or search for **Copilot Token Tracker: Backend** in the Settings UI and fill in the fields.
+
+That's it. The extension will start uploading data automatically. No authentication
+prompt — it reuses your existing GitHub session.
+
+## Building from source
+
+```bash
+# From the repo root:
+./build.ps1 -Project sharing
+
+# Or from the sharing-server/ directory:
+cd sharing-server
+npm ci
+npm run build            # development build
+npm run build:production # minified build
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `GITHUB_CLIENT_ID` | ✅ | GitHub OAuth App client ID (for dashboard login) |
+| `GITHUB_CLIENT_SECRET` | ✅ | GitHub OAuth App client secret (for dashboard login) |
+| `SESSION_SECRET` | ✅ | Random secret for signing session cookies (≥32 chars) |
+| `BASE_URL` | ✅ | Public base URL of the server (no trailing slash) |
+| `PORT` | ❌ | HTTP port (default: `3000`) |
+| `DB_PATH` | ❌ | SQLite database path (default: `/data/sharing.db`) |
+| `ALLOWED_GITHUB_ORG` | ❌ | If set, only members of this GitHub org can upload data |
+
+## REST API
+
+### Upload daily rollups (used by the VS Code extension)
+
+```
+POST /api/upload
+Authorization: Bearer <github-token>
+Content-Type: application/json
+
+[
+  {
+    "day": "2026-04-21",
+    "model": "gpt-4o",
+    "workspaceId": "my-project",
+    "workspaceName": "My Project",
+    "machineId": "laptop-abc123",
+    "machineName": "My Laptop",
+    "inputTokens": 15000,
+    "outputTokens": 8000,
+    "interactions": 42,
+    "datasetId": "default"
+  }
+]
+```
+
+Accepts up to **500 entries per request**. The server upserts by
+`(user_id, dataset_id, day, model, workspace_id, machine_id)` so repeated
+uploads are safe and idempotent.
+
+### Other endpoints
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/health` | Public | Health check |
+| `GET` | `/api/me` | Bearer token | Current user info |
+| `GET` | `/api/data?days=30` | Bearer token | Own usage data (last N days) |
+| `GET` | `/auth/github` | Public | Dashboard login (OAuth redirect) |
+| `GET` | `/auth/github/callback` | Public | OAuth callback |
+| `GET` | `/auth/logout` | Session | Clear session |
+| `GET` | `/dashboard` | Session cookie | Web dashboard |
+
+## Rate limits
+
+| Scope | Limit |
+|---|---|
+| Per IP (all requests) | 200 requests / minute |
+| Per user (uploads) | 100 upload requests / hour |
+
+## Security
+
+- **Bearer token auth** — the extension sends your GitHub OAuth token. The server
+  validates it against `GET https://api.github.com/user` and caches the result for
+  10 minutes. Bad tokens are cached for 1 minute to prevent API spam.
+- **CSRF protection** — the dashboard OAuth flow uses a short-lived state cookie.
+- **Signed session cookies** — dashboard sessions use HMAC-SHA256-signed cookies
+  storing only `{sub, iat, exp}`. User data is re-read from SQLite on each request.
+- **XSS prevention** — all user-supplied strings are HTML-escaped before rendering.
+- **No API keys** — authentication is fully managed by GitHub OAuth; there are no
+  API keys to issue, rotate, or leak.
+
+## Privacy note
+
+Unlike the Azure Storage backend which supports anonymized and pseudonymous modes,
+the sharing server is **identified mode only** — every upload is linked to a GitHub
+user ID. Workspace and machine names are included or excluded based on the extension's
+`shareWorkspaceMachineNames` setting (off by default).
+
+## Data schema
+
+```sql
+users (
+  id, github_id, github_login, github_name, avatar_url,
+  created_at, last_seen_at, is_admin
+)
+
+usage_uploads (
+  id, user_id, dataset_id, day, model,
+  workspace_id, workspace_name, machine_id, machine_name,
+  input_tokens, output_tokens, interactions, schema_version,
+  uploaded_at
+)
+-- UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id)
+```
+
+## Backup
+
+The entire state is one SQLite file at `/data/sharing.db` (or the path in `DB_PATH`).
+Back it up with any tool that can copy files, or use `sqlite3 /data/sharing.db .dump`.

--- a/sharing-server/clean-db.js
+++ b/sharing-server/clean-db.js
@@ -1,0 +1,42 @@
+const { rmSync, existsSync } = require('fs');
+const net = require('net');
+
+const port = parseInt(process.env.PORT ?? '3000', 10);
+
+function isServerRunning(port) {
+	return new Promise((resolve) => {
+		const socket = new net.Socket();
+		socket.setTimeout(500);
+		socket.on('connect', () => { socket.destroy(); resolve(true); });
+		socket.on('error', () => resolve(false));
+		socket.on('timeout', () => { socket.destroy(); resolve(false); });
+		socket.connect(port, '127.0.0.1');
+	});
+}
+
+async function main() {
+	if (await isServerRunning(port)) {
+		console.error(`Error: the sharing server is still running on port ${port}.`);
+		console.error('Stop it first, then re-run npm run clean:db.');
+		process.exit(1);
+	}
+
+	const files = ['./data/sharing.db', './data/sharing.db-shm', './data/sharing.db-wal'];
+	files.forEach(f => {
+		if (existsSync(f)) {
+			try {
+				rmSync(f);
+				console.log('Removed ' + f);
+			} catch (err) {
+				if (err.code === 'EPERM' || err.code === 'EBUSY') {
+					console.error(`Cannot remove ${f} — the file is locked.`);
+					process.exit(1);
+				}
+				throw err;
+			}
+		}
+	});
+	console.log('Done.');
+}
+
+main();

--- a/sharing-server/docker-compose.yml
+++ b/sharing-server/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  sharing-server:
+    build: .
+    image: ghcr.io/rajbos/copilot-sharing-server:latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Required: GitHub OAuth App credentials for the web dashboard login
+      # Create one at https://github.com/settings/developers
+      # Set Homepage URL to your server's base URL and Callback URL to <BASE_URL>/auth/github/callback
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:?Missing GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:?Missing GITHUB_CLIENT_SECRET}
+
+      # Required: random secret for signing session cookies
+      # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+      - SESSION_SECRET=${SESSION_SECRET:?Missing SESSION_SECRET}
+
+      # Required: base URL of this server (used in OAuth redirect URI)
+      - BASE_URL=${BASE_URL:-http://localhost:3000}
+
+      # Optional: restrict uploads and dashboard access to members of a GitHub org
+      # Leave empty or omit to allow any GitHub user
+      - ALLOWED_GITHUB_ORG=${ALLOWED_GITHUB_ORG:-}
+
+      - NODE_ENV=production
+      - DATA_DIR=/data
+      - PORT=3000
+    volumes:
+      - sharing-data:/data
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r=>process.exit(r.ok?0:1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  sharing-data:

--- a/sharing-server/esbuild.js
+++ b/sharing-server/esbuild.js
@@ -25,6 +25,16 @@ async function main() {
     logLevel: 'info',
   });
 
+  // Copy Chart.js UMD bundle so the dashboard can inline it without a CDN dependency
+  const chartSrc = path.join(__dirname, 'node_modules', 'chart.js', 'dist', 'chart.umd.min.js');
+  const chartDst = path.join(distDir, 'chart.min.js');
+  if (fs.existsSync(chartSrc)) {
+    fs.copyFileSync(chartSrc, chartDst);
+    console.log('Copied chart.js to dist/chart.min.js');
+  } else {
+    console.warn('WARNING: chart.js not found — charts will not render in the dashboard');
+  }
+
   console.log(`Sharing server built (${production ? 'production' : 'development'})`);
 }
 

--- a/sharing-server/esbuild.js
+++ b/sharing-server/esbuild.js
@@ -1,0 +1,34 @@
+const esbuild = require('esbuild');
+const path = require('path');
+const fs = require('fs');
+
+const production = process.argv.includes('--production');
+
+async function main() {
+  const distDir = path.join(__dirname, 'dist');
+  if (!fs.existsSync(distDir)) {
+    fs.mkdirSync(distDir, { recursive: true });
+  }
+
+  await esbuild.build({
+    entryPoints: ['src/server.ts'],
+    bundle: true,
+    outfile: 'dist/server.js',
+    format: 'cjs',
+    platform: 'node',
+    target: 'node22',
+    sourcemap: !production,
+    minify: production,
+    // node:sqlite is a built-in module — esbuild auto-externalises node:* with platform:node,
+    // but list explicitly for clarity
+    external: ['node:sqlite'],
+    logLevel: 'info',
+  });
+
+  console.log(`Sharing server built (${production ? 'production' : 'development'})`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sharing-server/package-lock.json
+++ b/sharing-server/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.5.0",
+        "chart.js": "^4.4.7",
         "esbuild": "^0.24.0",
         "typescript": "^5.8.0"
       },
@@ -458,6 +459,13 @@
         "hono": "^4"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -466,6 +474,19 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/esbuild": {

--- a/sharing-server/package-lock.json
+++ b/sharing-server/package-lock.json
@@ -1,0 +1,543 @@
+{
+  "name": "@rajbos/copilot-sharing-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@rajbos/copilot-sharing-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.13.0",
+        "hono": "^4.6.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.5.0",
+        "esbuild": "^0.24.0",
+        "typescript": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=22.5.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "node esbuild.js",
     "build:production": "node esbuild.js --production",
-    "start": "node dist/server.js",
-    "dev": "node --watch dist/server.js",
+    "start": "node --env-file=.env dist/server.js",
+    "dev": "node --env-file=.env --watch dist/server.js",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@rajbos/copilot-sharing-server",
+  "version": "0.1.0",
+  "description": "Self-hosted sharing server for GitHub Copilot Token Tracker — accepts daily usage uploads from VS Code via GitHub OAuth tokens",
+  "license": "MIT",
+  "author": "RobBos",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rajbos/github-copilot-token-usage.git",
+    "directory": "sharing-server"
+  },
+  "scripts": {
+    "build": "node esbuild.js",
+    "build:production": "node esbuild.js --production",
+    "start": "node dist/server.js",
+    "dev": "node --watch dist/server.js",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.0",
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.8.0"
+  },
+  "engines": {
+    "node": ">=22.5.0"
+  }
+}

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -14,6 +14,7 @@
     "build:production": "node esbuild.js --production",
     "start": "node --env-file=.env dist/server.js",
     "dev": "node --env-file=.env --watch dist/server.js",
+    "update": "npm ci && node esbuild.js",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -14,6 +14,8 @@
     "build:production": "node esbuild.js --production",
     "start": "node --env-file=.env dist/server.js",
     "dev": "node --env-file=.env --watch dist/server.js",
+    "serve": "node esbuild.js && node --env-file=.env --watch dist/server.js",
+    "clean:db": "node clean-db.js",
     "update": "npm ci && node esbuild.js",
     "check-types": "tsc --noEmit"
   },

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.5.0",
+    "chart.js": "^4.4.7",
     "esbuild": "^0.24.0",
     "typescript": "^5.8.0"
   },

--- a/sharing-server/src/auth.ts
+++ b/sharing-server/src/auth.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'crypto';
+import type { Context, Next } from 'hono';
+import { upsertUser, type UserRow } from './db.js';
+
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+interface CachedAuth {
+	user: UserRow;
+	expiresAt: number;
+}
+
+interface NegativeCacheEntry {
+	bannedUntil: number;
+}
+
+// Token validation cache: SHA-256(token) → { user, expiresAt }
+const tokenCache = new Map<string, CachedAuth>();
+
+// Negative cache: SHA-256(token) → bannedUntil timestamp (short TTL for bad tokens)
+const negativeCache = new Map<string, NegativeCacheEntry>();
+const NEGATIVE_TTL_MS = 60 * 1000; // 1 minute
+
+// Upload rate limiter: github_id → { count, resetAt }
+const uploadRateMap = new Map<number, { count: number; resetAt: number }>();
+const UPLOAD_RATE_MAX = 100;
+const UPLOAD_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour per user
+
+// Pre-auth IP rate limiter: IP → { count, resetAt }
+const ipRateMap = new Map<string, { count: number; resetAt: number }>();
+const IP_RATE_MAX = 200;
+const IP_RATE_WINDOW_MS = 60 * 1000; // 1 minute per IP
+
+export async function validateGitHubToken(token: string): Promise<UserRow | null> {
+	const cacheKey = createHash('sha256').update(token).digest('hex');
+
+	// Check negative cache first
+	const negative = negativeCache.get(cacheKey);
+	if (negative && negative.bannedUntil > Date.now()) {
+		return null;
+	}
+
+	// Check positive cache
+	const cached = tokenCache.get(cacheKey);
+	if (cached && cached.expiresAt > Date.now()) {
+		return cached.user;
+	}
+
+	let response: Response;
+	try {
+		response = await fetch('https://api.github.com/user', {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'User-Agent': 'copilot-sharing-server/1.0',
+				Accept: 'application/vnd.github+json',
+			},
+			signal: AbortSignal.timeout(10_000),
+		});
+	} catch {
+		// Network error — don't cache, let the caller retry
+		return null;
+	}
+
+	if (!response.ok) {
+		negativeCache.set(cacheKey, { bannedUntil: Date.now() + NEGATIVE_TTL_MS });
+		return null;
+	}
+
+	const data = await response.json() as { id: number; login: string; name: string | null; avatar_url: string };
+
+	// Optional org membership check
+	const allowedOrg = process.env.ALLOWED_GITHUB_ORG;
+	if (allowedOrg) {
+		const isMember = await checkOrgMembership(token, data.login, allowedOrg);
+		if (!isMember) {
+			negativeCache.set(cacheKey, { bannedUntil: Date.now() + NEGATIVE_TTL_MS });
+			return null;
+		}
+	}
+
+	const user = upsertUser(data.id, data.login, data.name, data.avatar_url);
+
+	tokenCache.set(cacheKey, { user, expiresAt: Date.now() + CACHE_TTL_MS });
+	return user;
+}
+
+async function checkOrgMembership(token: string, username: string, org: string): Promise<boolean> {
+	try {
+		const res = await fetch(`https://api.github.com/orgs/${org}/members/${username}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'User-Agent': 'copilot-sharing-server/1.0',
+				Accept: 'application/vnd.github+json',
+			},
+			signal: AbortSignal.timeout(10_000),
+		});
+		return res.status === 204;
+	} catch {
+		return false;
+	}
+}
+
+export function checkIpRateLimit(ip: string): boolean {
+	const now = Date.now();
+	const entry = ipRateMap.get(ip);
+	if (!entry || entry.resetAt <= now) {
+		ipRateMap.set(ip, { count: 1, resetAt: now + IP_RATE_WINDOW_MS });
+		return true;
+	}
+	if (entry.count >= IP_RATE_MAX) return false;
+	entry.count++;
+	return true;
+}
+
+export function checkUploadRateLimit(userId: number): boolean {
+	const now = Date.now();
+	const entry = uploadRateMap.get(userId);
+	if (!entry || entry.resetAt <= now) {
+		uploadRateMap.set(userId, { count: 1, resetAt: now + UPLOAD_RATE_WINDOW_MS });
+		return true;
+	}
+	if (entry.count >= UPLOAD_RATE_MAX) return false;
+	entry.count++;
+	return true;
+}
+
+export type AuthVariables = { user: UserRow };
+
+export async function requireBearerAuth(c: Context, next: Next): Promise<Response | void> {
+	const ip = c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? 'unknown';
+
+	if (!checkIpRateLimit(ip)) {
+		return c.json({ error: 'Too many requests' }, 429);
+	}
+
+	const authHeader = c.req.header('Authorization');
+	if (!authHeader?.startsWith('Bearer ')) {
+		return c.json({ error: 'Unauthorized' }, 401);
+	}
+
+	const token = authHeader.slice(7);
+	if (!token) {
+		return c.json({ error: 'Unauthorized' }, 401);
+	}
+
+	const user = await validateGitHubToken(token);
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401);
+	}
+
+	c.set('user', user);
+	await next();
+}

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -23,6 +23,7 @@ export interface UploadRow {
 	workspace_name: string | null;
 	machine_id: string;
 	machine_name: string | null;
+	editor: string;
 	input_tokens: number;
 	output_tokens: number;
 	interactions: number;
@@ -38,6 +39,7 @@ export interface UploadEntry {
 	workspaceName?: string;
 	machineId: string;
 	machineName?: string;
+	editor?: string;
 	inputTokens: number;
 	outputTokens: number;
 	interactions: number;
@@ -60,7 +62,28 @@ export function getDb(): DatabaseSync {
 	return _db;
 }
 
+const UPLOADS_TABLE_DDL = `
+	CREATE TABLE usage_uploads (
+		id             INTEGER PRIMARY KEY,
+		user_id        INTEGER NOT NULL REFERENCES users(id),
+		dataset_id     TEXT NOT NULL DEFAULT 'default',
+		day            TEXT NOT NULL,
+		model          TEXT NOT NULL,
+		workspace_id   TEXT NOT NULL,
+		workspace_name TEXT,
+		machine_id     TEXT NOT NULL,
+		machine_name   TEXT,
+		editor         TEXT NOT NULL DEFAULT 'VS Code',
+		input_tokens   INTEGER NOT NULL DEFAULT 0,
+		output_tokens  INTEGER NOT NULL DEFAULT 0,
+		interactions   INTEGER NOT NULL DEFAULT 0,
+		schema_version INTEGER NOT NULL DEFAULT 3,
+		uploaded_at    TEXT DEFAULT (datetime('now')),
+		UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id, editor)
+	)`;
+
 function initSchema(db: DatabaseSync): void {
+	// Users table — stable schema
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS users (
 			id           INTEGER PRIMARY KEY,
@@ -71,26 +94,56 @@ function initSchema(db: DatabaseSync): void {
 			created_at   TEXT DEFAULT (datetime('now')),
 			last_seen_at TEXT,
 			is_admin     INTEGER DEFAULT 0
-		);
+		)
+	`);
 
-		CREATE TABLE IF NOT EXISTS usage_uploads (
-			id             INTEGER PRIMARY KEY,
-			user_id        INTEGER NOT NULL REFERENCES users(id),
-			dataset_id     TEXT NOT NULL DEFAULT 'default',
-			day            TEXT NOT NULL,
-			model          TEXT NOT NULL,
-			workspace_id   TEXT NOT NULL,
-			workspace_name TEXT,
-			machine_id     TEXT NOT NULL,
-			machine_name   TEXT,
-			input_tokens   INTEGER NOT NULL DEFAULT 0,
-			output_tokens  INTEGER NOT NULL DEFAULT 0,
-			interactions   INTEGER NOT NULL DEFAULT 0,
-			schema_version INTEGER NOT NULL DEFAULT 3,
-			uploaded_at    TEXT DEFAULT (datetime('now')),
-			UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id)
-		);
+	// Check whether usage_uploads needs to be created or migrated
+	const tableRow = db
+		.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='usage_uploads'")
+		.get() as unknown as { sql: string } | undefined;
 
+	if (!tableRow) {
+		// Fresh database — create with current schema
+		db.exec(UPLOADS_TABLE_DDL);
+	} else if (!tableRow.sql.includes('editor')) {
+		// Old schema without the editor column — rebuild to add editor to the UNIQUE key.
+		// A plain ALTER TABLE is insufficient because SQLite cannot modify existing constraints.
+		db.exec(`
+			BEGIN TRANSACTION;
+
+			CREATE TABLE usage_uploads_v2 (
+				id             INTEGER PRIMARY KEY,
+				user_id        INTEGER NOT NULL REFERENCES users(id),
+				dataset_id     TEXT NOT NULL DEFAULT 'default',
+				day            TEXT NOT NULL,
+				model          TEXT NOT NULL,
+				workspace_id   TEXT NOT NULL,
+				workspace_name TEXT,
+				machine_id     TEXT NOT NULL,
+				machine_name   TEXT,
+				editor         TEXT NOT NULL DEFAULT 'VS Code',
+				input_tokens   INTEGER NOT NULL DEFAULT 0,
+				output_tokens  INTEGER NOT NULL DEFAULT 0,
+				interactions   INTEGER NOT NULL DEFAULT 0,
+				schema_version INTEGER NOT NULL DEFAULT 3,
+				uploaded_at    TEXT DEFAULT (datetime('now')),
+				UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id, editor)
+			);
+
+			INSERT INTO usage_uploads_v2
+				SELECT id, user_id, dataset_id, day, model, workspace_id, workspace_name,
+				       machine_id, machine_name, 'VS Code',
+				       input_tokens, output_tokens, interactions, schema_version, uploaded_at
+				FROM usage_uploads;
+
+			DROP TABLE usage_uploads;
+			ALTER TABLE usage_uploads_v2 RENAME TO usage_uploads;
+
+			COMMIT;
+		`);
+	}
+
+	db.exec(`
 		CREATE INDEX IF NOT EXISTS idx_uploads_user_day ON usage_uploads(user_id, day);
 		CREATE INDEX IF NOT EXISTS idx_uploads_dataset   ON usage_uploads(dataset_id, day);
 	`);
@@ -124,12 +177,13 @@ export function getUserByGithubId(githubId: number): UserRow | undefined {
 }
 
 export function upsertUpload(userId: number, entry: UploadEntry): void {
+	const editor = ((entry.editor ?? '').trim() || 'VS Code').slice(0, 100);
 	getDb().prepare(`
 		INSERT INTO usage_uploads
 			(user_id, dataset_id, day, model, workspace_id, workspace_name, machine_id, machine_name,
-			 input_tokens, output_tokens, interactions)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(user_id, dataset_id, day, model, workspace_id, machine_id) DO UPDATE SET
+			 editor, input_tokens, output_tokens, interactions)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(user_id, dataset_id, day, model, workspace_id, machine_id, editor) DO UPDATE SET
 			workspace_name = excluded.workspace_name,
 			machine_name   = excluded.machine_name,
 			input_tokens   = excluded.input_tokens,
@@ -145,6 +199,7 @@ export function upsertUpload(userId: number, entry: UploadEntry): void {
 		entry.workspaceName ?? null,
 		entry.machineId,
 		entry.machineName ?? null,
+		editor,
 		entry.inputTokens,
 		entry.outputTokens,
 		entry.interactions,

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -206,6 +206,21 @@ export function upsertUpload(userId: number, entry: UploadEntry): void {
 	);
 }
 
+/**
+ * Delete all rows for a user+dataset for specific days before a full re-upload.
+ * This prevents stale rows (e.g. old editor="VS Code" rows for what are now
+ * correctly-attributed CLI/Claude sessions) from accumulating when the upload
+ * schema changes.
+ */
+export function deleteUploadsForDays(userId: number, datasetId: string, days: string[]): void {
+	if (days.length === 0) return;
+	const placeholders = days.map(() => '?').join(', ');
+	getDb().prepare(`
+		DELETE FROM usage_uploads
+		WHERE user_id = ? AND dataset_id = ? AND day IN (${placeholders})
+	`).run(userId, datasetId, ...days);
+}
+
 export function getUploadsForUser(userId: number, days = 30): UploadRow[] {
 	return getDb().prepare(`
 		SELECT * FROM usage_uploads

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -1,0 +1,165 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+export interface UserRow {
+	id: number;
+	github_id: number;
+	github_login: string;
+	github_name: string | null;
+	avatar_url: string | null;
+	created_at: string;
+	last_seen_at: string | null;
+	is_admin: number;
+}
+
+export interface UploadRow {
+	id: number;
+	user_id: number;
+	dataset_id: string;
+	day: string;
+	model: string;
+	workspace_id: string;
+	workspace_name: string | null;
+	machine_id: string;
+	machine_name: string | null;
+	input_tokens: number;
+	output_tokens: number;
+	interactions: number;
+	schema_version: number;
+	uploaded_at: string;
+}
+
+export interface UploadEntry {
+	datasetId?: string;
+	day: string;
+	model: string;
+	workspaceId: string;
+	workspaceName?: string;
+	machineId: string;
+	machineName?: string;
+	inputTokens: number;
+	outputTokens: number;
+	interactions: number;
+}
+
+let _db: DatabaseSync | undefined;
+
+export function getDb(): DatabaseSync {
+	if (!_db) {
+		const dataDir = process.env.DATA_DIR ?? (process.env.NODE_ENV === 'production' ? '/data' : './data');
+		if (!existsSync(dataDir)) {
+			mkdirSync(dataDir, { recursive: true });
+		}
+		const dbPath = join(dataDir, 'sharing.db');
+		_db = new DatabaseSync(dbPath);
+		_db.exec('PRAGMA journal_mode = WAL');
+		_db.exec('PRAGMA foreign_keys = ON');
+		initSchema(_db);
+	}
+	return _db;
+}
+
+function initSchema(db: DatabaseSync): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS users (
+			id           INTEGER PRIMARY KEY,
+			github_id    INTEGER UNIQUE NOT NULL,
+			github_login TEXT NOT NULL,
+			github_name  TEXT,
+			avatar_url   TEXT,
+			created_at   TEXT DEFAULT (datetime('now')),
+			last_seen_at TEXT,
+			is_admin     INTEGER DEFAULT 0
+		);
+
+		CREATE TABLE IF NOT EXISTS usage_uploads (
+			id             INTEGER PRIMARY KEY,
+			user_id        INTEGER NOT NULL REFERENCES users(id),
+			dataset_id     TEXT NOT NULL DEFAULT 'default',
+			day            TEXT NOT NULL,
+			model          TEXT NOT NULL,
+			workspace_id   TEXT NOT NULL,
+			workspace_name TEXT,
+			machine_id     TEXT NOT NULL,
+			machine_name   TEXT,
+			input_tokens   INTEGER NOT NULL DEFAULT 0,
+			output_tokens  INTEGER NOT NULL DEFAULT 0,
+			interactions   INTEGER NOT NULL DEFAULT 0,
+			schema_version INTEGER NOT NULL DEFAULT 3,
+			uploaded_at    TEXT DEFAULT (datetime('now')),
+			UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_uploads_user_day ON usage_uploads(user_id, day);
+		CREATE INDEX IF NOT EXISTS idx_uploads_dataset   ON usage_uploads(dataset_id, day);
+	`);
+}
+
+export function upsertUser(
+	githubId: number,
+	login: string,
+	name: string | null,
+	avatarUrl: string | null,
+): UserRow {
+	const db = getDb();
+	db.prepare(`
+		INSERT INTO users (github_id, github_login, github_name, avatar_url, last_seen_at)
+		VALUES (?, ?, ?, ?, datetime('now'))
+		ON CONFLICT(github_id) DO UPDATE SET
+			github_login = excluded.github_login,
+			github_name  = excluded.github_name,
+			avatar_url   = excluded.avatar_url,
+			last_seen_at = datetime('now')
+	`).run(githubId, login, name, avatarUrl);
+	return db.prepare('SELECT * FROM users WHERE github_id = ?').get(githubId) as unknown as UserRow;
+}
+
+export function getUserById(id: number): UserRow | undefined {
+	return getDb().prepare('SELECT * FROM users WHERE id = ?').get(id) as unknown as UserRow | undefined;
+}
+
+export function getUserByGithubId(githubId: number): UserRow | undefined {
+	return getDb().prepare('SELECT * FROM users WHERE github_id = ?').get(githubId) as unknown as UserRow | undefined;
+}
+
+export function upsertUpload(userId: number, entry: UploadEntry): void {
+	getDb().prepare(`
+		INSERT INTO usage_uploads
+			(user_id, dataset_id, day, model, workspace_id, workspace_name, machine_id, machine_name,
+			 input_tokens, output_tokens, interactions)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(user_id, dataset_id, day, model, workspace_id, machine_id) DO UPDATE SET
+			workspace_name = excluded.workspace_name,
+			machine_name   = excluded.machine_name,
+			input_tokens   = excluded.input_tokens,
+			output_tokens  = excluded.output_tokens,
+			interactions   = excluded.interactions,
+			uploaded_at    = datetime('now')
+	`).run(
+		userId,
+		entry.datasetId ?? 'default',
+		entry.day,
+		entry.model,
+		entry.workspaceId,
+		entry.workspaceName ?? null,
+		entry.machineId,
+		entry.machineName ?? null,
+		entry.inputTokens,
+		entry.outputTokens,
+		entry.interactions,
+	);
+}
+
+export function getUploadsForUser(userId: number, days = 30): UploadRow[] {
+	return getDb().prepare(`
+		SELECT * FROM usage_uploads
+		WHERE user_id = ?
+		  AND day >= date('now', '-' || ? || ' days')
+		ORDER BY day DESC, model
+	`).all(userId, days) as unknown as UploadRow[];
+}
+
+export function getAllUsers(): UserRow[] {
+	return getDb().prepare('SELECT * FROM users ORDER BY created_at DESC').all() as unknown as UserRow[];
+}

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -9,6 +9,7 @@ const MAX_STRING_LENGTHS = {
 	machineId: 256,
 	machineName: 256,
 	datasetId: 128,
+	editor: 100,
 };
 const MAX_TOKEN_VALUE = 100_000_000; // 100M tokens per entry is already absurd
 const MAX_ENTRIES_PER_UPLOAD = 500;
@@ -141,6 +142,12 @@ function validateEntry(entry: unknown): string | null {
 		if (typeof e.datasetId !== 'string') return '"datasetId" must be a string';
 		if (e.datasetId.length > MAX_STRING_LENGTHS.datasetId) {
 			return `"datasetId" too long (max ${MAX_STRING_LENGTHS.datasetId})`;
+		}
+	}
+	if (e.editor !== undefined && e.editor !== null) {
+		if (typeof e.editor !== 'string') return '"editor" must be a string';
+		if (e.editor.length > MAX_STRING_LENGTHS.editor) {
+			return `"editor" too long (max ${MAX_STRING_LENGTHS.editor})`;
 		}
 	}
 

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -1,0 +1,152 @@
+import { Hono } from 'hono';
+import { requireBearerAuth, checkUploadRateLimit, type AuthVariables } from '../auth.js';
+import { upsertUpload, getUploadsForUser, type UploadEntry } from '../db.js';
+
+const MAX_STRING_LENGTHS = {
+	model: 128,
+	workspaceId: 256,
+	workspaceName: 256,
+	machineId: 256,
+	machineName: 256,
+	datasetId: 128,
+};
+const MAX_TOKEN_VALUE = 100_000_000; // 100M tokens per entry is already absurd
+const MAX_ENTRIES_PER_UPLOAD = 500;
+
+export const api = new Hono<{ Variables: AuthVariables }>();
+
+// GET /health — no auth required (mounted at root level, not here)
+
+/** POST /api/upload — Upload daily rollup data (one or more entries). */
+api.post('/upload', requireBearerAuth, async (c) => {
+	const user = c.get('user');
+
+	if (!checkUploadRateLimit(user.id)) {
+		return c.json({ error: 'Rate limit exceeded — max 100 uploads per hour.' }, 429);
+	}
+
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		return c.json({ error: 'Invalid JSON body.' }, 400);
+	}
+
+	if (!Array.isArray(body)) {
+		return c.json({ error: 'Body must be a JSON array of upload entries.' }, 400);
+	}
+
+	if (body.length === 0) {
+		return c.json({ uploaded: 0 });
+	}
+
+	if (body.length > MAX_ENTRIES_PER_UPLOAD) {
+		return c.json({ error: `Too many entries (max ${MAX_ENTRIES_PER_UPLOAD}).` }, 400);
+	}
+
+	let uploaded = 0;
+	const errors: string[] = [];
+
+	for (let i = 0; i < body.length; i++) {
+		const validationError = validateEntry(body[i]);
+		if (validationError) {
+			errors.push(`Entry ${i}: ${validationError}`);
+			continue;
+		}
+		try {
+			upsertUpload(user.id, body[i] as UploadEntry);
+			uploaded++;
+		} catch (err) {
+			errors.push(`Entry ${i}: ${String(err)}`);
+		}
+	}
+
+	return c.json({ uploaded, ...(errors.length > 0 ? { errors } : {}) });
+});
+
+/** GET /api/me — Return the authenticated user's GitHub profile info. */
+api.get('/me', requireBearerAuth, (c) => {
+	const user = c.get('user');
+	return c.json({
+		githubId: user.github_id,
+		login: user.github_login,
+		name: user.github_name,
+		avatarUrl: user.avatar_url,
+		createdAt: user.created_at,
+	});
+});
+
+/** GET /api/data?days=30 — Return the authenticated user's own upload data. */
+api.get('/data', requireBearerAuth, (c) => {
+	const user = c.get('user');
+	const daysRaw = c.req.query('days');
+	const days = clampDays(daysRaw);
+	const data = getUploadsForUser(user.id, days);
+	return c.json(data);
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function clampDays(raw: string | undefined): number {
+	const n = parseInt(raw ?? '30', 10);
+	if (!Number.isFinite(n)) return 30;
+	return Math.min(Math.max(n, 1), 90);
+}
+
+function validateEntry(entry: unknown): string | null {
+	if (typeof entry !== 'object' || entry === null) {
+		return 'must be an object';
+	}
+	const e = entry as Record<string, unknown>;
+
+	if (typeof e.day !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(e.day)) {
+		return '"day" must be a YYYY-MM-DD string';
+	}
+	if (typeof e.model !== 'string' || e.model.length === 0) {
+		return '"model" must be a non-empty string';
+	}
+	if (e.model.length > MAX_STRING_LENGTHS.model) {
+		return `"model" too long (max ${MAX_STRING_LENGTHS.model})`;
+	}
+	if (typeof e.workspaceId !== 'string' || e.workspaceId.length === 0) {
+		return '"workspaceId" must be a non-empty string';
+	}
+	if (e.workspaceId.length > MAX_STRING_LENGTHS.workspaceId) {
+		return `"workspaceId" too long (max ${MAX_STRING_LENGTHS.workspaceId})`;
+	}
+	if (typeof e.machineId !== 'string' || e.machineId.length === 0) {
+		return '"machineId" must be a non-empty string';
+	}
+	if (e.machineId.length > MAX_STRING_LENGTHS.machineId) {
+		return `"machineId" too long (max ${MAX_STRING_LENGTHS.machineId})`;
+	}
+	if (!isNonNegativeInt(e.inputTokens) || (e.inputTokens as number) > MAX_TOKEN_VALUE) {
+		return '"inputTokens" must be a non-negative integer ≤ 100,000,000';
+	}
+	if (!isNonNegativeInt(e.outputTokens) || (e.outputTokens as number) > MAX_TOKEN_VALUE) {
+		return '"outputTokens" must be a non-negative integer ≤ 100,000,000';
+	}
+	if (!isNonNegativeInt(e.interactions) || (e.interactions as number) > 100_000) {
+		return '"interactions" must be a non-negative integer ≤ 100,000';
+	}
+
+	// Optional string fields — truncate if too long (defensive, after length check)
+	if (e.workspaceName !== undefined && e.workspaceName !== null) {
+		if (typeof e.workspaceName !== 'string') return '"workspaceName" must be a string';
+	}
+	if (e.machineName !== undefined && e.machineName !== null) {
+		if (typeof e.machineName !== 'string') return '"machineName" must be a string';
+	}
+	if (e.datasetId !== undefined && e.datasetId !== null) {
+		if (typeof e.datasetId !== 'string') return '"datasetId" must be a string';
+		if (e.datasetId.length > MAX_STRING_LENGTHS.datasetId) {
+			return `"datasetId" too long (max ${MAX_STRING_LENGTHS.datasetId})`;
+		}
+	}
+
+	return null;
+}
+
+function isNonNegativeInt(value: unknown): boolean {
+	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { requireBearerAuth, checkUploadRateLimit, type AuthVariables } from '../auth.js';
-import { upsertUpload, getUploadsForUser, type UploadEntry } from '../db.js';
+import { upsertUpload, deleteUploadsForDays, getUploadsForUser, getDb, type UploadEntry } from '../db.js';
 
 const MAX_STRING_LENGTHS = {
 	model: 128,
@@ -48,17 +48,42 @@ api.post('/upload', requireBearerAuth, async (c) => {
 	let uploaded = 0;
 	const errors: string[] = [];
 
+	// Validate all entries first before touching the DB
+	const validEntries: UploadEntry[] = [];
 	for (let i = 0; i < body.length; i++) {
 		const validationError = validateEntry(body[i]);
 		if (validationError) {
 			errors.push(`Entry ${i}: ${validationError}`);
-			continue;
+		} else {
+			validEntries.push(body[i] as UploadEntry);
 		}
-		try {
-			upsertUpload(user.id, body[i] as UploadEntry);
-			uploaded++;
-		} catch (err) {
-			errors.push(`Entry ${i}: ${String(err)}`);
+	}
+
+	if (validEntries.length > 0) {
+		// Group by dataset_id so we can delete-then-insert per dataset atomically
+		const byDataset = new Map<string, UploadEntry[]>();
+		for (const entry of validEntries) {
+			const dsId = entry.datasetId ?? 'default';
+			if (!byDataset.has(dsId)) byDataset.set(dsId, []);
+			byDataset.get(dsId)!.push(entry);
+		}
+
+		for (const [datasetId, entries] of byDataset) {
+			// Collect the unique days being uploaded for this dataset
+			const days = [...new Set(entries.map(e => e.day))];
+			try {
+				// Run delete + insert in a single transaction so there's never a gap
+				getDb().exec('BEGIN');
+				deleteUploadsForDays(user.id, datasetId, days);
+				for (const entry of entries) {
+					upsertUpload(user.id, entry);
+					uploaded++;
+				}
+				getDb().exec('COMMIT');
+			} catch (err) {
+				getDb().exec('ROLLBACK');
+				errors.push(`Dataset "${datasetId}": ${String(err)}`);
+			}
 		}
 	}
 

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -11,7 +11,7 @@ const MAX_STRING_LENGTHS = {
 	datasetId: 128,
 	editor: 100,
 };
-const MAX_TOKEN_VALUE = 100_000_000; // 100M tokens per entry is already absurd
+const MAX_TOKEN_VALUE = 2_000_000_000; // 2B tokens — large agent sessions can exceed 100M in one day
 const MAX_ENTRIES_PER_UPLOAD = 500;
 
 export const api = new Hono<{ Variables: AuthVariables }>();

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -1,0 +1,321 @@
+import { Hono } from 'hono';
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
+import {
+	encodeSession, decodeSession, makeClaims,
+	COOKIE_NAME, OAUTH_STATE_COOKIE, SESSION_MAX_AGE,
+} from '../session.js';
+import { getUserById, getUserByGithubId, getUploadsForUser, getAllUsers, upsertUser, type UploadRow, type UserRow } from '../db.js';
+
+export const dashboard = new Hono();
+
+const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID ?? '';
+const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET ?? '';
+const BASE_URL = (process.env.BASE_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+/** GET /auth/github — Start GitHub OAuth for the web dashboard. */
+dashboard.get('/auth/github', (c) => {
+	if (!GITHUB_CLIENT_ID) {
+		return c.html(errorPage('GitHub OAuth is not configured on this server.'), 503);
+	}
+	const state = randomState();
+	const params = new URLSearchParams({
+		client_id: GITHUB_CLIENT_ID,
+		redirect_uri: `${BASE_URL}/auth/github/callback`,
+		scope: 'read:user',
+		state,
+	});
+	// Bind state to a short-lived cookie for CSRF validation
+	setCookie(c, OAUTH_STATE_COOKIE, state, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === 'production',
+		sameSite: 'Lax',
+		maxAge: 300, // 5 minutes
+		path: '/',
+	});
+	return c.redirect(`https://github.com/login/oauth/authorize?${params}`);
+});
+
+/** GET /auth/github/callback — GitHub OAuth callback. */
+dashboard.get('/auth/github/callback', async (c) => {
+	const code = c.req.query('code');
+	const state = c.req.query('state');
+	const storedState = getCookie(c, OAUTH_STATE_COOKIE);
+
+	// Validate CSRF state
+	deleteCookie(c, OAUTH_STATE_COOKIE, { path: '/' });
+	if (!code || !state || !storedState || state !== storedState) {
+		return c.html(errorPage('Invalid or expired authentication state. Please try again.'), 400);
+	}
+
+	// Exchange code for access token
+	let accessToken: string;
+	try {
+		const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+			body: JSON.stringify({
+				client_id: GITHUB_CLIENT_ID,
+				client_secret: GITHUB_CLIENT_SECRET,
+				code,
+				redirect_uri: `${BASE_URL}/auth/github/callback`,
+			}),
+			signal: AbortSignal.timeout(10_000),
+		});
+		const tokenData = await tokenRes.json() as { access_token?: string; error?: string };
+		if (!tokenData.access_token) {
+			return c.html(errorPage(`GitHub OAuth error: ${tokenData.error ?? 'no token returned'}`), 400);
+		}
+		accessToken = tokenData.access_token;
+	} catch (err) {
+		return c.html(errorPage(`Failed to reach GitHub: ${String(err)}`), 502);
+	}
+
+	// Fetch user profile
+	let userData: { id: number; login: string; name: string | null; avatar_url: string };
+	try {
+		const userRes = await fetch('https://api.github.com/user', {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				'User-Agent': 'copilot-sharing-server/1.0',
+				Accept: 'application/vnd.github+json',
+			},
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!userRes.ok) {
+			return c.html(errorPage('Failed to retrieve GitHub profile.'), 502);
+		}
+		userData = await userRes.json() as typeof userData;
+	} catch (err) {
+		return c.html(errorPage(`Failed to reach GitHub: ${String(err)}`), 502);
+	}
+
+	// Optional org membership check
+	const allowedOrg = process.env.ALLOWED_GITHUB_ORG;
+	if (allowedOrg) {
+		try {
+			const memberRes = await fetch(`https://api.github.com/orgs/${allowedOrg}/members/${userData.login}`, {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+					'User-Agent': 'copilot-sharing-server/1.0',
+				},
+				signal: AbortSignal.timeout(10_000),
+			});
+			if (memberRes.status !== 204) {
+				return c.html(errorPage(`Access denied: you are not a member of the "${allowedOrg}" organization.`), 403);
+			}
+		} catch {
+			return c.html(errorPage('Unable to verify organization membership. Please try again.'), 502);
+		}
+	}
+
+	const user = upsertUser(userData.id, userData.login, userData.name, userData.avatar_url);
+	const claims = makeClaims(user.id);
+	const sessionValue = encodeSession(claims);
+
+	setCookie(c, COOKIE_NAME, sessionValue, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === 'production',
+		sameSite: 'Lax',
+		maxAge: SESSION_MAX_AGE,
+		path: '/',
+	});
+
+	return c.redirect('/dashboard');
+});
+
+/** GET /auth/logout — Clear session cookie and redirect to dashboard. */
+dashboard.get('/auth/logout', (c) => {
+	deleteCookie(c, COOKIE_NAME, { path: '/' });
+	return c.redirect('/dashboard');
+});
+
+// ── Dashboard ─────────────────────────────────────────────────────────────────
+
+/** Redirect root to dashboard. */
+dashboard.get('/', (c) => c.redirect('/dashboard'));
+
+/** GET /dashboard — Main web dashboard. */
+dashboard.get('/dashboard', (c) => {
+	const cookieValue = getCookie(c, COOKIE_NAME);
+	const claims = cookieValue ? decodeSession(cookieValue) : null;
+
+	if (!claims) {
+		return c.html(loginPage());
+	}
+
+	// Re-read user from DB on every request (so is_admin/name changes take effect)
+	const user = getUserById(claims.sub);
+	if (!user) {
+		deleteCookie(c, COOKIE_NAME, { path: '/' });
+		return c.html(loginPage());
+	}
+
+	const uploads = getUploadsForUser(user.id, 30);
+	const isAdmin = user.is_admin === 1;
+	const allUsers = isAdmin ? getAllUsers() : undefined;
+
+	return c.html(dashboardPage(user, uploads, isAdmin, allUsers));
+});
+
+// ── HTML Rendering ────────────────────────────────────────────────────────────
+
+function h(text: unknown): string {
+	return String(text)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+function layout(title: string, body: string): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${h(title)} — Copilot Token Tracker Sharing</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    margin: 0; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  .header { background: #161b22; border-bottom: 1px solid #30363d; padding: 12px 24px;
+    display: flex; align-items: center; gap: 16px; }
+  .header h1 { margin: 0; font-size: 1.1rem; color: #58a6ff; }
+  .header .spacer { flex: 1; }
+  .header a { color: #8b949e; text-decoration: none; font-size: 0.9rem; }
+  .header a:hover { color: #e6edf3; }
+  .content { max-width: 1100px; margin: 32px auto; padding: 0 24px; }
+  h2 { color: #e6edf3; border-bottom: 1px solid #30363d; padding-bottom: 8px; }
+  h3 { color: #8b949e; font-size: 0.95rem; margin: 24px 0 8px; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th { background: #21262d; color: #8b949e; padding: 8px 12px; text-align: left;
+    border-bottom: 1px solid #30363d; }
+  td { padding: 8px 12px; border-bottom: 1px solid #21262d; }
+  tr:hover td { background: #161b22; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 12px;
+    font-size: 0.8rem; background: #1f6feb33; color: #58a6ff; }
+  .btn { display: inline-block; padding: 8px 16px; border-radius: 6px; text-decoration: none;
+    font-size: 0.9rem; font-weight: 600; cursor: pointer; border: none; }
+  .btn-primary { background: #238636; color: #fff; }
+  .btn-primary:hover { background: #2ea043; }
+  .btn-secondary { background: #21262d; color: #c9d1d9; border: 1px solid #30363d; }
+  .btn-secondary:hover { background: #30363d; }
+  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin: 16px 0; }
+  .stat-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }
+  .stat-card .label { color: #8b949e; font-size: 0.85rem; }
+  .stat-card .value { font-size: 1.5rem; font-weight: 700; color: #58a6ff; margin-top: 4px; }
+  .alert { padding: 12px 16px; border-radius: 6px; margin: 16px 0; }
+  .alert-warn { background: #3d2b0030; border: 1px solid #bb8009; color: #e3b341; }
+  .avatar { width: 32px; height: 32px; border-radius: 50%; vertical-align: middle; margin-right: 8px; }
+</style>
+</head>
+<body>
+${body}
+</body>
+</html>`;
+}
+
+function loginPage(): string {
+	return layout('Sign In', `
+<div class="header"><h1>🤖 Copilot Token Tracker Sharing</h1></div>
+<div class="content" style="text-align:center; margin-top: 80px">
+  <h2>Sign in to view your usage dashboard</h2>
+  <p style="color:#8b949e">Your data is linked to your GitHub account. No account creation needed.</p>
+  <a href="/auth/github" class="btn btn-primary" style="font-size:1rem; padding:12px 24px">
+    Sign in with GitHub
+  </a>
+  <p style="color:#8b949e; margin-top:32px; font-size:0.85rem">
+    The VS Code extension uploads data automatically using your existing GitHub session — no separate sign-in needed there.
+  </p>
+</div>`);
+}
+
+function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, allUsers?: UserRow[]): string {
+	const totalInput = uploads.reduce((s, r) => s + r.input_tokens, 0);
+	const totalOutput = uploads.reduce((s, r) => s + r.output_tokens, 0);
+	const totalInteractions = uploads.reduce((s, r) => s + r.interactions, 0);
+	const uniqueDays = new Set(uploads.map(r => r.day)).size;
+
+	const rows = uploads.map(r => `
+<tr>
+  <td>${h(r.day)}</td>
+  <td><span class="pill">${h(r.model)}</span></td>
+  <td>${h(r.workspace_name ?? r.workspace_id)}</td>
+  <td>${h(r.machine_name ?? r.machine_id)}</td>
+  <td>${r.input_tokens.toLocaleString()}</td>
+  <td>${r.output_tokens.toLocaleString()}</td>
+  <td>${r.interactions.toLocaleString()}</td>
+</tr>`).join('');
+
+	const adminSection = isAdmin && allUsers ? `
+<h2>Admin: All Users</h2>
+<table>
+  <thead><tr><th>GitHub Login</th><th>Name</th><th>Joined</th><th>Last Seen</th><th>Admin</th></tr></thead>
+  <tbody>
+    ${allUsers.map(u => `<tr>
+      <td><a href="https://github.com/${h(u.github_login)}" target="_blank">${h(u.github_login)}</a></td>
+      <td>${h(u.github_name ?? '—')}</td>
+      <td>${h(u.created_at.slice(0, 10))}</td>
+      <td>${h(u.last_seen_at?.slice(0, 10) ?? '—')}</td>
+      <td>${u.is_admin ? '✅' : ''}</td>
+    </tr>`).join('')}
+  </tbody>
+</table>` : '';
+
+	const avatarHtml = user.avatar_url
+		? `<img src="${h(user.avatar_url)}" class="avatar" alt="${h(user.github_login)}">`
+		: '';
+
+	return layout(`${user.github_login}'s Dashboard`, `
+<div class="header">
+  <h1>🤖 Copilot Token Tracker</h1>
+  <span class="spacer"></span>
+  ${avatarHtml}<span>${h(user.github_name ?? user.github_login)}</span>
+  <a href="/auth/logout" style="margin-left:16px">Sign out</a>
+</div>
+<div class="content">
+  <h2>Your Usage (last 30 days)</h2>
+  <div class="stat-grid">
+    <div class="stat-card"><div class="label">Input Tokens</div><div class="value">${fmt(totalInput)}</div></div>
+    <div class="stat-card"><div class="label">Output Tokens</div><div class="value">${fmt(totalOutput)}</div></div>
+    <div class="stat-card"><div class="label">Interactions</div><div class="value">${fmt(totalInteractions)}</div></div>
+    <div class="stat-card"><div class="label">Days with Data</div><div class="value">${uniqueDays}</div></div>
+  </div>
+
+  ${uploads.length === 0 ? `
+  <div class="alert alert-warn">
+    No data yet. Make sure the VS Code extension is configured with this server's endpoint URL
+    (<code>copilotTokenTracker.sharingServer.endpointUrl</code>).
+  </div>` : `
+  <h3>Detailed Breakdown</h3>
+  <table>
+    <thead><tr><th>Day</th><th>Model</th><th>Workspace</th><th>Machine</th>
+      <th>Input Tokens</th><th>Output Tokens</th><th>Interactions</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`}
+
+  ${adminSection}
+</div>`);
+}
+
+function errorPage(message: string): string {
+	return layout('Error', `
+<div class="header"><h1>🤖 Copilot Token Tracker Sharing</h1></div>
+<div class="content" style="text-align:center; margin-top:80px">
+  <h2>Something went wrong</h2>
+  <p style="color:#8b949e">${h(message)}</p>
+  <a href="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
+</div>`);
+}
+
+function fmt(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}
+
+function randomState(): string {
+	return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -181,6 +181,16 @@ function h(text: unknown): string {
 		.replace(/"/g, '&quot;');
 }
 
+/** Normalize raw vscode.env.appName values to the friendly names used by the extension. */
+function normalizeEditorName(raw: string | null | undefined): string {
+	const name = (raw ?? '').trim();
+	if (!name || name === 'VS Code') { return 'VS Code'; }
+	if (name === 'Visual Studio Code') { return 'VS Code'; }
+	if (name === 'Visual Studio Code - Insiders') { return 'VS Code Insiders'; }
+	if (name === 'Visual Studio Code - Exploration') { return 'VS Code Exploration'; }
+	return name;
+}
+
 /** Safely embed arbitrary data as a JS literal inside a <script> block. */
 function safeJson(data: unknown): string {
 	return JSON.stringify(data)
@@ -339,7 +349,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 	// ── Editor breakdown (last 30 days) ───────────────────────────────────────
 	const editorTotals = new Map<string, number>();
 	for (const r of uploads) {
-		const editor = r.editor || 'VS Code';
+		const editor = normalizeEditorName(r.editor);
 		editorTotals.set(editor, (editorTotals.get(editor) ?? 0) + r.input_tokens + r.output_tokens);
 	}
 	const grandTotal = [...editorTotals.values()].reduce((s, v) => s + v, 0);
@@ -355,7 +365,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 	const chartData = uploads.map(r => ({
 		day: r.day,
 		model: r.model,
-		editor: r.editor || 'VS Code',
+		editor: normalizeEditorName(r.editor),
 		inputTokens: r.input_tokens,
 		outputTokens: r.output_tokens,
 		interactions: r.interactions,
@@ -462,7 +472,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
       <tr>
         <td>${h(r.day)}</td>
         <td><span class="pill">${h(r.model)}</span></td>
-        <td>${h(r.editor || 'VS Code')}</td>
+        <td>${h(normalizeEditorName(r.editor))}</td>
         <td>${h(r.workspace_name ?? r.workspace_id)}</td>
         <td>${h(r.machine_name ?? r.machine_id)}</td>
         <td>${r.input_tokens.toLocaleString()}</td>

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -512,16 +512,29 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 	const interactiveJs = `
 (function () {
   // ── Period tabs ─────────────────────────────────────────────────────────
+  function activatePeriod(period) {
+    document.querySelectorAll('#period-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
+    var btn = document.querySelector('#period-tabs .tab[data-period="' + period + '"]');
+    if (btn) btn.classList.add('active');
+    document.querySelectorAll('.stats-panel').forEach(function(el) {
+      el.classList.toggle('hidden', el.id !== period);
+    });
+  }
+
   document.querySelectorAll('#period-tabs .tab').forEach(function(btn) {
     btn.addEventListener('click', function() {
-      document.querySelectorAll('#period-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
-      btn.classList.add('active');
       var target = btn.getAttribute('data-period');
-      document.querySelectorAll('.stats-panel').forEach(function(el) {
-        el.classList.toggle('hidden', el.id !== target);
-      });
+      location.hash = target;
+      activatePeriod(target);
     });
   });
+
+  // Restore period from URL hash on load (e.g. after refresh)
+  var hash = location.hash.replace('#', '');
+  var validPeriods = ['stats-today', 'stats-week', 'stats-month'];
+  if (validPeriods.indexOf(hash) !== -1) {
+    activatePeriod(hash);
+  }
 
   // ── Chart ────────────────────────────────────────────────────────────────
   var canvas = document.getElementById('trend-chart');

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -263,7 +263,7 @@ function layout(title: string, body: string): string {
 
   /* ── Editor bars ── */
   .editor-row { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
-  .editor-label { min-width: 110px; text-align: right; font-size: 0.85rem; color: #c9d1d9; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .editor-label { width: 160px; flex-shrink: 0; text-align: right; font-size: 0.85rem; color: #c9d1d9; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .editor-track { flex: 1; background: #21262d; border-radius: 4px; height: 8px; overflow: hidden; }
   .editor-fill { height: 100%; border-radius: 4px; }
   .editor-pct { min-width: 44px; text-align: right; font-size: 0.78rem; color: #8b949e; }

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -272,11 +272,13 @@ function layout(title: string, body: string): string {
   .chart-wrap { position: relative; height: 290px; margin-top: 4px; }
 
   /* ── Table ── */
-  table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin-top: 12px; }
+  .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin-top: 12px; min-width: 700px; }
   th { background: #0d1117; color: #8b949e; padding: 8px 10px; text-align: left; border-bottom: 1px solid #30363d; white-space: nowrap; }
-  td { padding: 7px 10px; border-bottom: 1px solid #161b22; }
+  td { padding: 7px 10px; border-bottom: 1px solid #161b22; white-space: nowrap; }
+  td.truncate { max-width: 180px; overflow: hidden; text-overflow: ellipsis; }
   tr:hover td { background: #21262d33; }
-  .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.78rem; background: #1f6feb33; color: #58a6ff; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.78rem; background: #1f6feb33; color: #58a6ff; white-space: nowrap; }
 
   /* ── Alerts ── */
   .alert { padding: 12px 16px; border-radius: 6px; margin: 4px 0; }
@@ -453,13 +455,14 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 </div>` : `
 <div class="alert alert-warn">
   No data yet. Configure the VS Code extension with this server's endpoint URL
-  (<code>copilotTokenTracker.sharingServer.endpointUrl</code>) and wait for the
+  (<code>aiEngineeringFluency.backend.sharingServer.endpointUrl</code>) and wait for the
   next sync (or trigger one from the status bar).
 </div>`;
 
 	const tableHtml = uploads.length > 0 ? `
 <details class="card">
   <summary>Detailed Breakdown (${uploads.length} rows, last 30 days)</summary>
+  <div class="table-scroll">
   <table>
     <thead>
       <tr>
@@ -473,19 +476,21 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
         <td>${h(r.day)}</td>
         <td><span class="pill">${h(r.model)}</span></td>
         <td>${h(normalizeEditorName(r.editor))}</td>
-        <td>${h(r.workspace_name ?? r.workspace_id)}</td>
-        <td>${h(r.machine_name ?? r.machine_id)}</td>
+        <td class="truncate" title="${h(r.workspace_name ?? r.workspace_id)}">${h(r.workspace_name ?? r.workspace_id)}</td>
+        <td class="truncate" title="${h(r.machine_name ?? r.machine_id)}">${h(r.machine_name ?? r.machine_id)}</td>
         <td>${r.input_tokens.toLocaleString()}</td>
         <td>${r.output_tokens.toLocaleString()}</td>
         <td>${r.interactions.toLocaleString()}</td>
       </tr>`).join('')}
     </tbody>
   </table>
+  </div>
 </details>` : '';
 
 	const adminHtml = isAdmin && allUsers ? `
 <details class="card">
   <summary>👑 Admin: All Users (${allUsers.length})</summary>
+  <div class="table-scroll">
   <table>
     <thead><tr><th></th><th>GitHub Login</th><th>Name</th><th>Joined</th><th>Last Seen</th><th>Admin</th></tr></thead>
     <tbody>
@@ -500,6 +505,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
       </tr>`).join('')}
     </tbody>
   </table>
+  </div>
 </details>` : '';
 
 	// ── Interactive JS ────────────────────────────────────────────────────────

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import {
 	encodeSession, decodeSession, makeClaims,
 	COOKIE_NAME, OAUTH_STATE_COOKIE, SESSION_MAX_AGE,
@@ -11,6 +13,16 @@ export const dashboard = new Hono();
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID ?? '';
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET ?? '';
 const BASE_URL = (process.env.BASE_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+
+// Load Chart.js UMD bundle once at startup — copied to dist/ by esbuild.js
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const _chartJsCode: string = (() => {
+	try {
+		return readFileSync(join(__dirname, 'chart.min.js'), 'utf-8');
+	} catch {
+		return '/* chart.js not bundled — run npm run build in sharing-server/ */';
+	}
+})();
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -169,46 +181,112 @@ function h(text: unknown): string {
 		.replace(/"/g, '&quot;');
 }
 
+/** Safely embed arbitrary data as a JS literal inside a <script> block. */
+function safeJson(data: unknown): string {
+	return JSON.stringify(data)
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/&/g, '\\u0026');
+}
+
+function fmt(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}
+
 function layout(title: string, body: string): string {
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${h(title)} — Copilot Token Tracker Sharing</title>
+<title>${h(title)} — Copilot Token Tracker</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     margin: 0; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+
+  /* ── Header ── */
   .header { background: #161b22; border-bottom: 1px solid #30363d; padding: 12px 24px;
-    display: flex; align-items: center; gap: 16px; }
+    display: flex; align-items: center; gap: 12px; }
   .header h1 { margin: 0; font-size: 1.1rem; color: #58a6ff; }
   .header .spacer { flex: 1; }
-  .header a { color: #8b949e; text-decoration: none; font-size: 0.9rem; }
+  .header a { color: #8b949e; text-decoration: none; font-size: 0.875rem; }
   .header a:hover { color: #e6edf3; }
-  .content { max-width: 1100px; margin: 32px auto; padding: 0 24px; }
-  h2 { color: #e6edf3; border-bottom: 1px solid #30363d; padding-bottom: 8px; }
-  h3 { color: #8b949e; font-size: 0.95rem; margin: 24px 0 8px; }
-  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-  th { background: #21262d; color: #8b949e; padding: 8px 12px; text-align: left;
-    border-bottom: 1px solid #30363d; }
-  td { padding: 8px 12px; border-bottom: 1px solid #21262d; }
-  tr:hover td { background: #161b22; }
-  .pill { display: inline-block; padding: 2px 8px; border-radius: 12px;
-    font-size: 0.8rem; background: #1f6feb33; color: #58a6ff; }
-  .btn { display: inline-block; padding: 8px 16px; border-radius: 6px; text-decoration: none;
+  .avatar-sm { width: 28px; height: 28px; border-radius: 50%; vertical-align: middle; }
+
+  /* ── Layout ── */
+  .content { max-width: 1100px; margin: 28px auto; padding: 0 20px; display: flex; flex-direction: column; gap: 16px; }
+
+  /* ── Cards ── */
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 20px; }
+  .card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; flex-wrap: wrap; gap: 8px; }
+  .card-header h3 { margin: 0; color: #c9d1d9; font-size: 0.95rem; font-weight: 600; }
+
+  /* ── Tabs ── */
+  .tabs { display: flex; gap: 3px; background: #0d1117; border: 1px solid #30363d; border-radius: 7px; padding: 3px; }
+  .tab { padding: 5px 14px; border-radius: 5px; border: none; cursor: pointer;
+    background: transparent; color: #8b949e; font-size: 0.8rem; font-weight: 500; transition: all 0.15s; }
+  .tab.active { background: #30363d; color: #e6edf3; }
+  .tab:hover:not(.active) { color: #c9d1d9; }
+
+  /* ── Profile ── */
+  .profile-card { background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 20px 24px;
+    display: flex; align-items: center; gap: 20px; }
+  .profile-avatar { width: 72px; height: 72px; border-radius: 50%; border: 2px solid #30363d; flex-shrink: 0; }
+  .profile-avatar-placeholder { width: 72px; height: 72px; border-radius: 50%; background: #21262d;
+    display: flex; align-items: center; justify-content: center; font-size: 2rem; flex-shrink: 0; }
+  .profile-name { font-size: 1.3rem; font-weight: 700; color: #e6edf3; margin-bottom: 2px; }
+  .profile-login a { color: #58a6ff; text-decoration: none; font-size: 0.9rem; }
+  .profile-login a:hover { text-decoration: underline; }
+  .profile-meta { color: #8b949e; font-size: 0.8rem; margin-top: 4px; }
+  .admin-badge { display: inline-block; padding: 1px 7px; border-radius: 10px; font-size: 0.7rem;
+    background: #b08800; color: #fff; margin-left: 8px; vertical-align: middle; }
+
+  /* ── Stat grid ── */
+  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 12px; }
+  .stat-card { background: #0d1117; border: 1px solid #21262d; border-radius: 8px; padding: 14px 16px; }
+  .stat-card .label { color: #8b949e; font-size: 0.8rem; }
+  .stat-card .value { font-size: 1.6rem; font-weight: 700; color: #58a6ff; margin-top: 2px; line-height: 1; }
+  .stats-panel.hidden { display: none; }
+
+  /* ── Editor bars ── */
+  .editor-row { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+  .editor-label { min-width: 110px; text-align: right; font-size: 0.85rem; color: #c9d1d9; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .editor-track { flex: 1; background: #21262d; border-radius: 4px; height: 8px; overflow: hidden; }
+  .editor-fill { height: 100%; border-radius: 4px; }
+  .editor-pct { min-width: 44px; text-align: right; font-size: 0.78rem; color: #8b949e; }
+
+  /* ── Chart ── */
+  .chart-wrap { position: relative; height: 290px; margin-top: 4px; }
+
+  /* ── Table ── */
+  table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin-top: 12px; }
+  th { background: #0d1117; color: #8b949e; padding: 8px 10px; text-align: left; border-bottom: 1px solid #30363d; white-space: nowrap; }
+  td { padding: 7px 10px; border-bottom: 1px solid #161b22; }
+  tr:hover td { background: #21262d33; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.78rem; background: #1f6feb33; color: #58a6ff; }
+
+  /* ── Alerts ── */
+  .alert { padding: 12px 16px; border-radius: 6px; margin: 4px 0; }
+  .alert-warn { background: #3d2b0030; border: 1px solid #bb8009; color: #e3b341; }
+
+  /* ── Collapsible ── */
+  details.card > summary { cursor: pointer; color: #8b949e; font-size: 0.9rem; padding: 0;
+    user-select: none; list-style: none; display: flex; align-items: center; gap: 6px; }
+  details.card > summary::before { content: "▶"; font-size: 0.7rem; transition: transform 0.15s; }
+  details.card[open] > summary::before { transform: rotate(90deg); }
+  details.card > summary:hover { color: #e6edf3; }
+
+  /* ── Misc ── */
+  .btn { display: inline-block; padding: 8px 18px; border-radius: 6px; text-decoration: none;
     font-size: 0.9rem; font-weight: 600; cursor: pointer; border: none; }
   .btn-primary { background: #238636; color: #fff; }
   .btn-primary:hover { background: #2ea043; }
   .btn-secondary { background: #21262d; color: #c9d1d9; border: 1px solid #30363d; }
   .btn-secondary:hover { background: #30363d; }
-  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin: 16px 0; }
-  .stat-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }
-  .stat-card .label { color: #8b949e; font-size: 0.85rem; }
-  .stat-card .value { font-size: 1.5rem; font-weight: 700; color: #58a6ff; margin-top: 4px; }
-  .alert { padding: 12px 16px; border-radius: 6px; margin: 16px 0; }
-  .alert-warn { background: #3d2b0030; border: 1px solid #bb8009; color: #e3b341; }
-  .avatar { width: 32px; height: 32px; border-radius: 50%; vertical-align: middle; margin-right: 8px; }
+  code { background: #21262d; border-radius: 4px; padding: 1px 5px; font-size: 0.875em; }
 </style>
 </head>
 <body>
@@ -220,100 +298,380 @@ ${body}
 function loginPage(): string {
 	return layout('Sign In', `
 <div class="header"><h1>🤖 Copilot Token Tracker Sharing</h1></div>
-<div class="content" style="text-align:center; margin-top: 80px">
-  <h2>Sign in to view your usage dashboard</h2>
+<div class="content" style="text-align:center; margin-top: 80px; align-items:center">
+  <h2 style="color:#e6edf3">Sign in to view your usage dashboard</h2>
   <p style="color:#8b949e">Your data is linked to your GitHub account. No account creation needed.</p>
-  <a href="/auth/github" class="btn btn-primary" style="font-size:1rem; padding:12px 24px">
+  <a href="/auth/github" class="btn btn-primary" style="font-size:1rem; padding:12px 28px">
     Sign in with GitHub
   </a>
   <p style="color:#8b949e; margin-top:32px; font-size:0.85rem">
-    The VS Code extension uploads data automatically using your existing GitHub session — no separate sign-in needed there.
+    The VS Code extension uploads data automatically using your existing GitHub session —
+    no separate sign-in required.
   </p>
 </div>`);
 }
 
 function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, allUsers?: UserRow[]): string {
-	const totalInput = uploads.reduce((s, r) => s + r.input_tokens, 0);
-	const totalOutput = uploads.reduce((s, r) => s + r.output_tokens, 0);
-	const totalInteractions = uploads.reduce((s, r) => s + r.interactions, 0);
-	const uniqueDays = new Set(uploads.map(r => r.day)).size;
+	// ── Per-period stats ───────────────────────────────────────────────────────
+	const today = new Date().toISOString().slice(0, 10);
+	const sevenDaysAgo = (() => {
+		const d = new Date();
+		d.setUTCDate(d.getUTCDate() - 6);
+		return d.toISOString().slice(0, 10);
+	})();
 
-	const rows = uploads.map(r => `
-<tr>
-  <td>${h(r.day)}</td>
-  <td><span class="pill">${h(r.model)}</span></td>
-  <td>${h(r.workspace_name ?? r.workspace_id)}</td>
-  <td>${h(r.machine_name ?? r.machine_id)}</td>
-  <td>${r.input_tokens.toLocaleString()}</td>
-  <td>${r.output_tokens.toLocaleString()}</td>
-  <td>${r.interactions.toLocaleString()}</td>
-</tr>`).join('');
+	const uploads1d = uploads.filter(r => r.day === today);
+	const uploads7d = uploads.filter(r => r.day >= sevenDaysAgo);
 
-	const adminSection = isAdmin && allUsers ? `
-<h2>Admin: All Users</h2>
-<table>
-  <thead><tr><th>GitHub Login</th><th>Name</th><th>Joined</th><th>Last Seen</th><th>Admin</th></tr></thead>
-  <tbody>
-    ${allUsers.map(u => `<tr>
-      <td><a href="https://github.com/${h(u.github_login)}" target="_blank">${h(u.github_login)}</a></td>
-      <td>${h(u.github_name ?? '—')}</td>
-      <td>${h(u.created_at.slice(0, 10))}</td>
-      <td>${h(u.last_seen_at?.slice(0, 10) ?? '—')}</td>
-      <td>${u.is_admin ? '✅' : ''}</td>
-    </tr>`).join('')}
-  </tbody>
-</table>` : '';
+	type PeriodStats = { inputTokens: number; outputTokens: number; interactions: number; daysActive: number };
+	const computeStats = (rows: UploadRow[]): PeriodStats => ({
+		inputTokens: rows.reduce((s, r) => s + r.input_tokens, 0),
+		outputTokens: rows.reduce((s, r) => s + r.output_tokens, 0),
+		interactions: rows.reduce((s, r) => s + r.interactions, 0),
+		daysActive: new Set(rows.map(r => r.day)).size,
+	});
+	const periodStats = {
+		today: computeStats(uploads1d),
+		week: computeStats(uploads7d),
+		month: computeStats(uploads),
+	};
 
-	const avatarHtml = user.avatar_url
-		? `<img src="${h(user.avatar_url)}" class="avatar" alt="${h(user.github_login)}">`
-		: '';
+	// ── Editor breakdown (last 30 days) ───────────────────────────────────────
+	const editorTotals = new Map<string, number>();
+	for (const r of uploads) {
+		const editor = r.editor || 'VS Code';
+		editorTotals.set(editor, (editorTotals.get(editor) ?? 0) + r.input_tokens + r.output_tokens);
+	}
+	const grandTotal = [...editorTotals.values()].reduce((s, v) => s + v, 0);
+	const editorList = [...editorTotals.entries()]
+		.sort((a, b) => b[1] - a[1])
+		.map(([editor, tokens]) => ({
+			editor,
+			tokens,
+			pct: grandTotal > 0 ? (tokens / grandTotal) * 100 : 0,
+		}));
+
+	// ── Chart data ────────────────────────────────────────────────────────────
+	const chartData = uploads.map(r => ({
+		day: r.day,
+		model: r.model,
+		editor: r.editor || 'VS Code',
+		inputTokens: r.input_tokens,
+		outputTokens: r.output_tokens,
+		interactions: r.interactions,
+	}));
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+	const EDITOR_COLORS = ['#58a6ff', '#3fb950', '#bc8cff', '#f0883e', '#e3b341', '#f778ba'];
+
+	function statCards(stats: PeriodStats, panelId: string, hidden: boolean): string {
+		return `<div id="${panelId}" class="stats-panel${hidden ? ' hidden' : ''}">
+  <div class="stat-grid">
+    <div class="stat-card"><div class="label">Input Tokens</div><div class="value">${fmt(stats.inputTokens)}</div></div>
+    <div class="stat-card"><div class="label">Output Tokens</div><div class="value">${fmt(stats.outputTokens)}</div></div>
+    <div class="stat-card"><div class="label">Interactions</div><div class="value">${fmt(stats.interactions)}</div></div>
+    <div class="stat-card"><div class="label">Days Active</div><div class="value">${stats.daysActive}</div></div>
+  </div>
+</div>`;
+	}
+
+	const avatarUrl = user.avatar_url ? h(user.avatar_url) : '';
+	const displayName = h(user.github_name ?? user.github_login);
+	const login = h(user.github_login);
+
+	// ── Build HTML blocks ─────────────────────────────────────────────────────
+
+	const profileHtml = `
+<div class="profile-card">
+  ${avatarUrl
+		? `<img src="${avatarUrl}" class="profile-avatar" alt="${login}">`
+		: `<div class="profile-avatar-placeholder">👤</div>`}
+  <div>
+    <div class="profile-name">${displayName}${isAdmin ? '<span class="admin-badge">admin</span>' : ''}</div>
+    <div class="profile-login"><a href="https://github.com/${login}" target="_blank" rel="noopener">@${login}</a></div>
+    <div class="profile-meta">
+      Member since ${h(user.created_at.slice(0, 10))}${user.last_seen_at ? ` &nbsp;·&nbsp; Last active ${h(user.last_seen_at.slice(0, 10))}` : ''}
+    </div>
+  </div>
+</div>`;
+
+	const summaryHtml = `
+<div class="card">
+  <div class="card-header">
+    <h3>Usage Summary</h3>
+    <div class="tabs" id="period-tabs">
+      <button class="tab active" data-period="stats-today">Today</button>
+      <button class="tab" data-period="stats-week">Last 7 Days</button>
+      <button class="tab" data-period="stats-month">Last 30 Days</button>
+    </div>
+  </div>
+  ${statCards(periodStats.today, 'stats-today', false)}
+  ${statCards(periodStats.week, 'stats-week', true)}
+  ${statCards(periodStats.month, 'stats-month', true)}
+</div>`;
+
+	const editorsHtml = editorList.length > 0 ? `
+<div class="card">
+  <div class="card-header"><h3>Editors Used (last 30 days)</h3></div>
+  ${editorList.map((e, i) => `
+  <div class="editor-row">
+    <span class="editor-label" title="${h(e.editor)}">${h(e.editor)}</span>
+    <div class="editor-track">
+      <div class="editor-fill" style="width:${e.pct.toFixed(1)}%;background:${EDITOR_COLORS[i % EDITOR_COLORS.length]}"></div>
+    </div>
+    <span class="editor-pct">${e.pct.toFixed(1)}%</span>
+  </div>`).join('')}
+</div>` : '';
+
+	const chartHtml = uploads.length > 0 ? `
+<div class="card">
+  <div class="card-header">
+    <h3>Token Usage Trend</h3>
+    <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+      <div class="tabs" id="group-tabs">
+        <button class="tab active" data-group="model">By Model</button>
+        <button class="tab" data-group="editor">By Editor</button>
+      </div>
+      <div class="tabs" id="view-tabs">
+        <button class="tab active" data-view="day">Day</button>
+        <button class="tab" data-view="week">Week</button>
+        <button class="tab" data-view="month">Month</button>
+      </div>
+    </div>
+  </div>
+  <div class="chart-wrap"><canvas id="trend-chart"></canvas></div>
+</div>` : `
+<div class="alert alert-warn">
+  No data yet. Configure the VS Code extension with this server's endpoint URL
+  (<code>copilotTokenTracker.sharingServer.endpointUrl</code>) and wait for the
+  next sync (or trigger one from the status bar).
+</div>`;
+
+	const tableHtml = uploads.length > 0 ? `
+<details class="card">
+  <summary>Detailed Breakdown (${uploads.length} rows, last 30 days)</summary>
+  <table>
+    <thead>
+      <tr>
+        <th>Day</th><th>Model</th><th>Editor</th><th>Workspace</th><th>Machine</th>
+        <th>Input Tokens</th><th>Output Tokens</th><th>Interactions</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${uploads.map(r => `
+      <tr>
+        <td>${h(r.day)}</td>
+        <td><span class="pill">${h(r.model)}</span></td>
+        <td>${h(r.editor || 'VS Code')}</td>
+        <td>${h(r.workspace_name ?? r.workspace_id)}</td>
+        <td>${h(r.machine_name ?? r.machine_id)}</td>
+        <td>${r.input_tokens.toLocaleString()}</td>
+        <td>${r.output_tokens.toLocaleString()}</td>
+        <td>${r.interactions.toLocaleString()}</td>
+      </tr>`).join('')}
+    </tbody>
+  </table>
+</details>` : '';
+
+	const adminHtml = isAdmin && allUsers ? `
+<details class="card">
+  <summary>👑 Admin: All Users (${allUsers.length})</summary>
+  <table>
+    <thead><tr><th></th><th>GitHub Login</th><th>Name</th><th>Joined</th><th>Last Seen</th><th>Admin</th></tr></thead>
+    <tbody>
+      ${allUsers.map(u => `
+      <tr>
+        <td>${u.avatar_url ? `<img src="${h(u.avatar_url)}" style="width:22px;height:22px;border-radius:50%;vertical-align:middle">` : ''}</td>
+        <td><a href="https://github.com/${h(u.github_login)}" target="_blank" rel="noopener" style="color:#58a6ff">${h(u.github_login)}</a></td>
+        <td>${h(u.github_name ?? '—')}</td>
+        <td>${h(u.created_at.slice(0, 10))}</td>
+        <td>${h(u.last_seen_at?.slice(0, 10) ?? '—')}</td>
+        <td>${u.is_admin ? '✅' : ''}</td>
+      </tr>`).join('')}
+    </tbody>
+  </table>
+</details>` : '';
+
+	// ── Interactive JS ────────────────────────────────────────────────────────
+	const interactiveJs = `
+(function () {
+  // ── Period tabs ─────────────────────────────────────────────────────────
+  document.querySelectorAll('#period-tabs .tab').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('#period-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      var target = btn.getAttribute('data-period');
+      document.querySelectorAll('.stats-panel').forEach(function(el) {
+        el.classList.toggle('hidden', el.id !== target);
+      });
+    });
+  });
+
+  // ── Chart ────────────────────────────────────────────────────────────────
+  var canvas = document.getElementById('trend-chart');
+  if (!canvas || !CHART_DATA.length) return;
+
+  var MODEL_PALETTE  = ['#58a6ff','#3fb950','#bc8cff','#f0883e','#e3b341','#f778ba','#79c0ff','#56d364','#d2a8ff','#ffa657'];
+  var CLAUDE_COLORS  = ['#bc8cff','#a371f7','#d2a8ff','#6e40c9','#8250df'];
+  var GPT_COLORS     = ['#58a6ff','#388bfd','#1f6feb','#79c0ff'];
+  var GEMINI_COLORS  = ['#3fb950','#2ea043','#56d364'];
+  var EDITOR_COLORS  = ['#58a6ff','#3fb950','#bc8cff','#f0883e','#e3b341','#f778ba'];
+  var colorIdx = { claude: 0, gpt: 0, gemini: 0, other: 0, editor: 0 };
+  var modelColorMap = {}, editorColorMap = {};
+
+  function getModelColor(m) {
+    if (!modelColorMap[m]) {
+      if (m.includes('claude'))         modelColorMap[m] = CLAUDE_COLORS[colorIdx.claude++  % CLAUDE_COLORS.length];
+      else if (m.match(/\\bgpt|o[134]\\b/)) modelColorMap[m] = GPT_COLORS[colorIdx.gpt++     % GPT_COLORS.length];
+      else if (m.includes('gemini'))    modelColorMap[m] = GEMINI_COLORS[colorIdx.gemini++ % GEMINI_COLORS.length];
+      else                               modelColorMap[m] = MODEL_PALETTE[colorIdx.other++  % MODEL_PALETTE.length];
+    }
+    return modelColorMap[m];
+  }
+  function getEditorColor(e) {
+    if (!editorColorMap[e]) editorColorMap[e] = EDITOR_COLORS[colorIdx.editor++ % EDITOR_COLORS.length];
+    return editorColorMap[e];
+  }
+
+  var allModels  = [...new Set(CHART_DATA.map(function(r) { return r.model; }))].sort();
+  var allEditors = [...new Set(CHART_DATA.map(function(r) { return r.editor; }))].sort();
+  allModels.forEach(getModelColor);
+  allEditors.forEach(getEditorColor);
+
+  function toWeekStart(day) {
+    var d = new Date(day + 'T00:00:00Z');
+    var dow = (d.getUTCDay() + 6) % 7;
+    d.setUTCDate(d.getUTCDate() - dow);
+    return d.toISOString().slice(0, 10);
+  }
+  function toMonth(day) { return day.slice(0, 7); }
+
+  function aggregate(keyFn, groupBy) {
+    var map = {};
+    CHART_DATA.forEach(function(r) {
+      var label = keyFn(r.day);
+      var dim   = groupBy === 'editor' ? r.editor : r.model;
+      if (!map[label]) map[label] = {};
+      map[label][dim] = (map[label][dim] || 0) + r.inputTokens + r.outputTokens;
+    });
+    return map;
+  }
+
+  function buildDatasets(grouped, labels, dims, colorFn) {
+    return dims
+      .map(function(dim) {
+        return {
+          label: dim,
+          data: labels.map(function(l) { return Math.round((grouped[l] && grouped[l][dim] || 0) / 1000); }),
+          backgroundColor: colorFn(dim) + 'bb',
+          borderColor: colorFn(dim),
+          borderWidth: 1,
+          borderRadius: 2,
+        };
+      })
+      .filter(function(ds) { return ds.data.some(function(v) { return v > 0; }); });
+  }
+
+  var currentGroup = 'model', currentView = 'day';
+  var grouped = aggregate(function(d) { return d; }, currentGroup);
+  var labels  = [...new Set(CHART_DATA.map(function(r) { return r.day; }))].sort();
+
+  var chart = new Chart(canvas, {
+    type: 'bar',
+    data: { labels: labels, datasets: buildDatasets(grouped, labels, allModels, getModelColor) },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        x: { stacked: true, grid: { color: '#21262d' }, ticks: { color: '#8b949e', maxTicksLimit: 16, font: { size: 11 } } },
+        y: { stacked: true, grid: { color: '#21262d' },
+          ticks: { color: '#8b949e', font: { size: 11 },
+            callback: function(v) { return v >= 1000 ? (v/1000).toFixed(1)+'M' : v+'K'; } },
+          title: { display: true, text: 'Tokens (K)', color: '#8b949e', font: { size: 11 } },
+        },
+      },
+      plugins: {
+        legend: { position: 'bottom', labels: { color: '#c9d1d9', boxWidth: 11, padding: 14, font: { size: 11 } } },
+        tooltip: {
+          backgroundColor: '#161b22', borderColor: '#30363d', borderWidth: 1,
+          callbacks: {
+            label: function(ctx) {
+              var v = ctx.parsed.y;
+              return '  ' + ctx.dataset.label + ': ' + (v >= 1000 ? (v/1000).toFixed(1)+'M' : v+'K') + ' tokens';
+            },
+            footer: function(items) {
+              var total = items.reduce(function(s,i) { return s + i.parsed.y; }, 0);
+              return 'Total: ' + (total >= 1000 ? (total/1000).toFixed(1)+'M' : total+'K') + ' tokens';
+            },
+          },
+        },
+      },
+    },
+  });
+
+  function rebuildChart() {
+    var keyFn = currentView === 'week' ? toWeekStart : currentView === 'month' ? toMonth : function(d) { return d; };
+    grouped = aggregate(keyFn, currentGroup);
+    labels  = [...new Set(CHART_DATA.map(function(r) { return keyFn(r.day); }))].sort();
+    var dims     = currentGroup === 'editor' ? allEditors : allModels;
+    var colorFn  = currentGroup === 'editor' ? getEditorColor : getModelColor;
+    chart.data.labels   = labels;
+    chart.data.datasets = buildDatasets(grouped, labels, dims, colorFn);
+    chart.update();
+  }
+
+  document.querySelectorAll('#group-tabs .tab').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('#group-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      currentGroup = btn.getAttribute('data-group');
+      rebuildChart();
+    });
+  });
+
+  document.querySelectorAll('#view-tabs .tab').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('#view-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      currentView = btn.getAttribute('data-view');
+      rebuildChart();
+    });
+  });
+})();`;
 
 	return layout(`${user.github_login}'s Dashboard`, `
 <div class="header">
   <h1>🤖 Copilot Token Tracker</h1>
   <span class="spacer"></span>
-  ${avatarHtml}<span>${h(user.github_name ?? user.github_login)}</span>
-  <a href="/auth/logout" style="margin-left:16px">Sign out</a>
+  ${avatarUrl ? `<img src="${avatarUrl}" class="avatar-sm" alt="${login}">` : ''}
+  <span style="color:#c9d1d9;font-size:0.875rem">${displayName}</span>
+  <a href="/auth/logout" style="margin-left:8px">Sign out</a>
 </div>
 <div class="content">
-  <h2>Your Usage (last 30 days)</h2>
-  <div class="stat-grid">
-    <div class="stat-card"><div class="label">Input Tokens</div><div class="value">${fmt(totalInput)}</div></div>
-    <div class="stat-card"><div class="label">Output Tokens</div><div class="value">${fmt(totalOutput)}</div></div>
-    <div class="stat-card"><div class="label">Interactions</div><div class="value">${fmt(totalInteractions)}</div></div>
-    <div class="stat-card"><div class="label">Days with Data</div><div class="value">${uniqueDays}</div></div>
-  </div>
+  ${profileHtml}
+  ${summaryHtml}
+  ${editorsHtml}
+  ${chartHtml}
+  ${tableHtml}
+  ${adminHtml}
+</div>
 
-  ${uploads.length === 0 ? `
-  <div class="alert alert-warn">
-    No data yet. Make sure the VS Code extension is configured with this server's endpoint URL
-    (<code>copilotTokenTracker.sharingServer.endpointUrl</code>).
-  </div>` : `
-  <h3>Detailed Breakdown</h3>
-  <table>
-    <thead><tr><th>Day</th><th>Model</th><th>Workspace</th><th>Machine</th>
-      <th>Input Tokens</th><th>Output Tokens</th><th>Interactions</th></tr></thead>
-    <tbody>${rows}</tbody>
-  </table>`}
-
-  ${adminSection}
-</div>`);
+<script>
+var CHART_DATA = ${safeJson(chartData)};
+</script>
+<script>${_chartJsCode}</script>
+<script>${interactiveJs}</script>`);
 }
 
 function errorPage(message: string): string {
 	return layout('Error', `
 <div class="header"><h1>🤖 Copilot Token Tracker Sharing</h1></div>
-<div class="content" style="text-align:center; margin-top:80px">
-  <h2>Something went wrong</h2>
+<div class="content" style="text-align:center; margin-top:80px; align-items:center">
+  <h2 style="color:#e6edf3">Something went wrong</h2>
   <p style="color:#8b949e">${h(message)}</p>
   <a href="/dashboard" class="btn btn-secondary">Back to Dashboard</a>
 </div>`);
-}
-
-function fmt(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-	return String(n);
 }
 
 function randomState(): string {

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -440,6 +440,11 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
   <div class="card-header">
     <h3>Token Usage Trend</h3>
     <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+      <div class="tabs" id="chart-period-tabs">
+        <button class="tab" data-chart-period="7">Last 7 days</button>
+        <button class="tab active" data-chart-period="30">Last 30 days</button>
+        <button class="tab" data-chart-period="0">All</button>
+      </div>
       <div class="tabs" id="group-tabs">
         <button class="tab active" data-group="model">By Model</button>
         <button class="tab" data-group="editor">By Editor</button>
@@ -448,6 +453,10 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
         <button class="tab active" data-view="day">Day</button>
         <button class="tab" data-view="week">Week</button>
         <button class="tab" data-view="month">Month</button>
+      </div>
+      <div class="tabs" id="scale-tabs">
+        <button class="tab active" data-scale="linear">Linear</button>
+        <button class="tab" data-scale="log">Log</button>
       </div>
     </div>
   </div>
@@ -601,7 +610,37 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
       .filter(function(ds) { return ds.data.some(function(v) { return v > 0; }); });
   }
 
-  var currentGroup = 'model', currentView = 'day';
+  var currentGroup = 'model', currentView = 'day', currentChartDays = 30, currentScale = 'linear';
+
+  function getChartData() {
+    if (currentChartDays === 0) { return CHART_DATA; }
+    var cutoff = new Date();
+    cutoff.setUTCDate(cutoff.getUTCDate() - (currentChartDays - 1));
+    var cutoffStr = cutoff.toISOString().slice(0, 10);
+    return CHART_DATA.filter(function(r) { return r.day >= cutoffStr; });
+  }
+
+  function makeYAxisConfig() {
+    var isLog = currentScale === 'log';
+    return {
+      stacked: !isLog,
+      type: isLog ? 'logarithmic' : 'linear',
+      grid: { color: '#21262d' },
+      ticks: {
+        color: '#8b949e', font: { size: 11 },
+        callback: function(v) {
+          // Show only "round" log-scale ticks
+          if (isLog) {
+            var log = Math.log10(v);
+            if (Math.abs(log - Math.round(log)) > 0.01) { return null; }
+          }
+          return v >= 1000 ? (v/1000).toFixed(1)+'M' : v+'K';
+        },
+      },
+      title: { display: true, text: 'Tokens (K)', color: '#8b949e', font: { size: 11 } },
+    };
+  }
+
   var grouped = aggregate(function(d) { return d; }, currentGroup);
   var labels  = [...new Set(CHART_DATA.map(function(r) { return r.day; }))].sort();
 
@@ -614,11 +653,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
       interaction: { mode: 'index', intersect: false },
       scales: {
         x: { stacked: true, grid: { color: '#21262d' }, ticks: { color: '#8b949e', maxTicksLimit: 16, font: { size: 11 } } },
-        y: { stacked: true, grid: { color: '#21262d' },
-          ticks: { color: '#8b949e', font: { size: 11 },
-            callback: function(v) { return v >= 1000 ? (v/1000).toFixed(1)+'M' : v+'K'; } },
-          title: { display: true, text: 'Tokens (K)', color: '#8b949e', font: { size: 11 } },
-        },
+        y: makeYAxisConfig(),
       },
       plugins: {
         legend: { position: 'bottom', labels: { color: '#c9d1d9', boxWidth: 11, padding: 14, font: { size: 11 } } },
@@ -640,15 +675,44 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
   });
 
   function rebuildChart() {
+    var filteredData = getChartData();
     var keyFn = currentView === 'week' ? toWeekStart : currentView === 'month' ? toMonth : function(d) { return d; };
-    grouped = aggregate(keyFn, currentGroup);
-    labels  = [...new Set(CHART_DATA.map(function(r) { return keyFn(r.day); }))].sort();
+    // Re-aggregate using filtered data
+    var filteredMap = {};
+    filteredData.forEach(function(r) {
+      var label = keyFn(r.day);
+      var dim   = currentGroup === 'editor' ? r.editor : r.model;
+      if (!filteredMap[label]) filteredMap[label] = {};
+      filteredMap[label][dim] = (filteredMap[label][dim] || 0) + r.inputTokens + r.outputTokens;
+    });
+    grouped = filteredMap;
+    labels  = [...new Set(filteredData.map(function(r) { return keyFn(r.day); }))].sort();
     var dims     = currentGroup === 'editor' ? allEditors : allModels;
     var colorFn  = currentGroup === 'editor' ? getEditorColor : getModelColor;
     chart.data.labels   = labels;
     chart.data.datasets = buildDatasets(grouped, labels, dims, colorFn);
+    chart.options.scales.x.stacked = currentScale !== 'log';
+    chart.options.scales.y = makeYAxisConfig();
     chart.update();
   }
+
+  document.querySelectorAll('#chart-period-tabs .tab').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('#chart-period-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      currentChartDays = parseInt(btn.getAttribute('data-chart-period'), 10);
+      rebuildChart();
+    });
+  });
+
+  document.querySelectorAll('#scale-tabs .tab').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('#scale-tabs .tab').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      currentScale = btn.getAttribute('data-scale');
+      rebuildChart();
+    });
+  });
 
   document.querySelectorAll('#group-tabs .tab').forEach(function(btn) {
     btn.addEventListener('click', function() {

--- a/sharing-server/src/server.ts
+++ b/sharing-server/src/server.ts
@@ -1,0 +1,30 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { api } from './routes/api.js';
+import { dashboard } from './routes/dashboard.js';
+
+const app = new Hono();
+
+// Health check — no auth required
+app.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }));
+
+// API routes (Bearer GitHub token auth)
+app.route('/api', api);
+
+// Dashboard + auth routes (session cookie)
+app.route('/', dashboard);
+
+// 404 fallback
+app.notFound((c) => c.json({ error: 'Not found' }, 404));
+
+const PORT = parseInt(process.env.PORT ?? '3000', 10);
+
+serve({ fetch: app.fetch, port: PORT }, (info) => {
+	const org = process.env.ALLOWED_GITHUB_ORG;
+	console.log(`Copilot Token Tracker sharing server listening on port ${info.port}`);
+	if (org) {
+		console.log(`  Access restricted to members of GitHub org: ${org}`);
+	} else {
+		console.log('  Access: open to any GitHub user (set ALLOWED_GITHUB_ORG to restrict)');
+	}
+});

--- a/sharing-server/src/session.ts
+++ b/sharing-server/src/session.ts
@@ -1,0 +1,59 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+const SESSION_SECRET = process.env.SESSION_SECRET ?? 'dev-secret-change-me-in-production';
+export const COOKIE_NAME = 'sharing-session';
+export const OAUTH_STATE_COOKIE = 'oauth-state';
+const MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+/** Minimal claims stored in the session cookie. User details are re-read from DB on every request. */
+export interface SessionClaims {
+	sub: number;  // users.id (internal DB id, not github_id)
+	iat: number;  // issued-at (epoch seconds)
+	exp: number;  // expires-at (epoch seconds)
+}
+
+function sign(payload: string): string {
+	return createHmac('sha256', SESSION_SECRET).update(payload).digest('base64url');
+}
+
+export function encodeSession(claims: SessionClaims): string {
+	const payload = Buffer.from(JSON.stringify(claims)).toString('base64url');
+	const signature = sign(payload);
+	return `${payload}.${signature}`;
+}
+
+export function decodeSession(cookie: string): SessionClaims | null {
+	const dotIndex = cookie.lastIndexOf('.');
+	if (dotIndex < 0) return null;
+	const payload = cookie.slice(0, dotIndex);
+	const signature = cookie.slice(dotIndex + 1);
+
+	const expected = sign(payload);
+	try {
+		const sigBuf = Buffer.from(signature, 'base64url');
+		const expBuf = Buffer.from(expected, 'base64url');
+		if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	try {
+		const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as SessionClaims;
+		// Reject expired sessions
+		if (typeof claims.exp !== 'number' || claims.exp < Date.now() / 1000) {
+			return null;
+		}
+		return claims;
+	} catch {
+		return null;
+	}
+}
+
+export function makeClaims(userId: number): SessionClaims {
+	const now = Math.floor(Date.now() / 1000);
+	return { sub: userId, iat: now, exp: now + MAX_AGE_SECONDS };
+}
+
+export const SESSION_MAX_AGE = MAX_AGE_SECONDS;

--- a/sharing-server/tsconfig.json
+++ b/sharing-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -147,15 +147,20 @@
         "copilotTokenTracker.backend.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable backend sync to an Azure-backed store (default: Azure Storage Tables)."
+          "description": "Enable backend sync to an Azure-backed store (default: Azure Storage Tables) or a self-hosted sharing server."
         },
         "copilotTokenTracker.backend.backend": {
           "type": "string",
           "enum": [
-            "storageTables"
+            "storageTables",
+            "sharingServer"
+          ],
+          "enumDescriptions": [
+            "Azure Storage Tables (requires Azure subscription + RBAC setup)",
+            "Self-hosted sharing server (configure endpoint URL; authenticates via your existing GitHub session)"
           ],
           "default": "storageTables",
-          "description": "Backend sync backend. MVP supports Azure Storage Tables."
+          "description": "Backend type for syncing usage data. 'storageTables' uses Azure. 'sharingServer' uses a self-hosted API server — only configure copilotTokenTracker.backend.sharingServer.endpointUrl."
         },
         "copilotTokenTracker.backend.authMode": {
           "type": "string",
@@ -280,6 +285,11 @@
           "type": "boolean",
           "default": true,
           "description": "Compress session log files with gzip before uploading to blob storage to reduce storage costs and bandwidth."
+        },
+        "copilotTokenTracker.backend.sharingServer.endpointUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Base URL of the self-hosted sharing server (e.g. https://copilot-sharing.example.com). Only used when 'backend' is set to 'sharingServer'. Authentication is handled automatically via your existing GitHub session — no API key needed."
         },
         "copilot-token-tracker.sampleDataDirectory": {
           "type": "string",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,6 +71,11 @@
         "category": "AI Engineering Fluency"
       },
       {
+        "command": "copilot-token-tracker.configureTeamServer",
+        "title": "Configure Team Server Backend",
+        "category": "AI Engineering Fluency"
+      },
+      {
         "command": "copilot-token-tracker.copyBackendConfig",
         "title": "Copy Backend Config (No Secrets)",
         "category": "AI Engineering Fluency"
@@ -286,10 +291,15 @@
           "default": true,
           "description": "Compress session log files with gzip before uploading to blob storage to reduce storage costs and bandwidth."
         },
+        "copilotTokenTracker.backend.sharingServer.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable syncing to the self-hosted Team Server backend. Can run simultaneously with Azure Storage (backend.enabled). Requires backend.sharingServer.endpointUrl to be configured."
+        },
         "copilotTokenTracker.backend.sharingServer.endpointUrl": {
           "type": "string",
           "default": "",
-          "description": "Base URL of the self-hosted sharing server (e.g. https://copilot-sharing.example.com). Only used when 'backend' is set to 'sharingServer'. Authentication is handled automatically via your existing GitHub session — no API key needed."
+          "description": "Base URL of the self-hosted sharing server (e.g. https://copilot-sharing.example.com). Authentication is handled automatically via your existing GitHub session — no API key needed."
         },
         "copilot-token-tracker.sampleDataDirectory": {
           "type": "string",

--- a/vscode-extension/src/backend/configPanel.ts
+++ b/vscode-extension/src/backend/configPanel.ts
@@ -11,6 +11,7 @@ export interface BackendConfigPanelState {
 	isConfigured: boolean;
 	authStatus: string;
 	shareConsentAt?: string;
+	lastSyncAt?: number;
 }
 
 export interface BackendConfigPanelCallbacks {
@@ -233,7 +234,8 @@ export class BackendConfigPanel implements vscode.Disposable {
 	<div class="layout">
 		<aside class="nav">
 			<vscode-button appearance="secondary" class="nav-btn selected" data-target="overview" aria-label="Navigate to Overview section">Overview</vscode-button>
-			<vscode-button appearance="secondary" class="nav-btn" data-target="azure" aria-label="Navigate to Azure section">Azure</vscode-button>
+			<vscode-button appearance="secondary" class="nav-btn" data-target="azure" aria-label="Navigate to Azure Storage section">Azure Storage</vscode-button>
+			<vscode-button appearance="secondary" class="nav-btn" data-target="teamserver" aria-label="Navigate to Team Server section">Team Server</vscode-button>
 			<vscode-button appearance="secondary" class="nav-btn" data-target="sharing" aria-label="Navigate to Sharing section">Sharing</vscode-button>
 			<vscode-button appearance="secondary" class="nav-btn" data-target="advanced" aria-label="Navigate to Advanced section">Advanced</vscode-button>
 			<vscode-button appearance="secondary" class="nav-btn" data-target="review" aria-label="Navigate to Review and Apply section">Review & Apply</vscode-button>
@@ -255,6 +257,14 @@ export class BackendConfigPanel implements vscode.Disposable {
 					<vscode-badge id="privacyBadge"></vscode-badge>
 					<vscode-badge id="authBadge"></vscode-badge>
 				</div>
+				<div class="field" style="margin-top: 12px;">
+					<label for="backendType">Storage backend</label>
+					<vscode-dropdown id="backendType" aria-describedby="backendType-help">
+						<vscode-option value="storageTables">Azure Storage (Table Storage)</vscode-option>
+						<vscode-option value="sharingServer">Team Server (self-hosted)</vscode-option>
+					</vscode-dropdown>
+					<div id="backendType-help" class="helper">Choose where to sync your usage data. Configure each backend under its own tab.</div>
+				</div>
 				<div id="overviewDetails" style="margin-top: 12px; display: grid; grid-template-columns: auto 1fr; gap: 8px 12px; font-size: 12px;">
 					<span style="color: #999;">Profile:</span>
 					<span id="overviewProfile" style="color: #e5e5e5;"></span>
@@ -265,11 +275,40 @@ export class BackendConfigPanel implements vscode.Disposable {
 			</div>
 			<div class="card">
 				<h3>How it works</h3>
-				<p class="helper"><strong>1. Azure Storage setup:</strong> Your usage data syncs to Azure Table Storage. Daily aggregates (tokens, interactions, model) are stored per workspace/machine/day. You own the data, you control access.</p>
-				<p class="helper"><strong>2. Authentication:</strong> Use Entra ID (role-based, recommended) or Storage Shared Key. Your credentials stay local and secure.</p>
-				<p class="helper"><strong>3. Automatic sync:</strong> Every 5 minutes, the extension calculates token usage from session files and pushes aggregates to Azure. Configurable lookback window (7-90 days).</p>
-				<p class="helper"><strong>4. Query & analyze:</strong> Use Azure Storage Explorer, Power BI, or custom tools to query your Table Storage data.</p>
-				<p class="helper">Need help? <vscode-link id="launchWizardLink" href="#">Launch the guided Azure setup walkthrough</vscode-link> to configure subscription, resource group, storage account, and auth mode step-by-step.</p>
+				<p class="helper"><strong>1. Storage backend:</strong> Choose between <strong>Azure Storage</strong> (Table Storage — you own the Azure resources) or a <strong>Team Server</strong> (self-hosted Node.js server your team runs, with GitHub OAuth login and a shared dashboard).</p>
+				<p class="helper"><strong>2. Authentication:</strong> Azure Storage uses Entra ID (role-based, recommended) or Storage Shared Key. Team Server uses a bearer token set in the extension settings.</p>
+				<p class="helper"><strong>3. Automatic sync:</strong> Every 5 minutes, the extension calculates token usage from session files and pushes aggregates to the configured backend. Configurable lookback window (7-90 days).</p>
+				<p class="helper"><strong>4. Query & analyze:</strong> Azure Storage: use Storage Explorer, Power BI, or custom tools. Team Server: view the shared dashboard in your browser.</p>
+				<p class="helper">Need help with Azure? <vscode-link id="launchWizardLink" href="#">Launch the guided Azure setup walkthrough</vscode-link> to configure subscription, resource group, storage account, and auth mode step-by-step.</p>
+			</div>
+		</section>
+		<section id="teamserver" class="section">
+			<div class="card">
+				<h3>Team Server</h3>
+				<p class="helper">A self-hosted sharing server lets your team run their own backend. Usage data is uploaded securely using a bearer token and stored in the server's SQLite database. Team members can view a shared dashboard after logging in with GitHub OAuth.</p>
+				<div class="field inline" style="margin-top: 8px;">
+					<vscode-checkbox id="enabledToggleTeam" aria-describedby="enabledToggleTeam-help">Enable backend sync to Team Server</vscode-checkbox>
+				</div>
+				<div id="enabledToggleTeam-help" class="helper">Independent of Azure Storage — both backends can sync simultaneously.</div>
+				<div class="status-line" id="lastSyncLine" style="margin-top: 12px;" role="status"></div>
+			</div>
+			<div class="card">
+				<h3>Connection</h3>
+				<p class="helper">Configure the URL of your self-hosted sharing server. The extension will POST daily usage rollups to <code>&lt;Server URL&gt;/api/upload</code> using the bearer token from the VS Code setting <code>copilotTokenTracker.backend.sharingServer.bearerToken</code> (stored in Settings, not here for security).</p>
+				<div class="field">
+					<label for="sharingServerEndpointUrl">Server URL</label>
+					<vscode-text-field id="sharingServerEndpointUrl" placeholder="http://localhost:3000" aria-describedby="sharingServerEndpointUrl-help sharingServerEndpointUrl-error"></vscode-text-field>
+					<div id="sharingServerEndpointUrl-error" class="error" role="alert" data-error-for="sharingServerEndpointUrl"></div>
+					<div id="sharingServerEndpointUrl-help" class="helper">Base URL of the sharing server (no trailing slash). Example: <code>https://copilot-tracker.mycompany.com</code></div>
+				</div>
+			</div>
+			<div class="card">
+				<h3>How to set up</h3>
+				<p class="helper"><strong>1. Run the server:</strong> Clone the <code>sharing-server/</code> folder, install dependencies (<code>npm install</code>), build (<code>npm run build</code>), and start with <code>npm start</code>. Requires Node.js 20+.</p>
+				<p class="helper"><strong>2. Configure GitHub OAuth:</strong> Create a GitHub OAuth App at <vscode-link href="https://github.com/settings/developers">github.com/settings/developers</vscode-link>. Set the callback URL to <code>&lt;Server URL&gt;/auth/github/callback</code>. Copy the Client ID and Secret into the server's <code>.env</code> file.</p>
+				<p class="helper"><strong>3. Set a bearer token:</strong> Add <code>BEARER_TOKEN=your-secret-token</code> to the server's <code>.env</code>. Then add the same token as <code>copilotTokenTracker.backend.sharingServer.bearerToken</code> in your VS Code settings.</p>
+				<p class="helper"><strong>4. Enter the Server URL above</strong> and select <em>Team Server</em> as the storage backend on the Overview tab.</p>
+				<p class="helper"><strong>5. Open the dashboard:</strong> Navigate to <code>&lt;Server URL&gt;/dashboard</code> in your browser, log in with GitHub, and you'll see shared usage statistics for everyone who has uploaded data.</p>
 			</div>
 		</section>
 		<section id="sharing" class="section">
@@ -479,6 +518,8 @@ export class BackendConfigPanel implements vscode.Disposable {
 
 		function setFieldValues(state) {
 			byId('enabledToggle').checked = !!state.draft.enabled;
+			byId('enabledToggleTeam').checked = !!state.draft.sharingServerEnabled;
+			byId('backendType').value = state.draft.backend || 'storageTables';
 			byId('sharingProfile').value = state.draft.sharingProfile;
 			byId('authMode').value = state.draft.authMode;
 			byId('subscriptionId').value = state.draft.subscriptionId || '';
@@ -490,6 +531,7 @@ export class BackendConfigPanel implements vscode.Disposable {
 			byId('lookbackDays').value = state.draft.lookbackDays ?? '';
 			byId('userIdentityMode').value = state.draft.userIdentityMode;
 			byId('userId').value = state.draft.userId || '';
+			byId('sharingServerEndpointUrl').value = state.draft.sharingServerEndpointUrl || '';
 			updateUserIdPlaceholder();
 			byId('blobUploadEnabled').checked = !!state.draft.blobUploadEnabled;
 			byId('blobContainerName').value = state.draft.blobContainerName || '';
@@ -497,18 +539,19 @@ export class BackendConfigPanel implements vscode.Disposable {
 			byId('blobCompressFiles').checked = state.draft.blobCompressFiles !== false;
 			byId('privacyBadge').innerText = 'Privacy: ' + state.privacyBadge;
 			byId('authBadge').innerText = state.authStatus;
-			byId('backendStateBadge').innerText = state.draft.enabled ? 'Backend: Enabled' : 'Backend: Disabled';
+			byId('backendStateBadge').innerText = (state.draft.enabled || state.draft.sharingServerEnabled) ? 'Backend: Enabled' : 'Backend: Disabled';
+			updateLastSyncLine(state.lastSyncAt);
 			
 			// Update overview details
 			const detailsDiv = byId('overviewDetails');
-			if (state.draft.enabled) {
+			if (state.draft.enabled || state.draft.sharingServerEnabled) {
 				detailsDiv.style.display = 'grid';
 				byId('overviewProfile').textContent = state.draft.sharingProfile;
 				byId('overviewDataset').textContent = state.draft.datasetId || 'not set';
 				byId('statusMessage').textContent = state.message || '';
 			} else {
 				detailsDiv.style.display = 'none';
-				byId('statusMessage').textContent = state.message || 'Backend is off. All data stays local; no Azure writes.';
+				byId('statusMessage').textContent = state.message || 'Backend is off. All data stays local; no cloud writes.';
 			}
 			byId('sharedKeyStatus').textContent = state.draft.authMode === 'sharedKey'
 				? (hasSharedKey() ? 'Shared key stored securely for this storage account.' : 'Shared key not stored yet. Add it to enable connection testing.')
@@ -540,12 +583,42 @@ export class BackendConfigPanel implements vscode.Disposable {
 			});
 		}
 
+		function updateLastSyncLine(lastSyncAt) {
+			const el = byId('lastSyncLine');
+			if (!el) return;
+			if (!lastSyncAt) {
+				el.className = 'status-line muted';
+				el.textContent = 'Last sync: Never';
+				return;
+			}
+			const diffMs = Date.now() - lastSyncAt;
+			const diffMin = Math.floor(diffMs / 60000);
+			const diffSec = Math.floor(diffMs / 1000);
+			let when;
+			if (diffSec < 60) {
+				when = diffSec + ' seconds ago';
+			} else if (diffMin < 60) {
+				when = diffMin + ' minutes ago';
+			} else {
+				const diffH = Math.floor(diffMin / 60);
+				when = diffH + ' hour' + (diffH === 1 ? '' : 's') + ' ago';
+			}
+			el.className = 'status-line ok';
+			el.textContent = 'Last sync: ' + when + ' (' + new Date(lastSyncAt).toLocaleTimeString() + ')';
+		}
+
 		function readDraft() {
 			const profile = byId('sharingProfile').value;
+			const backendType = byId('backendType').value;
+			// Each backend has its own independent enabled toggle
+			const enabledChecked = byId('enabledToggle').checked;
+			const sharingServerEnabledChecked = byId('enabledToggleTeam').checked;
 			// Derive shareWorkspaceMachineNames from profile
 			const shareWorkspaceMachineNames = profile === 'soloFull' || profile === 'teamPseudonymous' || profile === 'teamIdentified';
 			return {
-				enabled: byId('enabledToggle').checked,
+				enabled: enabledChecked,
+				sharingServerEnabled: sharingServerEnabledChecked,
+				backend: backendType,
 				authMode: byId('authMode').value,
 				sharingProfile: profile,
 				shareWorkspaceMachineNames,
@@ -559,6 +632,7 @@ export class BackendConfigPanel implements vscode.Disposable {
 				eventsTable: byId('eventsTable').value,
 				userIdentityMode: byId('userIdentityMode').value,
 				userId: byId('userId').value,
+				sharingServerEndpointUrl: byId('sharingServerEndpointUrl').value,
 				blobUploadEnabled: byId('blobUploadEnabled').checked,
 				blobContainerName: byId('blobContainerName').value,
 				blobUploadFrequencyHours: Number(byId('blobUploadFrequencyHours').value),
@@ -574,6 +648,13 @@ export class BackendConfigPanel implements vscode.Disposable {
 				['subscriptionId','resourceGroup','storageAccount','aggTable'].forEach(f => {
 					if (!draft[f] || !draft[f].trim()) errors[f] = 'Required';
 				});
+			}
+			if (draft.sharingServerEnabled) {
+				if (!draft.sharingServerEndpointUrl || !draft.sharingServerEndpointUrl.trim()) {
+					errors.sharingServerEndpointUrl = 'Required';
+				} else {
+					try { new URL(draft.sharingServerEndpointUrl); } catch { errors.sharingServerEndpointUrl = 'Enter a valid URL'; }
+				}
 			}
 			['aggTable','eventsTable'].forEach(f => {
 				if (draft[f] && !aliasRegex.test(draft[f].trim())) errors[f] = 'Use letters, numbers, dashes, underscores';
@@ -628,12 +709,17 @@ export class BackendConfigPanel implements vscode.Disposable {
 		}
 
 		function updateEnabledState() {
-			const enabled = byId('enabledToggle').checked;
+			const draft = readDraft();
+			const enabled = draft.enabled;
+			const sharingServerEnabled = draft.sharingServerEnabled;
 			const azureSection = document.getElementById('azure');
 			const sharingSection = document.getElementById('sharing');
 			const advancedSection = document.getElementById('advanced');
+			const teamSection = document.getElementById('teamserver');
 			
-			// Disable Azure settings and Auth card if backend is disabled
+			// Each toggle is independent — do not sync them
+			
+			// Disable Azure settings cards if Azure backend is disabled
 			const azureCards = azureSection.querySelectorAll('.card');
 			azureCards.forEach((card, index) => {
 				if (index > 0) { // Skip the first card (Enable backend toggle)
@@ -645,8 +731,21 @@ export class BackendConfigPanel implements vscode.Disposable {
 				}
 			});
 			
-			// Disable Sharing and Advanced sections if backend is disabled
-			if (enabled) {
+			// Disable Team Server connection card if Team Server is disabled
+			const teamCards = teamSection.querySelectorAll('.card');
+			teamCards.forEach((card, index) => {
+				if (index > 0) { // Skip the first card (header/toggle)
+					if (sharingServerEnabled) {
+						card.classList.remove('disabled-section');
+					} else {
+						card.classList.add('disabled-section');
+					}
+				}
+			});
+			
+			// Disable Sharing and Advanced sections if both backends are disabled
+			const anyEnabled = enabled || sharingServerEnabled;
+			if (anyEnabled) {
 				sharingSection.querySelectorAll('.card').forEach(c => c.classList.remove('disabled-section'));
 				advancedSection.querySelectorAll('.card').forEach(c => c.classList.remove('disabled-section'));
 			} else {
@@ -674,19 +773,27 @@ export class BackendConfigPanel implements vscode.Disposable {
 			
 			let html = '';
 			
-			if (!draft.enabled) {
-				html = '<div class="change-item danger"><div class="change-label">⚠️ Backend Disabled</div><div class="change-value">All token usage data will stay local-only. No sync to Azure.</div></div>';
+			const eitherEnabled = draft.enabled || draft.sharingServerEnabled;
+			if (!eitherEnabled) {
+				html = '<div class="change-item danger"><div class="change-label">⚠️ All Backends Disabled</div><div class="change-value">All token usage data will stay local-only. No sync to any backend.</div></div>';
 			} else {
-				html += '<div class="change-item"><div class="change-label">✓ Backend Enabled</div><div class="change-value">Token usage will sync to Azure Storage</div></div>';
-				
-				if (draft.subscriptionId && draft.resourceGroup && draft.storageAccount) {
-					html += '<div class="change-item"><div class="change-label">Azure Resources</div><div class="change-value">Subscription: ' + draft.subscriptionId + '<br>Resource Group: ' + draft.resourceGroup + '<br>Storage Account: ' + draft.storageAccount + '</div></div>';
-				} else {
-					html += '<div class="change-item warning"><div class="change-label">⚠️ Azure Resources</div><div class="change-value">Not fully configured - some fields are missing</div></div>';
+				if (draft.enabled) {
+					if (draft.subscriptionId && draft.resourceGroup && draft.storageAccount) {
+						html += '<div class="change-item"><div class="change-label">✓ Azure Storage Enabled</div><div class="change-value">Subscription: ' + draft.subscriptionId + '<br>Resource Group: ' + draft.resourceGroup + '<br>Storage Account: ' + draft.storageAccount + '</div></div>';
+					} else {
+						html += '<div class="change-item warning"><div class="change-label">⚠️ Azure Storage Enabled (incomplete)</div><div class="change-value">Not fully configured — some Azure fields are missing</div></div>';
+					}
+					const authLabel = draft.authMode === 'sharedKey' ? 'Storage Shared Key' : 'Entra ID (RBAC)';
+					html += '<div class="change-item"><div class="change-label">Azure Auth</div><div class="change-value">' + authLabel + '</div></div>';
 				}
 				
-				const authLabel = draft.authMode === 'sharedKey' ? 'Storage Shared Key' : 'Entra ID (RBAC)';
-				html += '<div class="change-item"><div class="change-label">Authentication</div><div class="change-value">' + authLabel + '</div></div>';
+				if (draft.sharingServerEnabled) {
+					if (draft.sharingServerEndpointUrl) {
+						html += '<div class="change-item"><div class="change-label">✓ Team Server Enabled</div><div class="change-value">URL: ' + draft.sharingServerEndpointUrl + '</div></div>';
+					} else {
+						html += '<div class="change-item warning"><div class="change-label">⚠️ Team Server Enabled (incomplete)</div><div class="change-value">Server URL not configured</div></div>';
+					}
+				}
 				
 				const profileLabels = {
 					'off': 'Off (Local-only)',
@@ -764,7 +871,7 @@ export class BackendConfigPanel implements vscode.Disposable {
 
 		function bindActions() {
 			const markDirty = () => vscodeApi.postMessage({ command: 'markDirty' });
-			const trackIds = ['sharingProfile','authMode','subscriptionId','resourceGroup','storageAccount','aggTable','eventsTable','datasetId','lookbackDays','enabledToggle','userIdentityMode','userId','blobUploadEnabled','blobContainerName','blobUploadFrequencyHours','blobCompressFiles'];
+			const trackIds = ['sharingProfile','authMode','subscriptionId','resourceGroup','storageAccount','aggTable','eventsTable','datasetId','lookbackDays','enabledToggle','enabledToggleTeam','backendType','userIdentityMode','userId','sharingServerEndpointUrl','blobUploadEnabled','blobContainerName','blobUploadFrequencyHours','blobCompressFiles'];
 			trackIds.forEach(id => {
 				const el = byId(id);
 				if (!el) return;

--- a/vscode-extension/src/backend/configurationFlow.ts
+++ b/vscode-extension/src/backend/configurationFlow.ts
@@ -1,5 +1,5 @@
 import { MIN_LOOKBACK_DAYS, MAX_LOOKBACK_DAYS } from './constants';
-import type { BackendSettings, BackendAuthMode } from './settings';
+import type { BackendSettings, BackendAuthMode, BackendType } from './settings';
 import type { BackendSharingProfile } from './sharingProfile';
 import type { BackendUserIdentityMode } from './identity';
 import { validateTeamAlias } from './identity';
@@ -7,6 +7,7 @@ import { ValidationMessages } from './ui/messages';
 
 export interface BackendConfigDraft {
 	enabled: boolean;
+	backend: BackendType;
 	authMode: BackendAuthMode;
 	sharingProfile: BackendSharingProfile;
 	shareWorkspaceMachineNames: boolean;
@@ -20,6 +21,8 @@ export interface BackendConfigDraft {
 	eventsTable: string;
 	userIdentityMode: BackendUserIdentityMode;
 	userId: string;
+	sharingServerEnabled: boolean;
+	sharingServerEndpointUrl: string;
 	// Blob upload settings
 	blobUploadEnabled: boolean;
 	blobContainerName: string;
@@ -37,6 +40,7 @@ export const ALIAS_REGEX = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 export function toDraft(settings: BackendSettings): BackendConfigDraft {
 	return {
 		enabled: settings.enabled,
+		backend: settings.backend,
 		authMode: settings.authMode,
 		sharingProfile: settings.sharingProfile,
 		shareWorkspaceMachineNames: settings.shareWorkspaceMachineNames,
@@ -50,6 +54,8 @@ export function toDraft(settings: BackendSettings): BackendConfigDraft {
 		eventsTable: settings.eventsTable,
 		userIdentityMode: settings.userIdentityMode,
 		userId: settings.userId,
+		sharingServerEnabled: settings.sharingServerEnabled,
+		sharingServerEndpointUrl: settings.sharingServerEndpointUrl,
 		blobUploadEnabled: settings.blobUploadEnabled,
 		blobContainerName: settings.blobContainerName,
 		blobUploadFrequencyHours: settings.blobUploadFrequencyHours,
@@ -195,6 +201,9 @@ export function applyDraftToSettings(
 		aggTable: draft.aggTable.trim(),
 		eventsTable: draft.eventsTable.trim(),
 		lookbackDays: clampLookback(draft.lookbackDays),
+		backend: draft.backend ?? 'storageTables',
+		sharingServerEnabled: !!draft.sharingServerEnabled,
+		sharingServerEndpointUrl: (draft.sharingServerEndpointUrl || '').trim(),
 		includeMachineBreakdown: !!draft.includeMachineBreakdown,
 		blobUploadEnabled: !!draft.blobUploadEnabled,
 		blobContainerName: (draft.blobContainerName || '').trim() || 'copilot-session-logs',

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -23,6 +23,7 @@ import {
   QueryService,
   type BackendQueryResultLike,
 } from "./services/queryService";
+import { SharingServerUploadService } from "./services/sharingServerUploadService";
 import { SyncService } from "./services/syncService";
 import { BackendUtility } from "./services/utilityService";
 import type { BackendQueryFilters, BackendSettings } from "./settings";
@@ -83,6 +84,8 @@ export interface BackendFacadeDeps {
   }>;
   // Visual Studio session detection (binary MessagePack — cannot be parsed as JSON)
   isVSSessionFile?: (sessionFile: string) => boolean;
+  /** Returns the current GitHub OAuth access token, or undefined if not authenticated. */
+  getGithubToken?: () => string | undefined;
 }
 
 export class BackendFacade {
@@ -139,11 +142,13 @@ export class BackendFacade {
         isCrushSession: deps.isCrushSession,
         getCrushSessionData: deps.getCrushSessionData,
         isVSSessionFile: deps.isVSSessionFile,
+        getGithubToken: deps.getGithubToken,
       },
       this.credentialService,
       this.dataPlaneService,
       this.blobUploadService,
       BackendUtility,
+      new SharingServerUploadService(),
     );
     this.azureResourceService = new AzureResourceService(
       {

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -626,7 +626,7 @@ export class BackendFacade {
           ? "Auth: Shared Key stored on this machine"
           : "Auth: Shared Key missing on this machine"
         : "Auth: Entra ID (RBAC)";
-    const lastSyncAt = this.deps.context?.globalState.get<number>('backend.lastSyncAt');
+    const lastSyncAt = this.deps.context?.globalState?.get<number>('backend.lastSyncAt');
     return {
       draft,
       sharedKeySet,

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -626,6 +626,7 @@ export class BackendFacade {
           ? "Auth: Shared Key stored on this machine"
           : "Auth: Shared Key missing on this machine"
         : "Auth: Entra ID (RBAC)";
+    const lastSyncAt = this.deps.context?.globalState.get<number>('backend.lastSyncAt');
     return {
       draft,
       sharedKeySet,
@@ -633,6 +634,7 @@ export class BackendFacade {
       isConfigured: this.isConfigured(settings),
       authStatus,
       shareConsentAt: settings.shareConsentAt,
+      lastSyncAt,
     };
   }
 
@@ -749,6 +751,21 @@ export class BackendFacade {
         next.blobCompressFiles,
         vscode.ConfigurationTarget.Global,
       ),
+      config.update(
+        "backend.backend",
+        next.backend,
+        vscode.ConfigurationTarget.Global,
+      ),
+      config.update(
+        "backend.sharingServer.enabled",
+        next.sharingServerEnabled,
+        vscode.ConfigurationTarget.Global,
+      ),
+      config.update(
+        "backend.sharingServer.endpointUrl",
+        next.sharingServerEndpointUrl,
+        vscode.ConfigurationTarget.Global,
+      ),
     ]);
   }
 
@@ -843,6 +860,7 @@ export class BackendFacade {
     // Create a draft with empty Azure settings
     const draft: BackendConfigDraft = {
       enabled: false,
+      backend: "storageTables",
       authMode: "entraId",
       sharingProfile: "off",
       shareWorkspaceMachineNames: false,
@@ -856,6 +874,8 @@ export class BackendFacade {
       eventsTable: "usageEvents",
       userIdentityMode: "pseudonymous",
       userId: "",
+      sharingServerEnabled: false,
+      sharingServerEndpointUrl: "",
       blobUploadEnabled: false,
       blobContainerName: "copilot-session-logs",
       blobUploadFrequencyHours: 24,

--- a/vscode-extension/src/backend/rollups.ts
+++ b/vscode-extension/src/backend/rollups.ts
@@ -14,6 +14,7 @@ export interface DailyRollupKey {
 	workspaceId: string;
 	machineId: string;
 	userId?: string;
+	editor?: string;       // Friendly editor name (e.g. 'VS Code', 'Copilot CLI'). Optional — omit for Azure Storage path.
 }
 
 /**
@@ -66,13 +67,19 @@ export interface DailyRollupValueLike {
  */
 export function dailyRollupMapKey(key: DailyRollupKey): string {
 	const userId = (key.userId ?? '').trim();
-	return JSON.stringify({
+	const entry: Record<string, unknown> = {
 		day: key.day,
 		model: key.model,
 		workspaceId: key.workspaceId,
 		machineId: key.machineId,
-		userId: userId || undefined
-	});
+		userId: userId || undefined,
+	};
+	// Only include editor in the map key when it is explicitly set.
+	// This keeps Azure Storage rollups (which omit editor) unchanged.
+	if (key.editor) {
+		entry.editor = key.editor;
+	}
+	return JSON.stringify(entry);
 }
 
 /**

--- a/vscode-extension/src/backend/services/sharingServerUploadService.ts
+++ b/vscode-extension/src/backend/services/sharingServerUploadService.ts
@@ -1,0 +1,64 @@
+/**
+ * Upload service for the self-hosted sharing server.
+ * Sends daily rollup data to a configured endpoint using a GitHub Bearer token.
+ */
+
+export interface SharingServerEntry {
+	day: string;
+	model: string;
+	workspaceId: string;
+	workspaceName?: string;
+	machineId: string;
+	machineName?: string;
+	inputTokens: number;
+	outputTokens: number;
+	interactions: number;
+	datasetId?: string;
+}
+
+/** Maximum number of entries per HTTP request (matches server-side limit). */
+const BATCH_SIZE = 500;
+
+export class SharingServerUploadService {
+	async uploadRollups(
+		endpointUrl: string,
+		githubToken: string,
+		entries: SharingServerEntry[],
+		log: (msg: string) => void,
+		warn: (msg: string) => void,
+	): Promise<{ success: boolean; entriesUploaded: number; message: string }> {
+		const baseUrl = endpointUrl.replace(/\/$/, '');
+		const url = `${baseUrl}/api/upload`;
+
+		try {
+			let totalUploaded = 0;
+			for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+				const batch = entries.slice(i, i + BATCH_SIZE);
+				const response = await fetch(url, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'Authorization': `Bearer ${githubToken}`,
+					},
+					body: JSON.stringify(batch),
+				});
+
+				if (!response.ok) {
+					const errorText = await response.text().catch(() => '');
+					const message = `HTTP ${response.status}: ${errorText}`;
+					warn(`Sharing server upload: ${message}`);
+					return { success: false, entriesUploaded: totalUploaded, message };
+				}
+				totalUploaded += batch.length;
+			}
+
+			const message = `Uploaded ${totalUploaded} entries`;
+			log(`Sharing server upload: ${message}`);
+			return { success: true, entriesUploaded: totalUploaded, message };
+		} catch (e: any) {
+			const message = `Upload failed: ${e?.message ?? e}`;
+			warn(`Sharing server upload: ${message}`);
+			return { success: false, entriesUploaded: 0, message };
+		}
+	}
+}

--- a/vscode-extension/src/backend/services/sharingServerUploadService.ts
+++ b/vscode-extension/src/backend/services/sharingServerUploadService.ts
@@ -10,6 +10,7 @@ export interface SharingServerEntry {
 	workspaceName?: string;
 	machineId: string;
 	machineName?: string;
+	editor?: string;
 	inputTokens: number;
 	outputTokens: number;
 	interactions: number;

--- a/vscode-extension/src/backend/services/sharingServerUploadService.ts
+++ b/vscode-extension/src/backend/services/sharingServerUploadService.ts
@@ -50,7 +50,17 @@ export class SharingServerUploadService {
 					warn(`Sharing server upload: ${message}`);
 					return { success: false, entriesUploaded: totalUploaded, message };
 				}
-				totalUploaded += batch.length;
+
+				// Read actual uploaded count — server may reject entries that fail validation
+				let serverUploaded = batch.length;
+				try {
+					const result = await response.json() as { uploaded?: number; errors?: string[] };
+					if (typeof result.uploaded === 'number') { serverUploaded = result.uploaded; }
+					if (result.errors && result.errors.length > 0) {
+						warn(`Sharing server upload: server rejected ${batch.length - serverUploaded} entries: ${result.errors.slice(0, 3).join('; ')}`);
+					}
+				} catch { /* response not JSON, use batch.length */ }
+				totalUploaded += serverUploaded;
 			}
 
 			const message = `Uploaded ${totalUploaded} entries`;

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1427,7 +1427,9 @@ export class SyncService {
 			});
 		}
 
-		this.deps.log(`Sharing server upload: uploading ${entries.length} rollup entries`);
+		const totalInputTokens = entries.reduce((s, e) => s + e.inputTokens, 0);
+		const totalOutputTokens = entries.reduce((s, e) => s + e.outputTokens, 0);
+		this.deps.log(`Sharing server upload: uploading ${entries.length} rollup entries (${(totalInputTokens + totalOutputTokens).toLocaleString()} tokens total)`);
 		await this.sharingServerUploadService.uploadRollups(
 			settings.sharingServerEndpointUrl,
 			githubToken,

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -502,7 +502,21 @@ export class SyncService {
 			}
 
 			// Now distribute cached token counts proportionally across day+model combinations
-			// based on the actual interaction distribution we just calculated
+			// based on the actual interaction distribution we just calculated.
+			//
+			// IMPORTANT: cachedData.tokens is the text-estimated total shown in the extension
+			// status bar (estimateTokensFromSession: input_est + output_est + thinking_est).
+			// cachedData.modelUsage values may use API-reported actual counts, which can differ
+			// from text estimates due to tokenization differences (e.g. Claude uses ~6-8 chars/token
+			// vs our 4 chars/token ratio). We scale the per-model values so the upload total
+			// matches what the extension displays.
+			const totalModelTokens = Object.values(cachedData.modelUsage)
+				.reduce((sum: number, u: any) => sum + (u.inputTokens || 0) + (u.outputTokens || 0), 0);
+			const displayTokens = (typeof (cachedData as any).tokens === 'number' && (cachedData as any).tokens > 0)
+				? (cachedData as any).tokens as number
+				: totalModelTokens;
+			const tokenScaleFactor = totalModelTokens > 0 ? displayTokens / totalModelTokens : 1;
+
 			for (const [dayKey, modelMap] of dayModelInteractions) {
 				for (const [model, interactions] of modelMap) {
 					const cachedUsage = cachedData.modelUsage[model];
@@ -531,8 +545,8 @@ export class SyncService {
 					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, tokenRatio);
 					
 					upsertDailyRollup(rollups, key, {
-						inputTokens: Math.round(cachedUsage.inputTokens * tokenRatio),
-						outputTokens: Math.round(cachedUsage.outputTokens * tokenRatio),
+						inputTokens: Math.round(cachedUsage.inputTokens * tokenRatio * tokenScaleFactor),
+						outputTokens: Math.round(cachedUsage.outputTokens * tokenRatio * tokenScaleFactor),
 						interactions: interactions,
 						fluencyMetrics
 					});

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -511,9 +511,15 @@ export class SyncService {
 			// combination gets a share of the total proportional to how many interactions it had.
 			// For the input/output split we use the output fraction from modelUsage (output tokens are
 			// not inflated by context the same way input tokens are).
-			const displayTokens: number = (typeof (cachedData as any).tokens === 'number' && (cachedData as any).tokens > 0)
-				? (cachedData as any).tokens as number
-				: 0;
+			// Mirror the extension's own token preference: prefer actual API-reported tokens when
+			// available (same logic as calculateDetailedStats: actualTokens > 0 ? actualTokens : estimatedTokens).
+			// Text-estimated tokens (~20M) are far smaller than API-actual numbers (~1.2B) because
+			// the estimators only measure visible conversation text, not the full context window.
+			const estimatedTokens: number = typeof (cachedData as any).tokens === 'number'
+				? (cachedData as any).tokens as number : 0;
+			const cachedActualTokens: number = typeof (cachedData as any).actualTokens === 'number'
+				? (cachedData as any).actualTokens as number : 0;
+			const displayTokens: number = cachedActualTokens > 0 ? cachedActualTokens : estimatedTokens;
 			const totalAllInteractions = Array.from(dayModelInteractions.values())
 				.reduce((sum, m) => { m.forEach(c => { sum += c; }); return sum; }, 0);
 

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -501,52 +501,53 @@ export class SyncService {
 				}
 			}
 
-			// Now distribute cached token counts proportionally across day+model combinations
-			// based on the actual interaction distribution we just calculated.
+			// Now distribute cachedData.tokens (text-estimated total matching extension display)
+			// proportionally across day+model combinations based on interaction count.
 			//
-			// IMPORTANT: cachedData.tokens is the text-estimated total shown in the extension
-			// status bar (estimateTokensFromSession: input_est + output_est + thinking_est).
-			// cachedData.modelUsage values may use API-reported actual counts, which can differ
-			// from text estimates due to tokenization differences (e.g. Claude uses ~6-8 chars/token
-			// vs our 4 chars/token ratio). We scale the per-model values so the upload total
-			// matches what the extension displays.
-			const totalModelTokens = Object.values(cachedData.modelUsage)
-				.reduce((sum: number, u: any) => sum + (u.inputTokens || 0) + (u.outputTokens || 0), 0);
-			const displayTokens = (typeof (cachedData as any).tokens === 'number' && (cachedData as any).tokens > 0)
+			// We do NOT use cachedData.modelUsage sums as a denominator because modelUsage.inputTokens
+			// accumulates the full context window per request (each chat turn re-sends all prior history),
+			// making totalModelTokens >> cachedData.tokens and producing a scale factor far below 1.
+			// Instead, distribute cachedData.tokens proportionally by interaction count: each [day,model]
+			// combination gets a share of the total proportional to how many interactions it had.
+			// For the input/output split we use the output fraction from modelUsage (output tokens are
+			// not inflated by context the same way input tokens are).
+			const displayTokens: number = (typeof (cachedData as any).tokens === 'number' && (cachedData as any).tokens > 0)
 				? (cachedData as any).tokens as number
-				: totalModelTokens;
-			const tokenScaleFactor = totalModelTokens > 0 ? displayTokens / totalModelTokens : 1;
+				: 0;
+			const totalAllInteractions = Array.from(dayModelInteractions.values())
+				.reduce((sum, m) => { m.forEach(c => { sum += c; }); return sum; }, 0);
 
 			for (const [dayKey, modelMap] of dayModelInteractions) {
 				for (const [model, interactions] of modelMap) {
 					const cachedUsage = cachedData.modelUsage[model];
 					if (!cachedUsage) { continue; }
 					
-					// Validate usage object structure
-					if (!Number.isFinite(cachedUsage.inputTokens) || cachedUsage.inputTokens < 0) {
-						this.deps.warn(`Backend sync: invalid inputTokens for model ${model}`);
-						continue;
-					}
-					if (!Number.isFinite(cachedUsage.outputTokens) || cachedUsage.outputTokens < 0) {
-						this.deps.warn(`Backend sync: invalid outputTokens for model ${model}`);
-						continue;
-					}
-					
 					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
 					
-					// For simplicity, if a file spans multiple days, distribute tokens proportionally
-					// In practice, most session files are from a single day, so this is accurate
+					// Interaction ratio for this [day, model] relative to all interactions in this file
+					const interactionFraction = totalAllInteractions > 0 ? interactions / totalAllInteractions : 0;
+					const modelDayTokens = Math.round(displayTokens * interactionFraction);
+					
+					// For the tokenRatio used by fluencyMetrics: fraction of this model's interactions on this day
 					const totalInteractionsForModel = Array.from(dayModelInteractions.values())
 						.reduce((sum, m) => sum + (m.get(model) || 0), 0);
-					
 					const tokenRatio = totalInteractionsForModel > 0 ? interactions / totalInteractionsForModel : 1;
+					
+					// Use output fraction from modelUsage for the input/output split.
+					// Output tokens are not inflated by context (each response is independent).
+					const totalModelUsageTokens = (cachedUsage.inputTokens || 0) + (cachedUsage.outputTokens || 0);
+					const outputFraction = totalModelUsageTokens > 0
+						? Math.min(0.5, (cachedUsage.outputTokens || 0) / totalModelUsageTokens)
+						: 0.2;
+					const outputTokens = Math.round(modelDayTokens * outputFraction);
+					const inputTokens = modelDayTokens - outputTokens;
 					
 					// Extract fluency metrics from cached usage analysis (if available)
 					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, tokenRatio);
 					
 					upsertDailyRollup(rollups, key, {
-						inputTokens: Math.round(cachedUsage.inputTokens * tokenRatio * tokenScaleFactor),
-						outputTokens: Math.round(cachedUsage.outputTokens * tokenRatio * tokenScaleFactor),
+						inputTokens,
+						outputTokens,
 						interactions: interactions,
 						fluencyMetrics
 					});

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1333,6 +1333,19 @@ export class SyncService {
 	}
 
 	/**
+	 * Normalize vscode.env.appName to the friendly editor names used throughout the extension.
+	 * "Visual Studio Code" → "VS Code", "Visual Studio Code - Insiders" → "VS Code Insiders", etc.
+	 */
+	private normalizeEditorName(appName: string): string {
+		const name = appName.trim();
+		if (name === 'Visual Studio Code') { return 'VS Code'; }
+		if (name === 'Visual Studio Code - Insiders') { return 'VS Code Insiders'; }
+		if (name === 'Visual Studio Code - Exploration') { return 'VS Code Exploration'; }
+		// Other editors (Cursor, VSCodium, Windsurf, etc.) already use clean names
+		return name || 'VS Code';
+	}
+
+	/**
 	 * Sync daily rollups to the self-hosted sharing server using a GitHub Bearer token.
 	 */
 	private async syncToSharingServer(
@@ -1379,7 +1392,7 @@ export class SyncService {
 				outputTokens: value.outputTokens,
 				interactions: value.interactions,
 				datasetId: settings.datasetId,
-				editor: vscode.env.appName,
+				editor: this.normalizeEditorName(vscode.env.appName),
 			});
 		}
 

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -22,6 +22,7 @@ import { DataPlaneService } from './dataPlaneService';
 import { BackendUtility } from './utilityService';
 import { SharingServerUploadService, type SharingServerEntry } from './sharingServerUploadService';
 import { isJsonlContent } from '../../tokenEstimation';
+import { getEditorTypeFromPath } from '../../workspaceHelpers';
 
 /**
  * Interface for blob upload service to avoid circular dependency.
@@ -298,7 +299,8 @@ export class SyncService {
 		userId: string | undefined,
 		rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>,
 		startMs: number,
-		now: Date
+		now: Date,
+		editor?: string
 	): Promise<boolean> {
 		try {
 			const cachedData = await this.deps.getSessionFileDataCached!(sessionFile, fileMtimeMs, fileSize);
@@ -516,7 +518,7 @@ export class SyncService {
 						continue;
 					}
 					
-					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId };
+					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
 					
 					// For simplicity, if a file spans multiple days, distribute tokens proportionally
 					// In practice, most session files are from a single day, so this is accurate
@@ -722,13 +724,14 @@ export class SyncService {
 	 * Compute daily rollups from local session files.
 	 * Uses cached session data when available to avoid re-parsing files.
 	 */
-	private async computeDailyRollupsFromLocalSessions(args: { lookbackDays: number; userId?: string; sessionFiles?: string[]; skipMtimeFilter?: boolean; onProgress?: (processed: number, total: number, daysFound: number) => void }): Promise<{
+	private async computeDailyRollupsFromLocalSessions(args: { lookbackDays: number; userId?: string; sessionFiles?: string[]; skipMtimeFilter?: boolean; includeEditorDimension?: boolean; onProgress?: (processed: number, total: number, daysFound: number) => void }): Promise<{
 		rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>;
 		workspaceNamesById: Record<string, string>;
 		machineNamesById: Record<string, string>;
 	}> {
 		const lookbackDays = args.lookbackDays;
 		const skipMtimeFilter = args.skipMtimeFilter === true;
+		const includeEditorDimension = args.includeEditorDimension === true;
 		const onProgress = args.onProgress;
 		const userId = (args.userId ?? '').trim() || undefined;
 		const now = new Date();
@@ -786,6 +789,11 @@ export class SyncService {
 				continue;
 			}
 
+			// Determine the editor for this session file (only used when includeEditorDimension is set)
+			const editorForFile = includeEditorDimension
+				? getEditorTypeFromPath(sessionFile, this.deps.isOpenCodeSession)
+				: undefined;
+
 			// Skip Visual Studio session files — they are binary MessagePack, not JSON
 			if (this.deps.isVSSessionFile && this.deps.isVSSessionFile(sessionFile)) {
 				filesSkipped++;
@@ -814,7 +822,7 @@ export class SyncService {
 
 					// Process each model's usage with per-model interaction counts
 					for (const [model, usage] of Object.entries(data.modelUsage)) {
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId };
+						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
 						upsertDailyRollup(rollups as any, key, {
 							inputTokens: (usage as any).inputTokens || 0,
 							outputTokens: (usage as any).outputTokens || 0,
@@ -850,7 +858,7 @@ export class SyncService {
 					await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, workspaceNamesById);
 
 					for (const [model, usage] of Object.entries(data.modelUsage)) {
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId };
+						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
 						upsertDailyRollup(rollups as any, key, {
 							inputTokens: (usage as any).inputTokens || 0,
 							outputTokens: (usage as any).outputTokens || 0,
@@ -881,7 +889,8 @@ export class SyncService {
 					userId,
 					rollups,
 					startMs,
-					now
+					now,
+					editorForFile
 				);
 				
 				if (cacheSuccess) {
@@ -971,7 +980,7 @@ export class SyncService {
 										}
 									}
 									if (inputTokens === 0 && outputTokens === 0) { continue; }
-									const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId };
+									const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
 									upsertDailyRollup(rollups as any, key, { inputTokens, outputTokens, interactions: 1 });
 								}
 							}
@@ -1001,7 +1010,7 @@ export class SyncService {
 							continue;
 						}
 
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId };
+						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
 						upsertDailyRollup(rollups as any, key, { inputTokens, outputTokens, interactions });
 					} catch {
 						// skip malformed line
@@ -1076,7 +1085,7 @@ export class SyncService {
 						continue;
 					}
 
-					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId };
+					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
 					upsertDailyRollup(rollups as any, key, { inputTokens, outputTokens, interactions: 1 });
 				} catch (e) {
 					this.deps.warn(`Backend sync: failed to process request in ${sessionFile}: ${e}`);
@@ -1371,6 +1380,7 @@ export class SyncService {
 			await this.computeDailyRollupsFromLocalSessions({
 				lookbackDays: settings.lookbackDays,
 				userId: resolvedIdentity.userId,
+				includeEditorDimension: true,
 			});
 
 		if (rollups.size === 0) {
@@ -1392,7 +1402,7 @@ export class SyncService {
 				outputTokens: value.outputTokens,
 				interactions: value.interactions,
 				datasetId: settings.datasetId,
-				editor: this.normalizeEditorName(vscode.env.appName),
+				editor: key.editor ?? this.normalizeEditorName(vscode.env.appName),
 			});
 		}
 

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -20,6 +20,7 @@ import { createDailyAggEntity } from '../storageTables';
 import { CredentialService } from './credentialService';
 import { DataPlaneService } from './dataPlaneService';
 import { BackendUtility } from './utilityService';
+import { SharingServerUploadService, type SharingServerEntry } from './sharingServerUploadService';
 import { isJsonlContent } from '../../tokenEstimation';
 
 /**
@@ -90,6 +91,8 @@ export interface SyncServiceDeps {
 	getCrushSessionData?: (sessionFile: string) => Promise<{ tokens: number; interactions: number; modelUsage: any; timestamp: number }>;
 	// Visual Studio session detection (binary MessagePack — cannot be parsed as JSON)
 	isVSSessionFile?: (sessionFile: string) => boolean;
+	/** Returns the current GitHub OAuth access token, or undefined if not authenticated. */
+	getGithubToken?: () => string | undefined;
 }
 
 /**
@@ -109,7 +112,8 @@ export class SyncService {
 		private readonly credentialService: CredentialService,
 		private readonly dataPlaneService: DataPlaneService,
 		private readonly blobUploadService: BlobUploadServiceLike | undefined,
-		private readonly utility: typeof BackendUtility
+		private readonly utility: typeof BackendUtility,
+		private readonly sharingServerUploadService: SharingServerUploadService | undefined,
 	) {}
 
 	// ── Cross-instance file lock ────────────────────────────────────────
@@ -1133,6 +1137,18 @@ export class SyncService {
 
 			this.backendSyncInProgress = true;
 			try {
+				// Sharing server backend: entirely different sync path — no Azure deps.
+				if (settings.backend === 'sharingServer') {
+					await this.syncToSharingServer(settings, sharingPolicy);
+					try {
+						await this.deps.context?.globalState.update('backend.lastSyncAt', Date.now());
+					} catch (e) {
+						this.deps.warn(`Backend sync: failed to update lastSyncAt: ${e}`);
+					}
+					this.consecutiveFailures = 0;
+					return;
+				}
+
 				this.deps.log('Backend sync: starting rollup sync');
 				const creds = await this.credentialService.getBackendDataPlaneCredentials(settings);
 				if (!creds) {
@@ -1314,6 +1330,66 @@ export class SyncService {
 			}
 		});
 		return this.syncQueue;
+	}
+
+	/**
+	 * Sync daily rollups to the self-hosted sharing server using a GitHub Bearer token.
+	 */
+	private async syncToSharingServer(
+		settings: BackendSettings,
+		sharingPolicy: ReturnType<typeof computeBackendSharingPolicy>,
+	): Promise<void> {
+		if (!this.sharingServerUploadService) {
+			this.deps.warn('Sharing server upload: service not available');
+			return;
+		}
+
+		const githubToken = this.deps.getGithubToken?.();
+		if (!githubToken) {
+			this.deps.log('Sharing server upload: skipping (no GitHub token — authenticate with GitHub in VS Code first)');
+			return;
+		}
+
+		const resolvedIdentity = await this.resolveEffectiveUserIdentityForSync(
+			settings,
+			sharingPolicy.includeUserDimension,
+		);
+		const { rollups, workspaceNamesById, machineNamesById } =
+			await this.computeDailyRollupsFromLocalSessions({
+				lookbackDays: settings.lookbackDays,
+				userId: resolvedIdentity.userId,
+			});
+
+		if (rollups.size === 0) {
+			this.deps.log('Sharing server upload: no data to upload');
+			return;
+		}
+
+		const includeNames = sharingPolicy.includeNames;
+		const entries: SharingServerEntry[] = [];
+		for (const { key, value } of rollups.values()) {
+			entries.push({
+				day: key.day,
+				model: key.model,
+				workspaceId: key.workspaceId,
+				workspaceName: includeNames ? workspaceNamesById[key.workspaceId] : undefined,
+				machineId: key.machineId,
+				machineName: includeNames ? machineNamesById[key.machineId] : undefined,
+				inputTokens: value.inputTokens,
+				outputTokens: value.outputTokens,
+				interactions: value.interactions,
+				datasetId: settings.datasetId,
+			});
+		}
+
+		this.deps.log(`Sharing server upload: uploading ${entries.length} rollup entries`);
+		await this.sharingServerUploadService.uploadRollups(
+			settings.sharingServerEndpointUrl,
+			githubToken,
+			entries,
+			this.deps.log,
+			this.deps.warn,
+		);
 	}
 
 	/**

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -501,56 +501,45 @@ export class SyncService {
 				}
 			}
 
-			// Now distribute cachedData.tokens (text-estimated total matching extension display)
-			// proportionally across day+model combinations based on interaction count.
-			//
-			// We do NOT use cachedData.modelUsage sums as a denominator because modelUsage.inputTokens
-			// accumulates the full context window per request (each chat turn re-sends all prior history),
-			// making totalModelTokens >> cachedData.tokens and producing a scale factor far below 1.
-			// Instead, distribute cachedData.tokens proportionally by interaction count: each [day,model]
-			// combination gets a share of the total proportional to how many interactions it had.
-			// For the input/output split we use the output fraction from modelUsage (output tokens are
-			// not inflated by context the same way input tokens are).
-			// Mirror the extension's own token preference: prefer actual API-reported tokens when
-			// available (same logic as calculateDetailedStats: actualTokens > 0 ? actualTokens : estimatedTokens).
-			// Text-estimated tokens (~20M) are far smaller than API-actual numbers (~1.2B) because
-			// the estimators only measure visible conversation text, not the full context window.
-			const estimatedTokens: number = typeof (cachedData as any).tokens === 'number'
-				? (cachedData as any).tokens as number : 0;
-			const cachedActualTokens: number = typeof (cachedData as any).actualTokens === 'number'
-				? (cachedData as any).actualTokens as number : 0;
-			const displayTokens: number = cachedActualTokens > 0 ? cachedActualTokens : estimatedTokens;
-			const totalAllInteractions = Array.from(dayModelInteractions.values())
-				.reduce((sum, m) => { m.forEach(c => { sum += c; }); return sum; }, 0);
+			// Total interactions per model (across all days) — used to compute each day's fraction
+			// for multi-day sessions.
+			const totalInteractionsPerModel = new Map<string, number>();
+			for (const modelMap of dayModelInteractions.values()) {
+				for (const [m, c] of modelMap) {
+					totalInteractionsPerModel.set(m, (totalInteractionsPerModel.get(m) || 0) + c);
+				}
+			}
 
 			for (const [dayKey, modelMap] of dayModelInteractions) {
 				for (const [model, interactions] of modelMap) {
-					const cachedUsage = cachedData.modelUsage[model];
+					const cachedUsage = cachedData.modelUsage[model] as any;
 					if (!cachedUsage) { continue; }
-					
+
+					// Validate individual model token values — reject negative or non-finite values.
+					const cachedInput = typeof cachedUsage.inputTokens === 'number' ? cachedUsage.inputTokens : NaN;
+					const cachedOutput = typeof cachedUsage.outputTokens === 'number' ? cachedUsage.outputTokens : NaN;
+					if (!Number.isFinite(cachedInput) || cachedInput < 0 ||
+						!Number.isFinite(cachedOutput) || cachedOutput < 0) {
+						this.deps.warn(`Backend sync: invalid inputTokens or outputTokens in model usage for ${sessionFile}`);
+						continue;
+					}
+
 					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
-					
-					// Interaction ratio for this [day, model] relative to all interactions in this file
-					const interactionFraction = totalAllInteractions > 0 ? interactions / totalAllInteractions : 0;
-					const modelDayTokens = Math.round(displayTokens * interactionFraction);
-					
-					// For the tokenRatio used by fluencyMetrics: fraction of this model's interactions on this day
-					const totalInteractionsForModel = Array.from(dayModelInteractions.values())
-						.reduce((sum, m) => sum + (m.get(model) || 0), 0);
-					const tokenRatio = totalInteractionsForModel > 0 ? interactions / totalInteractionsForModel : 1;
-					
-					// Use output fraction from modelUsage for the input/output split.
-					// Output tokens are not inflated by context (each response is independent).
-					const totalModelUsageTokens = (cachedUsage.inputTokens || 0) + (cachedUsage.outputTokens || 0);
-					const outputFraction = totalModelUsageTokens > 0
-						? Math.min(0.5, (cachedUsage.outputTokens || 0) / totalModelUsageTokens)
-						: 0.2;
-					const outputTokens = Math.round(modelDayTokens * outputFraction);
-					const inputTokens = modelDayTokens - outputTokens;
-					
-					// Extract fluency metrics from cached usage analysis (if available)
-					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, tokenRatio);
-					
+
+					// Fraction of this model's interactions that fall on this day (for multi-day sessions).
+					// For single-day sessions dayFraction = 1.0 and the full cached model usage is used.
+					const totalModelInteractions = totalInteractionsPerModel.get(model) || 1;
+					const dayFraction = totalModelInteractions > 0 ? interactions / totalModelInteractions : 1;
+
+					// Apply dayFraction directly to the cached per-model tokens.
+					// For API-actual data, cachedUsage already holds the exact per-model totals from the
+					// session, so no additional scaling is needed. For text-estimate sessions, both
+					// cachedData.tokens and cachedUsage are from the same estimation and are consistent.
+					const inputTokens = Math.round(cachedInput * dayFraction);
+					const outputTokens = Math.round(cachedOutput * dayFraction);
+
+					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, dayFraction);
+
 					upsertDailyRollup(rollups, key, {
 						inputTokens,
 						outputTokens,

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1379,6 +1379,7 @@ export class SyncService {
 				outputTokens: value.outputTokens,
 				interactions: value.interactions,
 				datasetId: settings.datasetId,
+				editor: vscode.env.appName,
 			});
 		}
 

--- a/vscode-extension/src/backend/settings.ts
+++ b/vscode-extension/src/backend/settings.ts
@@ -44,6 +44,7 @@ export interface BackendSettings {
 	blobUploadFrequencyHours: number;
 	blobCompressFiles: boolean;
 	// Sharing server settings
+	sharingServerEnabled: boolean;
 	sharingServerEndpointUrl: string;
 }
 
@@ -108,6 +109,7 @@ export function getBackendSettings(): BackendSettings {
 		blobUploadFrequencyHours: Math.max(1, config.get<number>('backend.blobUploadFrequencyHours', 24)),
 		blobCompressFiles: config.get<boolean>('backend.blobCompressFiles', true),
 		// Sharing server settings
+		sharingServerEnabled: config.get<boolean>('backend.sharingServer.enabled', false),
 		sharingServerEndpointUrl: config.get<string>('backend.sharingServer.endpointUrl', '').trim(),
 	};
 }

--- a/vscode-extension/src/backend/settings.ts
+++ b/vscode-extension/src/backend/settings.ts
@@ -3,7 +3,7 @@ import { MIN_LOOKBACK_DAYS, MAX_LOOKBACK_DAYS, DEFAULT_LOOKBACK_DAYS } from './c
 import type { BackendUserIdentityMode } from './identity';
 import { parseBackendSharingProfile, type BackendSharingProfile } from './sharingProfile';
 
-export type BackendType = 'storageTables';
+export type BackendType = 'storageTables' | 'sharingServer';
 
 export type BackendAuthMode = 'entraId' | 'sharedKey';
 
@@ -43,6 +43,8 @@ export interface BackendSettings {
 	blobContainerName: string;
 	blobUploadFrequencyHours: number;
 	blobCompressFiles: boolean;
+	// Sharing server settings
+	sharingServerEndpointUrl: string;
 }
 
 export interface BackendQueryFilters {
@@ -104,10 +106,15 @@ export function getBackendSettings(): BackendSettings {
 		blobUploadEnabled: config.get<boolean>('backend.blobUploadEnabled', false),
 		blobContainerName: config.get<string>('backend.blobContainerName', 'copilot-session-logs').trim() || 'copilot-session-logs',
 		blobUploadFrequencyHours: Math.max(1, config.get<number>('backend.blobUploadFrequencyHours', 24)),
-		blobCompressFiles: config.get<boolean>('backend.blobCompressFiles', true)
+		blobCompressFiles: config.get<boolean>('backend.blobCompressFiles', true),
+		// Sharing server settings
+		sharingServerEndpointUrl: config.get<string>('backend.sharingServer.endpointUrl', '').trim(),
 	};
 }
 
 export function isBackendConfigured(settings: BackendSettings): boolean {
+	if (settings.backend === 'sharingServer') {
+		return !!(settings.sharingServerEndpointUrl);
+	}
 	return !!(settings.subscriptionId && settings.resourceGroup && settings.storageAccount && settings.aggTable);
 }

--- a/vscode-extension/src/backend/teamServerConfigPanel.ts
+++ b/vscode-extension/src/backend/teamServerConfigPanel.ts
@@ -47,6 +47,7 @@ export class TeamServerConfigPanel implements vscode.Disposable {
 		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
 		const enabled: boolean = config.get<boolean>('backend.sharingServer.enabled', false);
 		const endpointUrl: string = config.get<string>('backend.sharingServer.endpointUrl', '');
+		const sharingProfile: string = config.get<string>('backend.sharingProfile', 'off');
 
 		this.panel = vscode.window.createWebviewPanel(
 			'copilotTeamServerConfig',
@@ -55,7 +56,7 @@ export class TeamServerConfigPanel implements vscode.Disposable {
 			{ enableScripts: true, retainContextWhenHidden: false }
 		);
 
-		this.panel.webview.html = this.renderHtml(this.panel.webview, enabled, endpointUrl);
+		this.panel.webview.html = this.renderHtml(this.panel.webview, enabled, endpointUrl, sharingProfile);
 
 		this.disposables.push(
 			this.panel.onDidDispose(() => this.dispose()),
@@ -69,6 +70,7 @@ export class TeamServerConfigPanel implements vscode.Disposable {
 		}
 		const enabled: boolean = Boolean(message.enabled);
 		const endpointUrl: string = String(message.endpointUrl ?? '').trim();
+		const sharingProfile: string = String(message.sharingProfile ?? 'off');
 
 		if (enabled && !endpointUrl) {
 			this.panel?.webview.postMessage({ command: 'validationError', field: 'endpointUrl', text: 'Endpoint URL is required when Team Server is enabled.' });
@@ -84,20 +86,31 @@ export class TeamServerConfigPanel implements vscode.Disposable {
 			}
 		}
 
+		const validProfiles = ['off', 'soloFull', 'teamAnonymized', 'teamPseudonymous', 'teamIdentified'];
+		const safeProfile = validProfiles.includes(sharingProfile) ? sharingProfile : 'off';
+
 		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
 		await config.update('backend.sharingServer.enabled', enabled, vscode.ConfigurationTarget.Global);
 		await config.update('backend.sharingServer.endpointUrl', endpointUrl, vscode.ConfigurationTarget.Global);
+		await config.update('backend.sharingProfile', safeProfile, vscode.ConfigurationTarget.Global);
 
 		vscode.window.showInformationMessage('Team Server configuration saved.');
 		this.panel?.dispose();
 	}
 
-	private renderHtml(webview: vscode.Webview, enabled: boolean, endpointUrl: string): string {
+	private renderHtml(webview: vscode.Webview, enabled: boolean, endpointUrl: string, sharingProfile: string): string {
 		const nonce = getNonce();
 		const csp = `default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';`;
 
 		const enabledChecked = enabled ? 'checked' : '';
 		const safeEndpoint = endpointUrl.replace(/"/g, '&quot;');
+		const profileOptions = [
+			{ value: 'off', label: 'Off — no user-level data synced' },
+			{ value: 'soloFull', label: 'Solo Full — personal, full fidelity' },
+			{ value: 'teamAnonymized', label: 'Team Anonymized — team data, no per-user key' },
+			{ value: 'teamPseudonymous', label: 'Team Pseudonymous — stable anonymous per-user key' },
+			{ value: 'teamIdentified', label: 'Team Identified — explicit user identity' },
+		].map(o => `<option value="${o.value}"${sharingProfile === o.value ? ' selected' : ''}>${o.label}</option>`).join('\n				');
 
 		return /* html */`<!DOCTYPE html>
 <html lang="en">
@@ -201,6 +214,21 @@ export class TeamServerConfigPanel implements vscode.Disposable {
     button.secondary:hover {
       background: var(--vscode-button-secondaryHoverBackground);
     }
+    .field select {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 6px 8px;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border, #ccc);
+      border-radius: 2px;
+      font-size: inherit;
+      font-family: inherit;
+    }
+    .field select:focus {
+      outline: 1px solid var(--vscode-focusBorder);
+      border-color: var(--vscode-focusBorder);
+    }
   </style>
 </head>
 <body>
@@ -221,6 +249,14 @@ export class TeamServerConfigPanel implements vscode.Disposable {
     <p class="field-hint">The base URL of your team sharing server (no trailing slash required).</p>
   </div>
 
+  <div class="field">
+    <label for="sel-profile">Sharing profile</label>
+    <select id="sel-profile">
+				${profileOptions}
+    </select>
+    <p class="field-hint">Controls what user-level data is included in each sync. <strong>Off</strong> sends only aggregate counts — no user identifiers. Team profiles add per-user keys at increasing fidelity.</p>
+  </div>
+
   <div class="actions">
     <button class="primary" id="btn-save">Save</button>
     <button class="secondary" id="btn-cancel">Cancel</button>
@@ -232,8 +268,9 @@ export class TeamServerConfigPanel implements vscode.Disposable {
     document.getElementById('btn-save').addEventListener('click', () => {
       const enabled = document.getElementById('chk-enabled').checked;
       const endpointUrl = document.getElementById('txt-endpoint').value.trim();
+      const sharingProfile = document.getElementById('sel-profile').value;
       clearErrors();
-      vscode.postMessage({ command: 'save', enabled, endpointUrl });
+      vscode.postMessage({ command: 'save', enabled, endpointUrl, sharingProfile });
     });
 
     document.getElementById('btn-cancel').addEventListener('click', () => {

--- a/vscode-extension/src/backend/teamServerConfigPanel.ts
+++ b/vscode-extension/src/backend/teamServerConfigPanel.ts
@@ -1,0 +1,265 @@
+import * as vscode from 'vscode';
+import * as crypto from 'crypto';
+
+function getNonce(): string {
+	return crypto.randomBytes(16).toString('hex');
+}
+
+export class TeamServerConfigPanel implements vscode.Disposable {
+	private static current: TeamServerConfigPanel | undefined;
+
+	private panel: vscode.WebviewPanel | undefined;
+	private readonly disposables: vscode.Disposable[] = [];
+	private disposed = false;
+
+	public static show(context: vscode.ExtensionContext): void {
+		if (TeamServerConfigPanel.current && !TeamServerConfigPanel.current.disposed) {
+			TeamServerConfigPanel.current.panel?.reveal();
+			return;
+		}
+		const instance = new TeamServerConfigPanel(context.extensionUri);
+		TeamServerConfigPanel.current = instance;
+		instance.open();
+	}
+
+	constructor(private readonly extensionUri: vscode.Uri) {}
+
+	public isDisposed(): boolean {
+		return this.disposed;
+	}
+
+	public dispose(): void {
+		this.disposed = true;
+		for (const d of this.disposables) {
+			d.dispose();
+		}
+		this.disposables.length = 0;
+		if (this.panel) {
+			this.panel.dispose();
+			this.panel = undefined;
+		}
+		if (TeamServerConfigPanel.current === this) {
+			TeamServerConfigPanel.current = undefined;
+		}
+	}
+
+	private open(): void {
+		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		const enabled: boolean = config.get<boolean>('backend.sharingServer.enabled', false);
+		const endpointUrl: string = config.get<string>('backend.sharingServer.endpointUrl', '');
+
+		this.panel = vscode.window.createWebviewPanel(
+			'copilotTeamServerConfig',
+			'AI Engineering Fluency: Configure Team Server',
+			{ viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+			{ enableScripts: true, retainContextWhenHidden: false }
+		);
+
+		this.panel.webview.html = this.renderHtml(this.panel.webview, enabled, endpointUrl);
+
+		this.disposables.push(
+			this.panel.onDidDispose(() => this.dispose()),
+			this.panel.webview.onDidReceiveMessage(async (message) => this.handleMessage(message))
+		);
+	}
+
+	private async handleMessage(message: any): Promise<void> {
+		if (message?.command !== 'save') {
+			return;
+		}
+		const enabled: boolean = Boolean(message.enabled);
+		const endpointUrl: string = String(message.endpointUrl ?? '').trim();
+
+		if (enabled && !endpointUrl) {
+			this.panel?.webview.postMessage({ command: 'validationError', field: 'endpointUrl', text: 'Endpoint URL is required when Team Server is enabled.' });
+			return;
+		}
+
+		try {
+			new URL(endpointUrl || 'http://placeholder'); // validate URL only when non-empty
+		} catch {
+			if (endpointUrl) {
+				this.panel?.webview.postMessage({ command: 'validationError', field: 'endpointUrl', text: 'Endpoint URL must be a valid URL (e.g. https://your-server.example.com).' });
+				return;
+			}
+		}
+
+		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		await config.update('backend.sharingServer.enabled', enabled, vscode.ConfigurationTarget.Global);
+		await config.update('backend.sharingServer.endpointUrl', endpointUrl, vscode.ConfigurationTarget.Global);
+
+		vscode.window.showInformationMessage('Team Server configuration saved.');
+		this.panel?.dispose();
+	}
+
+	private renderHtml(webview: vscode.Webview, enabled: boolean, endpointUrl: string): string {
+		const nonce = getNonce();
+		const csp = `default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';`;
+
+		const enabledChecked = enabled ? 'checked' : '';
+		const safeEndpoint = endpointUrl.replace(/"/g, '&quot;');
+
+		return /* html */`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Configure Team Server</title>
+  <style nonce="${nonce}">
+    :root {
+      --vscode-font-family: var(--vscode-font-family, system-ui, sans-serif);
+      --vscode-font-size: var(--vscode-font-size, 13px);
+    }
+    body {
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      color: var(--vscode-foreground);
+      background-color: var(--vscode-editor-background);
+      padding: 24px;
+      max-width: 560px;
+    }
+    h1 {
+      font-size: 1.2em;
+      margin-bottom: 24px;
+      font-weight: 600;
+    }
+    .field {
+      margin-bottom: 20px;
+    }
+    .field label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 500;
+    }
+    .field input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 6px 8px;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border, #ccc);
+      border-radius: 2px;
+      font-size: inherit;
+      font-family: inherit;
+    }
+    .field input[type="text"]:focus {
+      outline: 1px solid var(--vscode-focusBorder);
+      border-color: var(--vscode-focusBorder);
+    }
+    .field input[type="text"].error {
+      border-color: var(--vscode-inputValidation-errorBorder, #e51400);
+    }
+    .field-hint {
+      font-size: 0.9em;
+      color: var(--vscode-descriptionForeground);
+      margin-top: 4px;
+    }
+    .error-msg {
+      color: var(--vscode-inputValidation-errorForeground, #e51400);
+      background: var(--vscode-inputValidation-errorBackground, #f2dede);
+      border: 1px solid var(--vscode-inputValidation-errorBorder, #e51400);
+      border-radius: 2px;
+      padding: 4px 8px;
+      margin-top: 4px;
+      font-size: 0.9em;
+      display: none;
+    }
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .toggle-row label {
+      margin: 0;
+      cursor: pointer;
+    }
+    .actions {
+      display: flex;
+      gap: 10px;
+      margin-top: 28px;
+    }
+    button {
+      padding: 6px 16px;
+      font-size: inherit;
+      font-family: inherit;
+      border: none;
+      border-radius: 2px;
+      cursor: pointer;
+    }
+    button.primary {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    button.primary:hover {
+      background: var(--vscode-button-hoverBackground);
+    }
+    button.secondary {
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+    }
+    button.secondary:hover {
+      background: var(--vscode-button-secondaryHoverBackground);
+    }
+  </style>
+</head>
+<body>
+  <h1>Configure Team Server</h1>
+
+  <div class="field">
+    <div class="toggle-row">
+      <input type="checkbox" id="chk-enabled" ${enabledChecked}>
+      <label for="chk-enabled">Enable Team Server backend</label>
+    </div>
+    <p class="field-hint">When enabled, session data is pushed to your self-hosted sharing server.</p>
+  </div>
+
+  <div class="field">
+    <label for="txt-endpoint">Server endpoint URL</label>
+    <input type="text" id="txt-endpoint" placeholder="https://your-server.example.com" value="${safeEndpoint}">
+    <div class="error-msg" id="err-endpoint"></div>
+    <p class="field-hint">The base URL of your team sharing server (no trailing slash required).</p>
+  </div>
+
+  <div class="actions">
+    <button class="primary" id="btn-save">Save</button>
+    <button class="secondary" id="btn-cancel">Cancel</button>
+  </div>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+
+    document.getElementById('btn-save').addEventListener('click', () => {
+      const enabled = document.getElementById('chk-enabled').checked;
+      const endpointUrl = document.getElementById('txt-endpoint').value.trim();
+      clearErrors();
+      vscode.postMessage({ command: 'save', enabled, endpointUrl });
+    });
+
+    document.getElementById('btn-cancel').addEventListener('click', () => {
+      vscode.postMessage({ command: 'cancel' });
+    });
+
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      if (msg.command === 'validationError' && msg.field === 'endpointUrl') {
+        const input = document.getElementById('txt-endpoint');
+        const errEl = document.getElementById('err-endpoint');
+        input.classList.add('error');
+        errEl.textContent = msg.text;
+        errEl.style.display = 'block';
+        input.focus();
+      }
+    });
+
+    function clearErrors() {
+      const input = document.getElementById('txt-endpoint');
+      const errEl = document.getElementById('err-endpoint');
+      input.classList.remove('error');
+      errEl.style.display = 'none';
+    }
+  </script>
+</body>
+</html>`;
+	}
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -924,6 +924,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 				}
 				if (e.affectsConfiguration('aiEngineeringFluency.backend')) {
 					this.startBackendSyncAfterInitialAnalysis();
+					// Force an immediate sync so the "Last Sync" timestamp updates right away
+					// instead of waiting for the next timer tick.
+					const backend = (this as any).backend;
+					if (backend && typeof backend.syncToBackendStore === 'function') {
+						backend.syncToBackendStore(true).then(() => {
+							// Refresh diagnostics again after sync completes so "Last Sync" shows the new time
+							if (this.diagnosticsPanel) {
+								this.loadDiagnosticDataInBackground(this.diagnosticsPanel);
+							}
+						}).catch((err: unknown) => {
+							this.warn('Backend sync after settings change failed: ' + err);
+						});
+					}
 					// If the diagnostic report is open, refresh it so the Backend Storage
 					// section reflects the new settings immediately (e.g. after saving the
 					// Team Server config panel).

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8278,6 +8278,7 @@ export function activate(context: vscode.ExtensionContext) {
         (tokenTracker as any).crush.getCrushSessionData(sessionFile),
       isVSSessionFile: (sessionFile: string) =>
         (tokenTracker as any).visualStudio.isVSSessionFile(sessionFile),
+      getGithubToken: () => (tokenTracker as any).githubSession?.accessToken,
     });
 
     const backendHandler = new BackendCommandHandler({

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10,6 +10,7 @@ import customizationPatternsData from './customizationPatterns.json';
 import { REPO_HYGIENE_SKILL } from './backend/repoHygieneSkill';
 import { BackendFacade } from './backend/facade';
 import { BackendCommandHandler } from './backend/commands';
+import { TeamServerConfigPanel } from './backend/teamServerConfigPanel';
 import * as packageJson from '../package.json';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 import { ConfirmationMessages } from "./backend/ui/messages";
@@ -911,10 +912,20 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.log('Status bar item created and shown');
 
 		// Re-render open panels when display settings change
+		// Also restart backend sync timer when backend settings change
 		context.subscriptions.push(
 			vscode.workspace.onDidChangeConfiguration(e => {
 				if (e.affectsConfiguration('copilotTokenTracker.display')) {
 					this.refreshOpenPanelsForSettingChange();
+				}
+				if (e.affectsConfiguration('copilotTokenTracker.backend')) {
+					this.startBackendSyncAfterInitialAnalysis();
+					// If the diagnostic report is open, refresh it so the Backend Storage
+					// section reflects the new settings immediately (e.g. after saving the
+					// Team Server config panel).
+					if (this.diagnosticsPanel) {
+						this.loadDiagnosticDataInBackground(this.diagnosticsPanel);
+					}
 				}
 			})
 		);
@@ -7325,6 +7336,29 @@ ${hashtag}`;
             }
           });
           break;
+        case "configureTeamServer":
+          await this.dispatch('configureTeamServer:diagnostics', async () => {
+            try {
+              await vscode.commands.executeCommand(
+                "copilot-token-tracker.configureTeamServer",
+              );
+            } catch (err) {
+              vscode.window
+                .showInformationMessage(
+                  'Team Server configuration is available in settings. Search for "AI Engineering Fluency: Backend" in settings.',
+                  "Open Settings",
+                )
+                .then((choice) => {
+                  if (choice === "Open Settings") {
+                    vscode.commands.executeCommand(
+                      "workbench.action.openSettings",
+                      "copilotTokenTracker.backend.sharingServer",
+                    );
+                  }
+                });
+            }
+          });
+          break;
         case "openSettings":
           await this.dispatch('openSettings:diagnostics', () =>
             vscode.commands.executeCommand(
@@ -7665,31 +7699,33 @@ ${hashtag}`;
    */
   private async getBackendStorageInfo(): Promise<any> {
     const config = vscode.workspace.getConfiguration("copilotTokenTracker");
-    const enabled = config.get<boolean>("backend.enabled", false);
-    const storageAccount = config.get<string>("backend.storageAccount", "");
-    const subscriptionId = config.get<string>("backend.subscriptionId", "");
-    const resourceGroup = config.get<string>("backend.resourceGroup", "");
-    const aggTable = config.get<string>("backend.aggTable", "usageAggDaily");
-    const eventsTable = config.get<string>(
-      "backend.eventsTable",
-      "usageEvents",
-    );
-    const authMode = config.get<string>("backend.authMode", "entraId");
+    // Use the authoritative settings object so isConfigured uses the same logic as the sync engine
+    const settings = this.backend?.getSettings();
+
+    // Azure Storage settings
+    const azureEnabled = settings?.enabled ?? false;
+    const storageAccount = settings?.storageAccount ?? "";
+    const subscriptionId = settings?.subscriptionId ?? "";
+    const resourceGroup = settings?.resourceGroup ?? "";
+    const aggTable = settings?.aggTable ?? "usageAggDaily";
+    const eventsTable = settings?.eventsTable ?? "usageEvents";
+    const authMode = settings?.authMode ?? "entraId";
     const sharingProfile = config.get<string>("backend.sharingProfile", "off");
+    // Team Server settings
+    const sharingServerEnabled = settings?.sharingServerEnabled ?? false;
+    const sharingServerEndpointUrl = settings?.sharingServerEndpointUrl ?? "";
+
+    // Use the same isConfigured logic as the sync engine
+    const azureIsConfigured = settings ? this.backend!.isConfigured(settings) : false;
+    const teamServerIsConfigured = sharingServerEnabled && !!sharingServerEndpointUrl;
 
     // Get last sync time from global state
-    const lastSyncAt =
-      this.context.globalState.get<number>("backend.lastSyncAt");
+    const lastSyncAt = this.context.globalState.get<number>("backend.lastSyncAt");
     const lastSyncTime = lastSyncAt ? new Date(lastSyncAt).toISOString() : null;
-
-    // Check if backend is configured (has required settings)
-    const isConfigured =
-      enabled && storageAccount && subscriptionId && resourceGroup;
 
     // Get unique device count from session files (estimate based on unique workspace roots)
     const sessionFiles = await this.sessionDiscovery.getCopilotSessionFiles();
     const workspaceIds = new Set<string>();
-    const pathModule = require("path");
 
     for (const file of sessionFiles) {
       const parts = file.split(/[\\\/]/);
@@ -7705,21 +7741,29 @@ ${hashtag}`;
     }
 
     return {
-      enabled,
-      isConfigured,
-      storageAccount,
-      subscriptionId: subscriptionId
-        ? subscriptionId.substring(0, 8) + "..."
-        : "",
-      resourceGroup,
-      aggTable,
-      eventsTable,
-      authMode,
-      sharingProfile,
-      lastSyncTime,
-      deviceCount: workspaceIds.size,
-      sessionCount: sessionFiles.length,
-      recordCount: null, // Will be populated from Azure if configured
+      azure: {
+        enabled: azureEnabled,
+        isConfigured: azureIsConfigured,
+        storageAccount,
+        subscriptionId: subscriptionId ? subscriptionId.substring(0, 8) + "..." : "",
+        resourceGroup,
+        aggTable,
+        eventsTable,
+        authMode,
+        sharingProfile,
+        lastSyncTime: azureEnabled ? lastSyncTime : null,
+        deviceCount: workspaceIds.size,
+        sessionCount: sessionFiles.length,
+        recordCount: null,
+      },
+      teamServer: {
+        enabled: sharingServerEnabled,
+        isConfigured: teamServerIsConfigured,
+        endpointUrl: sharingServerEndpointUrl,
+        sharingProfile,
+        lastSyncTime: sharingServerEnabled ? lastSyncTime : null,
+        sessionCount: sessionFiles.length,
+      },
     };
   }
 
@@ -8303,6 +8347,15 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(configureBackendCommand);
+
+    const configureTeamServerCommand = vscode.commands.registerCommand(
+      "copilot-token-tracker.configureTeamServer",
+      async () => {
+        TeamServerConfigPanel.show(context);
+      },
+    );
+
+    context.subscriptions.push(configureTeamServerCommand);
   } catch (err) {
     // If backend wiring fails for any reason, don't block activation - fall back to settings behavior.
     (tokenTracker as any).warn(

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -99,6 +99,7 @@ type DiagnosticsData = {
 
 type DiagnosticsViewState = {
   activeTab?: string;
+  activeSubtab?: string;
 };
 
 declare function acquireVsCodeApi<TState = DiagnosticsViewState>(): {
@@ -1290,12 +1291,24 @@ function renderLayout(data: DiagnosticsData): void {
       if (message.backendStorageInfo) {
         const backendTabContent = document.getElementById("tab-backend");
         if (backendTabContent) {
+          // Capture active subtab before re-rendering so we can restore it
+          const activeSubtabEl = backendTabContent.querySelector(".subtab.active") as HTMLElement | null;
+          const previousSubtab = activeSubtabEl?.getAttribute("data-subtab")
+            ?? vscode.getState()?.activeSubtab;
+
           backendTabContent.innerHTML = renderBackendStoragePanel(
             message.backendStorageInfo,
           );
           // Re-attach event listeners for backend buttons
           setupBackendButtonHandlers();
           setupSubtabHandlers();
+
+          // Restore previously-active subtab (or default to first)
+          if (previousSubtab) {
+            activateSubtab(previousSubtab);
+            const currentState = vscode.getState() ?? {};
+            vscode.setState({ ...currentState, activeSubtab: previousSubtab });
+          }
         }
       } else {
         console.warn("diagnosticDataLoaded received but backendStorageInfo is missing or undefined");
@@ -1600,6 +1613,23 @@ function renderLayout(data: DiagnosticsData): void {
     });
   }
 
+  // Helper function to activate a subtab by its ID (without the "subtab-" prefix)
+  function activateSubtab(subtabId: string): boolean {
+    const subtabEl = document.querySelector(`.subtab[data-subtab="${subtabId}"]`);
+    const contentEl = document.getElementById(`subtab-${subtabId}`);
+    if (subtabEl && contentEl) {
+      const subtabBar = subtabEl.closest(".subtab-bar");
+      if (subtabBar) {
+        subtabBar.querySelectorAll(".subtab").forEach((s) => s.classList.remove("active"));
+      }
+      document.querySelectorAll(".subtab-content").forEach((c) => c.classList.remove("active"));
+      subtabEl.classList.add("active");
+      contentEl.classList.add("active");
+      return true;
+    }
+    return false;
+  }
+
   // Helper function to activate a tab by its ID
   function activateTab(tabId: string): boolean {
     const tabButton = document.querySelector(`.tab[data-tab="${tabId}"]`);
@@ -1714,6 +1744,10 @@ function renderLayout(data: DiagnosticsData): void {
     document
       .getElementById("btn-configure-backend-team")
       ?.addEventListener("click", () => {
+        // Pre-save the teamserver subtab so the diagnostics panel restores to it
+        // after the settings change triggers a panel refresh
+        const currentState = vscode.getState() ?? {};
+        vscode.setState({ ...currentState, activeTab: "backend", activeSubtab: "backend-teamserver" });
         vscode.postMessage({ command: "configureTeamServer" });
       });
 
@@ -1745,6 +1779,9 @@ function renderLayout(data: DiagnosticsData): void {
         document.querySelectorAll(".subtab-content").forEach((c) => c.classList.remove("active"));
         subtab.classList.add("active");
         document.getElementById(`subtab-${subtabId}`)?.classList.add("active");
+        // Persist active subtab so it can be restored after a data refresh
+        const currentState = vscode.getState() ?? {};
+        vscode.setState({ ...currentState, activeSubtab: subtabId });
       });
     });
   }
@@ -1968,6 +2005,11 @@ function renderLayout(data: DiagnosticsData): void {
   if (savedState?.activeTab && !activateTab(savedState.activeTab)) {
     // If saved tab doesn't exist (e.g., structure changed), activate default "report" tab
     activateTab("report");
+  }
+
+  // Restore active subtab from saved state
+  if (savedState?.activeSubtab) {
+    activateSubtab(savedState.activeSubtab);
   }
 }
 

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -43,7 +43,7 @@ type CacheInfo = {
   storagePath?: string | null;
 };
 
-type BackendStorageInfo = {
+type AzureStorageInfo = {
   enabled: boolean;
   isConfigured: boolean;
   storageAccount: string;
@@ -57,6 +57,20 @@ type BackendStorageInfo = {
   deviceCount: number;
   sessionCount: number;
   recordCount: number | null;
+};
+
+type TeamServerInfo = {
+  enabled: boolean;
+  isConfigured: boolean;
+  endpointUrl: string;
+  sharingProfile: string;
+  lastSyncTime: string | null;
+  sessionCount: number;
+};
+
+type BackendStorageInfo = {
+  azure: AzureStorageInfo;
+  teamServer: TeamServerInfo;
 };
 
 type GlobalStateCounters = {
@@ -810,171 +824,205 @@ ${authenticated ? `
   `;
 }
 
+function renderAzureStoragePanel(azureInfo: AzureStorageInfo): string {
+  const statusColor = azureInfo.isConfigured ? "#2d6a4f" : azureInfo.enabled ? "#d97706" : "#666";
+  const statusIcon = azureInfo.isConfigured ? "✅" : azureInfo.enabled ? "⚠️" : "⚪";
+  const statusText = azureInfo.isConfigured
+    ? "Configured & Enabled"
+    : azureInfo.enabled
+      ? "Enabled but Not Configured"
+      : "Disabled";
+
+  return `
+    <div class="info-box">
+      <div class="info-box-title">☁️ Azure Storage Backend</div>
+      <div>Sync your token usage data to Azure Storage Tables for team-wide reporting and multi-device access.</div>
+    </div>
+
+    <div class="summary-cards">
+      <div class="summary-card" style="border-left: 4px solid ${statusColor};">
+        <div class="summary-label">${statusIcon} Status</div>
+        <div class="summary-value" style="font-size: 16px; color: ${statusColor};">${statusText}</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">🔐 Auth Mode</div>
+        <div class="summary-value" style="font-size: 16px;">${azureInfo.authMode === "entraId" ? "Entra ID" : "Shared Key"}</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">👥 Sharing Profile</div>
+        <div class="summary-value" style="font-size: 14px;">${escapeHtml(azureInfo.sharingProfile)}</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">🕒 Last Sync</div>
+        <div class="summary-value" style="font-size: 14px;">${azureInfo.lastSyncTime ? getTimeSince(azureInfo.lastSyncTime) : "Never"}</div>
+      </div>
+    </div>
+
+    ${azureInfo.isConfigured ? `
+      <div style="margin-top: 24px;">
+        <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📊 Configuration Details</h4>
+        <table class="session-table">
+          <tbody>
+            <tr><td style="font-weight: 600; width: 200px;">Storage Account</td><td>${escapeHtml(azureInfo.storageAccount)}</td></tr>
+            <tr><td style="font-weight: 600;">Subscription ID</td><td>${escapeHtml(azureInfo.subscriptionId)}</td></tr>
+            <tr><td style="font-weight: 600;">Resource Group</td><td>${escapeHtml(azureInfo.resourceGroup)}</td></tr>
+            <tr><td style="font-weight: 600;">Aggregation Table</td><td>${escapeHtml(azureInfo.aggTable)}</td></tr>
+            <tr><td style="font-weight: 600;">Events Table</td><td>${escapeHtml(azureInfo.eventsTable)}</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div style="margin-top: 24px;">
+        <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📈 Local Session Statistics</h4>
+        <div class="summary-cards">
+          <div class="summary-card">
+            <div class="summary-label">💻 Unique Devices</div>
+            <div class="summary-value">${escapeHtml(String(azureInfo.deviceCount))}</div>
+            <div style="font-size: 11px; color: #999; margin-top: 4px;">Based on workspace IDs</div>
+          </div>
+          <div class="summary-card">
+            <div class="summary-label">📁 Total Sessions</div>
+            <div class="summary-value">${escapeHtml(String(azureInfo.sessionCount))}</div>
+            <div style="font-size: 11px; color: #999; margin-top: 4px;">Local session files</div>
+          </div>
+          <div class="summary-card">
+            <div class="summary-label">☁️ Cloud Records</div>
+            <div class="summary-value">${azureInfo.recordCount !== null ? escapeHtml(String(azureInfo.recordCount)) : "—"}</div>
+            <div style="font-size: 11px; color: #999; margin-top: 4px;">Azure Storage records</div>
+          </div>
+          <div class="summary-card">
+            <div class="summary-label">🔄 Sync Status</div>
+            <div class="summary-value" style="font-size: 14px;">${azureInfo.lastSyncTime ? formatDate(azureInfo.lastSyncTime) : "Never"}</div>
+          </div>
+        </div>
+      </div>
+    ` : `
+      <div style="margin-top: 24px;">
+        <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">🚀 Get Started with Azure Storage</h4>
+        <p style="color: #999; font-size: 12px; margin-bottom: 16px;">
+          To enable cloud synchronization, configure an Azure Storage account via the Backend configuration panel.
+        </p>
+        <ul style="margin: 8px 0 16px 20px; color: #999; font-size: 12px;">
+          <li>Azure subscription with Storage Account access</li>
+          <li>Appropriate permissions (Storage Table Data Contributor or Storage Account Key)</li>
+          <li>VS Code signed in with your Azure account (for Entra ID auth)</li>
+        </ul>
+      </div>
+    `}
+
+    <div class="button-group">
+      <button class="button" id="btn-configure-backend">
+        <span>${azureInfo.isConfigured ? "⚙️" : "🔧"}</span>
+        <span>${azureInfo.isConfigured ? "Manage Backend" : "Configure Backend"}</span>
+      </button>
+    </div>
+  `;
+}
+
+function renderTeamServerPanel(teamInfo: TeamServerInfo): string {
+  const statusColor = teamInfo.isConfigured ? "#2d6a4f" : teamInfo.enabled ? "#d97706" : "#666";
+  const statusIcon = teamInfo.isConfigured ? "✅" : teamInfo.enabled ? "⚠️" : "⚪";
+  const statusText = teamInfo.isConfigured
+    ? "Configured & Enabled"
+    : teamInfo.enabled
+      ? "Enabled but Not Configured"
+      : "Disabled";
+
+  return `
+    <div class="info-box">
+      <div class="info-box-title">🖥️ Team Server Backend</div>
+      <div>Sync your token usage data to a self-hosted team server for team-wide reporting.</div>
+    </div>
+
+    <div class="summary-cards">
+      <div class="summary-card" style="border-left: 4px solid ${statusColor};">
+        <div class="summary-label">${statusIcon} Status</div>
+        <div class="summary-value" style="font-size: 16px; color: ${statusColor};">${statusText}</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">👥 Sharing Profile</div>
+        <div class="summary-value" style="font-size: 14px;">${escapeHtml(teamInfo.sharingProfile)}</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">🕒 Last Sync</div>
+        <div class="summary-value" style="font-size: 14px;">${teamInfo.lastSyncTime ? getTimeSince(teamInfo.lastSyncTime) : "Never"}</div>
+      </div>
+    </div>
+
+    ${teamInfo.isConfigured ? `
+      <div style="margin-top: 24px;">
+        <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📊 Configuration Details</h4>
+        <table class="session-table">
+          <tbody>
+            <tr>
+              <td style="font-weight: 600; width: 200px;">Server URL</td>
+              <td>${escapeHtml(teamInfo.endpointUrl)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div style="margin-top: 24px;">
+        <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📈 Local Session Statistics</h4>
+        <div class="summary-cards">
+          <div class="summary-card">
+            <div class="summary-label">📁 Total Sessions</div>
+            <div class="summary-value">${escapeHtml(String(teamInfo.sessionCount))}</div>
+            <div style="font-size: 11px; color: #999; margin-top: 4px;">Local session files</div>
+          </div>
+          <div class="summary-card">
+            <div class="summary-label">🔄 Last Sync</div>
+            <div class="summary-value" style="font-size: 14px;">${teamInfo.lastSyncTime ? formatDate(teamInfo.lastSyncTime) : "Never"}</div>
+          </div>
+        </div>
+      </div>
+    ` : `
+      <div style="margin-top: 24px;">
+        <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">🚀 Get Started with Team Server</h4>
+        <p style="color: #999; font-size: 12px; margin-bottom: 16px;">
+          Deploy the sharing server and configure its URL in the Backend configuration panel.
+        </p>
+        <ul style="margin: 8px 0 16px 20px; color: #999; font-size: 12px;">
+          <li>Deploy the sharing server (see the <code>sharing-server/</code> folder in the repository)</li>
+          <li>Enter the server's base URL in the Backend configuration panel</li>
+          <li>Data syncs automatically every 5 minutes once configured</li>
+        </ul>
+      </div>
+    `}
+
+    <div class="button-group">
+      <button class="button" id="btn-configure-backend-team">
+        <span>${teamInfo.isConfigured ? "⚙️" : "🔧"}</span>
+        <span>${teamInfo.isConfigured ? "Manage Backend" : "Configure Backend"}</span>
+      </button>
+    </div>
+  `;
+}
+
 function renderBackendStoragePanel(
   backendInfo: BackendStorageInfo | undefined,
 ): string {
   if (!backendInfo) {
     return `
-			<div class="info-box">
-				<div class="info-box-title">☁️ Azure Storage Backend</div>
-				<div>
-					Backend storage information is not available. This may be a temporary issue.
-				</div>
-			</div>
-		`;
+      <div class="info-box">
+        <div class="info-box-title">☁️ Backend Storage</div>
+        <div>Backend storage information is not available. This may be a temporary issue.</div>
+      </div>
+    `;
   }
 
-  const statusColor = backendInfo.isConfigured
-    ? "#2d6a4f"
-    : backendInfo.enabled
-      ? "#d97706"
-      : "#666";
-  const statusIcon = backendInfo.isConfigured
-    ? "✅"
-    : backendInfo.enabled
-      ? "⚠️"
-      : "⚪";
-  const statusText = backendInfo.isConfigured
-    ? "Configured & Enabled"
-    : backendInfo.enabled
-      ? "Enabled but Not Configured"
-      : "Disabled";
-
-  const configButtonText = backendInfo.isConfigured
-    ? "⚙️ Manage Backend"
-    : "🔧 Configure Backend";
-  const configButtonStyle = backendInfo.isConfigured ? "secondary" : "";
-
   return `
-		<div class="info-box">
-			<div class="info-box-title">☁️ Azure Storage Backend</div>
-			<div>
-				Sync your token usage data to Azure Storage Tables for team-wide reporting and multi-device access.
-				Configure Azure resources and authentication settings to enable cloud synchronization.
-			</div>
-		</div>
-
-		<div class="summary-cards">
-			<div class="summary-card" style="border-left: 4px solid ${statusColor};">
-				<div class="summary-label">${statusIcon} Backend Status</div>
-				<div class="summary-value" style="font-size: 16px; color: ${statusColor};">${statusText}</div>
-			</div>
-			<div class="summary-card">
-				<div class="summary-label">🔐 Auth Mode</div>
-				<div class="summary-value" style="font-size: 16px;">${backendInfo.authMode === "entraId" ? "Entra ID" : "Shared Key"}</div>
-			</div>
-			<div class="summary-card">
-				<div class="summary-label">👥 Sharing Profile</div>
-				<div class="summary-value" style="font-size: 14px;">${escapeHtml(backendInfo.sharingProfile)}</div>
-			</div>
-			<div class="summary-card">
-				<div class="summary-label">🕒 Last Sync</div>
-				<div class="summary-value" style="font-size: 14px;">${backendInfo.lastSyncTime ? getTimeSince(backendInfo.lastSyncTime) : "Never"}</div>
-			</div>
-		</div>
-
-		${
-      backendInfo.isConfigured
-        ? `
-			<div style="margin-top: 24px;">
-				<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📊 Configuration Details</h4>
-				<table class="session-table">
-					<tbody>
-						<tr>
-							<td style="font-weight: 600; width: 200px;">Storage Account</td>
-							<td>${escapeHtml(backendInfo.storageAccount)}</td>
-						</tr>
-						<tr>
-							<td style="font-weight: 600;">Subscription ID</td>
-							<td>${escapeHtml(backendInfo.subscriptionId)}</td>
-						</tr>
-						<tr>
-							<td style="font-weight: 600;">Resource Group</td>
-							<td>${escapeHtml(backendInfo.resourceGroup)}</td>
-						</tr>
-						<tr>
-							<td style="font-weight: 600;">Aggregation Table</td>
-							<td>${escapeHtml(backendInfo.aggTable)}</td>
-						</tr>
-						<tr>
-							<td style="font-weight: 600;">Events Table</td>
-							<td>${escapeHtml(backendInfo.eventsTable)}</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
-
-			<div style="margin-top: 24px;">
-				<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📈 Local Session Statistics</h4>
-				<div class="summary-cards">
-					<div class="summary-card">
-						<div class="summary-label">💻 Unique Devices</div>
-						<div class="summary-value">${escapeHtml(String(backendInfo.deviceCount))}</div>
-						<div style="font-size: 11px; color: #999; margin-top: 4px;">Based on workspace IDs</div>
-					</div>
-					<div class="summary-card">
-						<div class="summary-label">📁 Total Sessions</div>
-						<div class="summary-value">${escapeHtml(String(backendInfo.sessionCount))}</div>
-						<div style="font-size: 11px; color: #999; margin-top: 4px;">Local session files</div>
-					</div>
-					<div class="summary-card">
-						<div class="summary-label">☁️ Cloud Records</div>
-						<div class="summary-value">${backendInfo.recordCount !== null ? escapeHtml(String(backendInfo.recordCount)) : "—"}</div>
-						<div style="font-size: 11px; color: #999; margin-top: 4px;">Azure Storage records</div>
-					</div>
-					<div class="summary-card">
-						<div class="summary-label">🔄 Sync Status</div>
-						<div class="summary-value" style="font-size: 14px;">${backendInfo.lastSyncTime ? formatDate(backendInfo.lastSyncTime) : "Never"}</div>
-					</div>
-				</div>
-			</div>
-
-			<div style="margin-top: 24px;">
-				<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">ℹ️ About Azure Storage Backend</h4>
-				<p style="color: #999; font-size: 12px; margin-bottom: 8px;">
-					The Azure Storage backend enables:
-				</p>
-				<ul style="margin: 8px 0 0 20px; color: #999; font-size: 12px;">
-					<li>Team-wide token usage reporting and analytics</li>
-					<li>Multi-device synchronization of your usage data</li>
-					<li>Long-term storage and historical analysis</li>
-					<li>Configurable privacy levels (anonymous, pseudonymous, or identified)</li>
-				</ul>
-			</div>
-		`
-        : `
-			<div style="margin-top: 24px;">
-				<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">🚀 Get Started with Azure Storage</h4>
-				<p style="color: #999; font-size: 12px; margin-bottom: 16px;">
-					To enable cloud synchronization, you'll need to configure an Azure Storage account.
-					The setup wizard will guide you through the process.
-				</p>
-				<ul style="margin: 8px 0 16px 20px; color: #999; font-size: 12px;">
-					<li>Azure subscription with Storage Account access</li>
-					<li>Appropriate permissions (Storage Table Data Contributor or Storage Account Key)</li>
-					<li>VS Code signed in with your Azure account (for Entra ID auth)</li>
-				</ul>
-			</div>
-		`
-    }
-
-		<div class="button-group">
-			<button class="button ${configButtonStyle}" id="btn-configure-backend">
-				<span>${configButtonText.split(" ")[0]}</span>
-				<span>${configButtonText.substring(configButtonText.indexOf(" ") + 1)}</span>
-			</button>
-			${
-        backendInfo.isConfigured
-          ? `
-				<button class="button secondary" id="btn-open-settings">
-					<span>⚙️</span>
-					<span>Open Backend Settings</span>
-				</button>
-			`
-          : ""
-      }
-		</div>
-	`;
+    <div class="subtab-bar">
+      <button class="subtab active" data-subtab="backend-azure">☁️ Azure Storage</button>
+      <button class="subtab" data-subtab="backend-teamserver">🖥️ Team Server</button>
+    </div>
+    <div id="subtab-backend-azure" class="subtab-content active">
+      ${renderAzureStoragePanel(backendInfo.azure)}
+    </div>
+    <div id="subtab-backend-teamserver" class="subtab-content">
+      ${renderTeamServerPanel(backendInfo.teamServer)}
+    </div>
+  `;
 }
 
 function renderLayout(data: DiagnosticsData): void {
@@ -1089,7 +1137,7 @@ function renderLayout(data: DiagnosticsData): void {
 				<button class="tab active" data-tab="report">📋 Report</button>
 				<button class="tab" data-tab="sessions">📁 Session Files (${detailedFiles.length})</button>
 				<button class="tab" data-tab="cache">💾 Cache</button>
-				<button class="tab" data-tab="backend">☁️ Azure Storage</button>
+				<button class="tab" data-tab="backend">☁️ Backend Storage</button>
 				<button class="tab" data-tab="github">🔑 GitHub Auth</button>
 				<button class="tab" data-tab="display">⚙️ Settings</button>
 				${data.isDebugMode ? '<button class="tab" data-tab="debug">🐛 Debug</button>' : ''}
@@ -1241,6 +1289,7 @@ function renderLayout(data: DiagnosticsData): void {
           );
           // Re-attach event listeners for backend buttons
           setupBackendButtonHandlers();
+          setupSubtabHandlers();
         }
       } else {
         console.warn("diagnosticDataLoaded received but backendStorageInfo is missing or undefined");
@@ -1657,6 +1706,12 @@ function renderLayout(data: DiagnosticsData): void {
       });
 
     document
+      .getElementById("btn-configure-backend-team")
+      ?.addEventListener("click", () => {
+        vscode.postMessage({ command: "configureTeamServer" });
+      });
+
+    document
       .getElementById("btn-open-settings")
       ?.addEventListener("click", () => {
         vscode.postMessage({ command: "openSettings" });
@@ -1667,6 +1722,25 @@ function renderLayout(data: DiagnosticsData): void {
       ?.addEventListener("click", () => {
         vscode.postMessage({ command: "openDisplaySettings" });
       });
+  }
+
+  function setupSubtabHandlers(): void {
+    document.querySelectorAll(".subtab").forEach((subtab) => {
+      subtab.addEventListener("click", () => {
+        const subtabId = (subtab as HTMLElement).getAttribute("data-subtab");
+        if (!subtabId) {
+          return;
+        }
+        // Deactivate all subtabs and content in the same subtab-bar
+        const subtabBar = subtab.closest(".subtab-bar");
+        if (subtabBar) {
+          subtabBar.querySelectorAll(".subtab").forEach((s) => s.classList.remove("active"));
+        }
+        document.querySelectorAll(".subtab-content").forEach((c) => c.classList.remove("active"));
+        subtab.classList.add("active");
+        document.getElementById(`subtab-${subtabId}`)?.classList.add("active");
+      });
+    });
   }
 
   // Re-render the session table with current filter/sort state
@@ -1878,6 +1952,7 @@ function renderLayout(data: DiagnosticsData): void {
   setupContextRefFilterHandlers();
   setupZeroInteractionFilterHandler();
   setupBackendButtonHandlers();
+  setupSubtabHandlers();
   setupFileLinks();
   setupStorageLinkHandlers();
   setupGitHubAuthHandlers();

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -112,6 +112,45 @@ body {
 	display: block;
 }
 
+/* Sub-tabs (used inside tabs, e.g. Backend Storage sub-tabs) */
+.subtab-bar {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 20px;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.subtab {
+	padding: 8px 16px;
+	cursor: pointer;
+	border: none;
+	background: transparent;
+	color: var(--text-secondary);
+	font-size: 12px;
+	font-weight: 500;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -1px;
+	transition: all 0.2s;
+}
+
+.subtab:hover {
+	color: var(--text-primary);
+	background: var(--list-hover-bg);
+}
+
+.subtab.active {
+	color: var(--link-color);
+	border-bottom-color: var(--link-color);
+}
+
+.subtab-content {
+	display: none;
+}
+
+.subtab-content.active {
+	display: block;
+}
+
 /* Editor filter panels */
 .editor-filter-panels {
 	display: flex;

--- a/vscode-extension/test/integration/backend.test.ts
+++ b/vscode-extension/test/integration/backend.test.ts
@@ -32,7 +32,8 @@ suite('Extension Test Suite', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 				});
 
 				assert.strictEqual(payload.version, 1);
@@ -120,7 +121,8 @@ suite('Extension Test Suite', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when subscriptionId is empty'
@@ -150,7 +152,8 @@ suite('Extension Test Suite', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when resourceGroup is empty'
@@ -180,7 +183,8 @@ suite('Extension Test Suite', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when storageAccount is empty'
@@ -210,7 +214,8 @@ suite('Extension Test Suite', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when aggTable is empty'
@@ -240,7 +245,8 @@ suite('Extension Test Suite', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 					}),
 					true,
 					'Should return true when required fields are present'

--- a/vscode-extension/test/integration/backend.test.ts
+++ b/vscode-extension/test/integration/backend.test.ts
@@ -31,7 +31,8 @@ suite('Extension Test Suite', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 				});
 
 				assert.strictEqual(payload.version, 1);
@@ -118,7 +119,8 @@ suite('Extension Test Suite', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when subscriptionId is empty'
@@ -147,7 +149,8 @@ suite('Extension Test Suite', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when resourceGroup is empty'
@@ -176,7 +179,8 @@ suite('Extension Test Suite', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when storageAccount is empty'
@@ -205,7 +209,8 @@ suite('Extension Test Suite', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 					}),
 					false,
 					'Should return false when aggTable is empty'
@@ -234,7 +239,8 @@ suite('Extension Test Suite', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 					}),
 					true,
 					'Should return true when required fields are present'

--- a/vscode-extension/test/unit/backend-configPanel-webview.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel-webview.test.ts
@@ -25,7 +25,10 @@ function createPanelHtml(): string {
 			blobUploadEnabled: false,
 			blobContainerName: 'copilot-session-logs',
 			blobUploadFrequencyHours: 24,
-			blobCompressFiles: true
+			blobCompressFiles: true,
+			backend: 'storageTables' as const,
+			sharingServerEnabled: false,
+			sharingServerEndpointUrl: ''
 		},
 		sharedKeySet: false,
 		privacyBadge: 'Solo',

--- a/vscode-extension/test/unit/backend-configPanel-webview.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel-webview.test.ts
@@ -63,11 +63,11 @@ describe('Backend Config Panel Webview (node:test)', { concurrency: false }, () 
 	describe('HTML Structure', () => {
 		beforeEach(() => { setupDom(); });
 
-		test('has all 5 navigation buttons with correct targets', () => {
+		test('has all 6 navigation buttons with correct targets', () => {
 			const navButtons = document.querySelectorAll('.nav-btn');
-			assert.equal(navButtons.length, 5);
+			assert.equal(navButtons.length, 6);
 			const targets = Array.from(navButtons).map(btn => btn.getAttribute('data-target'));
-			assert.deepEqual(targets, ['overview', 'azure', 'sharing', 'advanced', 'review']);
+			assert.deepEqual(targets, ['overview', 'azure', 'teamserver', 'sharing', 'advanced', 'review']);
 			teardownDom();
 		});
 

--- a/vscode-extension/test/unit/backend-configPanel.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel.test.ts
@@ -30,7 +30,8 @@ const baseSettings: BackendSettings = {
 	blobContainerName: 'copilot-session-logs',
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 };
 
 function makeState(overrides?: Partial<BackendConfigPanelState>): BackendConfigPanelState {

--- a/vscode-extension/test/unit/backend-configPanel.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel.test.ts
@@ -29,7 +29,8 @@ const baseSettings: BackendSettings = {
 	blobUploadEnabled: false,
 	blobContainerName: 'copilot-session-logs',
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 };
 
 function makeState(overrides?: Partial<BackendConfigPanelState>): BackendConfigPanelState {

--- a/vscode-extension/test/unit/backend-configurationFlow.test.ts
+++ b/vscode-extension/test/unit/backend-configurationFlow.test.ts
@@ -38,7 +38,8 @@ const baseSettings: BackendSettings = {
 	blobUploadEnabled: false,
 	blobContainerName: 'copilot-session-logs',
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 };
 
 // ── toDraft ──────────────────────────────────────────────────────────────

--- a/vscode-extension/test/unit/backend-configurationFlow.test.ts
+++ b/vscode-extension/test/unit/backend-configurationFlow.test.ts
@@ -39,7 +39,8 @@ const baseSettings: BackendSettings = {
 	blobContainerName: 'copilot-session-logs',
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 };
 
 // ── toDraft ──────────────────────────────────────────────────────────────

--- a/vscode-extension/test/unit/backend-configurator.test.ts
+++ b/vscode-extension/test/unit/backend-configurator.test.ts
@@ -41,7 +41,8 @@ const baseSettings: BackendSettings = {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 };
 
 test('validateDraft enforces lookback bounds, alias rules, and dataset/table format', () => {

--- a/vscode-extension/test/unit/backend-configurator.test.ts
+++ b/vscode-extension/test/unit/backend-configurator.test.ts
@@ -40,7 +40,8 @@ const baseSettings: BackendSettings = {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 };
 
 test('validateDraft enforces lookback bounds, alias rules, and dataset/table format', () => {

--- a/vscode-extension/test/unit/backend-integration.test.ts
+++ b/vscode-extension/test/unit/backend-integration.test.ts
@@ -141,7 +141,8 @@ test('BackendIntegration proxies facade calls and fallbacks', async () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 	const facade = {
 		getSettings: () => {

--- a/vscode-extension/test/unit/backend-integration.test.ts
+++ b/vscode-extension/test/unit/backend-integration.test.ts
@@ -142,7 +142,8 @@ test('BackendIntegration proxies facade calls and fallbacks', async () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 	const facade = {
 		getSettings: () => {

--- a/vscode-extension/test/unit/backend-queryService.test.ts
+++ b/vscode-extension/test/unit/backend-queryService.test.ts
@@ -56,6 +56,7 @@ function makeSettings(overrides?: Partial<BackendSettings>): BackendSettings {
 		blobContainerName: 'copilot-session-logs',
 		blobUploadFrequencyHours: 24,
 		blobCompressFiles: true,
+		sharingServerEnabled: false,
 		sharingServerEndpointUrl: '',
 		...overrides
 	};

--- a/vscode-extension/test/unit/backend-queryService.test.ts
+++ b/vscode-extension/test/unit/backend-queryService.test.ts
@@ -56,6 +56,7 @@ function makeSettings(overrides?: Partial<BackendSettings>): BackendSettings {
 		blobContainerName: 'copilot-session-logs',
 		blobUploadFrequencyHours: 24,
 		blobCompressFiles: true,
+		sharingServerEndpointUrl: '',
 		...overrides
 	};
 }

--- a/vscode-extension/test/unit/backend-redaction.test.ts
+++ b/vscode-extension/test/unit/backend-redaction.test.ts
@@ -28,7 +28,8 @@ test('config export fully redacts machineId', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);
@@ -61,7 +62,8 @@ test('config export includes sharingProfile', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);
@@ -94,7 +96,8 @@ test('config export JSON string does not contain full machineId or sessionId', (
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);
@@ -137,7 +140,8 @@ test('config export note mentions no secrets or PII', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);

--- a/vscode-extension/test/unit/backend-redaction.test.ts
+++ b/vscode-extension/test/unit/backend-redaction.test.ts
@@ -29,7 +29,8 @@ test('config export fully redacts machineId', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);
@@ -63,7 +64,8 @@ test('config export includes sharingProfile', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);
@@ -97,7 +99,8 @@ test('config export JSON string does not contain full machineId or sessionId', (
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);
@@ -141,7 +144,8 @@ test('config export note mentions no secrets or PII', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const payload = buildBackendConfigClipboardPayload(settings);

--- a/vscode-extension/test/unit/backend-settings.test.ts
+++ b/vscode-extension/test/unit/backend-settings.test.ts
@@ -122,7 +122,8 @@ test('isBackendConfigured checks required fields', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 		}),
 		true
 	);
@@ -151,7 +152,8 @@ test('isBackendConfigured checks required fields', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 		}),
 		false
 	);

--- a/vscode-extension/test/unit/backend-settings.test.ts
+++ b/vscode-extension/test/unit/backend-settings.test.ts
@@ -121,7 +121,8 @@ test('isBackendConfigured checks required fields', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 		}),
 		true
 	);
@@ -149,7 +150,8 @@ test('isBackendConfigured checks required fields', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 		}),
 		false
 	);

--- a/vscode-extension/test/unit/backend-sync-profiles.test.ts
+++ b/vscode-extension/test/unit/backend-sync-profiles.test.ts
@@ -34,7 +34,8 @@ test('backend sync: soloFull profile uploads raw workspace/machine IDs and names
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -73,7 +74,8 @@ test('backend sync: teamAnonymized profile hashes IDs, no user dimension, no nam
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -112,7 +114,8 @@ test('backend sync: teamPseudonymous profile includes user dimension with consen
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -152,7 +155,8 @@ test('backend sync: teamIdentified profile includes user dimension with explicit
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -193,7 +197,8 @@ test('regression: shareWithTeam=false with profile=off never uploads anything', 
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -230,7 +235,8 @@ test('regression: profile=off overrides shareWithTeam=true (safety gate)', () =>
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -267,7 +273,8 @@ test('consent timestamp: teamPseudonymous requires shareConsentAt', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	assert.ok(settingsWithConsent.shareConsentAt, 'teamPseudonymous should have shareConsentAt');
@@ -297,7 +304,8 @@ test('consent timestamp: teamIdentified requires shareConsentAt', () => {
 	blobUploadEnabled: false,
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
-	blobCompressFiles: true
+	blobCompressFiles: true,
+	sharingServerEndpointUrl: ''
 	};
 
 	assert.ok(settingsWithConsent.shareConsentAt, 'teamIdentified should have shareConsentAt');

--- a/vscode-extension/test/unit/backend-sync-profiles.test.ts
+++ b/vscode-extension/test/unit/backend-sync-profiles.test.ts
@@ -35,7 +35,8 @@ test('backend sync: soloFull profile uploads raw workspace/machine IDs and names
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -75,7 +76,8 @@ test('backend sync: teamAnonymized profile hashes IDs, no user dimension, no nam
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -115,7 +117,8 @@ test('backend sync: teamPseudonymous profile includes user dimension with consen
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -156,7 +159,8 @@ test('backend sync: teamIdentified profile includes user dimension with explicit
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -198,7 +202,8 @@ test('regression: shareWithTeam=false with profile=off never uploads anything', 
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -236,7 +241,8 @@ test('regression: profile=off overrides shareWithTeam=true (safety gate)', () =>
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	const policy = computeBackendSharingPolicy({
@@ -274,7 +280,8 @@ test('consent timestamp: teamPseudonymous requires shareConsentAt', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	assert.ok(settingsWithConsent.shareConsentAt, 'teamPseudonymous should have shareConsentAt');
@@ -305,7 +312,8 @@ test('consent timestamp: teamIdentified requires shareConsentAt', () => {
 	blobContainerName: "copilot-session-logs",
 	blobUploadFrequencyHours: 24,
 	blobCompressFiles: true,
-	sharingServerEndpointUrl: ''
+	sharingServerEnabled: false,
+		sharingServerEndpointUrl: ''
 	};
 
 	assert.ok(settingsWithConsent.shareConsentAt, 'teamIdentified should have shareConsentAt');

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -31,7 +31,7 @@ function makeService(depsOverrides?: Partial<SyncServiceDeps>): SyncService {
 	const deps = makeDeps(depsOverrides);
 	const credSvc = new CredentialService(undefined as any);
 	const dataSvc = new DataPlaneService(BackendUtility, () => {}, async () => []);
-	return new SyncService(deps, credSvc, dataSvc, undefined, BackendUtility);
+	return new SyncService(deps, credSvc, dataSvc, undefined, BackendUtility, undefined);
 }
 
 /**
@@ -46,7 +46,7 @@ function makeServiceWithServices(
 	const deps = makeDeps(depsOverrides);
 	const credSvc = credSvcOverride ?? new CredentialService(undefined as any);
 	const dataSvc = dataSvcOverride ?? new DataPlaneService(BackendUtility, () => {}, async () => []);
-	return new SyncService(deps, credSvc, dataSvc, blobSvcOverride ?? undefined, BackendUtility);
+	return new SyncService(deps, credSvc, dataSvc, blobSvcOverride ?? undefined, BackendUtility, undefined);
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a self-hosted sharing server as a radically simpler alternative to the existing Azure Storage backend. Team members configure a single endpoint URL and data uploads automatically via their existing GitHub session — no Azure account, no API keys, no extra consent.

---

## Problem

The current Azure Storage backend requires each user to:
- Have/create an Azure account
- Configure RBAC roles (Storage Table Data Contributor, etc.)
- Manage Entra ID credentials or rotate shared keys
- Know their storage account name, table name, and dataset ID

This is a high barrier that prevents casual adoption.

---

## Solution: Three-phase implementation

### Phase 1 — Sharing Server (`sharing-server/`)

A new Node.js/Hono sub-project deployable in one `docker compose up`:

- **Auth**: Extension sends `Authorization: Bearer <github-token>`. Server validates via `GET https://api.github.com/user` (positive cache 10 min, negative cache 1 min to prevent API spam).
- **Storage**: `node:sqlite` (built-in since Node 22.5.0 — no native compilation needed, tiny Docker image).
- **Rate limiting**: Per-IP 200 req/min (before auth), per-user 100 uploads/hr.
- **Dashboard**: Server-rendered HTML with GitHub OAuth login (separate browser flow).
- **CSRF protection**: State cookie on OAuth flow.
- **XSS prevention**: `h()` escaping function in dashboard HTML.
- **Org gating**: Optional `ALLOWED_GITHUB_ORG` env var.
- **Docker**: Multi-stage `node:24-slim` image, no `node_modules` in runtime (pure esbuild bundle).

### Phase 2 — VS Code Extension Integration

- `BackendType` gains `'sharingServer'`
- New setting: `copilotTokenTracker.backend.sharingServer.endpointUrl`
- `isBackendConfigured()` handles the new type (returns true when URL is set)
- New `SharingServerUploadService` sends batched rollup entries as Bearer-authed POST
- `SyncService` branches on `settings.backend === 'sharingServer'` before any Azure code — entirely independent path
- `getGithubToken` callback threads the existing `this.githubSession.accessToken` through to the sync service (same session already held by the extension for PR stats — **no new consent**)

### Phase 3 — Documentation

- `sharing-server/README.md`: full self-hosting guide (Docker Compose quickstart, env vars, REST API, rate limits, security, privacy, schema, backup)
- `README.md`: new "Self-Hosted Sharing Server" section with minimal setup snippet

---

## User experience

**Server operator** (one-time setup):
1. Create a GitHub OAuth App
2. `docker compose up -d` with 4 env vars

**Team members** (one-time config):
```json
{
  "copilotTokenTracker.backend.enabled": true,
  "copilotTokenTracker.backend.backend": "sharingServer",
  "copilotTokenTracker.backend.sharingServer.endpointUrl": "https://copilot.example.com"
}
```

That's it. Authentication is fully transparent — no prompts, no API keys, no Azure.

---

## Technical notes

- `node:sqlite` is stable (no flag needed) in Node 23.4+ and Node 24 LTS — the Dockerfile uses `node:24-slim`
- All existing Azure Storage functionality is unchanged
- The sharing server sync path completely bypasses Azure credential/table setup
- Upload payload is idempotent: upserts by `(user_id, dataset_id, day, model, workspace_id, machine_id)`
- Privacy: sharing server is identified mode only (linked to GitHub user ID). Workspace/machine names respect `shareWorkspaceMachineNames` setting.