### PR TITLE
Potential fix for code scanning alert no. 56: Client-side cross-site scripting

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -458,10 +458,34 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 				: undefined,
 		};
 
-		// Validated pass-through for customizationMatrix (nested shape check)
+		// Sanitize customizationMatrix (avoid pass-through of untrusted nested fields)
 		if (raw.customizationMatrix && typeof raw.customizationMatrix === 'object'
 			&& Array.isArray(raw.customizationMatrix.workspaces)) {
-			sanitized.customizationMatrix = raw.customizationMatrix as WorkspaceCustomizationMatrix;
+			const rawMatrix = raw.customizationMatrix as any;
+			const safeWorkspaces = rawMatrix.workspaces
+				.filter((w: any) => w && typeof w === 'object')
+				.map((w: any) => ({
+					workspacePath: typeof w.workspacePath === 'string' ? w.workspacePath : '',
+					repoName: typeof w.repoName === 'string' ? w.repoName : '',
+					hasCopilotInstructionsMd: !!w.hasCopilotInstructionsMd,
+					hasAgentsMd: !!w.hasAgentsMd,
+					hasCopilotSetupStepsMd: !!w.hasCopilotSetupStepsMd,
+					hasCustomChatmodes: !!w.hasCustomChatmodes,
+					hasCustomPrompts: !!w.hasCustomPrompts,
+					totalFiles: coerceNumber(w.totalFiles),
+					missingTypes: Array.isArray(w.missingTypes)
+						? w.missingTypes.filter((t: unknown) => typeof t === 'string')
+						: [],
+					extraTypes: Array.isArray(w.extraTypes)
+						? w.extraTypes.filter((t: unknown) => typeof t === 'string')
+						: [],
+				}));
+
+			sanitized.customizationMatrix = {
+				workspaces: safeWorkspaces,
+				totalWorkspaces: coerceNumber(rawMatrix.totalWorkspaces),
+				workspacesWithIssues: coerceNumber(rawMatrix.workspacesWithIssues),
+			} as WorkspaceCustomizationMatrix;
 		}
 
 		// Validated pass-through for missedPotential (array of objects)


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/56](https://github.com/rajbos/github-copilot-token-usage/security/code-scanning/56)

Best fix: **stop pass-through casting of `customizationMatrix` and sanitize/coerce its nested fields into a safe, strongly-typed object before rendering**. This preserves behavior while preventing attacker-controlled strings from being interpreted as HTML/JS when used in template literals.

In `vscode-extension/src/webview/usage/main.ts`, update the `sanitizeStats` function region where `customizationMatrix` is currently assigned via cast (around lines 461–465). Replace that with explicit reconstruction:
- Validate `workspaces` is an array.
- For each workspace entry, create a new object with safe defaults:
  - string fields: keep only `typeof === 'string'`, else `''`
  - numeric fields: coerce via existing `coerceNumber`
  - boolean fields: coerce via `!!`
  - nested arrays/maps: rebuild with per-entry type checks
- Compute top-level numeric counters with `coerceNumber`.
- Assign this rebuilt object to `sanitized.customizationMatrix`.

This is the minimal high-confidence fix within shown code and avoids changing rendering logic or imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
