### PR TITLE
Refresh model pricing data from current provider docs

### DIFF
--- a/vscode-extension/src/README.md
+++ b/vscode-extension/src/README.md
@@ -65,8 +65,8 @@ When these fields are absent, the full `inputCostPerMillion` rate is applied to 
 - Cache reads: **10% of input rate** (e.g. $0.30/M for Claude Sonnet 4 at $3.00/M input)
 - Cache creation: **125% of input rate** (e.g. $3.75/M for Claude Sonnet 4)
 
-**OpenAI prompt caching rates** (automatic prefix matching):
-- Cache reads: **50% of input rate** (e.g. $1.25/M for GPT-4o at $2.50/M input)
+**OpenAI prompt caching rates** (automatic prefix matching) vary by model family:
+- Cache reads use the explicit per-model `cachedInputCostPerMillion` values in `modelPricing.json` (for example: GPT-4o = 50% of input, GPT-4.1 = 25%, GPT-5.4 = 10%)
 - Note: OpenAI cache creation does not incur an extra fee, so `cacheCreationCostPerMillion` is not set for OpenAI models.
 
 ### Which data sources provide cache token breakdowns?

--- a/vscode-extension/src/modelPricing.json
+++ b/vscode-extension/src/modelPricing.json
@@ -2,12 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Model pricing data - costs per million tokens for input and output",
   "metadata": {
-    "lastUpdated": "2026-03-30",
+    "lastUpdated": "2026-04-24",
     "sources": [
       {
         "name": "OpenAI API Pricing",
-        "url": "https://openai.com/api/pricing/",
-        "retrievedDate": "2026-03-30"
+        "url": "https://developers.openai.com/api/docs/pricing",
+        "retrievedDate": "2026-04-24"
       },
       {
         "name": "Anthropic Claude Pricing",
@@ -127,6 +127,7 @@
     },
     "gpt-5.4": {
       "inputCostPerMillion": 2.50,
+      "cachedInputCostPerMillion": 0.25,
       "outputCostPerMillion": 15.0,
       "category": "GPT-5 models",
       "tier": "premium",
@@ -134,8 +135,9 @@
       "displayNames": ["GPT-5.4"]
     },
     "gpt-5.4-mini": {
-      "inputCostPerMillion": 0.25,
-      "outputCostPerMillion": 2.0,
+      "inputCostPerMillion": 0.75,
+      "cachedInputCostPerMillion": 0.075,
+      "outputCostPerMillion": 4.5,
       "category": "GPT-5 models",
       "tier": "standard",
       "multiplier": 0,
@@ -150,23 +152,26 @@
       "displayNames": ["GPT-4"]
     },
     "gpt-4.1": {
-      "inputCostPerMillion": 3.0,
-      "outputCostPerMillion": 12.0,
+      "inputCostPerMillion": 2.0,
+      "cachedInputCostPerMillion": 0.5,
+      "outputCostPerMillion": 8.0,
       "category": "GPT-4 models",
       "tier": "standard",
       "multiplier": 0,
       "displayNames": ["GPT-4.1"]
     },
     "gpt-4.1-mini": {
-      "inputCostPerMillion": 0.8,
-      "outputCostPerMillion": 3.2,
+      "inputCostPerMillion": 0.4,
+      "cachedInputCostPerMillion": 0.1,
+      "outputCostPerMillion": 1.6,
       "category": "GPT-4 models",
       "tier": "standard",
       "multiplier": 0
     },
     "gpt-4.1-nano": {
-      "inputCostPerMillion": 0.2,
-      "outputCostPerMillion": 0.8,
+      "inputCostPerMillion": 0.1,
+      "cachedInputCostPerMillion": 0.025,
+      "outputCostPerMillion": 0.4,
       "category": "GPT-4 models",
       "tier": "standard",
       "multiplier": 0


### PR DESCRIPTION
Cost estimates were using stale OpenAI reference pricing, which made the extension's model cost data drift away from current provider docs. This refresh updates the affected entries so pricing and cached-input assumptions better match the live provider documentation.

Updated the OpenAI pricing entries for the GPT-4.1 and GPT-5.4 families, including cached input rates where the provider now publishes them explicitly. The README note about OpenAI caching was also tightened so it no longer implies a single fixed cache discount across all OpenAI model families.

A few details worth noting:
- GPT-4.1, GPT-4.1 mini, and GPT-4.1 nano were corrected to current input/output pricing and now include cached input rates.
- GPT-5.4 gained an explicit cached input rate, and GPT-5.4 mini was updated to the current published pricing.
- `goldeneye` was intentionally left unchanged because I did not find a defensible first-party public price source for it.

This PR only updates the pricing reference data and its accompanying documentation note; no runtime logic changed.