### PR TITLE
fix: update uuid to 14.0.0 via overrides (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/.github/skills/azure-storage-loader/package-lock.json
+++ b/.github/skills/azure-storage-loader/package-lock.json
@@ -635,12 +635,16 @@
       "license": "0BSD"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/wsl-utils": {

--- a/.github/skills/azure-storage-loader/package.json
+++ b/.github/skills/azure-storage-loader/package.json
@@ -19,5 +19,8 @@
   "dependencies": {
     "@azure/data-tables": "^13.3.2",
     "@azure/identity": "^4.13.1"
+  },
+  "overrides": {
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Fixes Dependabot alert #69 — `uuid < 14.0.0` missing buffer bounds check (GHSA-w5hq-g745-h8pq, medium severity).

### Problem

`@azure/msal-node` (a transitive dependency of `@azure/identity`) pulls in `uuid@8.3.2`. UUID versions below 14.0.0 have a missing bounds check in `v3`, `v5`, and `v6` when an external output buffer is provided, allowing silent partial writes (CWE-787).

### Fix

Added an `overrides` entry in `.github/skills/azure-storage-loader/package.json` to force `uuid >= 14.0.0`, without downgrading `@azure/identity` (which `npm audit fix --force` would have done as a breaking change).

```json
"overrides": {
  "uuid": "^14.0.0"
}
```

After running `npm install`, `npm audit` reports **0 vulnerabilities**.

Closes #69 (Dependabot alert)