### PR TITLE
fix: rename VS Code command IDs to aiEngineeringFluency.*

### DIFF
--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -39,7 +39,7 @@ The entire extension's logic is contained within the `CopilotTokenTracker` class
 
 - **UI Components**:
   1. **Status Bar**: A `vscode.StatusBarItem` (`statusBarItem`) shows a brief summary. Its tooltip provides more detail.
-  2. **Details Panel**: The `copilot-token-tracker.showDetails` command opens a `vscode.WebviewPanel`. The content for this panel is generated dynamically as an HTML string by the `getDetailsHtml` method.
+  2. **Details Panel**: The `aiEngineeringFluency.showDetails` command opens a `vscode.WebviewPanel`. The content for this panel is generated dynamically as an HTML string by the `getDetailsHtml` method.
 
 ## Developer Workflow
 

--- a/docs/FLUENCY-LEVEL-VIEWER-TEST-PLAN.md
+++ b/docs/FLUENCY-LEVEL-VIEWER-TEST-PLAN.md
@@ -250,7 +250,7 @@
 
 ### Test Steps
 1. Run in console: `await vscode.commands.getCommands(true)`
-2. **Verify**: List includes `copilot-token-tracker.showFluencyLevelViewer`
+2. **Verify**: List includes `aiEngineeringFluency.showFluencyLevelViewer`
 3. Check package.json
 4. **Verify**: Command is listed in contributes.commands
 5. Run automated test: `npm test`

--- a/docs/specs/backend.md
+++ b/docs/specs/backend.md
@@ -416,18 +416,18 @@ All settings in VS Code user settings (global scope, Settings Sync compatible):
 ### Commands
 
 #### Core Commands
-- `copilot-token-tracker.configureBackend` - Guided setup wizard
-- `copilot-token-tracker.copyBackendConfig` - Copy config (secrets redacted)
-- `copilot-token-tracker.exportCurrentView` - Export filtered view as JSON
-- `copilot-token-tracker.setSharingProfile` - Change sharing profile
+- `` - Guided setup wizard
+- `` - Copy config (secrets redacted)
+- `` - Export filtered view as JSON
+- `` - Change sharing profile
 
 #### Shared Key Management (advanced)
-- `copilot-token-tracker.setBackendSharedKey` - Set/update key
-- `copilot-token-tracker.rotateBackendSharedKey` - Rotate key
-- `copilot-token-tracker.clearBackendSharedKey` - Clear key
+- `` - Set/update key
+- `` - Rotate key
+- `` - Clear key
 
 #### Data Management
