### PR TITLE
feat: add dedicated CLI interaction mode in Usage Analysis

### DIFF
--- a/cli/src/cliCache.ts
+++ b/cli/src/cliCache.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import type { SessionData } from './helpers';
 
 /** Bump this when the SessionData shape changes to force a full re-parse. */
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2;
 
 /** Maximum number of entries to keep in the cache file. */
 const MAX_CACHE_ENTRIES = 2000;

--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -177,7 +177,7 @@ export const fluencyCommand = new Command('fluency')
 		console.log(chalk.dim('─'.repeat(55)));
 		console.log(`  Sessions analyzed:       ${chalk.bold(fmt(p.sessions))}`);
 
-		const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent;
+		const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent + p.modeUsage.cli;
 		console.log(`  Total interactions:      ${chalk.bold(fmt(totalInteractions))}`);
 
 		if (p.modeUsage.ask > 0) {
@@ -188,6 +188,9 @@ export const fluencyCommand = new Command('fluency')
 		}
 		if (p.modeUsage.agent > 0) {
 			console.log(`    Agent mode:            ${fmt(p.modeUsage.agent)}`);
+		}
+		if (p.modeUsage.cli > 0) {
+			console.log(`    CLI:                   ${fmt(p.modeUsage.cli)}`);
 		}
 		if (p.toolCalls.total > 0) {
 			console.log(`  Tool calls:              ${fmt(p.toolCalls.total)}`);

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -473,7 +473,7 @@ function createEmptyUsageAnalysisPeriod(): UsageAnalysisPeriod {
 	return {
 		sessions: 0,
 		toolCalls: { total: 0, byTool: {} },
-		modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+		modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
 		contextReferences: createEmptyContextRefs(),
 		mcpTools: { total: 0, byServer: {}, byTool: {} },
 		modelSwitching: {

--- a/vscode-extension/src/adapters/claudeCodeAdapter.ts
+++ b/vscode-extension/src/adapters/claudeCodeAdapter.ts
@@ -74,7 +74,7 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		const models: string[] = [];
 		for (const event of events) {
 			if (event.type === 'user' && event.message?.role === 'user' && !event.isSidechain) {
-				analysis.modeUsage.ask++;
+				analysis.modeUsage.cli++;
 			} else if (event.type === 'assistant') {
 				const model = normalizeClaudeModelId(event.message?.model || 'unknown');
 				models.push(model);

--- a/vscode-extension/src/adapters/crushAdapter.ts
+++ b/vscode-extension/src/adapters/crushAdapter.ts
@@ -154,7 +154,7 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 			turns.push({
 				turnNumber,
 				timestamp: msg.created_at ? new Date(msg.created_at * 1000).toISOString() : null,
-				mode: 'agent',
+				mode: 'cli',
 				userMessage: userText,
 				assistantResponse: assistantText,
 				model,
@@ -178,7 +178,7 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 		const messages = await this.crush.getCrushMessages(sessionFile);
 		const models: string[] = [];
 		for (const msg of messages) {
-			if (msg.role === 'user') { analysis.modeUsage.agent++; }
+			if (msg.role === 'user') { analysis.modeUsage.cli++; }
 			if (msg.role === 'assistant') {
 				const model = msg.model || 'unknown';
 				models.push(model);

--- a/vscode-extension/src/adapters/mistralVibeAdapter.ts
+++ b/vscode-extension/src/adapters/mistralVibeAdapter.ts
@@ -111,7 +111,7 @@ export class MistralVibeAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 			turns.push({
 				turnNumber: t + 1,
 				timestamp: sessionMeta.firstInteraction,
-				mode: 'agent',
+				mode: 'cli',
 				userMessage: userText,
 				assistantResponse: assistantText,
 				model,
@@ -135,7 +135,7 @@ export class MistralVibeAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 		const models: string[] = [];
 		for (const msg of messages) {
 			if (msg.role === 'user' && msg.injected !== true) {
-				analysis.modeUsage.agent++;
+				analysis.modeUsage.cli++;
 			} else if (msg.role === 'assistant') {
 				models.push(model);
 				if (Array.isArray(msg.tool_calls)) {

--- a/vscode-extension/src/adapters/openCodeAdapter.ts
+++ b/vscode-extension/src/adapters/openCodeAdapter.ts
@@ -195,7 +195,7 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 				turns.push({
 					turnNumber,
 					timestamp: msg.time?.created ? new Date(msg.time.created).toISOString() : null,
-					mode: (msg.agent === 'build' || msg.agent === 'agent') ? 'agent' : (msg.agent === 'ask' ? 'ask' : 'agent'),
+					mode: 'cli',
 					userMessage: userText,
 					assistantResponse: assistantText,
 					model,
@@ -224,11 +224,7 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 			const models: string[] = [];
 			for (const msg of messages) {
 				if (msg.role === 'user') {
-					const mode = msg.agent || 'agent';
-					if (mode === 'build' || mode === 'agent') { analysis.modeUsage.agent++; }
-					else if (mode === 'ask') { analysis.modeUsage.ask++; }
-					else if (mode === 'edit') { analysis.modeUsage.edit++; }
-					else { analysis.modeUsage.agent++; }
+					analysis.modeUsage.cli++;
 				}
 				if (msg.role === 'assistant') {
 					const model = msg.modelID || 'unknown';

--- a/vscode-extension/src/backend/rollups.ts
+++ b/vscode-extension/src/backend/rollups.ts
@@ -39,6 +39,7 @@ export interface DailyRollupValueLike {
 		agentModeCount?: number;
 		planModeCount?: number;
 		customAgentModeCount?: number;
+		cliModeCount?: number;
 		toolCallsJson?: string;
 		contextRefsJson?: string;
 		mcpToolsJson?: string;
@@ -127,6 +128,9 @@ export function upsertDailyRollup(
 			}
 			if (val.customAgentModeCount !== undefined) {
 				ex.customAgentModeCount = (ex.customAgentModeCount || 0) + val.customAgentModeCount;
+			}
+			if (val.cliModeCount !== undefined) {
+				ex.cliModeCount = (ex.cliModeCount || 0) + val.cliModeCount;
 			}
 			if (val.multiTurnSessions !== undefined) {
 				ex.multiTurnSessions = (ex.multiTurnSessions || 0) + val.multiTurnSessions;

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -591,6 +591,7 @@ export class SyncService {
 			fluencyMetrics.agentModeCount = Math.round((analysis.modeUsage.agent || 0) * ratio);
 			fluencyMetrics.planModeCount = Math.round((analysis.modeUsage.plan || 0) * ratio);
 			fluencyMetrics.customAgentModeCount = Math.round((analysis.modeUsage.customAgent || 0) * ratio);
+			fluencyMetrics.cliModeCount = Math.round((analysis.modeUsage.cli || 0) * ratio);
 		}
 
 		// Serialize complex objects as JSON

--- a/vscode-extension/src/backend/storageTables.ts
+++ b/vscode-extension/src/backend/storageTables.ts
@@ -47,6 +47,7 @@ export interface BackendAggDailyEntityLike {
 	agentModeCount?: number;
 	planModeCount?: number;
 	customAgentModeCount?: number;
+	cliModeCount?: number;
 	toolCallsJson?: string; // Serialized ToolCallUsage: { total, byTool: {...} }
 	contextRefsJson?: string; // Serialized ContextReferenceUsage
 	mcpToolsJson?: string; // Serialized McpToolUsage: { total, byServer, byTool }

--- a/vscode-extension/src/backend/types.ts
+++ b/vscode-extension/src/backend/types.ts
@@ -38,6 +38,7 @@ export interface DailyRollupValue {
 		agentModeCount?: number;
 		planModeCount?: number;
 		customAgentModeCount?: number;
+		cliModeCount?: number;
 		toolCallsJson?: string;
 		contextRefsJson?: string;
 		mcpToolsJson?: string;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -165,7 +165,7 @@ type LocalViewRegressionCase = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 40; // Fix lastInteraction: use content timestamps only, not max(timestamp, mtime)
+	private static readonly CACHE_VERSION = 41; // Add 'cli' mode to ModeUsage for CLI-based tools
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -2027,7 +2027,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const emptyPeriod = (): UsageAnalysisPeriod => ({
 			sessions: 0,
 			toolCalls: { total: 0, byTool: {} },
-			modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+			modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
 			contextReferences: {
 				file: 0,
 				selection: 0,
@@ -2149,7 +2149,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					const interactions = sessionData.interactions;
 					const analysis = sessionData.usageAnalysis || {
 						toolCalls: { total: 0, byTool: {} },
-						modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+						modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
 						contextReferences: {
 							file: 0,
 							selection: 0,
@@ -2773,7 +2773,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const sessionData = await this.getSessionFileDataCached(sessionFile, mtime, fileSize);
 		const analysis = sessionData.usageAnalysis || {
 			toolCalls: { total: 0, byTool: {} },
-			modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+			modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
 			contextReferences: {
 				file: 0,
 				selection: 0,
@@ -2924,7 +2924,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			thinkingTokens: existingCache?.thinkingTokens,
 			usageAnalysis: existingCache?.usageAnalysis || {
 				toolCalls: { total: 0, byTool: {} },
-				modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+				modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
 				contextReferences: {
 					file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
 					workspace: 0, terminal: 0, vscode: 0,
@@ -3472,7 +3472,7 @@ usageAnalysis: undefined
 						const turn: ChatTurn = {
 							turnNumber,
 							timestamp: event.timestamp ? new Date(event.timestamp).toISOString() : null,
-							mode: 'agent', // CLI is typically agent mode
+							mode: 'cli', // CLI tool sessions use the dedicated cli mode
 							userMessage,
 							assistantResponse: '',
 							model: turnModel,
@@ -5809,7 +5809,7 @@ ${hashtag}`;
     // Aggregate fluency data per user (schema version 4+ entities only)
     const userFluencyMap = new Map<string, {
       askModeCount: number; editModeCount: number; agentModeCount: number;
-      planModeCount: number; customAgentModeCount: number;
+      planModeCount: number; customAgentModeCount: number; cliModeCount: number;
       toolCallsTotal: number; toolCallsByTool: Record<string, number>;
       ctxFile: number; ctxSelection: number; ctxSymbol: number;
       ctxCodebase: number; ctxWorkspace: number; ctxTerminal: number;
@@ -5918,7 +5918,7 @@ ${hashtag}`;
           if (!userFluencyMap.has(userKey)) {
             userFluencyMap.set(userKey, {
               askModeCount: 0, editModeCount: 0, agentModeCount: 0,
-              planModeCount: 0, customAgentModeCount: 0,
+              planModeCount: 0, customAgentModeCount: 0, cliModeCount: 0,
               toolCallsTotal: 0, toolCallsByTool: {},
               ctxFile: 0, ctxSelection: 0, ctxSymbol: 0,
               ctxCodebase: 0, ctxWorkspace: 0, ctxTerminal: 0,
@@ -5943,6 +5943,7 @@ ${hashtag}`;
           fd.agentModeCount += typeof entity.agentModeCount === "number" ? entity.agentModeCount : 0;
           fd.planModeCount += typeof entity.planModeCount === "number" ? entity.planModeCount : 0;
           fd.customAgentModeCount += typeof entity.customAgentModeCount === "number" ? entity.customAgentModeCount : 0;
+          fd.cliModeCount += typeof entity.cliModeCount === "number" ? entity.cliModeCount : 0;
           if (entity.toolCallsJson) {
             try {
               const tc = JSON.parse(entity.toolCallsJson);

--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -414,7 +414,7 @@ export function getFluencyLevelData(isDebugMode: boolean): {
    */
 export function calculateFluencyScoreForTeamMember(fd: {
     askModeCount: number; editModeCount: number; agentModeCount: number;
-    planModeCount: number; customAgentModeCount: number;
+    planModeCount: number; customAgentModeCount: number; cliModeCount: number;
     toolCallsTotal: number; toolCallsByTool: Record<string, number>;
     ctxFile: number; ctxSelection: number; ctxSymbol: number;
     ctxCodebase: number; ctxWorkspace: number; ctxTerminal: number;
@@ -439,11 +439,11 @@ export function calculateFluencyScoreForTeamMember(fd: {
       4: "Stage 4: AI Strategist",
     };
 
-    const totalInteractions = fd.askModeCount + fd.editModeCount + fd.agentModeCount;
+    const totalInteractions = fd.askModeCount + fd.editModeCount + fd.agentModeCount + fd.cliModeCount;
     const avgTurnsPerSession = fd.turnsPerSessionCount > 0 ? fd.turnsPerSessionSum / fd.turnsPerSessionCount : 0;
     const switchingFrequency = fd.switchingFreqCount > 0 ? fd.switchingFreqSum / fd.switchingFreqCount : 0;
     const hasModelSwitching = fd.mixedTierSessions > 0 || switchingFrequency > 0;
-    const hasAgentMode = fd.agentModeCount > 0;
+    const hasAgentMode = (fd.agentModeCount + fd.cliModeCount) > 0;
     const toolCount = Object.keys(fd.toolCallsByTool).length;
     const nonAutoToolCount = Object.keys(fd.toolCallsByTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase())).length;
     const avgFilesPerSession = fd.filesPerEditCount > 0 ? fd.filesPerEditSum / fd.filesPerEditCount : 0;
@@ -659,7 +659,7 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 	const peTips: string[] = [];
 	let peStage = 1;
 
-	const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent;
+	const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent + p.modeUsage.cli;
 	if (totalInteractions > 0) {
 		peEvidence.push(`${fmt(totalInteractions)} total interactions`);
 	}
@@ -668,6 +668,9 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 	}
 	if (p.modeUsage.agent > 0) {
 		peEvidence.push(`${fmt(p.modeUsage.agent)} agent-mode interactions`);
+	}
+	if (p.modeUsage.cli > 0) {
+		peEvidence.push(`${fmt(p.modeUsage.cli)} CLI interactions`);
 	}
 
 	// Conversation patterns (multi-turn shows iterative refinement)
@@ -699,7 +702,7 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 	}
 
 	const hasModelSwitching = p.modelSwitching.mixedTierSessions > 0 || p.modelSwitching.switchingFrequency > 0;
-	const hasAgentMode = p.modeUsage.agent > 0;
+	const hasAgentMode = p.modeUsage.agent > 0 || p.modeUsage.cli > 0;
 
 	if (totalInteractions >= 30 && (usedSlashCommands.length >= 2 || hasAgentMode)) {
 		peStage = 3; // Regular, purposeful use
@@ -831,6 +834,10 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 		agEvidence.push(`${fmt(p.modeUsage.agent)} agent-mode interactions`);
 		agStage = 2;
 	}
+	if (p.modeUsage.cli > 0) {
+		agEvidence.push(`${fmt(p.modeUsage.cli)} CLI interactions`);
+		agStage = Math.max(agStage, 2) as 1 | 2 | 3 | 4;
+	}
 	if (p.toolCalls.total > 0) {
 		agEvidence.push(`${fmt(p.toolCalls.total)} tool calls executed`);
 	}
@@ -862,12 +869,12 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 	// Diverse tool usage in agent mode
 	const toolCount = Object.keys(p.toolCalls.byTool).length;
 	const nonAutoToolCount = Object.keys(p.toolCalls.byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase())).length;
-	if (p.modeUsage.agent >= 10 && nonAutoToolCount >= 3) {
+	if ((p.modeUsage.agent + p.modeUsage.cli) >= 10 && nonAutoToolCount >= 3) {
 		agStage = 3;
 	}
 
 	// Heavy agentic use with many tool types or high multi-file edit rate
-	if (p.modeUsage.agent >= 50 && nonAutoToolCount >= 5) {
+	if ((p.modeUsage.agent + p.modeUsage.cli) >= 50 && nonAutoToolCount >= 5) {
 		agStage = 4;
 	}
 	if (p.editScope && p.editScope.multiFileEdits >= 20 && p.editScope.avgFilesPerSession >= 3) {
@@ -1069,10 +1076,10 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 		wiEvidence.push(`Avg ${avgMinutes}min session duration`);
 	}
 
-	// Multi-mode usage (ask + agent) - key indicator of integration
-	const modesUsed = [p.modeUsage.ask > 0, p.modeUsage.agent > 0].filter(Boolean).length;
+	// Multi-mode usage (ask + agent + cli) - key indicator of integration
+	const modesUsed = [p.modeUsage.ask > 0, p.modeUsage.agent > 0, p.modeUsage.cli > 0].filter(Boolean).length;
 	if (modesUsed >= 2) {
-		wiEvidence.push(`Uses ${modesUsed} modes (ask/agent)`);
+		wiEvidence.push(`Uses ${modesUsed} modes (ask/agent/cli)`);
 		wiStage = Math.max(wiStage, 3) as 1 | 2 | 3 | 4;
 	}
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -198,6 +198,7 @@ export interface ModeUsage {
   agent: number; // Agent mode interactions (standard agent mode)
   plan: number; // Plan mode interactions (built-in plan agent)
   customAgent: number; // Custom agent mode interactions (.agent.md files)
+  cli: number; // CLI tool interactions (Copilot CLI, Claude Code, OpenCode, Crush, Mistral Vibe)
 }
 
 export interface ContextReferenceUsage {
@@ -375,7 +376,7 @@ export interface ActualUsage {
 export interface ChatTurn {
   turnNumber: number;
   timestamp: string | null;
-  mode: "ask" | "edit" | "agent" | "plan" | "customAgent";
+  mode: "ask" | "edit" | "agent" | "plan" | "customAgent" | "cli";
   userMessage: string;
   assistantResponse: string;
   model: string | null;

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -65,6 +65,7 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 	period.modeUsage.agent += analysis.modeUsage.agent;
 	period.modeUsage.plan += analysis.modeUsage.plan;
 	period.modeUsage.customAgent += analysis.modeUsage.customAgent;
+	period.modeUsage.cli += analysis.modeUsage.cli;
 
 	// Merge context references
 	period.contextReferences.file += analysis.contextReferences.file;
@@ -464,7 +465,7 @@ export function analyzeVariableData(variableData: any, refs: ContextReferenceUsa
  * Called before every return in analyzeSessionUsage to ensure all file formats get patterns.
  */
 export function deriveConversationPatterns(analysis: SessionUsageAnalysis): void {
-	const totalRequests = analysis.modeUsage.ask + analysis.modeUsage.edit + analysis.modeUsage.agent;
+	const totalRequests = analysis.modeUsage.ask + analysis.modeUsage.edit + analysis.modeUsage.agent + analysis.modeUsage.cli;
 	analysis.conversationPatterns = {
 		multiTurnSessions: totalRequests > 1 ? 1 : 0,
 		singleTurnSessions: totalRequests === 1 ? 1 : 0,
@@ -944,7 +945,7 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 export function createEmptySessionUsageAnalysis(): SessionUsageAnalysis {
 	return {
 		toolCalls: { total: 0, byTool: {} },
-		modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+		modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
 		contextReferences: createEmptyContextRefs(),
 		mcpTools: { total: 0, byServer: {}, byTool: {} },
 		modelSwitching: {
@@ -1259,18 +1260,9 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 					}
 
 					// Handle Copilot CLI format
-					// Detect mode from event type - CLI can be chat or agent mode
+					// CLI sessions are always classified as 'cli' mode
 					if (event.type === 'user.message') {
-						analysis.modeUsage.ask++;
-					}
-
-					// If we see tool calls, upgrade to agent mode for this session
-					if (event.type === 'tool.call' || event.type === 'tool.result') {
-						// Tool usage indicates agent mode - adjust if we counted this as ask
-						if (analysis.modeUsage.ask > 0) {
-							analysis.modeUsage.ask--;
-							analysis.modeUsage.agent++;
-						}
+						analysis.modeUsage.cli++;
 					}
 
 					// Detect tool calls from Copilot CLI

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -36,7 +36,7 @@ type ChatTurn = {
 };
 
 type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number };
+type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
 type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 type ThinkingEffortUsage = { byEffort: { [effort: string]: number }; switchCount: number; defaultEffort: string | null };
 type SessionUsageAnalysis = {
@@ -246,6 +246,7 @@ function getModeIcon(mode: string): string {
 		case 'agent': return '🤖';
 		case 'plan': return '📋';
 		case 'customAgent': return '⚡';
+		case 'cli': return '🖥️';
 		default: return '❓';
 	}
 }
@@ -257,6 +258,7 @@ function getModeColor(mode: string): string {
 		case 'agent': return '#7c3aed';
 		case 'plan': return '#f59e0b';
 		case 'customAgent': return '#ec4899';
+		case 'cli': return '#06b6d4';
 		default: return '#888';
 	}
 }
@@ -555,7 +557,7 @@ function renderLayout(data: SessionLogData): void {
 	const totalRefs = getTotalContextRefs(data.contextReferences);
 	const usage = data.usageAnalysis;
 	const sessionEffort = usage?.thinkingEffort;
-	const usageMode = usage?.modeUsage || { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 };
+	const usageMode = usage?.modeUsage || { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 };
 	const usageToolTotal = usage?.toolCalls?.total ?? totalToolCalls;
 	const usageTopTools = usage ? getTopEntries(usage.toolCalls.byTool, 3) : [];
 	const usageMcpTotal = usage?.mcpTools?.total ?? totalMcpTools;
@@ -615,7 +617,7 @@ function renderLayout(data: SessionLogData): void {
 	};
 	
 	// Mode usage summary
-	const modeUsage = { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 };
+	const modeUsage = { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 };
 	const modelUsage: { [model: string]: number } = {};
 	for (const turn of data.turns) {
 		modeUsage[turn.mode]++;

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -6,7 +6,7 @@ import styles from './styles.css';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number };
+type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
 type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
 type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 type ModelSwitchingAnalysis = {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -7,7 +7,7 @@ import { formatFixed, formatNumber, formatPercent, setFormatLocale } from '../sh
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number };
+type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
 type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
 type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 
@@ -358,6 +358,7 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 		agent: coerceNumber(mode?.agent),
 		plan: coerceNumber(mode?.plan),
 		customAgent: coerceNumber(mode?.customAgent),
+		cli: coerceNumber(mode?.cli),
 	});
 
 	const sanitizeContextRefs = (refs: any): ContextReferenceUsage => ({
@@ -732,8 +733,8 @@ function renderLayout(stats: UsageAnalysisStats): void {
 
 	const todayTotalRefs = getTotalContextRefs(stats.today.contextReferences);
 	const last30DaysTotalRefs = getTotalContextRefs(stats.last30Days.contextReferences);
-	const todayTotalModes = stats.today.modeUsage.ask + stats.today.modeUsage.edit + stats.today.modeUsage.agent + stats.today.modeUsage.plan + stats.today.modeUsage.customAgent;
-	const last30DaysTotalModes = stats.last30Days.modeUsage.ask + stats.last30Days.modeUsage.edit + stats.last30Days.modeUsage.agent + stats.last30Days.modeUsage.plan + stats.last30Days.modeUsage.customAgent;
+	const todayTotalModes = stats.today.modeUsage.ask + stats.today.modeUsage.edit + stats.today.modeUsage.agent + stats.today.modeUsage.plan + stats.today.modeUsage.customAgent + stats.today.modeUsage.cli;
+	const last30DaysTotalModes = stats.last30Days.modeUsage.ask + stats.last30Days.modeUsage.edit + stats.last30Days.modeUsage.agent + stats.last30Days.modeUsage.plan + stats.last30Days.modeUsage.customAgent + stats.last30Days.modeUsage.cli;
 
 	const multiModelHtml = `
 			<!-- Multi-Model Usage Section -->
@@ -1073,6 +1074,10 @@ function renderLayout(stats: UsageAnalysisStats): void {
 							<div class="bar-item">
 								<div class="bar-label"><span>⚡ Custom Agent</span><span><strong>${formatNumber(stats.today.modeUsage.customAgent)}</strong> (${formatPercent(todayTotalModes > 0 ? ((stats.today.modeUsage.customAgent / todayTotalModes) * 100) : 0, 0)})</span></div>
 								<div class="bar-track"><div class="bar-fill" style="width: ${todayTotalModes > 0 ? ((stats.today.modeUsage.customAgent / todayTotalModes) * 100).toFixed(1) : 0}%; background: linear-gradient(90deg, #ec4899, #f472b6);"></div></div>
+							</div>
+							<div class="bar-item">
+								<div class="bar-label"><span>🖥️ CLI</span><span><strong>${formatNumber(stats.today.modeUsage.cli)}</strong> (${formatPercent(todayTotalModes > 0 ? ((stats.today.modeUsage.cli / todayTotalModes) * 100) : 0, 0)})</span></div>
+								<div class="bar-track"><div class="bar-fill" style="width: ${todayTotalModes > 0 ? ((stats.today.modeUsage.cli / todayTotalModes) * 100).toFixed(1) : 0}%; background: linear-gradient(90deg, #06b6d4, #22d3ee);"></div></div>
 							</div>						</div>
 						</div>
 						<div>
@@ -1096,6 +1101,10 @@ function renderLayout(stats: UsageAnalysisStats): void {
 							<div class="bar-item">
 								<div class="bar-label"><span>⚡ Custom Agent</span><span><strong>${formatNumber(stats.last30Days.modeUsage.customAgent)}</strong> (${formatPercent(last30DaysTotalModes > 0 ? ((stats.last30Days.modeUsage.customAgent / last30DaysTotalModes) * 100) : 0, 0)})</span></div>
 								<div class="bar-track"><div class="bar-fill" style="width: ${last30DaysTotalModes > 0 ? ((stats.last30Days.modeUsage.customAgent / last30DaysTotalModes) * 100).toFixed(1) : 0}%; background: linear-gradient(90deg, #ec4899, #f472b6);"></div></div>
+							</div>
+							<div class="bar-item">
+								<div class="bar-label"><span>🖥️ CLI</span><span><strong>${formatNumber(stats.last30Days.modeUsage.cli)}</strong> (${formatPercent(last30DaysTotalModes > 0 ? ((stats.last30Days.modeUsage.cli / last30DaysTotalModes) * 100) : 0, 0)})</span></div>
+								<div class="bar-track"><div class="bar-fill" style="width: ${last30DaysTotalModes > 0 ? ((stats.last30Days.modeUsage.cli / last30DaysTotalModes) * 100).toFixed(1) : 0}%; background: linear-gradient(90deg, #06b6d4, #22d3ee);"></div></div>
 							</div>						</div>
 						</div>
 					</div>

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -157,7 +157,7 @@ test('extractFluencyMetricsFromCache extracts mode usage with ratio=1', () => {
 	const svc = makeService();
 	const cached = {
 		usageAnalysis: {
-			modeUsage: { ask: 10, edit: 5, agent: 3, plan: 2, customAgent: 1 }
+			modeUsage: { ask: 10, edit: 5, agent: 3, plan: 2, customAgent: 1, cli: 0 }
 		}
 	};
 	const result = (svc as any).extractFluencyMetricsFromCache(cached, 1);
@@ -279,7 +279,7 @@ test('extractFluencyMetricsFromCache handles all metrics combined', () => {
 	const svc = makeService();
 	const cached = {
 		usageAnalysis: {
-			modeUsage: { ask: 1, edit: 2, agent: 3, plan: 0, customAgent: 0 },
+			modeUsage: { ask: 1, edit: 2, agent: 3, plan: 0, customAgent: 0, cli: 0 },
 			toolCalls: { search: 1 },
 			contextReferences: { file: 1 },
 			mcpTools: { t: 1 },

--- a/vscode-extension/test/unit/maturityScoring.test.ts
+++ b/vscode-extension/test/unit/maturityScoring.test.ts
@@ -13,7 +13,7 @@ import type { UsageAnalysisStats, UsageAnalysisPeriod } from '../../src/types';
 function emptyFd() {
     return {
         askModeCount: 0, editModeCount: 0, agentModeCount: 0,
-        planModeCount: 0, customAgentModeCount: 0,
+        planModeCount: 0, customAgentModeCount: 0, cliModeCount: 0,
         toolCallsTotal: 0, toolCallsByTool: {} as Record<string, number>,
         ctxFile: 0, ctxSelection: 0, ctxSymbol: 0,
         ctxCodebase: 0, ctxWorkspace: 0, ctxTerminal: 0,
@@ -37,7 +37,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
     return {
         sessions: 0,
         toolCalls: { total: 0, byTool: {} },
-        modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+        modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
         contextReferences: {
             file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
             workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0,

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -35,7 +35,7 @@ function emptyRefs(): ContextReferenceUsage {
 function emptyAnalysis(): SessionUsageAnalysis {
     return {
         toolCalls: { total: 0, byTool: {} },
-        modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+        modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
         contextReferences: emptyRefs(),
         mcpTools: { total: 0, byServer: {}, byTool: {} },
         modelSwitching: {
@@ -51,7 +51,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
     return {
         sessions: 0,
         toolCalls: { total: 0, byTool: {} },
-        modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0 },
+        modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
         contextReferences: emptyRefs(),
         mcpTools: { total: 0, byServer: {}, byTool: {} },
         modelSwitching: {
@@ -133,7 +133,7 @@ test('mergeUsageAnalysis: accumulates tool call counts across sessions', () => {
 test('mergeUsageAnalysis: accumulates mode usage counts', () => {
     const period = emptyPeriod();
     const a = emptyAnalysis();
-    a.modeUsage = { ask: 5, edit: 2, agent: 3, plan: 1, customAgent: 0 };
+    a.modeUsage = { ask: 5, edit: 2, agent: 3, plan: 1, customAgent: 0, cli: 0 };
     mergeUsageAnalysis(period, a);
     mergeUsageAnalysis(period, a); // merge twice
 


### PR DESCRIPTION
## Summary

Split CLI-based tool sessions out of "Ask Mode" / "Agent Mode" into a distinct **CLI** interaction mode in the Usage Analysis panel.

### Problem
Sessions from CLI tools (Copilot CLI, Claude Code, OpenCode, Crush, Mistral Vibe) were incorrectly counted under "Ask Mode" or "Agent Mode" in the Interaction Modes panel.

### Solution
Added a dedicated `cli` mode that correctly categorizes all CLI-based tool interactions:

- **Types**: Added `cli: number` to `ModeUsage` interface and `'cli'` to `ChatTurn.mode` union
- **Adapters**: Updated 4 CLI adapters (claudeCode, openCode, crush, mistralVibe) to count as `cli`
- **Usage Analysis webview**: Added teal 🖥️ CLI bar row in both Today and Last 30 Days sections
- **Log Viewer webview**: Added CLI mode icon and color
- **Maturity scoring**: CLI interactions count toward agent-like maturity thresholds
- **Backend**: Added `cliModeCount` to rollups, sync service, storage types, and team member fluency scoring
- **CLI project**: Added CLI mode display in fluency command output
- **Cache**: Bumped CACHE_VERSION (extension 40→41, cli 1→2) to invalidate stale data

### Files changed (21)
Core types, usage analysis, 4 adapters, extension.ts, 3 webview files, backend rollups/sync/storage/types, maturity scoring, CLI helpers/cache/fluency, and 3 test files.

### Testing
- ✅ All 961 unit tests pass
- ✅ Both vscode-extension and cli builds compile cleanly