### PR TITLE
feat: add AI fluency score to sharing server dashboard

### DIFF
--- a/sharing-server/.env.example
+++ b/sharing-server/.env.example
@@ -12,6 +12,25 @@ SESSION_SECRET=change_me_to_a_random_secret
 # Public base URL of this server (used in OAuth redirect URI and links)
 BASE_URL=http://localhost:3000
 
-# Optional: restrict to members of a specific GitHub organization
-# Leave empty to allow any GitHub user
+# Optional: restrict dashboard access and data uploads to members of this GitHub org.
+# Leave empty to allow any authenticated GitHub user.
+# Example: ALLOWED_GITHUB_ORG=my-company
 ALLOWED_GITHUB_ORG=
+
+# Optional: server-side GitHub PAT used to verify org membership (see ALLOWED_GITHUB_ORG).
+#
+# When ALLOWED_GITHUB_ORG is set, the server calls the GitHub API to check whether
+# the authenticated user is a member of that org. By default it uses the user's own
+# OAuth token, which fails for orgs that enforce SAML SSO (GitHub returns 403 because
+# the user's token is not SSO-authorized for the org).
+#
+# Setting this to a PAT that belongs to the server operator (who IS a member and has
+# authorized the token for SSO) bypasses that limitation: the server checks membership
+# on the user's behalf without requiring anything extra from the end user.
+#
+# How to create:
+#   1. Go to https://github.com/settings/tokens → Generate new token (classic)
+#   2. Grant the "read:org" scope
+#   3. Click "Configure SSO" next to the token and authorize it for ALLOWED_GITHUB_ORG
+#   4. Paste the generated token below
+GITHUB_ORG_CHECK_TOKEN=

--- a/sharing-server/src/auth.ts
+++ b/sharing-server/src/auth.ts
@@ -30,6 +30,14 @@ const ipRateMap = new Map<string, { count: number; resetAt: number }>();
 const IP_RATE_MAX = 200;
 const IP_RATE_WINDOW_MS = 60 * 1000; // 1 minute per IP
 
+/**
+ * Validates a GitHub Bearer token supplied by the client (e.g. the VS Code extension).
+ * Resolves the token to a local user row, or returns null if the token is invalid,
+ * the GitHub API is unreachable, or the user is not a member of ALLOWED_GITHUB_ORG.
+ *
+ * Results are cached for 10 minutes (positive) or 1 minute (negative) to reduce
+ * outbound GitHub API calls.
+ */
 export async function validateGitHubToken(token: string): Promise<UserRow | null> {
 	const cacheKey = createHash('sha256').update(token).digest('hex');
 
@@ -83,11 +91,25 @@ export async function validateGitHubToken(token: string): Promise<UserRow | null
 	return user;
 }
 
