### PR TITLE
Fix VS Code extension security alerts

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -11863,12 +11863,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -571,6 +571,7 @@
   },
   "overrides": {
     "diff": ">=8.0.3",
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.3",
+    "uuid": "^14.0.0"
   }
 }

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -304,7 +304,7 @@ function renderMissedPotential(stats: UsageAnalysisStats): string {
                                     <div style="display: flex; flex-direction: column; gap: 4px;">
                                         ${ws.nonCopilotFiles.map(f => `
                                             <div style="font-size: 11px; display: flex; align-items: center; gap: 6px;">
-                                                <span>${f.icon || '📄'}</span>
+                                                <span>${escapeHtml(f.icon || '📄')}</span>
                                                 <span style="font-weight: 500;">${escapeHtml(f.label || '')}:</span>
                                                 <span style="font-family: monospace; color: var(--text-muted);">${escapeHtml(f.relativePath)}</span>
                                             </div>
@@ -723,9 +723,9 @@ function renderLayout(stats: UsageAnalysisStats): void {
 														? 'Missing'
 														: 'Status unknown';
 										return `
-										<td style="position: relative; padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: center; font-size: 16px;" title="${statusLabel}" aria-label="${statusLabel}">
+										<td style="position: relative; padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: center; font-size: 16px;" title="${escapeHtml(statusLabel)}" aria-label="${escapeHtml(statusLabel)}">
 											<span aria-hidden="true">${escapeHtml(status)}</span>
-											<span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">${statusLabel}</span>
+											<span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">${escapeHtml(statusLabel)}</span>
 										</td>
 										`;
 									}).join('')}
@@ -1266,7 +1266,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 									<div style="display:flex; flex-wrap:wrap; gap:4px; margin-bottom:10px;">
 										${toolListHtml}
 									</div>
-									<a href="${issueUrl}" target="_blank" style="display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--button-bg); color: var(--button-fg); border-radius: 4px; text-decoration: none; font-size: 12px; font-weight: 500;">
+									<a href="${escapeHtml(issueUrl)}" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--button-bg); color: var(--button-fg); border-radius: 4px; text-decoration: none; font-size: 12px; font-weight: 500;">
 										<span>📝</span>
 										<span>Report Unknown Tools</span>
 									</a>


### PR DESCRIPTION
## Summary
- escape untrusted display values in the usage-analysis webview to address the client-side XSS finding
- harden a few adjacent HTML attribute insertions in the same webview
- override transitive `uuid` resolution to `^14.0.0` in the VS Code extension and refresh the lockfile

## Validation
- `npm run compile`
- `npm audit --omit=dev --audit-level=moderate`
- attempted `npm ci` and `npm run test:node`, but both hung on this machine before completion