### PR TITLE
fix: handle case-sensitive extension ID and nested chatSessions path

### DIFF
--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -355,19 +355,28 @@ export class SessionDiscovery {
 					if (await this.pathExists(workspaceStoragePath)) {
 						const workspaceDirs = await fs.promises.readdir(workspaceStoragePath);
 						await this.runWithConcurrency(workspaceDirs, async (workspaceDir) => {
-							const chatSessionsPath = path.join(workspaceStoragePath, workspaceDir, 'chatSessions');
-							try {
-								if (await this.pathExists(chatSessionsPath)) {
-									const sessionFiles2 = (await fs.promises.readdir(chatSessionsPath))
-										.filter(file => file.endsWith('.json') || file.endsWith('.jsonl'))
-										.map(file => path.join(chatSessionsPath, file));
-									if (sessionFiles2.length > 0) {
-										this.deps.log(`📄 Found ${sessionFiles2.length} session files in ${pathName}/workspaceStorage/${workspaceDir}`);
-										sessionFiles.push(...sessionFiles2);
+							// Older Copilot Chat versions stored sessions at <hash>/chatSessions/
+							// Newer versions (v0.45+) nest under <hash>/GitHub.copilot-chat/chatSessions/
+							// On Linux the filesystem is case-sensitive so check both casings.
+							const chatSessionsCandidates = [
+								path.join(workspaceStoragePath, workspaceDir, 'chatSessions'),
+								path.join(workspaceStoragePath, workspaceDir, 'GitHub.copilot-chat', 'chatSessions'),
+								path.join(workspaceStoragePath, workspaceDir, 'github.copilot-chat', 'chatSessions'),
+							];
+							for (const chatSessionsPath of chatSessionsCandidates) {
+								try {
+									if (await this.pathExists(chatSessionsPath)) {
+										const sessionFiles2 = (await fs.promises.readdir(chatSessionsPath))
+											.filter(file => file.endsWith('.json') || file.endsWith('.jsonl'))
+											.map(file => path.join(chatSessionsPath, file));
+										if (sessionFiles2.length > 0) {
+											this.deps.log(`📄 Found ${sessionFiles2.length} session files in ${pathName}/workspaceStorage/${workspaceDir}`);
+											sessionFiles.push(...sessionFiles2);
+										}
 									}
+								} catch {
+									// Ignore individual workspace dir errors
 								}
-							} catch {
-								// Ignore individual workspace dir errors
 							}
 						}, 6);
 					}
@@ -391,15 +400,20 @@ export class SessionDiscovery {
 					this.deps.warn(`Could not check global storage path ${globalStoragePath}: ${checkError}`);
 				}
 
-				// GitHub Copilot Chat extension global storage
-				const copilotChatGlobalPath = path.join(codeUserPath, 'globalStorage', 'github.copilot-chat');
-				try {
-					if (await this.pathExists(copilotChatGlobalPath)) {
-						this.deps.log(`📄 Scanning ${pathName}/globalStorage/github.copilot-chat`);
-						await this.scanDirectoryForSessionFiles(copilotChatGlobalPath, sessionFiles);
+				// GitHub Copilot Chat extension global storage.
+				// VS Code creates the folder using the extension's publisher+name ID as-is.
+				// On case-sensitive Linux filesystems 'GitHub.copilot-chat' and
+				// 'github.copilot-chat' are distinct — check both to be safe.
+				for (const extFolderName of ['GitHub.copilot-chat', 'github.copilot-chat']) {
+					const copilotChatGlobalPath = path.join(codeUserPath, 'globalStorage', extFolderName);
+					try {
+						if (await this.pathExists(copilotChatGlobalPath)) {
+							this.deps.log(`📄 Scanning ${pathName}/globalStorage/${extFolderName}`);
+							await this.scanDirectoryForSessionFiles(copilotChatGlobalPath, sessionFiles);
+						}
+					} catch (checkError) {
+						this.deps.warn(`Could not check Copilot Chat global storage path ${copilotChatGlobalPath}: ${checkError}`);
 					}
-				} catch (checkError) {
-					this.deps.warn(`Could not check Copilot Chat global storage path ${copilotChatGlobalPath}: ${checkError}`);
 				}
 			}, 4);
 


### PR DESCRIPTION
## Problem

Two related bugs cause 0 session files to be found for users running VS Code natively inside WSL (reported in #647):

### Bug 1 — Case-sensitive extension ID in globalStorage

VS Code creates the extension storage folder using the extension's publisher+name ID **as-is**. On a case-sensitive Linux filesystem `GitHub.copilot-chat` and `github.copilot-chat` are different paths. The extension hardcoded the all-lowercase variant `github.copilot-chat`, which silently found nothing when the real folder was `GitHub.copilot-chat`.

### Bug 2 — Nested `chatSessions` path in newer Copilot Chat

Older versions of Copilot Chat stored sessions at:
```
workspaceStorage/<hash>/chatSessions/
```
Newer versions (v0.45.0, as reported by the user in #647) nest their storage under the extension subfolder:
```
workspaceStorage/<hash>/GitHub.copilot-chat/chatSessions/
```
The extension only checked the flat path, so all sessions from newer Copilot Chat versions were invisible.

## Changes

**`sessionDiscovery.ts`**

- **`workspaceStorage` scan**: for each workspace hash, now checks three candidate `chatSessions` locations:
  1. `<hash>/chatSessions/` — legacy flat path (still used by some installs)
  2. `<hash>/GitHub.copilot-chat/chatSessions/` — mixed-case extension subfolder (Linux)
  3. `<hash>/github.copilot-chat/chatSessions/` — lowercase (Windows/macOS fallback)

- **`globalStorage` scan**: iterates over both `GitHub.copilot-chat` and `github.copilot-chat` so the correct folder is found regardless of filesystem case-sensitivity.

## Testing

935/935 unit tests pass. Compile and lint clean.

Closes #647