-async function checkOrgMembership(token: string, username: string, org: string): Promise<boolean> {
+/**
+ * Checks whether `username` is an active public member of `org`.
+ *
+ * Uses GITHUB_ORG_CHECK_TOKEN (a server-configured PAT) when set, so that the
+ * check works even when the org enforces SAML SSO — the server operator's PAT
+ * is pre-authorized for the org, meaning the end user's token never needs
+ * read:org scope or SSO authorization.
+ *
+ * Falls back to the user's own token if no server PAT is configured (works for
+ * orgs with public membership and no SAML enforcement).
+ */
+async function checkOrgMembership(userToken: string, username: string, org: string): Promise<boolean> {
+	// Prefer a server-side PAT (already SSO-authorized) so the user's OAuth token
+	// doesn't need read:org or SAML SSO authorization.
+	const checkToken = process.env.GITHUB_ORG_CHECK_TOKEN || userToken;
 	try {
 		const res = await fetch(`https://api.github.com/orgs/${org}/members/${username}`, {
 			headers: {
-				Authorization: `Bearer ${token}`,
+				Authorization: `Bearer ${checkToken}`,
 				'User-Agent': 'copilot-sharing-server/1.0',
 				Accept: 'application/vnd.github+json',
 			},
@@ -99,6 +121,7 @@ async function checkOrgMembership(token: string, username: string, org: string):
 	}
 }
 
+/** Returns true if the IP address is within the pre-auth rate limit window, false if it should be blocked. */
 export function checkIpRateLimit(ip: string): boolean {
 	const now = Date.now();
 	const entry = ipRateMap.get(ip);
@@ -111,6 +134,7 @@ export function checkIpRateLimit(ip: string): boolean {
 	return true;
 }
 
+/** Returns true if the user is within the upload rate limit window, false if they should be blocked. */
 export function checkUploadRateLimit(userId: number): boolean {
 	const now = Date.now();
 	const entry = uploadRateMap.get(userId);
@@ -125,6 +149,11 @@ export function checkUploadRateLimit(userId: number): boolean {
 
 export type AuthVariables = { user: UserRow };
 
+/**
+ * Hono middleware that enforces Bearer token authentication on API routes.
+ * Applies IP-level rate limiting before token validation, then resolves the
+ * token to a user and stores it in the Hono context for downstream handlers.
+ */
 export async function requireBearerAuth(c: Context, next: Next): Promise<Response | void> {
 	const ip = c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? 'unknown';
 

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -29,6 +29,7 @@ export interface UploadRow {
 	interactions: number;
 	schema_version: number;
 	uploaded_at: string;
+	fluency_json: string | null;
 }
 
 export interface UploadEntry {
@@ -43,6 +44,7 @@ export interface UploadEntry {
 	inputTokens: number;
 	outputTokens: number;
 	interactions: number;
+	fluencyMetrics?: Record<string, unknown>;
 }
 
 let _db: DatabaseSync | undefined;
@@ -79,6 +81,7 @@ const UPLOADS_TABLE_DDL = `
 		interactions   INTEGER NOT NULL DEFAULT 0,
 		schema_version INTEGER NOT NULL DEFAULT 3,
 		uploaded_at    TEXT DEFAULT (datetime('now')),
+		fluency_json   TEXT,
 		UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id, editor)
 	)`;
 
@@ -147,6 +150,14 @@ function initSchema(db: DatabaseSync): void {
 		CREATE INDEX IF NOT EXISTS idx_uploads_user_day ON usage_uploads(user_id, day);
 		CREATE INDEX IF NOT EXISTS idx_uploads_dataset   ON usage_uploads(dataset_id, day);
 	`);
+
+	// Add fluency_json column if it doesn't exist (migration for existing DBs)
+	const cols = db
+		.prepare("PRAGMA table_info(usage_uploads)")
+		.all() as unknown as Array<{ name: string }>;
+	if (!cols.some(c => c.name === 'fluency_json')) {
+		db.exec('ALTER TABLE usage_uploads ADD COLUMN fluency_json TEXT');
+	}
 }
 
 export function upsertUser(
@@ -178,17 +189,19 @@ export function getUserByGithubId(githubId: number): UserRow | undefined {
 
 export function upsertUpload(userId: number, entry: UploadEntry): void {
 	const editor = ((entry.editor ?? '').trim() || 'VS Code').slice(0, 100);
+	const fluencyJson = entry.fluencyMetrics ? JSON.stringify(entry.fluencyMetrics) : null;
 	getDb().prepare(`
 		INSERT INTO usage_uploads
 			(user_id, dataset_id, day, model, workspace_id, workspace_name, machine_id, machine_name,
-			 editor, input_tokens, output_tokens, interactions)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 editor, input_tokens, output_tokens, interactions, fluency_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id, dataset_id, day, model, workspace_id, machine_id, editor) DO UPDATE SET
 			workspace_name = excluded.workspace_name,
 			machine_name   = excluded.machine_name,
 			input_tokens   = excluded.input_tokens,
 			output_tokens  = excluded.output_tokens,
 			interactions   = excluded.interactions,
+			fluency_json   = excluded.fluency_json,
 			uploaded_at    = datetime('now')
 	`).run(
 		userId,
@@ -203,6 +216,7 @@ export function upsertUpload(userId: number, entry: UploadEntry): void {
 		entry.inputTokens,
 		entry.outputTokens,
 		entry.interactions,
+		fluencyJson,
 	);
 }
 

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -11,6 +11,7 @@ export interface UserRow {
 	created_at: string;
 	last_seen_at: string | null;
 	is_admin: number;
+	fluency_score_json: string | null;
 }
 
 export interface UploadRow {
@@ -158,6 +159,14 @@ function initSchema(db: DatabaseSync): void {
 	if (!cols.some(c => c.name === 'fluency_json')) {
 		db.exec('ALTER TABLE usage_uploads ADD COLUMN fluency_json TEXT');
 	}
+
+	// Add fluency_score_json column to users if it doesn't exist (migration for existing DBs)
+	const userCols = db
+		.prepare("PRAGMA table_info(users)")
+		.all() as unknown as Array<{ name: string }>;
+	if (!userCols.some(c => c.name === 'fluency_score_json')) {
+		db.exec('ALTER TABLE users ADD COLUMN fluency_score_json TEXT');
+	}
 }
 
 export function upsertUser(
@@ -246,4 +255,15 @@ export function getUploadsForUser(userId: number, days = 30): UploadRow[] {
 
 export function getAllUsers(): UserRow[] {
 	return getDb().prepare('SELECT * FROM users ORDER BY created_at DESC').all() as unknown as UserRow[];
+}
+
+export function upsertUserFluencyScore(userId: number, scoreJson: string): void {
+	getDb().prepare(`
+		UPDATE users SET fluency_score_json = ? WHERE id = ?
+	`).run(scoreJson, userId);
+}
+
+export function getUserFluencyScore(userId: number): string | null {
+	const row = getDb().prepare('SELECT fluency_score_json FROM users WHERE id = ?').get(userId) as unknown as { fluency_score_json: string | null } | undefined;
+	return row?.fluency_score_json ?? null;
 }

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { requireBearerAuth, checkUploadRateLimit, type AuthVariables } from '../auth.js';
-import { upsertUpload, deleteUploadsForDays, getUploadsForUser, getDb, type UploadEntry } from '../db.js';
+import { upsertUpload, deleteUploadsForDays, getUploadsForUser, getDb, upsertUserFluencyScore, type UploadEntry } from '../db.js';
 
 const MAX_STRING_LENGTHS = {
 	model: 128,
@@ -109,6 +109,35 @@ api.get('/data', requireBearerAuth, (c) => {
 	const days = clampDays(daysRaw);
 	const data = getUploadsForUser(user.id, days);
 	return c.json(data);
+});
+
+/**
+ * POST /api/fluency-score — Store the extension's locally-computed fluency score.
+ * Body: { overallStage, overallLabel, categories, computedAt }
+ * This is the authoritative score: the server dashboard uses it directly instead of
+ * re-computing from aggregated upload blobs.
+ */
+api.post('/fluency-score', requireBearerAuth, async (c) => {
+	const user = c.get('user');
+
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		return c.json({ error: 'Invalid JSON body.' }, 400);
+	}
+
+	if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+		return c.json({ error: 'Body must be a JSON object.' }, 400);
+	}
+
+	const b = body as Record<string, unknown>;
+	if (typeof b.overallStage !== 'number' || !Array.isArray(b.categories)) {
+		return c.json({ error: '"overallStage" (number) and "categories" (array) are required.' }, 400);
+	}
+
+	upsertUserFluencyScore(user.id, JSON.stringify(body));
+	return c.json({ ok: true });
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -175,6 +175,11 @@ function validateEntry(entry: unknown): string | null {
 			return `"editor" too long (max ${MAX_STRING_LENGTHS.editor})`;
 		}
 	}
+	if (e.fluencyMetrics !== undefined && e.fluencyMetrics !== null) {
+		if (typeof e.fluencyMetrics !== 'object' || Array.isArray(e.fluencyMetrics)) {
+			return '"fluencyMetrics" must be an object';
+		}
+	}
 
 	return null;
 }

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -722,7 +722,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
   document.querySelectorAll('#period-tabs .tab').forEach(function(btn) {
     btn.addEventListener('click', function() {
       var target = btn.getAttribute('data-period');
-      location.hash = target;
+      history.replaceState(null, '', '#' + target);
       activatePeriod(target);
     });
   });

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -258,6 +258,21 @@ function h(text: unknown): string {
 		.replace(/"/g, '&quot;');
 }
 
+/** Render a tip string: converts [text](url) markdown links to <a> tags, escapes everything else. */
+function renderTip(tip: string): string {
+	const mdLink = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+	const parts: string[] = [];
+	let last = 0;
+	let m: RegExpExecArray | null;
+	while ((m = mdLink.exec(tip)) !== null) {
+		parts.push(h(tip.slice(last, m.index)));
+		parts.push(`<a href="${h(m[2])}" target="_blank" rel="noopener noreferrer">${h(m[1])}</a>`);
+		last = m.index + m[0].length;
+	}
+	parts.push(h(tip.slice(last)));
+	return parts.join('');
+}
+
 /** Normalize raw vscode.env.appName values to the friendly names used by the extension. */
 function normalizeEditorName(raw: string | null | undefined): string {
 	const name = (raw ?? '').trim();
@@ -282,326 +297,13 @@ function fmt(n: number): string {
 	return String(n);
 }
 
-// ── Fluency Scoring ───────────────────────────────────────────────────────────
-
-/** Tools operated automatically by Copilot (excluded from user-driven tool scoring). */
-const AUTOMATIC_TOOLS = new Set([
-	'get_errors', 'read_file', 'list_dir', 'list_files', 'grep_search',
-	'file_search', 'codebase_search', 'semantic_search', 'find_references',
-	'codesearch', 'run_tests', 'check_errors', 'view_line_range', 'get_file_contents',
-	'read_resource', 'list_resources', 'list_tools', 'list_servers', 'get_resource',
-]);
-
-interface AggregatedFluency {
-	askModeCount: number;
-	editModeCount: number;
-	agentModeCount: number;
-	cliModeCount: number;
-	toolCallsByTool: Record<string, number>;
-	toolCallsTotal: number;
-	ctxFile: number; ctxSelection: number; ctxSymbol: number;
-	ctxCodebase: number; ctxWorkspace: number; ctxTerminal: number;
-	ctxVscode: number; ctxClipboard: number; ctxChanges: number;
-	ctxProblemsPanel: number; ctxOutputPanel: number;
-	ctxTerminalLastCommand: number; ctxTerminalSelection: number;
-	ctxByKind: Record<string, number>;
-	mcpTotal: number;
-	mcpByServer: Record<string, number>;
-	mixedTierSessions: number;
-	switchingFreqSum: number; switchingFreqCount: number;
-	standardModels: Set<string>; premiumModels: Set<string>;
-	multiFileEdits: number;
-	filesPerEditSum: number; filesPerEditCount: number;
-	editsAgentCount: number; workspaceAgentCount: number;
-	repositories: Set<string>; repositoriesWithCustomization: Set<string>;
-	applyRateSum: number; applyRateCount: number;
-	multiTurnSessions: number;
-	turnsPerSessionSum: number; turnsPerSessionCount: number;
-	sessionCount: number;
-	hasData: boolean;
-}
-
-function aggregateFluencyMetrics(uploads: UploadRow[]): AggregatedFluency {
-	const agg: AggregatedFluency = {
-		askModeCount: 0, editModeCount: 0, agentModeCount: 0, cliModeCount: 0,
-		toolCallsByTool: {}, toolCallsTotal: 0,
-		ctxFile: 0, ctxSelection: 0, ctxSymbol: 0, ctxCodebase: 0, ctxWorkspace: 0,
-		ctxTerminal: 0, ctxVscode: 0, ctxClipboard: 0, ctxChanges: 0,
-		ctxProblemsPanel: 0, ctxOutputPanel: 0, ctxTerminalLastCommand: 0, ctxTerminalSelection: 0,
-		ctxByKind: {},
-		mcpTotal: 0, mcpByServer: {},
-		mixedTierSessions: 0, switchingFreqSum: 0, switchingFreqCount: 0,
-		standardModels: new Set(), premiumModels: new Set(),
-		multiFileEdits: 0, filesPerEditSum: 0, filesPerEditCount: 0,
-		editsAgentCount: 0, workspaceAgentCount: 0,
-		repositories: new Set(), repositoriesWithCustomization: new Set(),
-		applyRateSum: 0, applyRateCount: 0,
-		multiTurnSessions: 0, turnsPerSessionSum: 0, turnsPerSessionCount: 0,
-		sessionCount: 0, hasData: false,
-	};
-
-	for (const upload of uploads) {
-		if (!upload.fluency_json) continue;
-		try {
-			const fm = JSON.parse(upload.fluency_json) as Record<string, unknown>;
-			agg.hasData = true;
-
-			agg.askModeCount += (fm.askModeCount as number) || 0;
-			agg.editModeCount += (fm.editModeCount as number) || 0;
-			agg.agentModeCount += (fm.agentModeCount as number) || 0;
-			agg.cliModeCount += (fm.cliModeCount as number) || 0;
-			agg.multiFileEdits += (fm.multiFileEdits as number) || 0;
-			agg.multiTurnSessions += (fm.multiTurnSessions as number) || 0;
-			agg.sessionCount += (fm.sessionCount as number) || 1;
-
-			if (fm.avgTurnsPerSession !== undefined) {
-				agg.turnsPerSessionSum += (fm.avgTurnsPerSession as number) || 0;
-				agg.turnsPerSessionCount++;
-			}
-
-			if (fm.toolCallsJson) {
-				try {
-					const tc = JSON.parse(fm.toolCallsJson as string) as Record<string, unknown>;
-					agg.toolCallsTotal += (tc.total as number) || 0;
-					for (const [k, v] of Object.entries((tc.byTool as Record<string, number>) || {})) {
-						agg.toolCallsByTool[k] = (agg.toolCallsByTool[k] || 0) + (v || 0);
-					}
-				} catch { /* skip */ }
-			}
-
-			if (fm.contextRefsJson) {
-				try {
-					const cr = JSON.parse(fm.contextRefsJson as string) as Record<string, unknown>;
-					agg.ctxFile += (cr.file as number) || 0;
-					agg.ctxSelection += (cr.selection as number) || 0;
-					agg.ctxSymbol += (cr.symbol as number) || 0;
-					agg.ctxCodebase += (cr.codebase as number) || 0;
-					agg.ctxWorkspace += (cr.workspace as number) || 0;
-					agg.ctxTerminal += (cr.terminal as number) || 0;
-					agg.ctxVscode += (cr.vscode as number) || 0;
-					agg.ctxClipboard += (cr.clipboard as number) || 0;
-					agg.ctxChanges += (cr.changes as number) || 0;
-					agg.ctxProblemsPanel += (cr.problemsPanel as number) || 0;
-					agg.ctxOutputPanel += (cr.outputPanel as number) || 0;
-					agg.ctxTerminalLastCommand += (cr.terminalLastCommand as number) || 0;
-					agg.ctxTerminalSelection += (cr.terminalSelection as number) || 0;
-					for (const [k, v] of Object.entries((cr.byKind as Record<string, number>) || {})) {
-						agg.ctxByKind[k] = (agg.ctxByKind[k] || 0) + (v || 0);
-					}
-				} catch { /* skip */ }
-			}
-
-			if (fm.mcpToolsJson) {
-				try {
-					const mcp = JSON.parse(fm.mcpToolsJson as string) as Record<string, unknown>;
-					agg.mcpTotal += (mcp.total as number) || 0;
-					for (const [k, v] of Object.entries((mcp.byServer as Record<string, number>) || {})) {
-						agg.mcpByServer[k] = (agg.mcpByServer[k] || 0) + (v || 0);
-					}
-				} catch { /* skip */ }
-			}
-
-			if (fm.modelSwitchingJson) {
-				try {
-					const ms = JSON.parse(fm.modelSwitchingJson as string) as Record<string, unknown>;
-					agg.mixedTierSessions += (ms.mixedTierSessions as number) || 0;
-					if (ms.switchingFrequency !== undefined) {
-						agg.switchingFreqSum += (ms.switchingFrequency as number) || 0;
-						agg.switchingFreqCount++;
-					}
-					for (const m of (ms.standardModels as string[]) || []) { agg.standardModels.add(m); }
-					for (const m of (ms.premiumModels as string[]) || []) { agg.premiumModels.add(m); }
-				} catch { /* skip */ }
-			}
-
-			if (fm.editScopeJson) {
-				try {
-					const es = JSON.parse(fm.editScopeJson as string) as Record<string, unknown>;
-					const editSessions = ((es.singleFileEdits as number) || 0) + ((es.multiFileEdits as number) || 0);
-					if (editSessions > 0) {
-						agg.filesPerEditSum += (es.totalEditedFiles as number) || 0;
-						agg.filesPerEditCount += editSessions;
-					}
-				} catch { /* skip */ }
-			}
-
-			if (fm.agentTypesJson) {
-				try {
-					const at = JSON.parse(fm.agentTypesJson as string) as Record<string, number>;
-					agg.editsAgentCount += at.editsAgent || 0;
-					agg.workspaceAgentCount += at.workspaceAgent || 0;
-				} catch { /* skip */ }
-			}
-
-			if (fm.repositoriesJson) {
-				try {
-					const rj = JSON.parse(fm.repositoriesJson as string) as { repositories?: string[]; repositoriesWithCustomization?: string[] };
-					for (const r of rj.repositories || []) { agg.repositories.add(r); }
-					for (const r of rj.repositoriesWithCustomization || []) { agg.repositoriesWithCustomization.add(r); }
-				} catch { /* skip */ }
-			}
-
-			if (fm.applyUsageJson) {
-				try {
-					const au = JSON.parse(fm.applyUsageJson as string) as Record<string, number>;
-					if (au.applyRate !== undefined) {
-						agg.applyRateSum += au.applyRate || 0;
-						agg.applyRateCount++;
-					}
-				} catch { /* skip */ }
-			}
-		} catch { /* skip malformed rows */ }
-	}
-
-	return agg;
-}
+// ── Fluency Score types (score is computed by the extension and uploaded directly) ──────────
 
 interface CategoryScore { category: string; icon: string; stage: number; tips: string[] }
 interface FluencyScore {
 	overallStage: number;
 	overallLabel: string;
 	categories: CategoryScore[];
-}
-
-function computeFluencyScore(fd: AggregatedFluency, dashboardSessions: number): FluencyScore {
-	const stageLabels: Record<number, string> = {
-		1: 'Stage 1: AI Skeptic',
-		2: 'Stage 2: AI Explorer',
-		3: 'Stage 3: AI Collaborator',
-		4: 'Stage 4: AI Strategist',
-	};
-
-	const totalInteractions = fd.askModeCount + fd.editModeCount + fd.agentModeCount + fd.cliModeCount;
-	const avgTurnsPerSession = fd.turnsPerSessionCount > 0 ? fd.turnsPerSessionSum / fd.turnsPerSessionCount : 0;
-	const switchingFrequency = fd.switchingFreqCount > 0 ? fd.switchingFreqSum / fd.switchingFreqCount : 0;
-	const hasModelSwitching = fd.mixedTierSessions > 0 || switchingFrequency > 0;
-	const hasAgentMode = (fd.agentModeCount + fd.cliModeCount) > 0;
-	const nonAutoToolCount = Object.keys(fd.toolCallsByTool).filter(t => !AUTOMATIC_TOOLS.has(t.toLowerCase())).length;
-	const avgFilesPerSession = fd.filesPerEditCount > 0 ? fd.filesPerEditSum / fd.filesPerEditCount : 0;
-	const avgApplyRate = fd.applyRateCount > 0 ? fd.applyRateSum / fd.applyRateCount : 0;
-	const totalContextRefs = fd.ctxFile + fd.ctxSelection + fd.ctxSymbol + fd.ctxCodebase + fd.ctxWorkspace;
-
-	// 1. Prompt Engineering
-	let peStage = 1;
-	const slashCmds = ['explain', 'fix', 'tests', 'doc', 'generate', 'optimize', 'new', 'search', 'fixTestFailure', 'setupTests'];
-	const usedSlashCommands = slashCmds.filter(cmd => (fd.toolCallsByTool[cmd] ?? 0) > 0);
-	if (avgTurnsPerSession >= 3 || totalInteractions >= 5) peStage = Math.max(peStage, 2);
-	if (avgTurnsPerSession >= 5) peStage = Math.max(peStage, 3);
-	if (totalInteractions >= 30 && (usedSlashCommands.length >= 2 || hasAgentMode)) peStage = Math.max(peStage, 3);
-	if (totalInteractions >= 100 && hasAgentMode && (hasModelSwitching || usedSlashCommands.length >= 3)) peStage = 4;
-	if (hasModelSwitching && fd.mixedTierSessions > 0) peStage = Math.max(peStage, 3);
-	const peTips: string[] = [];
-	if (peStage < 2) peTips.push('Try asking Copilot a question using the Chat panel');
-	if (peStage < 3) {
-		if (!hasAgentMode) peTips.push('Try agent mode for multi-file changes');
-		if (usedSlashCommands.length < 2) peTips.push('Use slash commands like /explain, /fix, or /tests for structured prompts');
-	}
-	if (peStage < 4) {
-		if (!hasAgentMode) peTips.push('Try agent mode for autonomous, multi-step coding tasks');
-		if (!hasModelSwitching) peTips.push('Experiment with different models — fast ones for simple queries, reasoning models for complex problems');
-	}
-
-	// 2. Context Engineering
-	const usedRefTypeCount = [
-		fd.ctxFile, fd.ctxSelection, fd.ctxSymbol, fd.ctxCodebase, fd.ctxWorkspace,
-		fd.ctxTerminal, fd.ctxVscode, fd.ctxClipboard, fd.ctxChanges,
-		fd.ctxProblemsPanel, fd.ctxOutputPanel, fd.ctxTerminalLastCommand, fd.ctxTerminalSelection,
-	].filter(v => v > 0).length;
-	let ceStage = 1;
-	if (totalContextRefs >= 1) ceStage = 2;
-	if (usedRefTypeCount >= 3 && totalContextRefs >= 10) ceStage = 3;
-	if (usedRefTypeCount >= 5 && totalContextRefs >= 30) ceStage = 4;
-	if ((fd.ctxByKind['copilot.image'] ?? 0) > 0) ceStage = Math.max(ceStage, 3);
-	const ceTips: string[] = [];
-	if (ceStage < 2) ceTips.push('Add #file or #selection references to give Copilot more context');
-	if (ceStage < 3) ceTips.push('Explore @workspace, #codebase, and @terminal for broader context');
-	if (ceStage < 4) ceTips.push('Try #changes, #problemsPanel, #outputPanel, and image attachments for advanced context');
-
-	// 3. Agentic
-	let agStage = 1;
-	if (hasAgentMode || fd.multiFileEdits > 0 || fd.editsAgentCount > 0) agStage = 2;
-	if (avgFilesPerSession >= 3) agStage = Math.max(agStage, 3);
-	if (fd.agentModeCount >= 10 && nonAutoToolCount >= 3) agStage = Math.max(agStage, 3);
-	if (fd.agentModeCount >= 50 && nonAutoToolCount >= 5) agStage = 4;
-	if (fd.multiFileEdits >= 20 && avgFilesPerSession >= 3) agStage = Math.max(agStage, 4);
-	const agTips: string[] = [];
-	if (agStage < 2) agTips.push('Try agent mode — it can run terminal commands, edit files, and explore your codebase');
-	if (agStage < 3) agTips.push('Use agent mode for multi-step tasks; let it chain tools like file search, terminal, and code edits');
-	if (agStage < 4) agTips.push('Tackle complex refactoring or debugging tasks in agent mode for deeper autonomous workflows');
-
-	// 4. Tool Usage
-	let tuStage = 1;
-	if (nonAutoToolCount > 0) tuStage = 2;
-	if (fd.workspaceAgentCount > 0) tuStage = Math.max(tuStage, 3);
-	const advancedTools = ['github_pull_request', 'github_repo', 'run_in_terminal', 'editFiles', 'listFiles'];
-	if (advancedTools.filter(t => (fd.toolCallsByTool[t] ?? 0) > 0).length >= 2) tuStage = Math.max(tuStage, 3);
-	if (fd.mcpTotal > 0) tuStage = Math.max(tuStage, 3);
-	if (Object.keys(fd.mcpByServer).length >= 2) tuStage = 4;
-	const tuTips: string[] = [];
-	if (tuStage < 2) tuTips.push('Try agent mode to let Copilot use built-in tools for file operations and terminal commands');
-	if (tuStage < 3) {
-		if (fd.mcpTotal === 0) tuTips.push('Set up MCP servers to connect Copilot to external tools (databases, APIs, cloud services)');
-		else tuTips.push('Explore GitHub integrations and advanced tools like editFiles and run_in_terminal');
-	}
-	if (tuStage < 4) {
-		if (Object.keys(fd.mcpByServer).length === 1) tuTips.push('Add more MCP servers to expand Copilot\'s capabilities');
-		else if (fd.mcpTotal === 0) tuTips.push('Explore MCP servers for tools that integrate with your workflow');
-	}
-
-	// 5. Customization
-	const totalRepos = fd.repositories.size;
-	const reposWithCustomization = fd.repositoriesWithCustomization.size;
-	const customizationRate = totalRepos > 0 ? reposWithCustomization / totalRepos : 0;
-	let cuStage = 1;
-	if (reposWithCustomization > 0) cuStage = 2;
-	if (customizationRate >= 0.3 && reposWithCustomization >= 2) cuStage = 3;
-	if (customizationRate >= 0.7 && reposWithCustomization >= 3) cuStage = 4;
-	const uniqueModels = new Set([...fd.standardModels, ...fd.premiumModels]);
-	if (uniqueModels.size >= 3) cuStage = Math.max(cuStage, 3);
-	if (uniqueModels.size >= 5 && reposWithCustomization >= 3) cuStage = 4;
-	const cuTips: string[] = [];
-	if (cuStage < 2) cuTips.push('Create a .github/copilot-instructions.md file with project-specific guidelines');
-	if (cuStage < 3) cuTips.push('Add custom instructions to more repositories to standardize your Copilot experience');
-	if (cuStage < 4) {
-		const uncustomized = totalRepos - reposWithCustomization;
-		if (uncustomized > 0) cuTips.push(`${reposWithCustomization} of ${totalRepos} repos customized — add instructions to the remaining ${uncustomized}`);
-		else cuTips.push('Aim for consistent customization across all projects');
-	}
-
-	// 6. Workflow Integration
-	const effectiveSessions = Math.max(dashboardSessions, fd.sessionCount);
-	const modesUsed = [fd.askModeCount > 0, fd.agentModeCount > 0].filter(Boolean).length;
-	let wiStage = 1;
-	if (effectiveSessions >= 3 || avgApplyRate >= 50) wiStage = 2;
-	if (modesUsed >= 2 || totalContextRefs >= 20) wiStage = Math.max(wiStage, 3);
-	if (effectiveSessions >= 15 && modesUsed >= 2 && totalContextRefs >= 20) wiStage = 4;
-	const wiTips: string[] = [];
-	if (wiStage < 2) wiTips.push('Use Copilot more regularly — even for quick questions');
-	if (wiStage < 3) {
-		if (modesUsed < 2) wiTips.push('Combine ask mode with agent mode in your daily workflow');
-		if (totalContextRefs < 10) wiTips.push('Use explicit context references like #file, @workspace, and #selection');
-	}
-	if (wiStage < 4) wiTips.push('Make Copilot part of every coding task: planning, coding, testing, and reviewing');
-
-	// Overall: median of 6 category stages
-	const scores = [peStage, ceStage, agStage, tuStage, cuStage, wiStage].sort((a, b) => a - b);
-	const mid = Math.floor(scores.length / 2);
-	const overallStage = scores.length % 2 === 0
-		? Math.round((scores[mid - 1] + scores[mid]) / 2)
-		: scores[mid];
-
-	return {
-		overallStage,
-		overallLabel: stageLabels[overallStage] ?? 'Stage 1: AI Skeptic',
-		categories: [
-			{ category: 'Prompt Engineering', icon: '💬', stage: peStage, tips: peTips },
-			{ category: 'Context Engineering', icon: '📎', stage: ceStage, tips: ceTips },
-			{ category: 'Agentic', icon: '🤖', stage: agStage, tips: agTips },
-			{ category: 'Tool Usage', icon: '🔧', stage: tuStage, tips: tuTips },
-			{ category: 'Customization', icon: '⚙️', stage: cuStage, tips: cuTips },
-			{ category: 'Workflow Integration', icon: '🔄', stage: wiStage, tips: wiTips },
-		],
-	};
 }
 
 function layout(title: string, body: string): string {
@@ -715,19 +417,23 @@ function layout(title: string, body: string): string {
   /* ── Category Cards ── */
   .fluency-categories { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; }
   .fluency-cat-card { background: #0d1117; border: 1px solid #21262d; border-radius: 8px;
-    padding: 14px 16px; }
-  .fluency-cat-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
-  .fluency-cat-icon { font-size: 1.1rem; }
-  .fluency-cat-name { font-size: 0.85rem; font-weight: 600; color: #c9d1d9; }
+    padding: 14px 16px; overflow: hidden; }
+  .fluency-cat-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
+  .fluency-cat-icon { font-size: 1.1rem; flex-shrink: 0; }
+  .fluency-cat-name { font-size: 0.85rem; font-weight: 600; color: #c9d1d9; min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
   .fluency-stage-pill { display: inline-block; padding: 2px 8px; border-radius: 10px;
-    font-size: 0.72rem; font-weight: 600; margin-left: auto; white-space: nowrap; }
-  .stage-1 { background: #6e768166; color: #8b949e; }
-  .stage-2 { background: #1f6feb33; color: #58a6ff; }
-  .stage-3 { background: #238636aa; color: #3fb950; }
-  .stage-4 { background: #b08800aa; color: #e3b341; }
+    font-size: 0.72rem; font-weight: 600; margin-left: auto; white-space: nowrap; flex-shrink: 0; }
+  .stage-1 { background: rgba(147,197,253,0.15); color: #93c5fd; border: 1px solid rgba(147,197,253,0.4); }
+  .stage-2 { background: rgba(110,231,183,0.15); color: #6ee7b7; border: 1px solid rgba(110,231,183,0.4); }
+  .stage-3 { background: rgba(59,130,246,0.15);  color: #3b82f6; border: 1px solid rgba(59,130,246,0.4); }
+  .stage-4 { background: rgba(16,185,129,0.15);  color: #10b981; border: 1px solid rgba(16,185,129,0.4); }
   .fluency-tips { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
-  .fluency-tips li { font-size: 0.8rem; color: #8b949e; padding-left: 14px; position: relative; }
+  .fluency-tips li { font-size: 0.8rem; color: #8b949e; padding-left: 14px; position: relative;
+    overflow-wrap: break-word; word-break: break-word; }
   .fluency-tips li::before { content: "→"; position: absolute; left: 0; color: #58a6ff66; }
+  .fluency-tips a { color: #58a6ff; text-decoration: none; }
+  .fluency-tips a:hover { text-decoration: underline; }
   .fluency-no-data { color: #8b949e; font-size: 0.85rem; font-style: italic; }
 
   /* ── Collapsible ── */
@@ -823,9 +529,13 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 	};
 
 	// ── Fluency score ─────────────────────────────────────────────────────────
-	const fluencyAgg = aggregateFluencyMetrics(uploads);
-	const dashSessions = new Set(uploads.map(r => r.day)).size; // use active days as proxy
-	const fluencyScore = fluencyAgg.hasData ? computeFluencyScore(fluencyAgg, dashSessions) : null;
+	// Use the score uploaded directly by the extension (exact same computation as local UI).
+	let fluencyScore: FluencyScore | null = null;
+	if (user.fluency_score_json) {
+		try {
+			fluencyScore = JSON.parse(user.fluency_score_json) as FluencyScore;
+		} catch { /* ignore malformed stored score */ }
+	}
 
 	// ── Editor breakdown (last 30 days) ───────────────────────────────────────
 	const editorTotals = new Map<string, number>();
@@ -1216,8 +926,8 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 	const stageStars = fluencyScore
 		? ['', '⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐'][fluencyScore.overallStage] ?? ''
 		: '';
-	const stageColors: Record<number, string> = { 1: '#6e7681', 2: '#58a6ff', 3: '#3fb950', 4: '#e3b341' };
-	const stageColor = fluencyScore ? (stageColors[fluencyScore.overallStage] ?? '#8b949e') : '#8b949e';
+	const stageColorMap: Record<number, string> = { 1: '#93c5fd', 2: '#6ee7b7', 3: '#3b82f6', 4: '#10b981' };
+	const stageColor = fluencyScore ? (stageColorMap[fluencyScore.overallStage] ?? '#93c5fd') : '#93c5fd';
 
 	const fluencyBadgeHtml = fluencyScore ? `
 <button class="fluency-badge" id="fluency-badge-btn" title="View your AI Fluency Score details">
@@ -1240,7 +950,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
       <span class="fluency-stage-pill stage-${cat.stage}">Stage ${cat.stage}</span>
     </div>
     ${cat.tips.length > 0
-		? `<ul class="fluency-tips">${cat.tips.map(t => `<li>${h(t)}</li>`).join('')}</ul>`
+		? `<ul class="fluency-tips">${cat.tips.map(t => `<li>${renderTip(t)}</li>`).join('')}</ul>`
 		: `<p class="fluency-no-data">🏆 You're at the highest level!</p>`}
   </div>`).join('');
 
@@ -1295,11 +1005,9 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
     var FLUENCY_DATA = ${safeJson(fluencyScore.categories.map(c => ({ category: c.category, icon: c.icon, stage: c.stage })))};
     var labels   = FLUENCY_DATA.map(function(c) { return c.icon + ' ' + c.category; });
     var values   = FLUENCY_DATA.map(function(c) { return c.stage; });
-    var stageColors = { 1: '#6e768166', 2: '#1f6feb88', 3: '#23863688', 4: '#b0880088' };
-    var borderColors = { 1: '#6e7681', 2: '#58a6ff', 3: '#3fb950', 4: '#e3b341' };
     var overallStage = ${fluencyScore.overallStage};
-    var fillColor   = stageColors[overallStage] || '#58a6ff44';
-    var borderColor = borderColors[overallStage] || '#58a6ff';
+    var fillColor   = 'rgba(88,166,255,0.25)';
+    var borderColor = '#58a6ff';
 
     radarChart = new Chart(radarCanvas, {
       type: 'radar',

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -105,11 +105,15 @@ dashboard.get('/auth/github/callback', async (c) => {
 	// Optional org membership check
 	const allowedOrg = process.env.ALLOWED_GITHUB_ORG;
 	if (allowedOrg) {
+		// Prefer a server-side PAT (already SSO-authorized) so the user's OAuth token
+		// doesn't need read:org or SAML SSO authorization.
+		const checkToken = process.env.GITHUB_ORG_CHECK_TOKEN || accessToken;
 		try {
 			const memberRes = await fetch(`https://api.github.com/orgs/${allowedOrg}/members/${userData.login}`, {
 				headers: {
-					Authorization: `Bearer ${accessToken}`,
+					Authorization: `Bearer ${checkToken}`,
 					'User-Agent': 'copilot-sharing-server/1.0',
+					Accept: 'application/vnd.github+json',
 				},
 				signal: AbortSignal.timeout(10_000),
 			});
@@ -139,6 +143,80 @@ dashboard.get('/auth/github/callback', async (c) => {
 /** GET /auth/logout — Clear session cookie and redirect to dashboard. */
 dashboard.get('/auth/logout', (c) => {
 	deleteCookie(c, COOKIE_NAME, { path: '/' });
+	return c.redirect('/dashboard');
+});
+
+/** POST /auth/pat — Sign in with a GitHub Personal Access Token. */
+dashboard.post('/auth/pat', async (c) => {
+	const body = await c.req.parseBody();
+	const token = (body['pat'] as string ?? '').trim();
+
+	if (!token) {
+		return c.html(errorPage('No token provided.'), 400);
+	}
+
+	// Fetch the authenticated user
+	let userData: { id: number; login: string; name: string | null; avatar_url: string };
+	try {
+		const userRes = await fetch('https://api.github.com/user', {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'User-Agent': 'copilot-sharing-server/1.0',
+				Accept: 'application/vnd.github+json',
+			},
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!userRes.ok) {
+			return c.html(errorPage('Invalid token or unable to verify GitHub identity.'), 401);
+		}
+		userData = await userRes.json() as typeof userData;
+	} catch (err) {
+		return c.html(errorPage(`Failed to reach GitHub: ${String(err)}`), 502);
+	}
+
+	// Optional org membership check
+	const allowedOrg = process.env.ALLOWED_GITHUB_ORG;
+	if (allowedOrg) {
+		try {
+			const memberRes = await fetch(`https://api.github.com/user/memberships/orgs/${allowedOrg}`, {
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'User-Agent': 'copilot-sharing-server/1.0',
+					Accept: 'application/vnd.github+json',
+				},
+				signal: AbortSignal.timeout(10_000),
+			});
+			if (memberRes.status === 403) {
+				return c.html(errorPage(
+					`Access denied: your token is not authorized for the "${allowedOrg}" organization. ` +
+					`If this org uses SAML SSO, go to github.com → Settings → Personal access tokens, ` +
+					`click your token, and grant SSO access to the "${allowedOrg}" org.`
+				), 403);
+			}
+			if (memberRes.status !== 200) {
+				return c.html(errorPage(`Access denied: you are not a member of the "${allowedOrg}" organization.`), 403);
+			}
+			const membership = await memberRes.json() as { state: string };
+			if (membership.state !== 'active') {
+				return c.html(errorPage(`Access denied: your membership in the "${allowedOrg}" organization is not active.`), 403);
+			}
+		} catch {
+			return c.html(errorPage('Unable to verify organization membership. Please try again.'), 502);
+		}
+	}
+
+	const user = upsertUser(userData.id, userData.login, userData.name, userData.avatar_url);
+	const claims = makeClaims(user.id);
+	const sessionValue = encodeSession(claims);
+
+	setCookie(c, COOKIE_NAME, sessionValue, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === 'production',
+		sameSite: 'Lax',
+		maxAge: SESSION_MAX_AGE,
+		path: '/',
+	});
+
 	return c.redirect('/dashboard');
 });
 
@@ -676,14 +754,42 @@ ${body}
 }
 
 function loginPage(): string {
+	const oauthAvailable = !!process.env.GITHUB_CLIENT_ID;
+	const oauthSection = oauthAvailable ? `
+  <a href="/auth/github" class="btn btn-primary" style="font-size:1rem; padding:12px 28px">
+    Sign in with GitHub (OAuth)
+  </a>
+  <p style="color:#8b949e; margin-top:8px; font-size:0.85rem">
+    Note: requires org admin approval for SSO organizations.
+  </p>
+  <div style="color:#8b949e; margin: 24px 0; font-size:0.9rem">— or —</div>` : '';
+
 	return layout('Sign In', `
 <div class="header"><h1>🤖 Copilot Token Tracker Sharing</h1></div>
 <div class="content" style="text-align:center; margin-top: 80px; align-items:center">
   <h2 style="color:#e6edf3">Sign in to view your usage dashboard</h2>
   <p style="color:#8b949e">Your data is linked to your GitHub account. No account creation needed.</p>
-  <a href="/auth/github" class="btn btn-primary" style="font-size:1rem; padding:12px 28px">
-    Sign in with GitHub
-  </a>
+  ${oauthSection}
+  <form method="POST" action="/auth/pat" style="max-width:420px; margin:0 auto; text-align:left">
+    <label style="color:#8b949e; font-size:0.9rem; display:block; margin-bottom:6px">
+      Sign in with a GitHub Personal Access Token (PAT)
+    </label>
+    <input
+      type="password"
+      name="pat"
+      placeholder="ghp_..."
+      required
+      autocomplete="off"
+      style="width:100%; padding:10px 12px; border-radius:6px; border:1px solid #30363d;
+             background:#161b22; color:#e6edf3; font-size:0.95rem; box-sizing:border-box"
+    />
+    <p style="color:#8b949e; font-size:0.8rem; margin:6px 0 12px">
+      Needs <code>read:user</code> scope (and <code>read:org</code> + SSO authorization if your org enforces SAML SSO).
+    </p>
+    <button type="submit" class="btn btn-primary" style="width:100%; font-size:1rem; padding:10px">
+      Sign in with PAT
+    </button>
+  </form>
   <p style="color:#8b949e; margin-top:32px; font-size:0.85rem">
     The VS Code extension uploads data automatically using your existing GitHub session —
     no separate sign-in required.
@@ -1269,6 +1375,30 @@ var CHART_DATA = ${safeJson(chartData)};
 </script>
 <script>${_chartJsCode}</script>
 <script>${interactiveJs}</script>
+<script>
+// Re-compute "Today" stats using browser's local timezone (server pre-renders in UTC)
+(function() {
+  function fmtLocal(n) {
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+    return String(n);
+  }
+  var todayLocal = new Date().toLocaleDateString('sv-SE'); // YYYY-MM-DD in local timezone
+  var todayData = CHART_DATA.filter(function(r) { return r.day === todayLocal; });
+  var inputTokens = todayData.reduce(function(s, r) { return s + r.inputTokens; }, 0);
+  var outputTokens = todayData.reduce(function(s, r) { return s + r.outputTokens; }, 0);
+  var interactions = todayData.reduce(function(s, r) { return s + r.interactions; }, 0);
+  var daysActive = todayData.length > 0 ? 1 : 0;
+  var panel = document.getElementById('stats-today');
+  if (panel) {
+    var values = panel.querySelectorAll('.stat-card .value');
+    if (values[0]) values[0].textContent = fmtLocal(inputTokens);
+    if (values[1]) values[1].textContent = fmtLocal(outputTokens);
+    if (values[2]) values[2].textContent = fmtLocal(interactions);
+    if (values[3]) values[3].textContent = String(daysActive);
+  }
+})();
+</script>
 <script>${fluencyJs}</script>`);
 }
 

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -7,7 +7,6 @@ import {
 	COOKIE_NAME, OAUTH_STATE_COOKIE, SESSION_MAX_AGE,
 } from '../session.js';
 import { getUserById, getUserByGithubId, getUploadsForUser, getAllUsers, upsertUser, type UploadRow, type UserRow } from '../db.js';
-
 export const dashboard = new Hono();
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID ?? '';
@@ -205,6 +204,328 @@ function fmt(n: number): string {
 	return String(n);
 }
 
+// ── Fluency Scoring ───────────────────────────────────────────────────────────
+
+/** Tools operated automatically by Copilot (excluded from user-driven tool scoring). */
+const AUTOMATIC_TOOLS = new Set([
+	'get_errors', 'read_file', 'list_dir', 'list_files', 'grep_search',
+	'file_search', 'codebase_search', 'semantic_search', 'find_references',
+	'codesearch', 'run_tests', 'check_errors', 'view_line_range', 'get_file_contents',
+	'read_resource', 'list_resources', 'list_tools', 'list_servers', 'get_resource',
+]);
+
+interface AggregatedFluency {
+	askModeCount: number;
+	editModeCount: number;
+	agentModeCount: number;
+	cliModeCount: number;
+	toolCallsByTool: Record<string, number>;
+	toolCallsTotal: number;
+	ctxFile: number; ctxSelection: number; ctxSymbol: number;
+	ctxCodebase: number; ctxWorkspace: number; ctxTerminal: number;
+	ctxVscode: number; ctxClipboard: number; ctxChanges: number;
+	ctxProblemsPanel: number; ctxOutputPanel: number;
+	ctxTerminalLastCommand: number; ctxTerminalSelection: number;
+	ctxByKind: Record<string, number>;
+	mcpTotal: number;
+	mcpByServer: Record<string, number>;
+	mixedTierSessions: number;
+	switchingFreqSum: number; switchingFreqCount: number;
+	standardModels: Set<string>; premiumModels: Set<string>;
+	multiFileEdits: number;
+	filesPerEditSum: number; filesPerEditCount: number;
+	editsAgentCount: number; workspaceAgentCount: number;
+	repositories: Set<string>; repositoriesWithCustomization: Set<string>;
+	applyRateSum: number; applyRateCount: number;
+	multiTurnSessions: number;
+	turnsPerSessionSum: number; turnsPerSessionCount: number;
+	sessionCount: number;
+	hasData: boolean;
+}
+
+function aggregateFluencyMetrics(uploads: UploadRow[]): AggregatedFluency {
+	const agg: AggregatedFluency = {
+		askModeCount: 0, editModeCount: 0, agentModeCount: 0, cliModeCount: 0,
+		toolCallsByTool: {}, toolCallsTotal: 0,
+		ctxFile: 0, ctxSelection: 0, ctxSymbol: 0, ctxCodebase: 0, ctxWorkspace: 0,
+		ctxTerminal: 0, ctxVscode: 0, ctxClipboard: 0, ctxChanges: 0,
+		ctxProblemsPanel: 0, ctxOutputPanel: 0, ctxTerminalLastCommand: 0, ctxTerminalSelection: 0,
+		ctxByKind: {},
+		mcpTotal: 0, mcpByServer: {},
+		mixedTierSessions: 0, switchingFreqSum: 0, switchingFreqCount: 0,
+		standardModels: new Set(), premiumModels: new Set(),
+		multiFileEdits: 0, filesPerEditSum: 0, filesPerEditCount: 0,
+		editsAgentCount: 0, workspaceAgentCount: 0,
+		repositories: new Set(), repositoriesWithCustomization: new Set(),
+		applyRateSum: 0, applyRateCount: 0,
+		multiTurnSessions: 0, turnsPerSessionSum: 0, turnsPerSessionCount: 0,
+		sessionCount: 0, hasData: false,
+	};
+
+	for (const upload of uploads) {
+		if (!upload.fluency_json) continue;
+		try {
+			const fm = JSON.parse(upload.fluency_json) as Record<string, unknown>;
+			agg.hasData = true;
+
+			agg.askModeCount += (fm.askModeCount as number) || 0;
+			agg.editModeCount += (fm.editModeCount as number) || 0;
+			agg.agentModeCount += (fm.agentModeCount as number) || 0;
+			agg.cliModeCount += (fm.cliModeCount as number) || 0;
+			agg.multiFileEdits += (fm.multiFileEdits as number) || 0;
+			agg.multiTurnSessions += (fm.multiTurnSessions as number) || 0;
+			agg.sessionCount += (fm.sessionCount as number) || 1;
+
+			if (fm.avgTurnsPerSession !== undefined) {
+				agg.turnsPerSessionSum += (fm.avgTurnsPerSession as number) || 0;
+				agg.turnsPerSessionCount++;
+			}
+
+			if (fm.toolCallsJson) {
+				try {
+					const tc = JSON.parse(fm.toolCallsJson as string) as Record<string, unknown>;
+					agg.toolCallsTotal += (tc.total as number) || 0;
+					for (const [k, v] of Object.entries((tc.byTool as Record<string, number>) || {})) {
+						agg.toolCallsByTool[k] = (agg.toolCallsByTool[k] || 0) + (v || 0);
+					}
+				} catch { /* skip */ }
+			}
+
+			if (fm.contextRefsJson) {
+				try {
+					const cr = JSON.parse(fm.contextRefsJson as string) as Record<string, unknown>;
+					agg.ctxFile += (cr.file as number) || 0;
+					agg.ctxSelection += (cr.selection as number) || 0;
+					agg.ctxSymbol += (cr.symbol as number) || 0;
+					agg.ctxCodebase += (cr.codebase as number) || 0;
+					agg.ctxWorkspace += (cr.workspace as number) || 0;
+					agg.ctxTerminal += (cr.terminal as number) || 0;
+					agg.ctxVscode += (cr.vscode as number) || 0;
+					agg.ctxClipboard += (cr.clipboard as number) || 0;
+					agg.ctxChanges += (cr.changes as number) || 0;
+					agg.ctxProblemsPanel += (cr.problemsPanel as number) || 0;
+					agg.ctxOutputPanel += (cr.outputPanel as number) || 0;
+					agg.ctxTerminalLastCommand += (cr.terminalLastCommand as number) || 0;
+					agg.ctxTerminalSelection += (cr.terminalSelection as number) || 0;
+					for (const [k, v] of Object.entries((cr.byKind as Record<string, number>) || {})) {
+						agg.ctxByKind[k] = (agg.ctxByKind[k] || 0) + (v || 0);
+					}
+				} catch { /* skip */ }
+			}
+
+			if (fm.mcpToolsJson) {
+				try {
+					const mcp = JSON.parse(fm.mcpToolsJson as string) as Record<string, unknown>;
+					agg.mcpTotal += (mcp.total as number) || 0;
+					for (const [k, v] of Object.entries((mcp.byServer as Record<string, number>) || {})) {
+						agg.mcpByServer[k] = (agg.mcpByServer[k] || 0) + (v || 0);
+					}
+				} catch { /* skip */ }
+			}
+
+			if (fm.modelSwitchingJson) {
+				try {
+					const ms = JSON.parse(fm.modelSwitchingJson as string) as Record<string, unknown>;
+					agg.mixedTierSessions += (ms.mixedTierSessions as number) || 0;
+					if (ms.switchingFrequency !== undefined) {
+						agg.switchingFreqSum += (ms.switchingFrequency as number) || 0;
+						agg.switchingFreqCount++;
+					}
+					for (const m of (ms.standardModels as string[]) || []) { agg.standardModels.add(m); }
+					for (const m of (ms.premiumModels as string[]) || []) { agg.premiumModels.add(m); }
+				} catch { /* skip */ }
+			}
+
+			if (fm.editScopeJson) {
+				try {
+					const es = JSON.parse(fm.editScopeJson as string) as Record<string, unknown>;
+					const editSessions = ((es.singleFileEdits as number) || 0) + ((es.multiFileEdits as number) || 0);
+					if (editSessions > 0) {
+						agg.filesPerEditSum += (es.totalEditedFiles as number) || 0;
+						agg.filesPerEditCount += editSessions;
+					}
+				} catch { /* skip */ }
+			}
+
+			if (fm.agentTypesJson) {
+				try {
+					const at = JSON.parse(fm.agentTypesJson as string) as Record<string, number>;
+					agg.editsAgentCount += at.editsAgent || 0;
+					agg.workspaceAgentCount += at.workspaceAgent || 0;
+				} catch { /* skip */ }
+			}
+
+			if (fm.repositoriesJson) {
+				try {
+					const rj = JSON.parse(fm.repositoriesJson as string) as { repositories?: string[]; repositoriesWithCustomization?: string[] };
+					for (const r of rj.repositories || []) { agg.repositories.add(r); }
+					for (const r of rj.repositoriesWithCustomization || []) { agg.repositoriesWithCustomization.add(r); }
+				} catch { /* skip */ }
+			}
+
+			if (fm.applyUsageJson) {
+				try {
+					const au = JSON.parse(fm.applyUsageJson as string) as Record<string, number>;
+					if (au.applyRate !== undefined) {
+						agg.applyRateSum += au.applyRate || 0;
+						agg.applyRateCount++;
+					}
+				} catch { /* skip */ }
+			}
+		} catch { /* skip malformed rows */ }
+	}
+
+	return agg;
+}
+
+interface CategoryScore { category: string; icon: string; stage: number; tips: string[] }
+interface FluencyScore {
+	overallStage: number;
+	overallLabel: string;
+	categories: CategoryScore[];
+}
+
+function computeFluencyScore(fd: AggregatedFluency, dashboardSessions: number): FluencyScore {
+	const stageLabels: Record<number, string> = {
+		1: 'Stage 1: AI Skeptic',
+		2: 'Stage 2: AI Explorer',
+		3: 'Stage 3: AI Collaborator',
+		4: 'Stage 4: AI Strategist',
+	};
+
+	const totalInteractions = fd.askModeCount + fd.editModeCount + fd.agentModeCount + fd.cliModeCount;
+	const avgTurnsPerSession = fd.turnsPerSessionCount > 0 ? fd.turnsPerSessionSum / fd.turnsPerSessionCount : 0;
+	const switchingFrequency = fd.switchingFreqCount > 0 ? fd.switchingFreqSum / fd.switchingFreqCount : 0;
+	const hasModelSwitching = fd.mixedTierSessions > 0 || switchingFrequency > 0;
+	const hasAgentMode = (fd.agentModeCount + fd.cliModeCount) > 0;
+	const nonAutoToolCount = Object.keys(fd.toolCallsByTool).filter(t => !AUTOMATIC_TOOLS.has(t.toLowerCase())).length;
+	const avgFilesPerSession = fd.filesPerEditCount > 0 ? fd.filesPerEditSum / fd.filesPerEditCount : 0;
+	const avgApplyRate = fd.applyRateCount > 0 ? fd.applyRateSum / fd.applyRateCount : 0;
+	const totalContextRefs = fd.ctxFile + fd.ctxSelection + fd.ctxSymbol + fd.ctxCodebase + fd.ctxWorkspace;
+
+	// 1. Prompt Engineering
+	let peStage = 1;
+	const slashCmds = ['explain', 'fix', 'tests', 'doc', 'generate', 'optimize', 'new', 'search', 'fixTestFailure', 'setupTests'];
+	const usedSlashCommands = slashCmds.filter(cmd => (fd.toolCallsByTool[cmd] ?? 0) > 0);
+	if (avgTurnsPerSession >= 3 || totalInteractions >= 5) peStage = Math.max(peStage, 2);
+	if (avgTurnsPerSession >= 5) peStage = Math.max(peStage, 3);
+	if (totalInteractions >= 30 && (usedSlashCommands.length >= 2 || hasAgentMode)) peStage = Math.max(peStage, 3);
+	if (totalInteractions >= 100 && hasAgentMode && (hasModelSwitching || usedSlashCommands.length >= 3)) peStage = 4;
+	if (hasModelSwitching && fd.mixedTierSessions > 0) peStage = Math.max(peStage, 3);
+	const peTips: string[] = [];
+	if (peStage < 2) peTips.push('Try asking Copilot a question using the Chat panel');
+	if (peStage < 3) {
+		if (!hasAgentMode) peTips.push('Try agent mode for multi-file changes');
+		if (usedSlashCommands.length < 2) peTips.push('Use slash commands like /explain, /fix, or /tests for structured prompts');
+	}
+	if (peStage < 4) {
+		if (!hasAgentMode) peTips.push('Try agent mode for autonomous, multi-step coding tasks');
+		if (!hasModelSwitching) peTips.push('Experiment with different models — fast ones for simple queries, reasoning models for complex problems');
+	}
+
+	// 2. Context Engineering
+	const usedRefTypeCount = [
+		fd.ctxFile, fd.ctxSelection, fd.ctxSymbol, fd.ctxCodebase, fd.ctxWorkspace,
+		fd.ctxTerminal, fd.ctxVscode, fd.ctxClipboard, fd.ctxChanges,
+		fd.ctxProblemsPanel, fd.ctxOutputPanel, fd.ctxTerminalLastCommand, fd.ctxTerminalSelection,
+	].filter(v => v > 0).length;
+	let ceStage = 1;
+	if (totalContextRefs >= 1) ceStage = 2;
+	if (usedRefTypeCount >= 3 && totalContextRefs >= 10) ceStage = 3;
+	if (usedRefTypeCount >= 5 && totalContextRefs >= 30) ceStage = 4;
+	if ((fd.ctxByKind['copilot.image'] ?? 0) > 0) ceStage = Math.max(ceStage, 3);
+	const ceTips: string[] = [];
+	if (ceStage < 2) ceTips.push('Add #file or #selection references to give Copilot more context');
+	if (ceStage < 3) ceTips.push('Explore @workspace, #codebase, and @terminal for broader context');
+	if (ceStage < 4) ceTips.push('Try #changes, #problemsPanel, #outputPanel, and image attachments for advanced context');
+
+	// 3. Agentic
+	let agStage = 1;
+	if (hasAgentMode || fd.multiFileEdits > 0 || fd.editsAgentCount > 0) agStage = 2;
+	if (avgFilesPerSession >= 3) agStage = Math.max(agStage, 3);
+	if (fd.agentModeCount >= 10 && nonAutoToolCount >= 3) agStage = Math.max(agStage, 3);
+	if (fd.agentModeCount >= 50 && nonAutoToolCount >= 5) agStage = 4;
+	if (fd.multiFileEdits >= 20 && avgFilesPerSession >= 3) agStage = Math.max(agStage, 4);
+	const agTips: string[] = [];
+	if (agStage < 2) agTips.push('Try agent mode — it can run terminal commands, edit files, and explore your codebase');
+	if (agStage < 3) agTips.push('Use agent mode for multi-step tasks; let it chain tools like file search, terminal, and code edits');
+	if (agStage < 4) agTips.push('Tackle complex refactoring or debugging tasks in agent mode for deeper autonomous workflows');
+
+	// 4. Tool Usage
+	let tuStage = 1;
+	if (nonAutoToolCount > 0) tuStage = 2;
+	if (fd.workspaceAgentCount > 0) tuStage = Math.max(tuStage, 3);
+	const advancedTools = ['github_pull_request', 'github_repo', 'run_in_terminal', 'editFiles', 'listFiles'];
+	if (advancedTools.filter(t => (fd.toolCallsByTool[t] ?? 0) > 0).length >= 2) tuStage = Math.max(tuStage, 3);
+	if (fd.mcpTotal > 0) tuStage = Math.max(tuStage, 3);
+	if (Object.keys(fd.mcpByServer).length >= 2) tuStage = 4;
+	const tuTips: string[] = [];
+	if (tuStage < 2) tuTips.push('Try agent mode to let Copilot use built-in tools for file operations and terminal commands');
+	if (tuStage < 3) {
+		if (fd.mcpTotal === 0) tuTips.push('Set up MCP servers to connect Copilot to external tools (databases, APIs, cloud services)');
+		else tuTips.push('Explore GitHub integrations and advanced tools like editFiles and run_in_terminal');
+	}
+	if (tuStage < 4) {
+		if (Object.keys(fd.mcpByServer).length === 1) tuTips.push('Add more MCP servers to expand Copilot\'s capabilities');
+		else if (fd.mcpTotal === 0) tuTips.push('Explore MCP servers for tools that integrate with your workflow');
+	}
+
+	// 5. Customization
+	const totalRepos = fd.repositories.size;
+	const reposWithCustomization = fd.repositoriesWithCustomization.size;
+	const customizationRate = totalRepos > 0 ? reposWithCustomization / totalRepos : 0;
+	let cuStage = 1;
+	if (reposWithCustomization > 0) cuStage = 2;
+	if (customizationRate >= 0.3 && reposWithCustomization >= 2) cuStage = 3;
+	if (customizationRate >= 0.7 && reposWithCustomization >= 3) cuStage = 4;
+	const uniqueModels = new Set([...fd.standardModels, ...fd.premiumModels]);
+	if (uniqueModels.size >= 3) cuStage = Math.max(cuStage, 3);
+	if (uniqueModels.size >= 5 && reposWithCustomization >= 3) cuStage = 4;
+	const cuTips: string[] = [];
+	if (cuStage < 2) cuTips.push('Create a .github/copilot-instructions.md file with project-specific guidelines');
+	if (cuStage < 3) cuTips.push('Add custom instructions to more repositories to standardize your Copilot experience');
+	if (cuStage < 4) {
+		const uncustomized = totalRepos - reposWithCustomization;
+		if (uncustomized > 0) cuTips.push(`${reposWithCustomization} of ${totalRepos} repos customized — add instructions to the remaining ${uncustomized}`);
+		else cuTips.push('Aim for consistent customization across all projects');
+	}
+
+	// 6. Workflow Integration
+	const effectiveSessions = Math.max(dashboardSessions, fd.sessionCount);
+	const modesUsed = [fd.askModeCount > 0, fd.agentModeCount > 0].filter(Boolean).length;
+	let wiStage = 1;
+	if (effectiveSessions >= 3 || avgApplyRate >= 50) wiStage = 2;
+	if (modesUsed >= 2 || totalContextRefs >= 20) wiStage = Math.max(wiStage, 3);
+	if (effectiveSessions >= 15 && modesUsed >= 2 && totalContextRefs >= 20) wiStage = 4;
+	const wiTips: string[] = [];
+	if (wiStage < 2) wiTips.push('Use Copilot more regularly — even for quick questions');
+	if (wiStage < 3) {
+		if (modesUsed < 2) wiTips.push('Combine ask mode with agent mode in your daily workflow');
+		if (totalContextRefs < 10) wiTips.push('Use explicit context references like #file, @workspace, and #selection');
+	}
+	if (wiStage < 4) wiTips.push('Make Copilot part of every coding task: planning, coding, testing, and reviewing');
+
+	// Overall: median of 6 category stages
+	const scores = [peStage, ceStage, agStage, tuStage, cuStage, wiStage].sort((a, b) => a - b);
+	const mid = Math.floor(scores.length / 2);
+	const overallStage = scores.length % 2 === 0
+		? Math.round((scores[mid - 1] + scores[mid]) / 2)
+		: scores[mid];
+
+	return {
+		overallStage,
+		overallLabel: stageLabels[overallStage] ?? 'Stage 1: AI Skeptic',
+		categories: [
+			{ category: 'Prompt Engineering', icon: '💬', stage: peStage, tips: peTips },
+			{ category: 'Context Engineering', icon: '📎', stage: ceStage, tips: ceTips },
+			{ category: 'Agentic', icon: '🤖', stage: agStage, tips: agTips },
+			{ category: 'Tool Usage', icon: '🔧', stage: tuStage, tips: tuTips },
+			{ category: 'Customization', icon: '⚙️', stage: cuStage, tips: cuTips },
+			{ category: 'Workflow Integration', icon: '🔄', stage: wiStage, tips: wiTips },
+		],
+	};
+}
+
 function layout(title: string, body: string): string {
 	return `<!DOCTYPE html>
 <html lang="en">
@@ -284,6 +605,53 @@ function layout(title: string, body: string): string {
   .alert { padding: 12px 16px; border-radius: 6px; margin: 4px 0; }
   .alert-warn { background: #3d2b0030; border: 1px solid #bb8009; color: #e3b341; }
 
+  /* ── Fluency Score Badge ── */
+  .fluency-badge { display: flex; align-items: center; gap: 8px; padding: 6px 12px;
+    background: #1c2433; border: 1px solid #30363d; border-radius: 8px;
+    cursor: pointer; transition: all 0.15s; text-decoration: none; user-select: none; }
+  .fluency-badge:hover { background: #21262d; border-color: #58a6ff44; }
+  .fluency-badge .fb-label { font-size: 0.75rem; color: #8b949e; }
+  .fluency-badge .fb-stage { font-size: 0.9rem; font-weight: 700; color: #e6edf3; }
+  .fluency-badge .fb-stars { font-size: 0.8rem; letter-spacing: 1px; }
+  .fluency-badge .fb-icon { font-size: 1.1rem; }
+
+  /* ── Fluency Modal Overlay ── */
+  .fluency-modal-overlay { display: none; position: fixed; inset: 0; background: #0d111799;
+    z-index: 1000; align-items: center; justify-content: center; padding: 20px; }
+  .fluency-modal-overlay.open { display: flex; }
+  .fluency-modal { background: #161b22; border: 1px solid #30363d; border-radius: 12px;
+    width: 100%; max-width: 860px; max-height: 90vh; overflow-y: auto;
+    display: flex; flex-direction: column; }
+  .fluency-modal-header { padding: 20px 24px 0; display: flex; align-items: flex-start;
+    justify-content: space-between; gap: 16px; }
+  .fluency-modal-title { font-size: 1.2rem; font-weight: 700; color: #e6edf3; margin: 0; }
+  .fluency-modal-subtitle { color: #8b949e; font-size: 0.85rem; margin-top: 4px; }
+  .fluency-modal-close { background: none; border: none; color: #8b949e; font-size: 1.4rem;
+    cursor: pointer; padding: 0 4px; line-height: 1; flex-shrink: 0; }
+  .fluency-modal-close:hover { color: #e6edf3; }
+  .fluency-modal-body { padding: 20px 24px 24px; display: flex; flex-direction: column; gap: 20px; }
+
+  /* ── Radar Chart ── */
+  .fluency-chart-wrap { position: relative; height: 320px; display: flex; align-items: center; justify-content: center; }
+
+  /* ── Category Cards ── */
+  .fluency-categories { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; }
+  .fluency-cat-card { background: #0d1117; border: 1px solid #21262d; border-radius: 8px;
+    padding: 14px 16px; }
+  .fluency-cat-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+  .fluency-cat-icon { font-size: 1.1rem; }
+  .fluency-cat-name { font-size: 0.85rem; font-weight: 600; color: #c9d1d9; }
+  .fluency-stage-pill { display: inline-block; padding: 2px 8px; border-radius: 10px;
+    font-size: 0.72rem; font-weight: 600; margin-left: auto; white-space: nowrap; }
+  .stage-1 { background: #6e768166; color: #8b949e; }
+  .stage-2 { background: #1f6feb33; color: #58a6ff; }
+  .stage-3 { background: #238636aa; color: #3fb950; }
+  .stage-4 { background: #b08800aa; color: #e3b341; }
+  .fluency-tips { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+  .fluency-tips li { font-size: 0.8rem; color: #8b949e; padding-left: 14px; position: relative; }
+  .fluency-tips li::before { content: "→"; position: absolute; left: 0; color: #58a6ff66; }
+  .fluency-no-data { color: #8b949e; font-size: 0.85rem; font-style: italic; }
+
   /* ── Collapsible ── */
   details.card > summary { cursor: pointer; color: #8b949e; font-size: 0.9rem; padding: 0;
     user-select: none; list-style: none; display: flex; align-items: center; gap: 6px; }
@@ -347,6 +715,11 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
 		week: computeStats(uploads7d),
 		month: computeStats(uploads),
 	};
+
+	// ── Fluency score ─────────────────────────────────────────────────────────
+	const fluencyAgg = aggregateFluencyMetrics(uploads);
+	const dashSessions = new Set(uploads.map(r => r.day)).size; // use active days as proxy
+	const fluencyScore = fluencyAgg.hasData ? computeFluencyScore(fluencyAgg, dashSessions) : null;
 
 	// ── Editor breakdown (last 30 days) ───────────────────────────────────────
 	const editorTotals = new Map<string, number>();
@@ -733,11 +1106,151 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
   });
 })();`;
 
+	// ── Fluency badge (header) ────────────────────────────────────────────────
+	const stageStars = fluencyScore
+		? ['', '⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐'][fluencyScore.overallStage] ?? ''
+		: '';
+	const stageColors: Record<number, string> = { 1: '#6e7681', 2: '#58a6ff', 3: '#3fb950', 4: '#e3b341' };
+	const stageColor = fluencyScore ? (stageColors[fluencyScore.overallStage] ?? '#8b949e') : '#8b949e';
+
+	const fluencyBadgeHtml = fluencyScore ? `
+<button class="fluency-badge" id="fluency-badge-btn" title="View your AI Fluency Score details">
+  <span class="fb-icon">🎯</span>
+  <div>
+    <div class="fb-label">AI Fluency</div>
+    <div class="fb-stage" style="color:${stageColor}">${h(fluencyScore.overallLabel)}</div>
+  </div>
+  <span class="fb-stars">${stageStars}</span>
+</button>` : '';
+
+	// ── Fluency modal ─────────────────────────────────────────────────────────
+	const fluencyModalHtml = fluencyScore ? (() => {
+		const cats = fluencyScore.categories;
+		const catCards = cats.map(cat => `
+  <div class="fluency-cat-card">
+    <div class="fluency-cat-header">
+      <span class="fluency-cat-icon">${cat.icon}</span>
+      <span class="fluency-cat-name">${h(cat.category)}</span>
+      <span class="fluency-stage-pill stage-${cat.stage}">Stage ${cat.stage}</span>
+    </div>
+    ${cat.tips.length > 0
+		? `<ul class="fluency-tips">${cat.tips.map(t => `<li>${h(t)}</li>`).join('')}</ul>`
+		: `<p class="fluency-no-data">🏆 You're at the highest level!</p>`}
+  </div>`).join('');
+
+		return `
+<div class="fluency-modal-overlay" id="fluency-modal-overlay">
+  <div class="fluency-modal">
+    <div class="fluency-modal-header">
+      <div>
+        <p class="fluency-modal-title">🎯 AI Fluency Score</p>
+        <p class="fluency-modal-subtitle">
+          Overall: <strong style="color:${stageColor}">${h(fluencyScore.overallLabel)}</strong>
+          &nbsp;${stageStars}&nbsp;·&nbsp;Based on your last 30 days of activity
+        </p>
+      </div>
+      <button class="fluency-modal-close" id="fluency-modal-close" aria-label="Close">✕</button>
+    </div>
+    <div class="fluency-modal-body">
+      <div class="fluency-chart-wrap">
+        <canvas id="fluency-radar-chart" style="max-height:300px"></canvas>
+      </div>
+      <div class="fluency-categories">${catCards}</div>
+    </div>
+  </div>
+</div>`;
+	})() : '';
+
+	// ── Fluency JS ────────────────────────────────────────────────────────────
+	const fluencyJs = fluencyScore ? `
+(function() {
+  var overlay = document.getElementById('fluency-modal-overlay');
+  var badge   = document.getElementById('fluency-badge-btn');
+  var closeBtn = document.getElementById('fluency-modal-close');
+  var radarCanvas = document.getElementById('fluency-radar-chart');
+  var radarChart = null;
+
+  function openModal() {
+    overlay.classList.add('open');
+    if (!radarChart && radarCanvas) { buildRadar(); }
+  }
+  function closeModal() { overlay.classList.remove('open'); }
+
+  if (badge)    badge.addEventListener('click', openModal);
+  if (closeBtn) closeBtn.addEventListener('click', closeModal);
+  if (overlay)  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) { closeModal(); }
+  });
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') { closeModal(); }
+  });
+
+  function buildRadar() {
+    var FLUENCY_DATA = ${safeJson(fluencyScore.categories.map(c => ({ category: c.category, icon: c.icon, stage: c.stage })))};
+    var labels   = FLUENCY_DATA.map(function(c) { return c.icon + ' ' + c.category; });
+    var values   = FLUENCY_DATA.map(function(c) { return c.stage; });
+    var stageColors = { 1: '#6e768166', 2: '#1f6feb88', 3: '#23863688', 4: '#b0880088' };
+    var borderColors = { 1: '#6e7681', 2: '#58a6ff', 3: '#3fb950', 4: '#e3b341' };
+    var overallStage = ${fluencyScore.overallStage};
+    var fillColor   = stageColors[overallStage] || '#58a6ff44';
+    var borderColor = borderColors[overallStage] || '#58a6ff';
+
+    radarChart = new Chart(radarCanvas, {
+      type: 'radar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Your Score',
+          data: values,
+          backgroundColor: fillColor,
+          borderColor: borderColor,
+          borderWidth: 2,
+          pointBackgroundColor: borderColor,
+          pointRadius: 5,
+          pointHoverRadius: 7,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: true,
+        scales: {
+          r: {
+            min: 0, max: 4,
+            ticks: {
+              stepSize: 1, color: '#8b949e', backdropColor: 'transparent', font: { size: 10 },
+              callback: function(v) {
+                return v === 0 ? '' : ['','AI Skeptic','Explorer','Collaborator','Strategist'][v] || v;
+              },
+            },
+            grid: { color: '#30363d' },
+            pointLabels: { color: '#c9d1d9', font: { size: 11 } },
+            angleLines: { color: '#30363d' },
+          },
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: '#161b22', borderColor: '#30363d', borderWidth: 1,
+            callbacks: {
+              label: function(ctx) {
+                var s = ctx.parsed.r;
+                var labels = ['','AI Skeptic','AI Explorer','AI Collaborator','AI Strategist'];
+                return ' Stage ' + s + ': ' + (labels[s] || '');
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+})();` : '';
+
 	return layout(`${user.github_login}'s Dashboard`, `
 <div class="header">
   <h1>🤖 Copilot Token Tracker</h1>
   <span class="spacer"></span>
-  ${avatarUrl ? `<img src="${avatarUrl}" class="avatar-sm" alt="${login}">` : ''}
+  ${fluencyBadgeHtml}
+  ${avatarUrl ? `<img src="${avatarUrl}" class="avatar-sm" alt="${login}" style="margin-left:8px">` : ''}
   <span style="color:#c9d1d9;font-size:0.875rem">${displayName}</span>
   <a href="/auth/logout" style="margin-left:8px">Sign out</a>
 </div>
@@ -749,12 +1262,14 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean, al
   ${tableHtml}
   ${adminHtml}
 </div>
+${fluencyModalHtml}
 
 <script>
 var CHART_DATA = ${safeJson(chartData)};
 </script>
 <script>${_chartJsCode}</script>
-<script>${interactiveJs}</script>`);
+<script>${interactiveJs}</script>
+<script>${fluencyJs}</script>`);
 }
 
 function errorPage(message: string): string {

--- a/vscode-extension/src/backend/configPanel.ts
+++ b/vscode-extension/src/backend/configPanel.ts
@@ -10,6 +10,7 @@ export interface BackendConfigPanelState {
 	privacyBadge: string;
 	isConfigured: boolean;
 	authStatus: string;
+	githubTokenAvailable: boolean;
 	shareConsentAt?: string;
 	lastSyncAt?: number;
 }
@@ -291,6 +292,9 @@ export class BackendConfigPanel implements vscode.Disposable {
 				</div>
 				<div id="enabledToggleTeam-help" class="helper">Independent of Azure Storage — both backends can sync simultaneously.</div>
 				<div class="status-line" id="lastSyncLine" style="margin-top: 12px;" role="status"></div>
+			<div id="githubAuthWarning" style="display:none; margin-top: 12px; padding: 10px 12px; background: #4d2c00; border-left: 3px solid #f0883e; border-radius: 4px; font-size: 12px; color: #e5c07b;">
+				⚠️ <strong>GitHub sign-in required.</strong> The extension uses your VS Code GitHub session as the upload token. Open the <strong>Accounts</strong> menu (bottom-left) and grant access to <em>AI Engineering Fluency</em>, then wait for the next sync.
+			</div>
 			</div>
 			<div class="card">
 				<h3>Connection</h3>
@@ -540,6 +544,8 @@ export class BackendConfigPanel implements vscode.Disposable {
 			byId('privacyBadge').innerText = 'Privacy: ' + state.privacyBadge;
 			byId('authBadge').innerText = state.authStatus;
 			byId('backendStateBadge').innerText = (state.draft.enabled || state.draft.sharingServerEnabled) ? 'Backend: Enabled' : 'Backend: Disabled';
+			const showGithubWarning = state.draft.sharingServerEnabled && !state.githubTokenAvailable;
+			byId('githubAuthWarning').style.display = showGithubWarning ? 'block' : 'none';
 			updateLastSyncLine(state.lastSyncAt);
 			
 			// Update overview details

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -281,6 +281,13 @@ export class BackendFacade {
     return this.syncService.getSyncQueue();
   }
 
+  public async uploadFluencyScoreToSharingServer(
+    settings: BackendSettings,
+    score: Record<string, unknown>,
+  ): Promise<void> {
+    return this.syncService.uploadFluencyScoreToSharingServer(settings, score);
+  }
+
   // Cache state exposed for testing via QueryService accessors
   public get backendLastQueryResult(): BackendQueryResultLike | undefined {
     return this.queryService.getLastQueryResult();

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -627,12 +627,14 @@ export class BackendFacade {
           : "Auth: Shared Key missing on this machine"
         : "Auth: Entra ID (RBAC)";
     const lastSyncAt = this.deps.context?.globalState?.get<number>('backend.lastSyncAt');
+    const githubTokenAvailable = !!(this.deps.getGithubToken?.());
     return {
       draft,
       sharedKeySet,
       privacyBadge,
       isConfigured: this.isConfigured(settings),
       authStatus,
+      githubTokenAvailable,
       shareConsentAt: settings.shareConsentAt,
       lastSyncAt,
     };

--- a/vscode-extension/src/backend/services/sharingServerUploadService.ts
+++ b/vscode-extension/src/backend/services/sharingServerUploadService.ts
@@ -73,4 +73,37 @@ export class SharingServerUploadService {
 			return { success: false, entriesUploaded: 0, message };
 		}
 	}
+
+	/**
+	 * Upload the extension's locally-computed fluency score so the server dashboard
+	 * shows the exact same result as the extension's AI Fluency Score panel.
+	 */
+	async uploadFluencyScore(
+		endpointUrl: string,
+		githubToken: string,
+		score: Record<string, unknown>,
+		log: (msg: string) => void,
+		warn: (msg: string) => void,
+	): Promise<void> {
+		const baseUrl = endpointUrl.replace(/\/$/, '');
+		const url = `${baseUrl}/api/fluency-score`;
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': `Bearer ${githubToken}`,
+				},
+				body: JSON.stringify(score),
+			});
+			if (!response.ok) {
+				const errorText = await response.text().catch(() => '');
+				warn(`Sharing server fluency-score upload: HTTP ${response.status}: ${errorText}`);
+				return;
+			}
+			log('Sharing server fluency-score upload: ok');
+		} catch (e: any) {
+			warn(`Sharing server fluency-score upload failed: ${e?.message ?? e}`);
+		}
+	}
 }

--- a/vscode-extension/src/backend/services/sharingServerUploadService.ts
+++ b/vscode-extension/src/backend/services/sharingServerUploadService.ts
@@ -15,6 +15,7 @@ export interface SharingServerEntry {
 	outputTokens: number;
 	interactions: number;
 	datasetId?: string;
+	fluencyMetrics?: Record<string, unknown>;
 }
 
 /** Maximum number of entries per HTTP request (matches server-side limit). */

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -120,22 +120,15 @@ export class SyncService {
 	// ── Cross-instance file lock ────────────────────────────────────────
 
 	/**
-	 * Path for the sync lock file.  Uses globalStorageUri which is already
-	 * scoped per VS Code edition (stable vs insiders).
-	 */
-	private getSyncLockPath(): string | undefined {
-		const ctx = this.deps.context;
-		if (!ctx) { return undefined; }
-		return path.join(ctx.globalStorageUri.fsPath, 'backend_sync.lock');
-	}
-
-	/**
 	 * Try to acquire an exclusive file lock so only one VS Code window
 	 * can run a backend sync at a time.
 	 */
-	private async acquireSyncLock(): Promise<boolean> {
-		const lockPath = this.getSyncLockPath();
-		if (!lockPath) { return true; } // No context → allow (tests)
+	private async acquireSyncLock(backend?: string): Promise<boolean> {
+		const ctx = this.deps.context;
+		if (!ctx) { return true; } // No context → allow (tests)
+		// Use a backend-specific lock so Azure and sharingServer syncs don't block each other.
+		const suffix = backend === 'sharingServer' ? '_sharingserver' : '';
+		const lockPath = path.join(ctx.globalStorageUri.fsPath, `backend_sync${suffix}.lock`);
 		try {
 			await fs.promises.mkdir(path.dirname(lockPath), { recursive: true });
 			const fd = await fs.promises.open(lockPath, 'wx');
@@ -179,9 +172,11 @@ export class SyncService {
 	/**
 	 * Release the sync lock, but only if we own it.
 	 */
-	private async releaseSyncLock(): Promise<void> {
-		const lockPath = this.getSyncLockPath();
-		if (!lockPath) { return; }
+	private async releaseSyncLock(backend?: string): Promise<void> {
+		const ctx = this.deps.context;
+		if (!ctx) { return; }
+		const suffix = backend === 'sharingServer' ? '_sharingserver' : '';
+		const lockPath = path.join(ctx.globalStorageUri.fsPath, `backend_sync${suffix}.lock`);
 		try {
 			const content = await fs.promises.readFile(lockPath, 'utf-8');
 			const lock = JSON.parse(content);
@@ -318,9 +313,57 @@ export class SyncService {
 				this.deps.warn(`Backend sync: invalid interactions count in cached data for ${sessionFile}`);
 				return false;
 			}
-			
-			// Parse the session file to get actual request timestamps and create per-day rollups
-			// This ensures accurate day assignment while using cached token counts
+
+			// Fast path: use pre-computed dailyRollups (same data as extension stats — avoids re-parsing the file).
+			// When present, token attribution is already distributed per-UTC-day and per-model, so results
+			// will exactly match what the extension shows locally.
+			if (cachedData.dailyRollups && Object.keys(cachedData.dailyRollups).length > 0) {
+				const totalSessionInteractions = cachedData.interactions || 1;
+				const dayKeys = Object.keys(cachedData.dailyRollups).sort();
+
+				for (const dayKey of dayKeys) {
+					const dayEntry = cachedData.dailyRollups[dayKey];
+					const dayStartMs = new Date(dayKey + 'T00:00:00Z').getTime();
+					if (dayStartMs < startMs) { continue; }
+
+					const modelEntries = Object.entries(dayEntry.modelUsage).filter(([, mu]) =>
+						mu && ((mu.inputTokens || 0) > 0 || (mu.outputTokens || 0) > 0)
+					);
+					if (modelEntries.length === 0) { continue; }
+
+					// Distribute this day's interactions across models proportionally by output token share.
+					const totalDayOutput = modelEntries.reduce((s, [, mu]) => s + (mu.outputTokens || 0), 0);
+					const dayFraction = totalSessionInteractions > 0 ? dayEntry.interactions / totalSessionInteractions : 1;
+					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, dayFraction);
+
+					let remainingInteractions = dayEntry.interactions;
+					for (let i = 0; i < modelEntries.length; i++) {
+						const [model, mu] = modelEntries[i];
+						const isLast = i === modelEntries.length - 1;
+						const share = (!isLast && totalDayOutput > 0) ? (mu.outputTokens || 0) / totalDayOutput : 1;
+						const modelInteractions = isLast
+							? remainingInteractions
+							: Math.min(Math.round(dayEntry.interactions * share), remainingInteractions);
+						remainingInteractions -= modelInteractions;
+
+						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
+						upsertDailyRollup(rollups, key, {
+							inputTokens: mu.inputTokens || 0,
+							outputTokens: mu.outputTokens || 0,
+							interactions: Math.max(0, modelInteractions),
+							fluencyMetrics,
+						});
+					}
+				}
+
+				if (dayKeys.length > 1) {
+					this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} spans ${dayKeys.length} days (dailyRollups fast path): ${dayKeys.join(', ')}`);
+				}
+				return true;
+			}
+
+			// Slow path: parse the session file to get actual request timestamps and create per-day rollups.
+			// Used when dailyRollups is absent (old cache entries before CACHE_VERSION bump, ecosystem sessions).
 			const content = await fs.promises.readFile(sessionFile, 'utf8');
 			
 			// Map to track per-day per-model interactions for proper distribution
@@ -1149,7 +1192,7 @@ export class SyncService {
 			}
 
 			// Acquire cross-instance file lock to prevent concurrent syncs from multiple VS Code windows
-			const lockAcquired = await this.acquireSyncLock();
+			const lockAcquired = await this.acquireSyncLock(settings.backend);
 			if (!lockAcquired) {
 				this.deps.log('Backend sync: skipping (another VS Code window is currently syncing)');
 				return;
@@ -1346,7 +1389,7 @@ export class SyncService {
 				this.deps.warn(`Backend sync: ${safeStringifyError(e, secretsToRedact)}`);
 			} finally {
 				this.backendSyncInProgress = false;
-				await this.releaseSyncLock();
+				await this.releaseSyncLock(settings.backend);
 			}
 		});
 		return this.syncQueue;

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1474,6 +1474,30 @@ export class SyncService {
 	}
 
 	/**
+	 * Upload the extension's locally-computed fluency score to the sharing server.
+	 * Call this after calculateMaturityScores() to keep the server dashboard in sync
+	 * with the extension's AI Fluency Score panel.
+	 */
+	async uploadFluencyScoreToSharingServer(
+		settings: BackendSettings,
+		score: Record<string, unknown>,
+	): Promise<void> {
+		if (!this.sharingServerUploadService) { return; }
+		if (!settings.sharingServerEnabled || !settings.sharingServerEndpointUrl) { return; }
+
+		const githubToken = this.deps.getGithubToken?.();
+		if (!githubToken) { return; }
+
+		await this.sharingServerUploadService.uploadFluencyScore(
+			settings.sharingServerEndpointUrl,
+			githubToken,
+			score,
+			this.deps.log,
+			this.deps.warn,
+		);
+	}
+
+	/**
 	 * Backfill historical data to Azure Table Storage.
 	 * Scans ALL local session files (ignoring file mtime) and upserts daily rollups for every
 	 * day that has local data within the given lookback window. This is safe to run at any time

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1414,6 +1414,7 @@ export class SyncService {
 				interactions: value.interactions,
 				datasetId: settings.datasetId,
 				editor: key.editor ?? this.normalizeEditorName(vscode.env.appName),
+				fluencyMetrics: value.fluencyMetrics as Record<string, unknown> | undefined,
 			});
 		}
 

--- a/vscode-extension/src/backend/types.ts
+++ b/vscode-extension/src/backend/types.ts
@@ -2,27 +2,10 @@
  * TypeScript type definitions for the backend module.
  */
 
-/**
- * Session file cache entry (pre-computed session data).
- * This data is validated at runtime before use to prevent injection attacks.
- * Validation checks: structure, modelUsage object, numeric bounds on all fields.
- */
-export interface SessionFileCache {
-	tokens: number;
-	interactions: number;
-	modelUsage: ModelUsage;
-	mtime: number;
-}
-
-/**
- * Model usage statistics (tokens per model).
- */
-export interface ModelUsage {
-	[model: string]: {
-		inputTokens: number;
-		outputTokens: number;
-	};
-}
+// Import shared cache/model types from the root types module so all consumers
+// stay in sync with a single source of truth.
+import type { ModelUsage } from '../types';
+export type { SessionFileCache, DailyRollupEntry, ModelUsage } from '../types';
 
 /**
  * Daily rollup value (aggregated stats for a day).

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -34,6 +34,7 @@ import type {
   DailyTokenStats,
   ChartDataPayload,
   SessionFileCache,
+  DailyRollupEntry,
   CustomizationFileEntry,
   SessionUsageAnalysis,
   ToolCallUsage,
@@ -165,7 +166,7 @@ type LocalViewRegressionCase = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 41; // Add 'cli' mode to ModeUsage for CLI-based tools
+	private static readonly CACHE_VERSION = 42; // Use UTC-based daily rollups for consistent token attribution
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -1508,13 +1509,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private async calculateDetailedStats(progressCallback?: (completed: number, total: number) => void): Promise<DetailedStats> {
 		const now = new Date();
-		const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-		const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-		// Calculate Previous Month boundaries
-		const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999); // Last day of previous month
-		const lastMonthStart = new Date(lastMonthEnd.getFullYear(), lastMonthEnd.getMonth(), 1);
-		// Calculate last 30 days boundary (midnight, so numbers don't shift during a refresh)
-		const last30DaysStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+		// UTC-based date keys for consistent daily attribution (matching server-side)
+		const todayUtcKey = now.toISOString().slice(0, 10);
+		const monthUtcStartKey = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0, 10);
+		const lastMonthLastDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0));
+		const lastMonthUtcEndKey = lastMonthLastDay.toISOString().slice(0, 10);
+		const lastMonthUtcStartKey = new Date(Date.UTC(lastMonthLastDay.getUTCFullYear(), lastMonthLastDay.getUTCMonth(), 1)).toISOString().slice(0, 10);
+		const last30DaysUtcStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
+		const last30DaysUtcStartKey = last30DaysUtcStart.toISOString().slice(0, 10);
+		const last30DaysStartMs = last30DaysUtcStart.getTime();
 
 		const todayStats = { tokens: 0, thinkingTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
 		const monthStats = { tokens: 0, thinkingTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
@@ -1523,6 +1526,21 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		// Also compute daily stats for the chart as a byproduct (avoids a second full file scan)
 		const dailyStatsMap = new Map<string, DailyTokenStats>();
+
+		// Helper to merge model usage into a target map
+		const addModelUsage = (target: ModelUsage, source: ModelUsage) => {
+			for (const [model, usage] of Object.entries(source)) {
+				if (!target[model]) { target[model] = { inputTokens: 0, outputTokens: 0 }; }
+				target[model].inputTokens += usage.inputTokens;
+				target[model].outputTokens += usage.outputTokens;
+			}
+		};
+		// Helper to add editor usage to a period stat
+		const addEditorUsage = (target: EditorUsage, editorType: string, tokens: number) => {
+			if (!target[editorType]) { target[editorType] = { tokens: 0, sessions: 0 }; }
+			target[editorType].tokens += tokens;
+			target[editorType].sessions += 1;
+		};
 
 		try {
 			// Clean expired cache entries
@@ -1546,7 +1564,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const fileStats = await this.statSessionFile(sessionFile);
 				const mtime = fileStats.mtime.getTime();
 				const fileSize = fileStats.size;
-				if (mtime < last30DaysStart.getTime()) { return null; }
+				if (mtime < last30DaysStartMs) { return null; }
 				const cachedData = this.getCachedSessionData(sessionFile);
 				const wasCached = cachedData !== undefined && cachedData.mtime === mtime && cachedData.size === fileSize;
 				const sessionData = await this.getSessionFileDataCached(sessionFile, mtime, fileSize);
@@ -1560,165 +1578,157 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const { sessionFile, sessionData, details, mtime, wasCached } = r;
 
 				try {
-					// Extract remaining data from the cached session
-					const interactions = sessionData.interactions;
-					const estimatedTokens = sessionData.tokens; // Text-based estimate (user content only)
-					const actualTokens = sessionData.actualTokens || 0; // Actual LLM API tokens (when available)
-					const tokens = actualTokens > 0 ? actualTokens : estimatedTokens; // Best available
-					const modelUsage = sessionData.modelUsage;
 					const editorType = this.getEditorTypeFromPath(sessionFile);
-
-					// For date filtering, get lastInteraction from session details
-					const lastActivity = details.lastInteraction
-						? new Date(details.lastInteraction)
-						: new Date(details.modified);
+					const repository = sessionData.repository || 'Unknown';
 
 					// Update cache statistics (do this once per file)
-					if (wasCached) {
-						cacheHits++;
-					} else {
-						cacheMisses++;
-					}
+					if (wasCached) { cacheHits++; } else { cacheMisses++; }
 
-					// Check if activity is within last 30 days
-					if (lastActivity >= last30DaysStart) {
+					if (sessionData.dailyRollups && Object.keys(sessionData.dailyRollups).length > 0) {
+						// Per-UTC-day rollup path: distribute tokens accurately across days
+						let addedToLast30Days = false;
+						let addedToMonth = false;
+						let addedToLastMonth = false;
+						let addedToToday = false;
+
+						for (const [dayKey, dayRollup] of Object.entries(sessionData.dailyRollups)) {
+							if (dayKey < last30DaysUtcStartKey) { continue; }
+
+							const dayTokens = dayRollup.actualTokens > 0 ? dayRollup.actualTokens : dayRollup.tokens;
+							const dayInteractions = dayRollup.interactions;
+
+							// Accumulate daily stats for the chart view
+							if (!dailyStatsMap.has(dayKey)) {
+								dailyStatsMap.set(dayKey, { date: dayKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
+							}
+							const dailyEntry = dailyStatsMap.get(dayKey)!;
+							dailyEntry.tokens += dayTokens;
+							dailyEntry.sessions += 1;
+							dailyEntry.interactions += dayInteractions;
+							if (!dailyEntry.editorUsage[editorType]) { dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
+							dailyEntry.editorUsage[editorType].tokens += dayTokens;
+							dailyEntry.editorUsage[editorType].sessions += 1;
+							if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
+							dailyEntry.repositoryUsage[repository].tokens += dayTokens;
+							dailyEntry.repositoryUsage[repository].sessions += 1;
+							addModelUsage(dailyEntry.modelUsage, dayRollup.modelUsage);
+
+							// last30Days accumulation
+							last30DaysStats.tokens += dayTokens;
+							last30DaysStats.estimatedTokens += dayRollup.tokens;
+							last30DaysStats.actualTokens += dayRollup.actualTokens;
+							last30DaysStats.thinkingTokens += dayRollup.thinkingTokens;
+							last30DaysStats.interactions += dayInteractions;
+							if (!addedToLast30Days) { last30DaysStats.sessions += 1; addedToLast30Days = true; }
+							addEditorUsage(last30DaysStats.editorUsage, editorType, dayTokens);
+							addModelUsage(last30DaysStats.modelUsage, dayRollup.modelUsage);
+
+							if (dayKey >= monthUtcStartKey) {
+								// This month
+								monthStats.tokens += dayTokens;
+								monthStats.estimatedTokens += dayRollup.tokens;
+								monthStats.actualTokens += dayRollup.actualTokens;
+								monthStats.thinkingTokens += dayRollup.thinkingTokens;
+								monthStats.interactions += dayInteractions;
+								if (!addedToMonth) { monthStats.sessions += 1; addedToMonth = true; }
+								addEditorUsage(monthStats.editorUsage, editorType, dayTokens);
+								addModelUsage(monthStats.modelUsage, dayRollup.modelUsage);
+
+								if (dayKey === todayUtcKey) {
+									todayStats.tokens += dayTokens;
+									todayStats.estimatedTokens += dayRollup.tokens;
+									todayStats.actualTokens += dayRollup.actualTokens;
+									todayStats.thinkingTokens += dayRollup.thinkingTokens;
+									todayStats.interactions += dayInteractions;
+									if (!addedToToday) { todayStats.sessions += 1; addedToToday = true; }
+									addEditorUsage(todayStats.editorUsage, editorType, dayTokens);
+									addModelUsage(todayStats.modelUsage, dayRollup.modelUsage);
+								}
+							} else if (dayKey >= lastMonthUtcStartKey && dayKey <= lastMonthUtcEndKey) {
+								// Previous calendar month
+								lastMonthStats.tokens += dayTokens;
+								lastMonthStats.estimatedTokens += dayRollup.tokens;
+								lastMonthStats.actualTokens += dayRollup.actualTokens;
+								lastMonthStats.thinkingTokens += dayRollup.thinkingTokens;
+								lastMonthStats.interactions += dayInteractions;
+								if (!addedToLastMonth) { lastMonthStats.sessions += 1; addedToLastMonth = true; }
+								addEditorUsage(lastMonthStats.editorUsage, editorType, dayTokens);
+								addModelUsage(lastMonthStats.modelUsage, dayRollup.modelUsage);
+							}
+						}
+
+						if (!addedToLast30Days) { skippedFiles++; }
+					} else {
+						// Fallback: session-level attribution using UTC boundaries
+						const interactions = sessionData.interactions;
+						const estimatedTokens = sessionData.tokens;
+						const actualTokens = sessionData.actualTokens || 0;
+						const tokens = actualTokens > 0 ? actualTokens : estimatedTokens;
+						const modelUsage = sessionData.modelUsage;
+
+						const lastInteractionStr = sessionData.lastInteraction || details.lastInteraction;
+						const lastActivity = lastInteractionStr ? new Date(lastInteractionStr) : new Date(mtime);
+						const lastActivityUtcKey = lastActivity.toISOString().slice(0, 10);
+
+						if (lastActivityUtcKey < last30DaysUtcStartKey) { skippedFiles++; continue; }
+
+						// Accumulate daily stats
+						const repository2 = sessionData.repository || 'Unknown';
+						if (!dailyStatsMap.has(lastActivityUtcKey)) {
+							dailyStatsMap.set(lastActivityUtcKey, { date: lastActivityUtcKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
+						}
+						const dailyEntry = dailyStatsMap.get(lastActivityUtcKey)!;
+						dailyEntry.tokens += tokens;
+						dailyEntry.sessions += 1;
+						dailyEntry.interactions += interactions;
+						if (!dailyEntry.editorUsage[editorType]) { dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
+						dailyEntry.editorUsage[editorType].tokens += tokens;
+						dailyEntry.editorUsage[editorType].sessions += 1;
+						if (!dailyEntry.repositoryUsage[repository2]) { dailyEntry.repositoryUsage[repository2] = { tokens: 0, sessions: 0 }; }
+						dailyEntry.repositoryUsage[repository2].tokens += tokens;
+						dailyEntry.repositoryUsage[repository2].sessions += 1;
+						addModelUsage(dailyEntry.modelUsage, modelUsage);
+
+						// last30Days
 						last30DaysStats.tokens += tokens;
 						last30DaysStats.estimatedTokens += estimatedTokens;
 						last30DaysStats.actualTokens += actualTokens;
 						last30DaysStats.thinkingTokens += (sessionData.thinkingTokens || 0);
 						last30DaysStats.sessions += 1;
 						last30DaysStats.interactions += interactions;
+						addEditorUsage(last30DaysStats.editorUsage, editorType, tokens);
+						addModelUsage(last30DaysStats.modelUsage, modelUsage);
 
-						// Add editor usage to last 30 days stats
-						if (!last30DaysStats.editorUsage[editorType]) {
-							last30DaysStats.editorUsage[editorType] = { tokens: 0, sessions: 0 };
-						}
-						last30DaysStats.editorUsage[editorType].tokens += tokens;
-						last30DaysStats.editorUsage[editorType].sessions += 1;
+						if (lastActivityUtcKey >= monthUtcStartKey) {
+							monthStats.tokens += tokens;
+							monthStats.estimatedTokens += estimatedTokens;
+							monthStats.actualTokens += actualTokens;
+							monthStats.thinkingTokens += (sessionData.thinkingTokens || 0);
+							monthStats.sessions += 1;
+							monthStats.interactions += interactions;
+							addEditorUsage(monthStats.editorUsage, editorType, tokens);
+							addModelUsage(monthStats.modelUsage, modelUsage);
 
-						// Add model usage to last 30 days stats
-						for (const [model, usage] of Object.entries(modelUsage)) {
-							if (!last30DaysStats.modelUsage[model]) {
-								last30DaysStats.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+							if (lastActivityUtcKey === todayUtcKey) {
+								todayStats.tokens += tokens;
+								todayStats.estimatedTokens += estimatedTokens;
+								todayStats.actualTokens += actualTokens;
+								todayStats.thinkingTokens += (sessionData.thinkingTokens || 0);
+								todayStats.sessions += 1;
+								todayStats.interactions += interactions;
+								addEditorUsage(todayStats.editorUsage, editorType, tokens);
+								addModelUsage(todayStats.modelUsage, modelUsage);
 							}
-							last30DaysStats.modelUsage[model].inputTokens += usage.inputTokens;
-							last30DaysStats.modelUsage[model].outputTokens += usage.outputTokens;
+						} else if (lastActivityUtcKey >= lastMonthUtcStartKey && lastActivityUtcKey <= lastMonthUtcEndKey) {
+							lastMonthStats.tokens += tokens;
+							lastMonthStats.estimatedTokens += estimatedTokens;
+							lastMonthStats.actualTokens += actualTokens;
+							lastMonthStats.thinkingTokens += (sessionData.thinkingTokens || 0);
+							lastMonthStats.sessions += 1;
+							lastMonthStats.interactions += interactions;
+							addEditorUsage(lastMonthStats.editorUsage, editorType, tokens);
+							addModelUsage(lastMonthStats.modelUsage, modelUsage);
 						}
-
-						// Accumulate daily stats for the chart view
-						const dateKey = this.formatDateKey(lastActivity);
-						const repository = sessionData.repository || 'Unknown';
-						if (!dailyStatsMap.has(dateKey)) {
-							dailyStatsMap.set(dateKey, {
-								date: dateKey,
-								tokens: 0,
-								sessions: 0,
-								interactions: 0,
-								modelUsage: {},
-								editorUsage: {},
-								repositoryUsage: {}
-							});
-						}
-						const dailyEntry = dailyStatsMap.get(dateKey)!;
-						dailyEntry.tokens += tokens;
-						dailyEntry.sessions += 1;
-						dailyEntry.interactions += interactions;
-						if (!dailyEntry.editorUsage[editorType]) {
-							dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 };
-						}
-						dailyEntry.editorUsage[editorType].tokens += tokens;
-						dailyEntry.editorUsage[editorType].sessions += 1;
-						if (!dailyEntry.repositoryUsage[repository]) {
-							dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 };
-						}
-						dailyEntry.repositoryUsage[repository].tokens += tokens;
-						dailyEntry.repositoryUsage[repository].sessions += 1;
-						for (const [model, usage] of Object.entries(modelUsage)) {
-							if (!dailyEntry.modelUsage[model]) {
-								dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
-							}
-							dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
-							dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
-						}
-					}
-
-					if (lastActivity >= monthStart) {
-						monthStats.tokens += tokens;
-						monthStats.estimatedTokens += estimatedTokens;
-						monthStats.actualTokens += actualTokens;
-						monthStats.thinkingTokens += (sessionData.thinkingTokens || 0);
-						monthStats.sessions += 1;
-						monthStats.interactions += interactions;
-
-						// Add editor usage to month stats
-						if (!monthStats.editorUsage[editorType]) {
-							monthStats.editorUsage[editorType] = { tokens: 0, sessions: 0 };
-						}
-						monthStats.editorUsage[editorType].tokens += tokens;
-						monthStats.editorUsage[editorType].sessions += 1;
-
-						// Add model usage to month stats
-						for (const [model, usage] of Object.entries(modelUsage)) {
-							if (!monthStats.modelUsage[model]) {
-								monthStats.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
-							}
-							monthStats.modelUsage[model].inputTokens += usage.inputTokens;
-							monthStats.modelUsage[model].outputTokens += usage.outputTokens;
-						}
-
-						if (lastActivity >= todayStart) {
-							todayStats.tokens += tokens;
-							todayStats.estimatedTokens += estimatedTokens;
-							todayStats.actualTokens += actualTokens;
-							todayStats.thinkingTokens += (sessionData.thinkingTokens || 0);
-							todayStats.sessions += 1;
-							todayStats.interactions += interactions;
-
-							// Add editor usage to today stats
-							if (!todayStats.editorUsage[editorType]) {
-								todayStats.editorUsage[editorType] = { tokens: 0, sessions: 0 };
-							}
-							todayStats.editorUsage[editorType].tokens += tokens;
-							todayStats.editorUsage[editorType].sessions += 1;
-
-							// Add model usage to today stats
-							for (const [model, usage] of Object.entries(modelUsage)) {
-								if (!todayStats.modelUsage[model]) {
-									todayStats.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
-								}
-								todayStats.modelUsage[model].inputTokens += usage.inputTokens;
-								todayStats.modelUsage[model].outputTokens += usage.outputTokens;
-							}
-						}
-					}
-					else if (lastActivity >= lastMonthStart && lastActivity <= lastMonthEnd) {
-						// Session is from Previous Month - only track lastMonth stats
-						lastMonthStats.tokens += tokens;
-						lastMonthStats.estimatedTokens += estimatedTokens;
-						lastMonthStats.actualTokens += actualTokens;
-						lastMonthStats.thinkingTokens += (sessionData.thinkingTokens || 0);
-						lastMonthStats.sessions += 1;
-						lastMonthStats.interactions += interactions;
-
-						// Add editor usage to Previous Month stats
-						if (!lastMonthStats.editorUsage[editorType]) {
-							lastMonthStats.editorUsage[editorType] = { tokens: 0, sessions: 0 };
-						}
-						lastMonthStats.editorUsage[editorType].tokens += tokens;
-						lastMonthStats.editorUsage[editorType].sessions += 1;
-
-						// Add model usage to Previous Month stats
-						for (const [model, usage] of Object.entries(modelUsage)) {
-							if (!lastMonthStats.modelUsage[model]) {
-								lastMonthStats.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
-							}
-							lastMonthStats.modelUsage[model].inputTokens += usage.inputTokens;
-							lastMonthStats.modelUsage[model].outputTokens += usage.outputTokens;
-						}
-					}
-					else {
-						// Session is too old (no activity in last 30 days), skip it
-						skippedFiles++;
 					}
 				} catch (fileError) {
 					this.warn(`Error processing session file ${sessionFile}: ${fileError}`);
@@ -1736,12 +1746,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 
 		// Finalize daily stats: fill in missing days with zero values
-		const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-		const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const thirtyDaysAgo = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
+		const todayDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 		const existingDates = new Set(dailyStatsMap.keys());
 		const fillDate = new Date(thirtyDaysAgo);
-		while (fillDate <= today) {
-			const dateKey = this.formatDateKey(fillDate);
+		while (fillDate <= todayDate) {
+			const dateKey = fillDate.toISOString().slice(0, 10);
 			if (!existingDates.has(dateKey)) {
 				dailyStatsMap.set(dateKey, {
 					date: dateKey,
@@ -1753,7 +1763,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					repositoryUsage: {}
 				});
 			}
-			fillDate.setDate(fillDate.getDate() + 1);
+			fillDate.setUTCDate(fillDate.getUTCDate() + 1);
 		}
 		this.lastDailyStats = Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
 
@@ -1840,7 +1850,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private formatDateKey(date: Date): string {
-		return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+		return date.toISOString().slice(0, 10); // UTC-based YYYY-MM-DD key
 	}
 
 	/**
@@ -1878,12 +1888,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	/** Compute daily token stats for up to `daysBack` days, using the same token preference
-	 *  (actualTokens > estimatedTokens) and date assignment (lastInteraction || mtime) as
-	 *  calculateDetailedStats so all chart period views are consistent. Stores the result in
+	 *  (actualTokens > estimatedTokens) and UTC date assignment as calculateDetailedStats
+	 *  so all chart period views are consistent. Stores the result in
 	 *  `lastFullDailyStats` and returns it. Zero-fill is handled per-period in buildChartData. */
 	private async calculateDailyStats(daysBack = 365): Promise<DailyTokenStats[]> {
 		const now = new Date();
-		const cutoffDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack);
+		const cutoffUtcStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - daysBack));
+		const cutoffUtcStartKey = cutoffUtcStart.toISOString().slice(0, 10);
+		const cutoffMs = cutoffUtcStart.getTime();
 
 		const dailyStatsMap = new Map<string, DailyTokenStats>();
 
@@ -1895,9 +1907,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const fileStats = await this.statSessionFile(sessionFile);
 				const mtime = fileStats.mtime.getTime();
 				const fileSize = fileStats.size;
-				if (mtime < cutoffDate.getTime()) { return null; }
-				// getSessionFileDataCached already stores lastInteraction in its cache entry;
-				// calling getSessionFileDetails() would be a redundant second stat + cache lookup.
+				if (mtime < cutoffMs) { return null; }
 				const sessionData = await this.getSessionFileDataCached(sessionFile, mtime, fileSize);
 				return { sessionFile, sessionData, mtime };
 			});
@@ -1906,57 +1916,66 @@ class CopilotTokenTracker implements vscode.Disposable {
 				if (!r) { continue; }
 				const { sessionFile, sessionData, mtime } = r;
 				try {
-					// Prefer actualTokens when available (same as calculateDetailedStats)
-					const estimatedTokens = sessionData.tokens;
-					const actualTokens = sessionData.actualTokens || 0;
-					const tokens = actualTokens > 0 ? actualTokens : estimatedTokens;
-
-					const interactions = sessionData.interactions;
-					const modelUsage = sessionData.modelUsage;
 					const editorType = this.getEditorTypeFromPath(sessionFile);
 					const repository = sessionData.repository || 'Unknown';
 
-					// Use lastInteraction for date (same as calculateDetailedStats), falling back to mtime
-					const lastActivity = sessionData.lastInteraction
-						? new Date(sessionData.lastInteraction)
-						: new Date(mtime);
-					const dateKey = this.formatDateKey(lastActivity);
+					if (sessionData.dailyRollups && Object.keys(sessionData.dailyRollups).length > 0) {
+						// Per-UTC-day rollup path
+						for (const [dayKey, dayRollup] of Object.entries(sessionData.dailyRollups)) {
+							if (dayKey < cutoffUtcStartKey) { continue; }
+							const dayTokens = dayRollup.actualTokens > 0 ? dayRollup.actualTokens : dayRollup.tokens;
 
-					if (!dailyStatsMap.has(dateKey)) {
-						dailyStatsMap.set(dateKey, {
-							date: dateKey,
-							tokens: 0,
-							sessions: 0,
-							interactions: 0,
-							modelUsage: {},
-							editorUsage: {},
-							repositoryUsage: {}
-						});
-					}
-
-					const dailyEntry = dailyStatsMap.get(dateKey)!;
-					dailyEntry.tokens += tokens;
-					dailyEntry.sessions += 1;
-					dailyEntry.interactions += interactions;
-
-					if (!dailyEntry.editorUsage[editorType]) {
-						dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 };
-					}
-					dailyEntry.editorUsage[editorType].tokens += tokens;
-					dailyEntry.editorUsage[editorType].sessions += 1;
-
-					if (!dailyEntry.repositoryUsage[repository]) {
-						dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 };
-					}
-					dailyEntry.repositoryUsage[repository].tokens += tokens;
-					dailyEntry.repositoryUsage[repository].sessions += 1;
-
-					for (const [model, usage] of Object.entries(modelUsage)) {
-						if (!dailyEntry.modelUsage[model]) {
-							dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+							if (!dailyStatsMap.has(dayKey)) {
+								dailyStatsMap.set(dayKey, { date: dayKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
+							}
+							const dailyEntry = dailyStatsMap.get(dayKey)!;
+							dailyEntry.tokens += dayTokens;
+							dailyEntry.sessions += 1;
+							dailyEntry.interactions += dayRollup.interactions;
+							if (!dailyEntry.editorUsage[editorType]) { dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
+							dailyEntry.editorUsage[editorType].tokens += dayTokens;
+							dailyEntry.editorUsage[editorType].sessions += 1;
+							if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
+							dailyEntry.repositoryUsage[repository].tokens += dayTokens;
+							dailyEntry.repositoryUsage[repository].sessions += 1;
+							for (const [model, usage] of Object.entries(dayRollup.modelUsage)) {
+								if (!dailyEntry.modelUsage[model]) { dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
+								dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
+								dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
+							}
 						}
-						dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
-						dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
+					} else {
+						// Fallback: session-level attribution
+						const estimatedTokens = sessionData.tokens;
+						const actualTokens = sessionData.actualTokens || 0;
+						const tokens = actualTokens > 0 ? actualTokens : estimatedTokens;
+						const interactions = sessionData.interactions;
+						const modelUsage = sessionData.modelUsage;
+
+						const lastActivity = sessionData.lastInteraction
+							? new Date(sessionData.lastInteraction)
+							: new Date(mtime);
+						const dateKey = lastActivity.toISOString().slice(0, 10);
+						if (dateKey < cutoffUtcStartKey) { continue; }
+
+						if (!dailyStatsMap.has(dateKey)) {
+							dailyStatsMap.set(dateKey, { date: dateKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
+						}
+						const dailyEntry = dailyStatsMap.get(dateKey)!;
+						dailyEntry.tokens += tokens;
+						dailyEntry.sessions += 1;
+						dailyEntry.interactions += interactions;
+						if (!dailyEntry.editorUsage[editorType]) { dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
+						dailyEntry.editorUsage[editorType].tokens += tokens;
+						dailyEntry.editorUsage[editorType].sessions += 1;
+						if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
+						dailyEntry.repositoryUsage[repository].tokens += tokens;
+						dailyEntry.repositoryUsage[repository].sessions += 1;
+						for (const [model, usage] of Object.entries(modelUsage)) {
+							if (!dailyEntry.modelUsage[model]) { dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
+							dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
+							dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
+						}
 					}
 				} catch (fileError) {
 					this.warn(`Error processing session file ${sessionFile} for daily stats: ${fileError}`);
@@ -2016,9 +2035,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 
 		const now = new Date();
-		const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-		const last30DaysStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-		const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+		// UTC-based day keys for consistent period boundaries (matching server-side)
+		const todayUtcKey = now.toISOString().slice(0, 10);
+		const last30DaysUtcStartKey = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30)).toISOString().slice(0, 10);
+		const monthUtcStartKey = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0, 10);
+		const last30DaysStartMs = new Date(last30DaysUtcStartKey).getTime();
 
 		this.log('🔍 [Usage Analysis] Starting calculation...');
 		this._cacheHits = 0; // Reset cache hit counter
@@ -2130,7 +2151,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const fileStats = await this.statSessionFile(sessionFile);
 				const mtime = fileStats.mtime.getTime();
 				const fileSize = fileStats.size;
-				if (mtime < last30DaysStart.getTime()) { return null; }
+				if (mtime < last30DaysStartMs) { return null; }
 				const sessionData = await this.getSessionFileDataCached(sessionFile, mtime, fileSize);
 				return { sessionFile, sessionData, mtime };
 			});
@@ -2194,14 +2215,20 @@ class CopilotTokenTracker implements vscode.Disposable {
 							continue;
 						}
 
-						// Derive lastActivity from session content timestamp (not mtime) to avoid
-						// date mis-classification when VS Code writes the file after midnight.
-						const lastActivity = sessionData.lastInteraction
-							? new Date(sessionData.lastInteraction)
-							: new Date(mtime);
+						// Derive lastActivityUtcKey using dailyRollups if available, else lastInteraction
+						let lastActivityUtcKey: string;
+						if (sessionData.dailyRollups && Object.keys(sessionData.dailyRollups).length > 0) {
+							// Use the most recent day in the rollups
+							lastActivityUtcKey = Object.keys(sessionData.dailyRollups).sort().pop()!;
+						} else {
+							const lastActivity = sessionData.lastInteraction
+								? new Date(sessionData.lastInteraction)
+								: new Date(mtime);
+							lastActivityUtcKey = lastActivity.toISOString().slice(0, 10);
+						}
 
 						// Add to last 30 days stats
-						if (lastActivity < last30DaysStart) {
+						if (lastActivityUtcKey < last30DaysUtcStartKey) {
 							processed++;
 							continue;
 						}
@@ -2240,13 +2267,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 						}
 
 						// Add to month stats if activity falls in this calendar month
-						if (lastActivity >= monthStart) {
+						if (lastActivityUtcKey >= monthUtcStartKey) {
 							monthStats.sessions++;
 							this.mergeUsageAnalysis(monthStats, analysis);
 						}
 
 						// Add to today stats if activity falls today
-						if (lastActivity >= todayStart) {
+						if (lastActivityUtcKey === todayUtcKey) {
 							todayStats.sessions++;
 							this.mergeUsageAnalysis(todayStats, analysis);
 						}
@@ -2618,19 +2645,25 @@ class CopilotTokenTracker implements vscode.Disposable {
 		title: string | undefined;
 		firstInteraction: string | null;
 		lastInteraction: string | null;
+		dailyInteractions: { [utcDayKey: string]: number };
 	}> {
 		let title: string | undefined;
 		const timestamps: number[] = [];
+		// Request-level timestamps (excludes session creationDate) for per-day interaction counts
+		const requestTimestamps: number[] = [];
 
 		try {
 			const eco = this.findEcosystem(sessionFile);
-			if (eco) { return eco.getMeta(sessionFile); }
+			if (eco) {
+				const meta = await eco.getMeta(sessionFile);
+				return { ...meta, dailyInteractions: {} };
+			}
 
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 
 			// Check if this is a UUID-only file (new Copilot CLI format)
 			if (_isUuidPointerFile(fileContent)) {
-				return { title, firstInteraction: null, lastInteraction: null };
+				return { title, firstInteraction: null, lastInteraction: null, dailyInteractions: {} };
 			}
 
 			const isJsonlContent = sessionFile.endsWith('.jsonl') || _isJsonlContent(fileContent);
@@ -2646,7 +2679,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 						// Handle Copilot CLI format
 						if (event.type === 'user.message') {
 							const ts = event.timestamp || event.ts || event.data?.timestamp;
-							if (ts) { timestamps.push(new Date(ts).getTime()); }
+							if (ts) {
+								const ms = new Date(ts).getTime();
+								timestamps.push(ms);
+								requestTimestamps.push(ms);
+							}
 							if (!firstUserMessage && event.data?.content) {
 								firstUserMessage = event.data.content;
 							}
@@ -2659,6 +2696,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 						// Handle VS Code incremental .jsonl format
 						if (event.kind === 0 && event.v) {
+							// creationDate is session creation, not a request — only add to timestamps (not requestTimestamps)
 							if (event.v.creationDate) { timestamps.push(event.v.creationDate); }
 							// Always update title - we want the LAST title in the file (matches VS Code UI)
 							if (event.v.customTitle) { title = event.v.customTitle; }
@@ -2669,6 +2707,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 							for (const request of event.v) {
 								if (request.timestamp) {
 									timestamps.push(request.timestamp);
+									requestTimestamps.push(request.timestamp);
 								}
 							}
 						}
@@ -2692,13 +2731,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 				try {
 					const parsed = JSON.parse(fileContent);
 					if (parsed.customTitle) { title = parsed.customTitle; }
+					// creationDate is session creation, not a request — only add to timestamps
 					if (parsed.creationDate) { timestamps.push(parsed.creationDate); }
 					// Extract timestamps from requests array (like getSessionFileDetails does)
 					if (parsed.requests && Array.isArray(parsed.requests)) {
 						for (const request of parsed.requests) {
 							if (request.timestamp || request.ts || request.result?.timestamp) {
 								const ts = request.timestamp || request.ts || request.result?.timestamp;
-								timestamps.push(new Date(ts).getTime());
+								const ms = new Date(ts).getTime();
+								timestamps.push(ms);
+								requestTimestamps.push(ms);
 							}
 						}
 					}
@@ -2718,7 +2760,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 			lastInteraction = new Date(timestamps[timestamps.length - 1]).toISOString();
 		}
 
-		return { title, firstInteraction, lastInteraction };
+		// Build per-UTC-day interaction counts from request timestamps
+		const dailyInteractions: { [utcDayKey: string]: number } = {};
+		for (const ts of requestTimestamps) {
+			const dayKey = new Date(ts).toISOString().slice(0, 10);
+			dailyInteractions[dayKey] = (dailyInteractions[dayKey] || 0) + 1;
+		}
+
+		return { title, firstInteraction, lastInteraction, dailyInteractions };
 	}
 
 	// Cached versions of session file reading methods
@@ -2748,6 +2797,31 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Extract title and timestamps from the session file
 		const sessionMeta = await this.extractSessionMetadata(sessionFilePath, preloadedContent);
 
+		// Compute per-UTC-day rollups by distributing cached totals proportionally across days
+		// (same approach as syncService.processCachedSessionFile)
+		const dailyRollups: { [utcDayKey: string]: DailyRollupEntry } = {};
+		const dailyInteractionMap = sessionMeta.dailyInteractions;
+		const totalInteractions = Object.values(dailyInteractionMap).reduce((a, b) => a + b, 0);
+		if (totalInteractions > 0) {
+			for (const [dayKey, dayInteractionCount] of Object.entries(dailyInteractionMap)) {
+				const fraction = dayInteractionCount / totalInteractions;
+				const dayModelUsage: ModelUsage = {};
+				for (const [model, usage] of Object.entries(modelUsage)) {
+					dayModelUsage[model] = {
+						inputTokens: Math.round(usage.inputTokens * fraction),
+						outputTokens: Math.round(usage.outputTokens * fraction),
+					};
+				}
+				dailyRollups[dayKey] = {
+					tokens: Math.round(tokenResult.tokens * fraction),
+					actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction),
+					thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction),
+					interactions: dayInteractionCount,
+					modelUsage: dayModelUsage,
+				};
+			}
+		}
+
 		const sessionData: SessionFileCache = {
 			tokens: tokenResult.tokens,
 			interactions,
@@ -2759,7 +2833,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			firstInteraction: sessionMeta.firstInteraction,
 			lastInteraction: sessionMeta.lastInteraction,
 			thinkingTokens: tokenResult.thinkingTokens,
-			actualTokens: tokenResult.actualTokens
+			actualTokens: tokenResult.actualTokens,
+			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
 		};
 
 		this.setCachedSessionData(sessionFilePath, sessionData, fileSize);
@@ -6951,7 +7026,7 @@ ${hashtag}`;
       // Get backend storage info
       const backendStorageInfo = await this.getBackendStorageInfo();
       this.log(
-        `Backend storage info retrieved: enabled=${backendStorageInfo.enabled}, configured=${backendStorageInfo.isConfigured}`,
+        `Backend storage info retrieved: azure.enabled=${backendStorageInfo.azure?.enabled}, azure.configured=${backendStorageInfo.azure?.isConfigured}, teamServer.enabled=${backendStorageInfo.teamServer?.enabled}, teamServer.configured=${backendStorageInfo.teamServer?.isConfigured}`,
       );
 
       // Get GitHub authentication status

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1422,9 +1422,38 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 			// If the maturity panel is open, update its content.
 			// During background (silent) updates, skip to preserve demo panel state and user overrides.
-			if (this.maturityPanel && !silent) {
-				const maturityData = await this.calculateMaturityScores(false); // Force recalculation on refresh
-				this.maturityPanel.webview.html = this.getMaturityHtml(this.maturityPanel.webview, maturityData);
+			// Always compute a fresh score so it can be reused for the sharing server upload below.
+			const freshMaturityData = (!silent || this.maturityPanel)
+				? await this.calculateMaturityScores(false)
+				: undefined;
+			if (this.maturityPanel && !silent && freshMaturityData) {
+				this.maturityPanel.webview.html = this.getMaturityHtml(this.maturityPanel.webview, freshMaturityData);
+			}
+
+			// Upload the fluency score to the sharing server so its dashboard shows the same result
+			// as the extension's local AI Fluency Score panel (avoids independent re-computation).
+			// Run fire-and-forget to not block the UI update.
+			if (this.backend) {
+				const settings = this.backend.getSettings();
+				if (settings.sharingServerEnabled && settings.sharingServerEndpointUrl) {
+					// Use the already-computed fresh score when available; otherwise compute now.
+					Promise.resolve(freshMaturityData ?? this.calculateMaturityScores(false)).then((maturityData) => {
+						const scorePayload: Record<string, unknown> = {
+							overallStage: maturityData.overallStage,
+							overallLabel: maturityData.overallLabel,
+							categories: maturityData.categories.map((c: any) => ({
+								category: c.category,
+								icon: c.icon,
+								stage: c.stage,
+								tips: c.tips,
+							})),
+							computedAt: new Date().toISOString(),
+						};
+						return this.backend!.uploadFluencyScoreToSharingServer(settings, scorePayload);
+					}).catch((err: unknown) => {
+						this.warn(`Failed to upload fluency score to sharing server: ${err}`);
+					});
+				}
 			}
 
 			// If the environmental panel is open, update its content

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -123,6 +123,15 @@ export interface ChartDataPayload {
   periodsReady?: boolean;
 }
 
+/** Per-UTC-day token/interaction breakdown for a single session. Used for accurate daily stats. */
+export interface DailyRollupEntry {
+  tokens: number;
+  actualTokens: number;
+  thinkingTokens: number;
+  interactions: number;
+  modelUsage: ModelUsage;
+}
+
 export interface SessionFileCache {
   tokens: number;
   interactions: number;
@@ -137,6 +146,8 @@ export interface SessionFileCache {
   workspaceFolderPath?: string; // Full local path to the workspace folder (optional)
   thinkingTokens?: number; // Estimated thinking/reasoning tokens
   actualTokens?: number; // Actual token count from LLM API usage data (when available)
+  /** Per-UTC-day token/interaction breakdown (keyed by YYYY-MM-DD UTC). Used for consistent daily stats. */
+  dailyRollups?: { [utcDayKey: string]: DailyRollupEntry };
 }
 
 // Local copy of customization file entry type (mirrors webview/shared/contextRefUtils.ts)

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -100,12 +100,16 @@ const STAGE_DESCRIPTIONS: Record<number, string> = {
 
 // ── Radar chart SVG ────────────────────────────────────────────────────
 
-function renderRadarChart(categories: CategoryScore[]): string {
+function renderRadarChart(categories: CategoryScore[], overallStage: number): string {
 	const cx = 325, cy = 325, maxR = 150;
 	const n = categories.length;
 	const angleStep = (2 * Math.PI) / n;
 	// Start from top (- PI/2)
 	const startAngle = -Math.PI / 2;
+
+	// Overall-stage fill/stroke colors — fixed blue palette
+	const polyFill = 'rgba(88,166,255,0.25)';
+	const polyStroke = '#58a6ff';
 
 	// Grid rings (1–4)
 	const rings = [1, 2, 3, 4].map(level => {
@@ -146,26 +150,26 @@ function renderRadarChart(categories: CategoryScore[]): string {
 			class="radar-label" font-size="14" font-weight="600">${cat.icon} ${cat.category}</text>`;
 	}).join('');
 
-	// Stage dots
+	// Stage dots — use overall-stage color for consistency with polygon
 	const dots = categories.map((cat, i) => {
 		const r = (cat.stage / 4) * maxR;
 		const angle = startAngle + i * angleStep;
 		const x = cx + r * Math.cos(angle);
 		const y = cy + r * Math.sin(angle);
-		const color = stageColor(cat.stage);
-		return `<circle cx="${x}" cy="${y}" r="5" fill="${color}" class="radar-dot" stroke-width="1.5" />`;
+		return `<circle cx="${x}" cy="${y}" r="5" fill="${polyStroke}" class="radar-dot" stroke-width="1.5" />`;
 	}).join('');
 
-	// Ring labels
+	// Ring labels — stage names matching server
+	const ringLabelNames = ['', 'AI Skeptic', 'Explorer', 'Collaborator', 'Strategist'];
 	const ringLabels = [1, 2, 3, 4].map(level => {
 		const r = (level / 4) * maxR;
-		return `<text x="${cx + 4}" y="${cy - r + 3}" class="radar-ring-label" font-size="9">${level}</text>`;
+		return `<text x="${cx + 4}" y="${cy - r + 3}" class="radar-ring-label" font-size="9">${ringLabelNames[level]}</text>`;
 	}).join('');
 
 	return `<svg viewBox="0 0 650 650" class="radar-svg" xmlns="http://www.w3.org/2000/svg">
 		${rings}
 		${axes}
-		<polygon points="${dataPoints}" fill="rgba(59,130,246,0.15)" stroke="#3b82f6" stroke-width="2" />
+		<polygon points="${dataPoints}" fill="${polyFill}" stroke="${polyStroke}" stroke-width="2" />
 		${dots}
 		${labels}
 		${ringLabels}
@@ -429,7 +433,7 @@ function renderLayout(data: MaturityData): void {
 		<!-- Radar chart with legend -->
 		<div class="radar-wrapper">
 			<div class="radar-container">
-				${renderRadarChart(demoModeActive ? data.categories.map((c, i) => ({ ...c, stage: demoStageOverrides[i] ?? c.stage })) : data.categories)}
+				${renderRadarChart(demoModeActive ? data.categories.map((c, i) => ({ ...c, stage: demoStageOverrides[i] ?? c.stage })) : data.categories, demoModeActive ? Math.round(demoStageOverrides.reduce((s, v) => s + v, 0) / demoStageOverrides.length) : data.overallStage)}
 			</div>
 			<div class="legend-panel">
 				<div class="legend-title">Stage Reference</div>

--- a/vscode-extension/test/unit/backend-configPanel-webview.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel-webview.test.ts
@@ -33,7 +33,8 @@ function createPanelHtml(): string {
 		sharedKeySet: false,
 		privacyBadge: 'Solo',
 		isConfigured: true,
-		authStatus: 'Entra ID'
+		authStatus: 'Entra ID',
+		githubTokenAvailable: false
 	};
 
 	const webview = {

--- a/vscode-extension/test/unit/backend-configPanel.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel.test.ts
@@ -41,6 +41,7 @@ function makeState(overrides?: Partial<BackendConfigPanelState>): BackendConfigP
 		privacyBadge: 'Solo',
 		isConfigured: true,
 		authStatus: 'Entra ID',
+		githubTokenAvailable: false,
 		...overrides
 	};
 }

--- a/vscode-extension/test/unit/backend-configurator.test.ts
+++ b/vscode-extension/test/unit/backend-configurator.test.ts
@@ -286,7 +286,8 @@ test('BackendConfigPanel routes webview messages to callbacks', async () => {
 		sharedKeySet: false,
 		privacyBadge: 'Team Anonymized',
 		isConfigured: true,
-		authStatus: 'Auth: Entra ID (RBAC)'
+		authStatus: 'Auth: Entra ID (RBAC)',
+		githubTokenAvailable: false
 	});
 
 	const panel = new BackendConfigPanel((vscode as any).Uri.parse('file:///ext'), {
@@ -314,7 +315,8 @@ test('config panel HTML marks offline state and disables test button when offlin
 		sharedKeySet: false,
 		privacyBadge: 'Team Anonymized',
 		isConfigured: false,
-		authStatus: 'Auth: Entra ID (RBAC)'
+		authStatus: 'Auth: Entra ID (RBAC)',
+		githubTokenAvailable: false
 	});
 
 	const panel: any = new BackendConfigPanel((vscode as any).Uri.parse('file:///ext'), {
@@ -361,7 +363,8 @@ test('config panel HTML disables test button when backend is disabled', async ()
 		sharedKeySet: false,
 		privacyBadge: 'Team Anonymized',
 		isConfigured: false,
-		authStatus: 'Auth: Entra ID (RBAC)'
+		authStatus: 'Auth: Entra ID (RBAC)',
+		githubTokenAvailable: false
 	});
 
 	const panel: any = new BackendConfigPanel((vscode as any).Uri.parse('file:///ext'), {
@@ -406,7 +409,8 @@ test('config panel HTML toggles shared-key controls, keeps enable-first layout, 
 		sharedKeySet: false,
 		privacyBadge: 'Team Anonymized',
 		isConfigured: false,
-		authStatus: 'Auth: Entra ID (RBAC)'
+		authStatus: 'Auth: Entra ID (RBAC)',
+		githubTokenAvailable: false
 	};
 
 	const panel: any = new BackendConfigPanel((vscode as any).Uri.parse('file:///ext'), {


### PR DESCRIPTION
## Summary

Adds AI Fluency/Maturity scoring to the self-hosted sharing server dashboard.

## Changes

### VS Code Extension
- `sharingServerUploadService.ts`: Added `fluencyMetrics` field to `SharingServerEntry` interface
- `syncService.ts`: Pass `fluencyMetrics` from rollup data when syncing to sharing server

### Sharing Server
- **`db.ts`**: Added `fluency_json TEXT` column with auto-migration (no manual DB changes needed)
- **`api.ts`**: Added validation for optional `fluencyMetrics` object field in upload entries
- **`dashboard.ts`**:
  - Aggregates fluency metrics from all upload rows
  - Ports 6-category scoring logic from the extension's `maturityScoring.ts`
  - Fluency badge in the header showing overall stage + stars
  - Clickable modal with a Chart.js radar chart (6 axes = 6 categories) and per-category cards with improvement tips

## UI Preview

- **Header badge**: `🎯 AI Fluency | AI Collaborator ⭐⭐⭐` — color-coded by stage
- **Modal**: Full radar chart across 6 categories (Prompt Engineering, Context Engineering, Agentic, Tool Usage, Customization, Workflow Integration) + cards with stage pills and next-step tips

## No new settings required

Works automatically alongside existing sharing server uploads — no user configuration needed.