-- `copilot-token-tracker.deleteMyData` - Delete all user data from dataset (GDPR right to erasure)
+- `aiEngineeringFluency.deleteMyData` - Delete all user data from dataset (GDPR right to erasure)
 
 ---
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -142,12 +142,14 @@
         "copilotTokenTracker.display.compactNumbers": {
           "type": "boolean",
           "default": true,
-          "description": "Show token counts in compact format using K/M suffixes (e.g. 1.5K, 1.2M). When disabled, full numbers are shown (e.g. 1,500, 1,200,000)."
+          "description": "Show token counts in compact format using K/M suffixes (e.g. 1.5K, 1.2M). When disabled, full numbers are shown (e.g. 1,500, 1,200,000).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.display.compactNumbers. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable backend sync to an Azure-backed store (default: Azure Storage Tables)."
+          "description": "Enable backend sync to an Azure-backed store (default: Azure Storage Tables).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.enabled. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.backend": {
           "type": "string",
@@ -155,7 +157,8 @@
             "storageTables"
           ],
           "default": "storageTables",
-          "description": "Backend sync backend. MVP supports Azure Storage Tables."
+          "description": "Backend sync backend. MVP supports Azure Storage Tables.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.backend. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.authMode": {
           "type": "string",
@@ -164,12 +167,14 @@
             "sharedKey"
           ],
           "default": "entraId",
-          "description": "Authentication mode for backend sync data-plane access. Default is Entra ID RBAC (DefaultAzureCredential). Shared Key uses VS Code SecretStorage and does not sync across devices."
+          "description": "Authentication mode for backend sync data-plane access. Default is Entra ID RBAC (DefaultAzureCredential). Shared Key uses VS Code SecretStorage and does not sync across devices.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.authMode. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.datasetId": {
           "type": "string",
           "default": "default",
-          "description": "Logical dataset identifier to avoid accidental mixing when sharing a backend."
+          "description": "Logical dataset identifier to avoid accidental mixing when sharing a backend.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.datasetId. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.sharingProfile": {
           "type": "string",
@@ -181,27 +186,32 @@
             "teamIdentified"
           ],
           "default": "off",
-          "description": "Sharing Profile (single source of truth): off (no cloud sync), soloFull (personal full fidelity), teamAnonymized (no per-user key), teamPseudonymous (stable per-user key), teamIdentified (explicit identity)."
+          "description": "Sharing Profile (single source of truth): off (no cloud sync), soloFull (personal full fidelity), teamAnonymized (no per-user key), teamPseudonymous (stable per-user key), teamIdentified (explicit identity).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.sharingProfile. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.userId": {
           "type": "string",
           "default": "",
-          "description": "Optional user identifier to enable team-wide reporting with per-user filtering. Empty disables the user dimension."
+          "description": "Optional user identifier to enable team-wide reporting with per-user filtering. Empty disables the user dimension.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.userId. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.shareWithTeam": {
           "type": "boolean",
           "default": false,
-          "description": "Explicit consent flag. When false, no per-user identifier is written to the backend store."
+          "description": "Explicit consent flag. When false, no per-user identifier is written to the backend store.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.shareWithTeam. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.shareWorkspaceMachineNames": {
           "type": "boolean",
           "default": false,
-          "description": "When team sharing is enabled, also write workspace and machine display names to the backend store (may contain sensitive information)."
+          "description": "When team sharing is enabled, also write workspace and machine display names to the backend store (may contain sensitive information).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.shareWorkspaceMachineNames. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.shareConsentAt": {
           "type": "string",
           "default": "",
-          "description": "ISO timestamp when team sharing was enabled (consent recorded)."
+          "description": "ISO timestamp when team sharing was enabled (consent recorded).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.shareConsentAt. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.userIdentityMode": {
           "type": "string",
@@ -211,7 +221,8 @@
             "entraObjectId"
           ],
           "default": "pseudonymous",
-          "description": "How the per-user dimension is derived when team sharing is enabled. pseudonymous hashes Entra claims scoped to datasetId; teamAlias uses backend.userId (validated); entraObjectId stores a GUID (advanced)."
+          "description": "How the per-user dimension is derived when team sharing is enabled. pseudonymous hashes Entra claims scoped to datasetId; teamAlias uses backend.userId (validated); entraObjectId stores a GUID (advanced).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.userIdentityMode. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.userIdMode": {
           "type": "string",
@@ -220,73 +231,242 @@
             "custom"
           ],
           "default": "alias",
-          "description": "How the user identifier is intended to be used. 'alias' is recommended; 'custom' may contain personal data (PII)."
+          "description": "How the user identifier is intended to be used. 'alias' is recommended; 'custom' may contain personal data (PII).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.userIdMode. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.subscriptionId": {
           "type": "string",
           "default": "",
-          "description": "Azure subscription ID used for provisioning (wizard-managed)."
+          "description": "Azure subscription ID used for provisioning (wizard-managed).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.subscriptionId. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.resourceGroup": {
           "type": "string",
           "default": "",
-          "description": "Azure resource group name for the Storage account (wizard-managed)."
+          "description": "Azure resource group name for the Storage account (wizard-managed).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.resourceGroup. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.storageAccount": {
           "type": "string",
           "default": "",
-          "description": "Azure Storage account name for backend sync (wizard-managed)."
+          "description": "Azure Storage account name for backend sync (wizard-managed).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.storageAccount. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.aggTable": {
           "type": "string",
           "default": "usageAggDaily",
-          "description": "Azure Table name for daily rollups."
+          "description": "Azure Table name for daily rollups.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.aggTable. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.eventsTable": {
           "type": "string",
           "default": "usageEvents",
-          "description": "Azure Table name for optional raw events (not required for MVP reporting)."
+          "description": "Azure Table name for optional raw events (not required for MVP reporting).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.eventsTable. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.lookbackDays": {
           "type": "number",
           "default": 30,
           "minimum": 1,
           "maximum": 90,
-          "description": "Default backfill/lookback window (days) for syncing local usage to the backend store."
+          "description": "Default backfill/lookback window (days) for syncing local usage to the backend store.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.lookbackDays. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.includeMachineBreakdown": {
           "type": "boolean",
           "default": false,
-          "description": "Include machine dimension in backend rollups. Recommended for correct cross-device convergence."
+          "description": "Include machine dimension in backend rollups. Recommended for correct cross-device convergence.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.includeMachineBreakdown. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.blobUploadEnabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable uploading session log files to Azure Blob Storage. Files are uploaded with configurable frequency and can be used by GitHub Copilot Coding Agent."
+          "description": "Enable uploading session log files to Azure Blob Storage. Files are uploaded with configurable frequency and can be used by GitHub Copilot Coding Agent.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.blobUploadEnabled. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.blobContainerName": {
           "type": "string",
           "default": "copilot-session-logs",
-          "description": "Name of the Azure Blob Storage container for session log files."
+          "description": "Name of the Azure Blob Storage container for session log files.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.blobContainerName. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.blobUploadFrequencyHours": {
           "type": "number",
           "default": 24,
           "minimum": 1,
           "maximum": 168,
-          "description": "How often to upload session log files to blob storage (in hours). Default is once per day (24 hours)."
+          "description": "How often to upload session log files to blob storage (in hours). Default is once per day (24 hours).",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.blobUploadFrequencyHours. Will be removed in a future release."
         },
         "copilotTokenTracker.backend.blobCompressFiles": {
           "type": "boolean",
           "default": true,
-          "description": "Compress session log files with gzip before uploading to blob storage to reduce storage costs and bandwidth."
+          "description": "Compress session log files with gzip before uploading to blob storage to reduce storage costs and bandwidth.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.backend.blobCompressFiles. Will be removed in a future release."
         },
         "copilotTokenTracker.sampleDataDirectory": {
           "type": "string",
           "default": "",
-          "description": "Screenshot/demo mode: when set to a folder path, overrides all session file scanning and returns only .json/.jsonl files from this directory. Leave empty for normal operation."
+          "description": "Screenshot/demo mode: when set to a folder path, overrides all session file scanning and returns only .json/.jsonl files from this directory. Leave empty for normal operation.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.sampleDataDirectory. Will be removed in a future release."
         },
         "copilotTokenTracker.suppressedUnknownTools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "List of tool names to suppress from the 'Unknown Tools Found' section in the Usage Analysis dashboard. Useful for tools you are testing that don't yet have friendly display names.",
+          "deprecationMessage": "Renamed to aiEngineeringFluency.suppressedUnknownTools. Will be removed in a future release."
+        },
+        "aiEngineeringFluency.display.compactNumbers": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show token counts in compact format using K/M suffixes (e.g. 1.5K, 1.2M). When disabled, full numbers are shown (e.g. 1,500, 1,200,000)."
+        },
+        "aiEngineeringFluency.backend.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable backend sync to an Azure-backed store (default: Azure Storage Tables)."
+        },
+        "aiEngineeringFluency.backend.backend": {
+          "type": "string",
+          "enum": [
+            "storageTables"
+          ],
+          "default": "storageTables",
+          "description": "Backend sync backend. MVP supports Azure Storage Tables."
+        },
+        "aiEngineeringFluency.backend.authMode": {
+          "type": "string",
+          "enum": [
+            "entraId",
+            "sharedKey"
+          ],
+          "default": "entraId",
+          "description": "Authentication mode for backend sync data-plane access. Default is Entra ID RBAC (DefaultAzureCredential). Shared Key uses VS Code SecretStorage and does not sync across devices."
+        },
+        "aiEngineeringFluency.backend.datasetId": {
+          "type": "string",
+          "default": "default",
+          "description": "Logical dataset identifier to avoid accidental mixing when sharing a backend."
+        },
+        "aiEngineeringFluency.backend.sharingProfile": {
+          "type": "string",
+          "enum": [
+            "off",
+            "soloFull",
+            "teamAnonymized",
+            "teamPseudonymous",
+            "teamIdentified"
+          ],
+          "default": "off",
+          "description": "Sharing Profile (single source of truth): off (no cloud sync), soloFull (personal full fidelity), teamAnonymized (no per-user key), teamPseudonymous (stable per-user key), teamIdentified (explicit identity)."
+        },
+        "aiEngineeringFluency.backend.userId": {
+          "type": "string",
+          "default": "",
+          "description": "Optional user identifier to enable team-wide reporting with per-user filtering. Empty disables the user dimension."
+        },
+        "aiEngineeringFluency.backend.shareWithTeam": {
+          "type": "boolean",
+          "default": false,
+          "description": "Explicit consent flag. When false, no per-user identifier is written to the backend store."
+        },
+        "aiEngineeringFluency.backend.shareWorkspaceMachineNames": {
+          "type": "boolean",
+          "default": false,
+          "description": "When team sharing is enabled, also write workspace and machine display names to the backend store (may contain sensitive information)."
+        },
+        "aiEngineeringFluency.backend.shareConsentAt": {
+          "type": "string",
+          "default": "",
+          "description": "ISO timestamp when team sharing was enabled (consent recorded)."
+        },
+        "aiEngineeringFluency.backend.userIdentityMode": {
+          "type": "string",
+          "enum": [
+            "pseudonymous",
+            "teamAlias",
+            "entraObjectId"
+          ],
+          "default": "pseudonymous",
+          "description": "How the per-user dimension is derived when team sharing is enabled. pseudonymous hashes Entra claims scoped to datasetId; teamAlias uses backend.userId (validated); entraObjectId stores a GUID (advanced)."
+        },
+        "aiEngineeringFluency.backend.userIdMode": {
+          "type": "string",
+          "enum": [
+            "alias",
+            "custom"
+          ],
+          "default": "alias",
+          "description": "How the user identifier is intended to be used. 'alias' is recommended; 'custom' may contain personal data (PII)."
+        },
+        "aiEngineeringFluency.backend.subscriptionId": {
+          "type": "string",
+          "default": "",
+          "description": "Azure subscription ID used for provisioning (wizard-managed)."
+        },
+        "aiEngineeringFluency.backend.resourceGroup": {
+          "type": "string",
+          "default": "",
+          "description": "Azure resource group name for the Storage account (wizard-managed)."
+        },
+        "aiEngineeringFluency.backend.storageAccount": {
+          "type": "string",
+          "default": "",
+          "description": "Azure Storage account name for backend sync (wizard-managed)."
+        },
+        "aiEngineeringFluency.backend.aggTable": {
+          "type": "string",
+          "default": "usageAggDaily",
+          "description": "Azure Table name for daily rollups."
+        },
+        "aiEngineeringFluency.backend.eventsTable": {
+          "type": "string",
+          "default": "usageEvents",
+          "description": "Azure Table name for optional raw events (not required for MVP reporting)."
+        },
+        "aiEngineeringFluency.backend.lookbackDays": {
+          "type": "number",
+          "default": 30,
+          "minimum": 1,
+          "maximum": 90,
+          "description": "Default backfill/lookback window (days) for syncing local usage to the backend store."
+        },
+        "aiEngineeringFluency.backend.includeMachineBreakdown": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include machine dimension in backend rollups. Recommended for correct cross-device convergence."
+        },
+        "aiEngineeringFluency.backend.blobUploadEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable uploading session log files to Azure Blob Storage. Files are uploaded with configurable frequency and can be used by GitHub Copilot Coding Agent."
+        },
+        "aiEngineeringFluency.backend.blobContainerName": {
+          "type": "string",
+          "default": "copilot-session-logs",
+          "description": "Name of the Azure Blob Storage container for session log files."
+        },
+        "aiEngineeringFluency.backend.blobUploadFrequencyHours": {
+          "type": "number",
+          "default": 24,
+          "minimum": 1,
+          "maximum": 168,
+          "description": "How often to upload session log files to blob storage (in hours). Default is once per day (24 hours)."
+        },
+        "aiEngineeringFluency.backend.blobCompressFiles": {
+          "type": "boolean",
+          "default": true,
+          "description": "Compress session log files with gzip before uploading to blob storage to reduce storage costs and bandwidth."
+        },
+        "aiEngineeringFluency.sampleDataDirectory": {
+          "type": "string",
+          "default": "",
+          "description": "Screenshot/demo mode: when set to a folder path, overrides all session file scanning and returns only .json/.jsonl files from this directory. Leave empty for normal operation."
+        },
+        "aiEngineeringFluency.suppressedUnknownTools": {
           "type": "array",
           "items": {
             "type": "string"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -26,112 +26,112 @@
   "contributes": {
     "commands": [
       {
-        "command": "copilot-token-tracker.refresh",
+        "command": "aiEngineeringFluency.refresh",
         "title": "Refresh Token Usage",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showDetails",
+        "command": "aiEngineeringFluency.showDetails",
         "title": "Show Token Usage Details",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showChart",
+        "command": "aiEngineeringFluency.showChart",
         "title": "Show Token Usage Chart",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showUsageAnalysis",
+        "command": "aiEngineeringFluency.showUsageAnalysis",
         "title": "Show Usage Analysis Dashboard",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.generateDiagnosticReport",
+        "command": "aiEngineeringFluency.generateDiagnosticReport",
         "title": "Generate Diagnostic Report",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showMaturity",
+        "command": "aiEngineeringFluency.showMaturity",
         "title": "Show AI Engineering Fluency Score",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showFluencyLevelViewer",
+        "command": "aiEngineeringFluency.showFluencyLevelViewer",
         "title": "Show Fluency Level Viewer (Debug Only)",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.runLocalViewRegression",
+        "command": "aiEngineeringFluency.runLocalViewRegression",
         "title": "Run Local View Regression (Debug Only)",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.configureBackend",
+        "command": "aiEngineeringFluency.configureBackend",
         "title": "Configure Backend",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.copyBackendConfig",
+        "command": "aiEngineeringFluency.copyBackendConfig",
         "title": "Copy Backend Config (No Secrets)",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.exportCurrentView",
+        "command": "aiEngineeringFluency.exportCurrentView",
         "title": "Export Current View (JSON)",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.setBackendSharedKey",
+        "command": "aiEngineeringFluency.setBackendSharedKey",
         "title": "Set Backend Storage Shared Key",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.rotateBackendSharedKey",
+        "command": "aiEngineeringFluency.rotateBackendSharedKey",
         "title": "Rotate Backend Storage Shared Key",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.clearBackendSharedKey",
+        "command": "aiEngineeringFluency.clearBackendSharedKey",
         "title": "Clear Backend Storage Shared Key",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.toggleBackendWorkspaceMachineNameSync",
+        "command": "aiEngineeringFluency.toggleBackendWorkspaceMachineNameSync",
         "title": "Backend: Toggle Workspace/Machine Name Sync",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.setSharingProfile",
+        "command": "aiEngineeringFluency.setSharingProfile",
         "title": "Set Sharing Profile",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.clearAzureSettings",
+        "command": "aiEngineeringFluency.clearAzureSettings",
         "title": "Clear Azure Settings",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.clearCache",
+        "command": "aiEngineeringFluency.clearCache",
         "title": "Clear Cache",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showDashboard",
+        "command": "aiEngineeringFluency.showDashboard",
         "title": "Show Team Dashboard",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.showEnvironmental",
+        "command": "aiEngineeringFluency.showEnvironmental",
         "title": "Show Environmental Impact",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.authenticateGitHub",
+        "command": "aiEngineeringFluency.authenticateGitHub",
         "title": "Authenticate with GitHub",
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "copilot-token-tracker.signOutGitHub",
+        "command": "aiEngineeringFluency.signOutGitHub",
         "title": "Disconnect GitHub",
         "category": "AI Engineering Fluency"
       }
@@ -281,7 +281,7 @@
           "default": true,
           "description": "Compress session log files with gzip before uploading to blob storage to reduce storage costs and bandwidth."
         },
-        "copilot-token-tracker.sampleDataDirectory": {
+        "copilotTokenTracker.sampleDataDirectory": {
           "type": "string",
           "default": "",
           "description": "Screenshot/demo mode: when set to a folder path, overrides all session file scanning and returns only .json/.jsonl files from this directory. Leave empty for normal operation."

--- a/vscode-extension/src/backend/commands.ts
+++ b/vscode-extension/src/backend/commands.ts
@@ -259,7 +259,7 @@ export class BackendCommandHandler {
 	 * Handles enabling team sharing (consent gate).
 	 */
 	async handleEnableTeamSharing(): Promise<void> {
-		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 		const conf = ConfirmationMessages.enableTeamSharing();
 		const consent = await vscode.window.showWarningMessage(
 			conf.message,
@@ -296,7 +296,7 @@ export class BackendCommandHandler {
 			return;
 		}
 
-		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 		try {
 			await config.update('backend.sharingProfile', 'teamAnonymized', vscode.ConfigurationTarget.Global);
 			await config.update('backend.shareWithTeam', false, vscode.ConfigurationTarget.Global);

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -580,7 +580,7 @@ export class BackendFacade {
   }
 
   public async toggleBackendWorkspaceMachineNameSync(): Promise<void> {
-    const config = vscode.workspace.getConfiguration("copilotTokenTracker");
+    const config = vscode.workspace.getConfiguration("aiEngineeringFluency");
     const current = config.get<boolean>(
       "backend.shareWorkspaceMachineNames",
       false,
@@ -637,7 +637,7 @@ export class BackendFacade {
         "Extension context is unavailable; cannot update configuration.",
       );
     }
-    const config = vscode.workspace.getConfiguration("copilotTokenTracker");
+    const config = vscode.workspace.getConfiguration("aiEngineeringFluency");
     await Promise.all([
       config.update(
         "backend.enabled",
@@ -1030,7 +1030,7 @@ export class BackendFacade {
       }
     }
 
-    const config = vscode.workspace.getConfiguration("copilotTokenTracker");
+    const config = vscode.workspace.getConfiguration("aiEngineeringFluency");
     await Promise.all([
       config.update(
         "backend.enabled",

--- a/vscode-extension/src/backend/services/azureResourceService.ts
+++ b/vscode-extension/src/backend/services/azureResourceService.ts
@@ -37,7 +37,7 @@ export class AzureResourceService {
 	 * Configure backend wizard (MVP: Storage Tables only).
 	 */
 	async configureBackendWizard(): Promise<void> {
-		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 		const credential = this.credentialService.createAzureCredential();
 
 		// Sanity check that we can get a token (common failure is "not logged in")
@@ -495,7 +495,7 @@ export class AzureResourceService {
 	 * Set sharing profile command.
 	 */
 	async setSharingProfileCommand(): Promise<void> {
-		const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 		const currentSettings = this.deps.getSettings();
 		const currentProfile = currentSettings.sharingProfile;
 

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -235,7 +235,7 @@ export class SyncService {
 							'Configure Backend'
 						).then(choice => {
 							if (choice === 'Configure Backend') {
-								vscode.commands.executeCommand('copilotTokenTracker.configureBackend');
+								vscode.commands.executeCommand('aiEngineeringFluency.configureBackend');
 							}
 						});
 						this.stopTimer();

--- a/vscode-extension/src/backend/settings.ts
+++ b/vscode-extension/src/backend/settings.ts
@@ -54,7 +54,7 @@ export interface BackendQueryFilters {
 }
 
 export function getBackendSettings(): BackendSettings {
-	const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+	const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 	const sharingProfileInspect = typeof (config as any).inspect === 'function'
 		? config.inspect<string>('backend.sharingProfile')
 		: undefined;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -905,14 +905,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		// Create status bar item
 		this.statusBarItem = vscode.window.createStatusBarItem(
-			'copilot-token-tracker',
+			'ai-engineering-fluency',
 			vscode.StatusBarAlignment.Right,
 			100
 		);
 		this.statusBarItem.name = "AI Engineering Fluency";
 		this.setStatusBarText("$(loading~spin) AI Fluency: Loading...");
 		this.statusBarItem.tooltip = "AI Engineering Fluency — daily and 30-day token usage - Click to open details";
-		this.statusBarItem.command = 'copilot-token-tracker.showDetails';
+		this.statusBarItem.command = 'aiEngineeringFluency.showDetails';
 		this.statusBarItem.show();
 
 		this.log('Status bar item created and shown');
@@ -7416,7 +7416,7 @@ ${hashtag}`;
             // Execute the configureBackend command if it exists
             try {
               await vscode.commands.executeCommand(
-                "copilot-token-tracker.configureBackend",
+                "aiEngineeringFluency.configureBackend",
               );
             } catch (err) {
               // If command is not registered, show settings
@@ -8406,7 +8406,7 @@ export function activate(context: vscode.ExtensionContext) {
     // (see startBackendSyncAfterInitialAnalysis method)
 
     const configureBackendCommand = vscode.commands.registerCommand(
-      "copilot-token-tracker.configureBackend",
+      "aiEngineeringFluency.configureBackend",
       async () => {
         await backendHandler.handleConfigureBackend();
       },
@@ -8422,7 +8422,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the refresh command
   const refreshCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.refresh",
+    "aiEngineeringFluency.refresh",
     async () => {
       tokenTracker.log("Refresh command called");
       await tokenTracker.updateTokenStats();
@@ -8432,7 +8432,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the show details command
   const showDetailsCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showDetails",
+    "aiEngineeringFluency.showDetails",
     async () => {
       tokenTracker.log("Show details command called");
       await tokenTracker.showDetails();
@@ -8441,7 +8441,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the show chart command
   const showChartCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showChart",
+    "aiEngineeringFluency.showChart",
     async () => {
       tokenTracker.log("Show chart command called");
       await tokenTracker.showChart();
@@ -8450,7 +8450,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the show usage analysis command
   const showUsageAnalysisCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showUsageAnalysis",
+    "aiEngineeringFluency.showUsageAnalysis",
     async () => {
       tokenTracker.log("Show usage analysis command called");
       await tokenTracker.showUsageAnalysis();
@@ -8459,7 +8459,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the show maturity / fluency score command
   const showMaturityCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showMaturity",
+    "aiEngineeringFluency.showMaturity",
     async () => {
       tokenTracker.log("Show maturity command called");
       await tokenTracker.showMaturity();
@@ -8468,7 +8468,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the show dashboard command
   const showDashboardCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showDashboard",
+    "aiEngineeringFluency.showDashboard",
     async () => {
       tokenTracker.log("Show dashboard command called");
       await tokenTracker.showDashboard();
@@ -8476,7 +8476,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   const showEnvironmentalCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showEnvironmental",
+    "aiEngineeringFluency.showEnvironmental",
     async () => {
       tokenTracker.log("Show environmental impact command called");
       await tokenTracker.showEnvironmental();
@@ -8485,7 +8485,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the show fluency level viewer command (debug-only)
   const showFluencyLevelViewerCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.showFluencyLevelViewer",
+    "aiEngineeringFluency.showFluencyLevelViewer",
     async () => {
       tokenTracker.log("Show fluency level viewer command called");
       await tokenTracker.showFluencyLevelViewer();
@@ -8493,7 +8493,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   const runLocalViewRegressionCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.runLocalViewRegression",
+    "aiEngineeringFluency.runLocalViewRegression",
     async () => {
       tokenTracker.log("Run local view regression command called");
       await tokenTracker.runLocalViewRegression();
@@ -8502,7 +8502,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the generate diagnostic report command
   const generateDiagnosticReportCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.generateDiagnosticReport",
+    "aiEngineeringFluency.generateDiagnosticReport",
     async () => {
       tokenTracker.log("Generate diagnostic report command called");
       await tokenTracker.showDiagnosticReport();
@@ -8511,7 +8511,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the clear cache command
   const clearCacheCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.clearCache",
+    "aiEngineeringFluency.clearCache",
     async () => {
       tokenTracker.log("Clear cache command called");
       await tokenTracker.clearCache();
@@ -8520,7 +8520,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the GitHub authentication command
   const authenticateGitHubCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.authenticateGitHub",
+    "aiEngineeringFluency.authenticateGitHub",
     async () => {
       tokenTracker.log("GitHub authentication command called");
       await tokenTracker.authenticateWithGitHub();
@@ -8529,7 +8529,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register the GitHub sign out command
   const signOutGitHubCommand = vscode.commands.registerCommand(
-    "copilot-token-tracker.signOutGitHub",
+    "aiEngineeringFluency.signOutGitHub",
     async () => {
       tokenTracker.log("GitHub sign out command called");
       await tokenTracker.signOutFromGitHub();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -920,7 +920,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Re-render open panels when display settings change
 		context.subscriptions.push(
 			vscode.workspace.onDidChangeConfiguration(e => {
-				if (e.affectsConfiguration('copilotTokenTracker.display')) {
+				if (e.affectsConfiguration('aiEngineeringFluency.display')) {
 					this.refreshOpenPanelsForSettingChange();
 				}
 			})
@@ -1828,7 +1828,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private getCompactNumbersSetting(): boolean {
-		return vscode.workspace.getConfiguration('copilotTokenTracker').get<boolean>('display.compactNumbers', true);
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('display.compactNumbers', true);
 	}
 
 	private refreshOpenPanelsForSettingChange(): void {
@@ -4839,7 +4839,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				case 'suppressUnknownTool': {
 					const toolName = message.toolName as string;
 					if (toolName) {
-						const config = vscode.workspace.getConfiguration('copilotTokenTracker');
+						const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 						const current = config.get<string[]>('suppressedUnknownTools', []);
 						if (!current.includes(toolName)) {
 							await config.update('suppressedUnknownTools', [...current, toolName], vscode.ConfigurationTarget.Global);
@@ -7429,7 +7429,7 @@ ${hashtag}`;
                   if (choice === "Open Settings") {
                     vscode.commands.executeCommand(
                       "workbench.action.openSettings",
-                      "copilotTokenTracker.backend",
+                      "aiEngineeringFluency.backend",
                     );
                   }
                 });
@@ -7440,7 +7440,7 @@ ${hashtag}`;
           await this.dispatch('openSettings:diagnostics', () =>
             vscode.commands.executeCommand(
               "workbench.action.openSettings",
-              "copilotTokenTracker.backend",
+              "aiEngineeringFluency.backend",
             )
           );
           break;
@@ -7448,7 +7448,7 @@ ${hashtag}`;
           await this.dispatch('openDisplaySettings:diagnostics', () =>
             vscode.commands.executeCommand(
               "workbench.action.openSettings",
-              "copilotTokenTracker.display",
+              "aiEngineeringFluency.display",
             )
           );
           break;
@@ -7775,7 +7775,7 @@ ${hashtag}`;
    * Get backend storage information for diagnostics
    */
   private async getBackendStorageInfo(): Promise<any> {
-    const config = vscode.workspace.getConfiguration("copilotTokenTracker");
+    const config = vscode.workspace.getConfiguration("aiEngineeringFluency");
     const enabled = config.get<boolean>("backend.enabled", false);
     const storageAccount = config.get<string>("backend.storageAccount", "");
     const subscriptionId = config.get<string>("backend.subscriptionId", "");
@@ -8266,7 +8266,7 @@ ${hashtag}`;
     );
 
     const suppressedUnknownTools = vscode.workspace
-      .getConfiguration('copilotTokenTracker')
+      .getConfiguration('aiEngineeringFluency')
       .get<string[]>('suppressedUnknownTools', []);
 
     const initialData = stats ? JSON.stringify({
@@ -8334,9 +8334,71 @@ ${hashtag}`;
   }
 }
 
-export function activate(context: vscode.ExtensionContext) {
+/**
+ * One-time migration: copies any user-set values from the old `copilotTokenTracker.*` namespace
+ * to the new `aiEngineeringFluency.*` namespace.  The old settings remain in package.json
+ * with `deprecationMessage` so VS Code continues to show them as deprecated; this function
+ * handles users who already had values configured before the rename.
+ *
+ * Leave this migration in place for a couple of extension versions before removing it.
+ */
+async function migrateSettingsIfNeeded(log: (m: string) => void): Promise<void> {
+  const keys = [
+    'display.compactNumbers',
+    'backend.enabled',
+    'backend.backend',
+    'backend.authMode',
+    'backend.datasetId',
+    'backend.sharingProfile',
+    'backend.userId',
+    'backend.shareWithTeam',
+    'backend.shareWorkspaceMachineNames',
+    'backend.shareConsentAt',
+    'backend.userIdentityMode',
+    'backend.userIdMode',
+    'backend.subscriptionId',
+    'backend.resourceGroup',
+    'backend.storageAccount',
+    'backend.aggTable',
+    'backend.eventsTable',
+    'backend.lookbackDays',
+    'backend.includeMachineBreakdown',
+    'backend.blobUploadEnabled',
+    'backend.blobContainerName',
+    'backend.blobUploadFrequencyHours',
+    'backend.blobCompressFiles',
+    'sampleDataDirectory',
+    'suppressedUnknownTools',
+  ];
+
+  const oldCfg = vscode.workspace.getConfiguration('copilotTokenTracker');
+  const newCfg = vscode.workspace.getConfiguration('aiEngineeringFluency');
+
+  let migrated = 0;
+  for (const key of keys) {
+    const insp = oldCfg.inspect(key);
+    if (insp?.globalValue !== undefined) {
+      await newCfg.update(key, insp.globalValue, vscode.ConfigurationTarget.Global);
+      migrated++;
+    }
+    if (insp?.workspaceValue !== undefined) {
+      await newCfg.update(key, insp.workspaceValue, vscode.ConfigurationTarget.Workspace);
+      migrated++;
+    }
+  }
+
+  if (migrated > 0) {
+    log(`Migrated ${migrated} setting(s) from 'copilotTokenTracker' to 'aiEngineeringFluency' namespace.`);
+  }
+}
+
+export async function activate(context: vscode.ExtensionContext) {
   // Create the token tracker
   const tokenTracker = new CopilotTokenTracker(context.extensionUri, context);
+
+  // Migrate settings from the old copilotTokenTracker namespace to aiEngineeringFluency.
+  // Run before any other settings are read so the new keys are populated first.
+  await migrateSettingsIfNeeded((m) => (tokenTracker as any).log(m));
 
   // Wire up backend facade and commands so the diagnostics webview can launch the
   // configuration wizard. Uses tokenTracker logging and helpers via casting to any.

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -246,7 +246,7 @@ export class SessionDiscovery {
 
 		// Screenshot/demo mode: if a sample data directory is configured, use it exclusively
 		const sampleDir = this.deps.sampleDataDirectoryOverride?.()
-			?? vscode.workspace.getConfiguration('copilot-token-tracker').get<string>('sampleDataDirectory');
+			?? vscode.workspace.getConfiguration('copilotTokenTracker').get<string>('sampleDataDirectory');
 		if (sampleDir && sampleDir.trim().length > 0) {
 			const resolvedSampleDir = sampleDir.trim();
 			try {

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -246,7 +246,7 @@ export class SessionDiscovery {
 
 		// Screenshot/demo mode: if a sample data directory is configured, use it exclusively
 		const sampleDir = this.deps.sampleDataDirectoryOverride?.()
-			?? vscode.workspace.getConfiguration('copilotTokenTracker').get<string>('sampleDataDirectory');
+			?? vscode.workspace.getConfiguration('aiEngineeringFluency').get<string>('sampleDataDirectory');
 		if (sampleDir && sampleDir.trim().length > 0) {
 			const resolvedSampleDir = sampleDir.trim();
 			try {

--- a/vscode-extension/test/integration/extension.test.ts
+++ b/vscode-extension/test/integration/extension.test.ts
@@ -27,13 +27,13 @@ suite('Extension Test Suite', () => {
 		const commands = await vscode.commands.getCommands(true);
 		
 		const expectedCommands = [
-			'copilot-token-tracker.refresh',
-			'copilot-token-tracker.showDetails',
-			'copilot-token-tracker.showChart',
-			'copilot-token-tracker.showMaturity',
-			'copilot-token-tracker.showFluencyLevelViewer',
-			'copilot-token-tracker.runLocalViewRegression',
-			'copilot-token-tracker.generateDiagnosticReport'
+			'aiEngineeringFluency.refresh',
+			'aiEngineeringFluency.showDetails',
+			'aiEngineeringFluency.showChart',
+			'aiEngineeringFluency.showMaturity',
+			'aiEngineeringFluency.showFluencyLevelViewer',
+			'aiEngineeringFluency.runLocalViewRegression',
+			'aiEngineeringFluency.generateDiagnosticReport'
 		];
 
 		for (const expectedCommand of expectedCommands) {

--- a/vscode-extension/test/unit/backend-facade-methods.test.ts
+++ b/vscode-extension/test/unit/backend-facade-methods.test.ts
@@ -209,7 +209,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('getConfigPanelState with sharedKey set returns sharedKeySet=true', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount', 'copilotTokenTracker.backend.authMode': 'sharedKey' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount', 'aiEngineeringFluency.backend.authMode': 'sharedKey' });
 		facade.credentialService.getStoredStorageSharedKey = async () => 'abc123';
 		const state = await facade.getConfigPanelState();
 		assert.equal(state.sharedKeySet, true);
@@ -218,7 +218,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('getConfigPanelState with entraId authMode shows Entra ID status', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.authMode': 'entraId' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.authMode': 'entraId' });
 		facade.credentialService.getStoredStorageSharedKey = async () => null;
 		const state = await facade.getConfigPanelState();
 		assert.ok(state.authStatus.includes('Entra ID'));
@@ -226,7 +226,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('getConfigPanelState with sharedKey authMode and no key shows missing', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.authMode': 'sharedKey', 'copilotTokenTracker.backend.storageAccount': 'acct' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.authMode': 'sharedKey', 'aiEngineeringFluency.backend.storageAccount': 'acct' });
 		facade.credentialService.getStoredStorageSharedKey = async () => null;
 		const state = await facade.getConfigPanelState();
 		assert.ok(state.authStatus.includes('missing'));
@@ -604,7 +604,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('clearBackendSharedKey with storageAccount confirms and clears', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		(vscode as any).__mock.setNextPick('Remove Key');
 		let cleared = false;
 		facade.credentialService.clearStoredStorageSharedKey = async () => { cleared = true; };
@@ -617,7 +617,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('clearBackendSharedKey cancelled by user does nothing', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		// No nextPick => user dismisses
 		let cleared = false;
 		facade.credentialService.clearStoredStorageSharedKey = async () => { cleared = true; };
@@ -627,7 +627,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('clearBackendSharedKey error path shows error message', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		(vscode as any).__mock.setNextPick('Remove Key');
 		facade.credentialService.clearStoredStorageSharedKey = async () => { throw new Error('boom'); };
 		await facade.clearBackendSharedKey();
@@ -638,7 +638,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('setBackendSharedKey with storageAccount prompts and stores key', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		// promptForAndStoreSharedKey calls showInputBox which returns undefined by default 
 		await facade.setBackendSharedKey();
 		// Since showInputBox returns undefined, no success message
@@ -647,7 +647,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('setBackendSharedKey error path shows error message', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		facade.promptForAndStoreSharedKey = async () => { throw new Error('fail!'); };
 		await facade.setBackendSharedKey();
 		assert.ok((vscode as any).__mock.state.lastErrorMessages.some(
@@ -657,7 +657,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('rotateBackendSharedKey error path shows error message', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		facade.promptForAndStoreSharedKey = async () => { throw new Error('rotation fail!'); };
 		await facade.rotateBackendSharedKey();
 		assert.ok((vscode as any).__mock.state.lastErrorMessages.some(
@@ -674,8 +674,8 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 		facade.dataPlaneService.listEntitiesForRange = async () => [{ model: 'gpt-4o', inputTokens: 50 }];
 		const settings = facade.getSettings();
 		(vscode as any).__mock.setConfig({
-			'copilotTokenTracker.backend.storageAccount': 'acct1',
-			'copilotTokenTracker.backend.aggTable': 'usageAggDaily',
+			'aiEngineeringFluency.backend.storageAccount': 'acct1',
+			'aiEngineeringFluency.backend.aggTable': 'usageAggDaily',
 		});
 		const result = await facade.getAggEntitiesForRange(facade.getSettings(), '2025-01-01', '2025-01-07');
 		assert.ok(Array.isArray(result));
@@ -702,8 +702,8 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 			return { deletedCount: 3, errors: [] };
 		};
 		(vscode as any).__mock.setConfig({
-			'copilotTokenTracker.backend.storageAccount': 'acct1',
-			'copilotTokenTracker.backend.aggTable': 'usageAggDaily',
+			'aiEngineeringFluency.backend.storageAccount': 'acct1',
+			'aiEngineeringFluency.backend.aggTable': 'usageAggDaily',
 		});
 		const result = await facade.deleteUserDataset('user1', 'ds1');
 		assert.ok(deleteCalled);
@@ -729,7 +729,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('setBackendSharedKey success shows info message', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		facade.promptForAndStoreSharedKey = async () => true;
 		await facade.setBackendSharedKey();
 		assert.ok((vscode as any).__mock.state.lastInfoMessages.some(
@@ -739,7 +739,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('rotateBackendSharedKey success shows info message', async () => {
 		const facade: any = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		facade.promptForAndStoreSharedKey = async () => true;
 		await facade.rotateBackendSharedKey();
 		assert.ok((vscode as any).__mock.state.lastInfoMessages.some(
@@ -749,7 +749,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 
 	test('toggleBackendWorkspaceMachineNameSync includes team sharing suffix', async () => {
 		const facade = createFacade();
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.shareWithTeam': true });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.shareWithTeam': true });
 		await facade.toggleBackendWorkspaceMachineNameSync();
 		// When shareWithTeam is true, the suffix about team sharing should NOT be appended
 		const msgs = (vscode as any).__mock.state.lastInfoMessages;
@@ -762,7 +762,7 @@ describe('BackendFacade private methods via casting', { concurrency: false }, ()
 		let clearedKey = false;
 		facade.credentialService.clearStoredStorageSharedKey = async () => { clearedKey = true; };
 		facade.credentialService.getStoredStorageSharedKey = async () => undefined;
-		(vscode as any).__mock.setConfig({ 'copilotTokenTracker.backend.storageAccount': 'myaccount' });
+		(vscode as any).__mock.setConfig({ 'aiEngineeringFluency.backend.storageAccount': 'myaccount' });
 		// Mock showWarningMessage to return "Clear Settings"
 		(vscode as any).__mock.setNextPick('Clear Settings');
 		const state = await facade.clearAzureSettings();

--- a/vscode-extension/test/unit/backend-settings.test.ts
+++ b/vscode-extension/test/unit/backend-settings.test.ts
@@ -18,23 +18,23 @@ test('shouldPromptToSetSharedKey gates on authMode/storageAccount/sharedKey pres
 test('getBackendSettings reads config defaults and clamps lookbackDays', () => {
 	(vscode as any).__mock.reset();
 	(vscode as any).__mock.setConfig({
-		'copilotTokenTracker.backend.enabled': true,
-		'copilotTokenTracker.backend.backend': 'storageTables',
-		'copilotTokenTracker.backend.authMode': 'entraId',
-		'copilotTokenTracker.backend.datasetId': '  myds  ',
-		'copilotTokenTracker.backend.shareWithTeam': false,
-		'copilotTokenTracker.backend.shareWorkspaceMachineNames': false,
-		'copilotTokenTracker.backend.shareConsentAt': '',
-		'copilotTokenTracker.backend.userIdentityMode': 'pseudonymous',
-		'copilotTokenTracker.backend.userId': '  ',
-		'copilotTokenTracker.backend.userIdMode': 'alias',
-		'copilotTokenTracker.backend.subscriptionId': 'sub',
-		'copilotTokenTracker.backend.resourceGroup': 'rg',
-		'copilotTokenTracker.backend.storageAccount': 'sa',
-		'copilotTokenTracker.backend.aggTable': 'agg',
-		'copilotTokenTracker.backend.eventsTable': 'events',
-		'copilotTokenTracker.backend.lookbackDays': 999,
-		'copilotTokenTracker.backend.includeMachineBreakdown': true
+		'aiEngineeringFluency.backend.enabled': true,
+		'aiEngineeringFluency.backend.backend': 'storageTables',
+		'aiEngineeringFluency.backend.authMode': 'entraId',
+		'aiEngineeringFluency.backend.datasetId': '  myds  ',
+		'aiEngineeringFluency.backend.shareWithTeam': false,
+		'aiEngineeringFluency.backend.shareWorkspaceMachineNames': false,
+		'aiEngineeringFluency.backend.shareConsentAt': '',
+		'aiEngineeringFluency.backend.userIdentityMode': 'pseudonymous',
+		'aiEngineeringFluency.backend.userId': '  ',
+		'aiEngineeringFluency.backend.userIdMode': 'alias',
+		'aiEngineeringFluency.backend.subscriptionId': 'sub',
+		'aiEngineeringFluency.backend.resourceGroup': 'rg',
+		'aiEngineeringFluency.backend.storageAccount': 'sa',
+		'aiEngineeringFluency.backend.aggTable': 'agg',
+		'aiEngineeringFluency.backend.eventsTable': 'events',
+		'aiEngineeringFluency.backend.lookbackDays': 999,
+		'aiEngineeringFluency.backend.includeMachineBreakdown': true
 	});
 
 	const s = getBackendSettings();
@@ -49,9 +49,9 @@ test('getBackendSettings reads config defaults and clamps lookbackDays', () => {
 test('getBackendSettings sharingProfile is off when backend disabled', () => {
 	(vscode as any).__mock.reset();
 	(vscode as any).__mock.setConfig({
-		'copilotTokenTracker.backend.enabled': false,
-		'copilotTokenTracker.backend.shareWithTeam': true,
-		'copilotTokenTracker.backend.userIdentityMode': 'alias',
+		'aiEngineeringFluency.backend.enabled': false,
+		'aiEngineeringFluency.backend.shareWithTeam': true,
+		'aiEngineeringFluency.backend.userIdentityMode': 'alias',
 	});
 	const s = getBackendSettings();
 	assert.equal(s.sharingProfile, 'off');
@@ -60,9 +60,9 @@ test('getBackendSettings sharingProfile is off when backend disabled', () => {
 test('getBackendSettings sharingProfile is teamIdentified when shareWithTeam and non-pseudonymous', () => {
 	(vscode as any).__mock.reset();
 	(vscode as any).__mock.setConfig({
-		'copilotTokenTracker.backend.enabled': true,
-		'copilotTokenTracker.backend.shareWithTeam': true,
-		'copilotTokenTracker.backend.userIdentityMode': 'alias',
+		'aiEngineeringFluency.backend.enabled': true,
+		'aiEngineeringFluency.backend.shareWithTeam': true,
+		'aiEngineeringFluency.backend.userIdentityMode': 'alias',
 	});
 	const s = getBackendSettings();
 	assert.equal(s.sharingProfile, 'teamIdentified');
@@ -71,9 +71,9 @@ test('getBackendSettings sharingProfile is teamIdentified when shareWithTeam and
 test('getBackendSettings sharingProfile is teamPseudonymous when shareWithTeam and pseudonymous', () => {
 	(vscode as any).__mock.reset();
 	(vscode as any).__mock.setConfig({
-		'copilotTokenTracker.backend.enabled': true,
-		'copilotTokenTracker.backend.shareWithTeam': true,
-		'copilotTokenTracker.backend.userIdentityMode': 'pseudonymous',
+		'aiEngineeringFluency.backend.enabled': true,
+		'aiEngineeringFluency.backend.shareWithTeam': true,
+		'aiEngineeringFluency.backend.userIdentityMode': 'pseudonymous',
 	});
 	const s = getBackendSettings();
 	assert.equal(s.sharingProfile, 'teamPseudonymous');
@@ -82,7 +82,7 @@ test('getBackendSettings sharingProfile is teamPseudonymous when shareWithTeam a
 test('getBackendSettings clamps lookbackDays to minimum', () => {
 	(vscode as any).__mock.reset();
 	(vscode as any).__mock.setConfig({
-		'copilotTokenTracker.backend.lookbackDays': 0,
+		'aiEngineeringFluency.backend.lookbackDays': 0,
 	});
 	const s = getBackendSettings();
 	assert.ok(s.lookbackDays >= 1);
@@ -91,7 +91,7 @@ test('getBackendSettings clamps lookbackDays to minimum', () => {
 test('getBackendSettings defaults empty datasetId to "default"', () => {
 	(vscode as any).__mock.reset();
 	(vscode as any).__mock.setConfig({
-		'copilotTokenTracker.backend.datasetId': '   ',
+		'aiEngineeringFluency.backend.datasetId': '   ',
 	});
 	const s = getBackendSettings();
 	assert.equal(s.datasetId, 'default');


### PR DESCRIPTION
## Problem

The VS Code command palette (and keyboard shortcuts editor) showed an inconsistent mix:
- Command **categories** showed `AI Engineering Fluency` (new name) ✅
- Command **IDs** showed `copilot-token-tracker.*` (old name) ❌
- One setting key `copilot-token-tracker.sampleDataDirectory` used the old hyphenated format while all other settings used `copilotTokenTracker.*` ❌

## Changes

- **`package.json`**: All 22 command IDs renamed from `copilot-token-tracker.*` → `aiEngineeringFluency.*`; setting key `copilot-token-tracker.sampleDataDirectory` → `copilotTokenTracker.sampleDataDirectory`
- **`extension.ts`**: Updated all `registerCommand`/`executeCommand` calls and `statusBarItem.command`; status bar item ID updated to `ai-engineering-fluency`
- **`sessionDiscovery.ts`**: Reads setting from `copilotTokenTracker` namespace
- **`test/integration/extension.test.ts`**: Updated expected command IDs
- **Docs**: Updated command ID references in instructions, test plan, and backend spec

## ⚠️ Breaking Change

Users with custom keybindings pointing to the old `copilot-token-tracker.*` command IDs will need to update them to use `aiEngineeringFluency.*`.