### PR TITLE
fix: pin Docker base image to SHA256 digest

### DIFF
--- a/sharing-server/Dockerfile
+++ b/sharing-server/Dockerfile
@@ -2,7 +2,7 @@
 
 # ── Build stage ──────────────────────────────────────────────────────────────
 # Uses node:sqlite (built-in, no native compilation needed)
-FROM node:24-slim AS builder
+FROM node:24-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build:production
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM node:24-slim AS runtime
+FROM node:24-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \


### PR DESCRIPTION
## Summary

Pin both `FROM` lines in `sharing-server/Dockerfile` to the specific SHA256 digest for `node:24-slim`, resolving code scanning alerts **#54** and **#55** (Pinned-Dependencies).

## Changes

- `FROM node:24-slim AS builder` → pinned to `node:24-slim@sha256:03eae3ef...`
- `FROM node:24-slim AS runtime` → pinned to `node:24-slim@sha256:03eae3ef...`

This ensures reproducible builds and prevents supply-chain attacks via tag mutation.