### PR TITLE
feat: improve fluency spiderweb for Claude-only users

### DIFF
--- a/cli/src/commands/all.ts
+++ b/cli/src/commands/all.ts
@@ -3,8 +3,6 @@
  * Used by the Visual Studio extension to load every view in one CLI call
  * instead of spawning four separate processes.
  */
-import * as fs from 'fs';
-import * as path from 'path';
 import { Command } from 'commander';
 import {
 	discoverSessionFiles,
@@ -12,63 +10,9 @@ import {
 	calculateDailyStats,
 	buildChartPayload,
 	calculateUsageAnalysisStats,
+	buildCustomizationMatrix,
 } from '../helpers';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
-import type { WorkspaceCustomizationMatrix } from '../../../vscode-extension/src/types';
-
-/**
- * Builds a WorkspaceCustomizationMatrix by deriving workspace folder paths from
- * VS Code-style session file paths (workspaceStorage/<hash>/chatSessions/<file>),
- * then checking each workspace for .github/copilot-instructions.md or agents.md.
- *
- * Non-VS Code session files (Crush, OpenCode, Copilot CLI, Visual Studio) are skipped.
- */
-async function buildCustomizationMatrix(sessionFiles: string[]): Promise<WorkspaceCustomizationMatrix | undefined> {
-	const workspacePaths = new Set<string>();
-
-	for (const sessionFile of sessionFiles) {
-		// Expected structure: .../workspaceStorage/<hash>/chatSessions/<file>
-		const chatSessionsDir = path.dirname(sessionFile);
-		if (path.basename(chatSessionsDir) !== 'chatSessions') { continue; }
-		const hashDir = path.dirname(chatSessionsDir);
-		const workspaceJsonPath = path.join(hashDir, 'workspace.json');
-
-		try {
-			if (!fs.existsSync(workspaceJsonPath)) { continue; }
-			const content = JSON.parse(await fs.promises.readFile(workspaceJsonPath, 'utf-8'));
-			const folderUri: string | undefined = content.folder;
-			if (!folderUri || !folderUri.startsWith('file://')) { continue; }
-
-			// Convert file URI to a local path, handling Windows drive letters
-			let folderPath = decodeURIComponent(folderUri.replace(/^file:\/\//, ''));
-			// On Windows, file:///C:/... becomes /C:/... — strip the leading slash
-			if (/^\/[A-Za-z]:/.test(folderPath)) { folderPath = folderPath.slice(1); }
-			workspacePaths.add(folderPath);
-		} catch {
-			// Skip unreadable workspace.json files
-		}
-	}
-
-	if (workspacePaths.size === 0) { return undefined; }
-
-	let workspacesWithIssues = 0;
-	for (const wsPath of workspacePaths) {
-		try {
-			const hasInstructions = fs.existsSync(path.join(wsPath, '.github', 'copilot-instructions.md'));
-			const hasAgentsMd    = fs.existsSync(path.join(wsPath, 'agents.md'));
-			if (!hasInstructions && !hasAgentsMd) { workspacesWithIssues++; }
-		} catch {
-			workspacesWithIssues++; // Count inaccessible workspaces as lacking customization
-		}
-	}
-
-	return {
-		customizationTypes: [],
-		workspaces: [],
-		totalWorkspaces: workspacePaths.size,
-		workspacesWithIssues,
-	};
-}
 
 export const allCommand = new Command('all')
 	.description('Output all view data in a single JSON response (for Visual Studio extension)')

--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -1,68 +1,10 @@
 /**
  * `fluency` command - Show Copilot Fluency Score based on usage patterns.
  */
-import * as fs from 'fs';
-import * as path from 'path';
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { discoverSessionFiles, calculateUsageAnalysisStats, fmt } from '../helpers';
+import { discoverSessionFiles, calculateUsageAnalysisStats, fmt, buildCustomizationMatrix } from '../helpers';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
-import type { WorkspaceCustomizationMatrix } from '../../../vscode-extension/src/types';
-
-/**
- * Builds a WorkspaceCustomizationMatrix by deriving workspace folder paths from
- * VS Code-style session file paths (workspaceStorage/<hash>/chatSessions/<file>),
- * then checking each workspace for .github/copilot-instructions.md or agents.md.
- *
- * Non-VS Code session files (Crush, OpenCode, Copilot CLI, Visual Studio) are skipped.
- */
-async function buildCustomizationMatrix(sessionFiles: string[]): Promise<WorkspaceCustomizationMatrix | undefined> {
-	const workspacePaths = new Set<string>();
-
-	for (const sessionFile of sessionFiles) {
-		// Expected structure: .../workspaceStorage/<hash>/chatSessions/<file>
-		// Go up 2 levels to reach the hash directory, then read workspace.json
-		const chatSessionsDir = path.dirname(sessionFile);
-		if (path.basename(chatSessionsDir) !== 'chatSessions') { continue; }
-		const hashDir = path.dirname(chatSessionsDir);
-		const workspaceJsonPath = path.join(hashDir, 'workspace.json');
-
-		try {
-			if (!fs.existsSync(workspaceJsonPath)) { continue; }
-			const content = JSON.parse(await fs.promises.readFile(workspaceJsonPath, 'utf-8'));
-			const folderUri: string | undefined = content.folder;
-			if (!folderUri || !folderUri.startsWith('file://')) { continue; }
-
-			// Convert file URI to a local path, handling Windows drive letters
-			let folderPath = decodeURIComponent(folderUri.replace(/^file:\/\//, ''));
-			// On Windows, file:///C:/... becomes /C:/... — strip the leading slash
-			if (/^\/[A-Za-z]:/.test(folderPath)) { folderPath = folderPath.slice(1); }
-			workspacePaths.add(folderPath);
-		} catch {
-			// Skip unreadable workspace.json files
-		}
-	}
-
-	if (workspacePaths.size === 0) { return undefined; }
-
-	let workspacesWithIssues = 0;
-	for (const wsPath of workspacePaths) {
-		try {
-			const hasInstructions = fs.existsSync(path.join(wsPath, '.github', 'copilot-instructions.md'));
-			const hasAgentsMd    = fs.existsSync(path.join(wsPath, 'agents.md'));
-			if (!hasInstructions && !hasAgentsMd) { workspacesWithIssues++; }
-		} catch {
-			workspacesWithIssues++; // Count inaccessible workspaces as lacking customization
-		}
-	}
-
-	return {
-		customizationTypes: [],
-		workspaces: [],
-		totalWorkspaces: workspacePaths.size,
-		workspacesWithIssues,
-	};
-}
 
 export const fluencyCommand = new Command('fluency')
 	.description('Show your Copilot Fluency Score and improvement tips')

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -16,9 +16,10 @@ import { ClaudeDesktopCoworkDataAccess } from '../../vscode-extension/src/claude
 import { MistralVibeDataAccess } from '../../vscode-extension/src/mistralvibe';
 import type { IEcosystemAdapter } from '../../vscode-extension/src/ecosystemAdapter';
 import { OpenCodeAdapter, CrushAdapter, ContinueAdapter, ClaudeDesktopAdapter, ClaudeCodeAdapter, VisualStudioAdapter, MistralVibeAdapter, CopilotChatAdapter, CopilotCliAdapter } from '../../vscode-extension/src/adapters';
+import { isMcpTool, extractMcpServerName } from '../../vscode-extension/src/workspaceHelpers';
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, getModelTier } from '../../vscode-extension/src/tokenEstimation';
-import type { DetailedStats, PeriodStats, ModelUsage, EditorUsage, SessionFileCache, UsageAnalysisStats, UsageAnalysisPeriod } from '../../vscode-extension/src/types';
+import type { DetailedStats, PeriodStats, ModelUsage, EditorUsage, SessionFileCache, UsageAnalysisStats, UsageAnalysisPeriod, WorkspaceCustomizationMatrix } from '../../vscode-extension/src/types';
 import { analyzeSessionUsage, mergeUsageAnalysis, calculateModelSwitching, trackEnhancedMetrics } from '../../vscode-extension/src/usageAnalysis';
 import { createEmptyContextRefs } from '../../vscode-extension/src/tokenEstimation';
 import * as vscodeStub from './vscode-stub';
@@ -95,7 +96,12 @@ const _ecosystems: IEcosystemAdapter[] = [
 	new CrushAdapter(_crushInstance),
 	new VisualStudioAdapter(_visualStudioInstance, (t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators)),
 	new ContinueAdapter(_continueInstance),
-	new ClaudeDesktopAdapter(_claudeDesktopCoworkInstance),
+	new ClaudeDesktopAdapter(
+		_claudeDesktopCoworkInstance,
+		isMcpTool,
+		extractMcpServerName,
+		(t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators)
+	),
 	new ClaudeCodeAdapter(_claudeCodeInstance),
 	new MistralVibeAdapter(_mistralVibeInstance),
 	// Copilot Chat / CLI adapters: discovery-only. Their handles() returns
@@ -114,6 +120,79 @@ function createSessionDiscovery(): SessionDiscovery {
 export async function discoverSessionFiles(): Promise<string[]> {
 	const discovery = createSessionDiscovery();
 	return discovery.getCopilotSessionFiles();
+}
+
+/**
+ * Builds a WorkspaceCustomizationMatrix from session file paths.
+ *
+ * - For VS Code sessions: derives workspace folder from workspaceStorage/<hash>/workspace.json,
+ *   then checks for .github/copilot-instructions.md, agents.md, or CLAUDE.md.
+ * - For Claude Code sessions (~/.claude/projects/<hash>/): reads the JSONL to extract the
+ *   `cwd` workspace path, then checks for CLAUDE.md there.
+ */
+export async function buildCustomizationMatrix(sessionFiles: string[]): Promise<WorkspaceCustomizationMatrix | undefined> {
+	const workspacePaths = new Set<string>();
+	const claudeBasePath = path.join(os.homedir(), '.claude', 'projects');
+
+	for (const sessionFile of sessionFiles) {
+		// Claude Code session: ~/.claude/projects/<hash>/<uuid>.jsonl
+		if (sessionFile.startsWith(claudeBasePath + path.sep) || sessionFile.startsWith(claudeBasePath + '/')) {
+			try {
+				const content = await fs.promises.readFile(sessionFile, 'utf-8');
+				const lines = content.split('\n').slice(0, 30);
+				for (const line of lines) {
+					if (!line.trim()) { continue; }
+					try {
+						const event = JSON.parse(line);
+						if (event.cwd && typeof event.cwd === 'string') {
+							workspacePaths.add(event.cwd);
+							break;
+						}
+					} catch { /* skip malformed lines */ }
+				}
+			} catch { /* skip unreadable files */ }
+			continue;
+		}
+
+		// VS Code session: .../workspaceStorage/<hash>/chatSessions/<file>
+		const chatSessionsDir = path.dirname(sessionFile);
+		if (path.basename(chatSessionsDir) !== 'chatSessions') { continue; }
+		const hashDir = path.dirname(chatSessionsDir);
+		const workspaceJsonPath = path.join(hashDir, 'workspace.json');
+
+		try {
+			if (!fs.existsSync(workspaceJsonPath)) { continue; }
+			const content = JSON.parse(await fs.promises.readFile(workspaceJsonPath, 'utf-8'));
+			const folderUri: string | undefined = content.folder;
+			if (!folderUri || !folderUri.startsWith('file://')) { continue; }
+
+			let folderPath = decodeURIComponent(folderUri.replace(/^file:\/\//, ''));
+			// On Windows, file:///C:/... becomes /C:/... — strip the leading slash
+			if (/^\/[A-Za-z]:/.test(folderPath)) { folderPath = folderPath.slice(1); }
+			workspacePaths.add(folderPath);
+		} catch { /* skip unreadable workspace.json files */ }
+	}
+
+	if (workspacePaths.size === 0) { return undefined; }
+
+	let workspacesWithIssues = 0;
+	for (const wsPath of workspacePaths) {
+		try {
+			const hasInstructions = fs.existsSync(path.join(wsPath, '.github', 'copilot-instructions.md'));
+			const hasAgentsMd    = fs.existsSync(path.join(wsPath, 'agents.md'));
+			const hasClaudeMd    = fs.existsSync(path.join(wsPath, 'CLAUDE.md'));
+			if (!hasInstructions && !hasAgentsMd && !hasClaudeMd) { workspacesWithIssues++; }
+		} catch {
+			workspacesWithIssues++;
+		}
+	}
+
+	return {
+		customizationTypes: [],
+		workspaces: [],
+		totalWorkspaces: workspacePaths.size,
+		workspacesWithIssues,
+	};
 }
 
 /** Get diagnostic candidate paths info */

--- a/vscode-extension/src/adapters/claudeCodeAdapter.ts
+++ b/vscode-extension/src/adapters/claudeCodeAdapter.ts
@@ -3,6 +3,39 @@ import type { ModelUsage } from '../types';
 import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
 import { ClaudeCodeDataAccess, normalizeClaudeModelId } from '../claudecode';
 import { readClaudeCodeEventsForAnalysis, createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+import { isMcpTool, extractMcpServerName } from '../workspaceHelpers';
+
+/**
+ * Claude Code slash commands that map to Prompt Engineering fluency.
+ * These are stored in toolCalls.byTool with a __slash__ prefix so they
+ * are tracked without inflating tool call counts or agentic metrics.
+ */
+const CLAUDE_SLASH_ALLOWLIST = new Set(['review', 'bug', 'think', 'compact', 'pr_comments']);
+
+/**
+ * Extract a Claude slash command from the first non-empty text line of a user message.
+ * Returns the command name (without leading '/') if found and in the allowlist, else null.
+ * Only matches at the very start of the message to avoid false-positives from pasted code.
+ * Exported for reuse by other Claude-family adapters.
+ */
+export function extractClaudeSlashCommand(content: unknown): string | null {
+	let text = '';
+	if (typeof content === 'string') {
+		text = content;
+	} else if (Array.isArray(content)) {
+		for (const block of content) {
+			if (block?.type === 'text' && typeof block.text === 'string') {
+				text = block.text;
+				break;
+			}
+		}
+	}
+	const firstLine = text.trimStart().split('\n')[0].trim();
+	const m = firstLine.match(/^\/([a-z_]+)(?:\s|$)/i);
+	if (!m) { return null; }
+	const cmd = m[1].toLowerCase();
+	return CLAUDE_SLASH_ALLOWLIST.has(cmd) ? cmd : null;
+}
 
 export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'claudecode';
@@ -75,15 +108,30 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		for (const event of events) {
 			if (event.type === 'user' && event.message?.role === 'user' && !event.isSidechain) {
 				analysis.modeUsage.cli++;
+				// Detect Claude Code slash commands from the first line of user messages
+				const cmd = extractClaudeSlashCommand(event.message?.content);
+				if (cmd) {
+					const key = `__slash__${cmd}`;
+					analysis.toolCalls.byTool[key] = (analysis.toolCalls.byTool[key] || 0) + 1;
+					// Note: do NOT increment analysis.toolCalls.total — slash commands are not tool calls
+				}
 			} else if (event.type === 'assistant') {
 				const model = normalizeClaudeModelId(event.message?.model || 'unknown');
 				models.push(model);
 				const content: any[] = Array.isArray(event.message?.content) ? event.message.content : [];
 				for (const c of content) {
 					if (c?.type === 'tool_use') {
-						analysis.toolCalls.total++;
 						const toolName = String(c.name || 'tool');
-						analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+						if (isMcpTool(toolName)) {
+							// Route MCP tools to mcpTools tracking
+							const server = extractMcpServerName(toolName, ctx.toolNameMap);
+							analysis.mcpTools.total++;
+							analysis.mcpTools.byServer[server] = (analysis.mcpTools.byServer[server] || 0) + 1;
+							analysis.mcpTools.byTool[toolName] = (analysis.mcpTools.byTool[toolName] || 0) + 1;
+						} else {
+							analysis.toolCalls.total++;
+							analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+						}
 					}
 				}
 			}

--- a/vscode-extension/src/adapters/claudeDesktopAdapter.ts
+++ b/vscode-extension/src/adapters/claudeDesktopAdapter.ts
@@ -5,6 +5,7 @@ import { ClaudeDesktopCoworkDataAccess } from '../claudedesktop';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { readClaudeCodeEventsForAnalysis, createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
 import { normalizeClaudeModelId } from '../claudecode';
+import { extractClaudeSlashCommand } from './claudeCodeAdapter';
 
 export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'claudedesktop';
@@ -170,6 +171,13 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 		for (const event of events) {
 			if (event.type === 'user' && event.message?.role === 'user' && !event.isSidechain) {
 				analysis.modeUsage.ask++;
+				// Detect Claude slash commands from the first line of user messages
+				const cmd = extractClaudeSlashCommand(event.message?.content);
+				if (cmd) {
+					const key = `__slash__${cmd}`;
+					analysis.toolCalls.byTool[key] = (analysis.toolCalls.byTool[key] || 0) + 1;
+					// Note: do NOT increment analysis.toolCalls.total — slash commands are not tool calls
+				}
 			} else if (event.type === 'assistant') {
 				const model = normalizeClaudeModelId(event.message?.model || 'unknown');
 				models.push(model);

--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -295,12 +295,12 @@ export function getFluencyLevelData(isDebugMode: boolean): {
               label: "Stage 1: AI Skeptic",
               description: "Using default Copilot without customization",
               thresholds: [
-                "No repositories with custom instructions or agents.md",
+                "No repositories with custom instructions, agents.md, or CLAUDE.md",
                 "Using fewer than 3 different models",
               ],
               tips: [
-                "Create a [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) file with project-specific guidelines — [▶ User Instructions video](https://tech.hub.ms/github-copilot/videos/user-instructions)",
-                "Start customizing Copilot for your workflow",
+                "Create a [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) or [CLAUDE.md](https://docs.anthropic.com/en/docs/claude-code/memory) file with project-specific guidelines — [▶ User Instructions video](https://tech.hub.ms/github-copilot/videos/user-instructions)",
+                "Start customizing Copilot or Claude Code for your workflow",
               ],
             },
             {
@@ -445,15 +445,22 @@ export function calculateFluencyScoreForTeamMember(fd: {
     const hasModelSwitching = fd.mixedTierSessions > 0 || switchingFrequency > 0;
     const hasAgentMode = (fd.agentModeCount + fd.cliModeCount) > 0;
     const toolCount = Object.keys(fd.toolCallsByTool).length;
-    const nonAutoToolCount = Object.keys(fd.toolCallsByTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase())).length;
+    // Exclude __slash__ pseudo-entries from real tool counts (they track Claude slash commands, not actual tool calls)
+    const nonAutoToolCount = Object.keys(fd.toolCallsByTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase()) && !t.startsWith('__slash__')).length;
     const avgFilesPerSession = fd.filesPerEditCount > 0 ? fd.filesPerEditSum / fd.filesPerEditCount : 0;
     const avgApplyRate = fd.applyRateCount > 0 ? fd.applyRateSum / fd.applyRateCount : 0;
     const totalContextRefs = fd.ctxFile + fd.ctxSelection + fd.ctxSymbol + fd.ctxCodebase + fd.ctxWorkspace;
 
     // 1. Prompt Engineering
     let peStage = 1;
+    // VS Code Copilot slash commands (stored as tool calls by the session parser)
     const slashCmds = ["explain", "fix", "tests", "doc", "generate", "optimize", "new", "newNotebook", "search", "fixTestFailure", "setupTests"];
-    const usedSlashCommands = slashCmds.filter(cmd => (fd.toolCallsByTool[cmd] ?? 0) > 0);
+    // Claude Code slash commands (stored with __slash__ prefix to avoid inflating tool counts)
+    const claudeSlashCmds = ["review", "bug", "think", "compact", "pr_comments"];
+    const usedSlashCommands = [
+      ...slashCmds.filter(cmd => (fd.toolCallsByTool[cmd] ?? 0) > 0),
+      ...claudeSlashCmds.filter(cmd => (fd.toolCallsByTool[`__slash__${cmd}`] ?? 0) > 0),
+    ];
     if (avgTurnsPerSession >= 3) { peStage = Math.max(peStage, 2); }
     if (avgTurnsPerSession >= 5) { peStage = Math.max(peStage, 3); }
     if (totalInteractions >= 5) { peStage = Math.max(peStage, 2); }
@@ -574,7 +581,7 @@ export function calculateFluencyScoreForTeamMember(fd: {
     if (uniqueModels.size >= 3) { cuStage = Math.max(cuStage, 3); }
     if (uniqueModels.size >= 5 && reposWithCustomization >= 3) { cuStage = 4; }
     const cuTips: string[] = [];
-    if (cuStage < 2) { cuTips.push("Create a .github/copilot-instructions.md file with project-specific guidelines"); }
+    if (cuStage < 2) { cuTips.push("Create a .github/copilot-instructions.md or CLAUDE.md file with project-specific guidelines"); }
     if (cuStage < 3) { cuTips.push("Add custom instructions to more repositories to standardize your Copilot experience"); }
     if (cuStage < 4) {
       const uncustomized = totalRepos - reposWithCustomization;
@@ -695,8 +702,14 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 	}
 
 	// Check slash command / tool usage (indicates structured prompts)
+	// VS Code Copilot slash commands (stored as tool calls by the session parser)
 	const slashCommands = ['explain', 'fix', 'tests', 'doc', 'generate', 'optimize', 'new', 'newNotebook', 'search', 'fixTestFailure', 'setupTests'];
-	const usedSlashCommands = slashCommands.filter(cmd => (p.toolCalls.byTool[cmd] || 0) > 0);
+	// Claude Code slash commands (stored with __slash__ prefix to avoid inflating tool counts)
+	const claudeSlashCommands = ['review', 'bug', 'think', 'compact', 'pr_comments'];
+	const usedSlashCommands = [
+		...slashCommands.filter(cmd => (p.toolCalls.byTool[cmd] || 0) > 0),
+		...claudeSlashCommands.filter(cmd => (p.toolCalls.byTool[`__slash__${cmd}`] || 0) > 0),
+	];
 	if (usedSlashCommands.length > 0) {
 		peEvidence.push(`Used slash commands: /${usedSlashCommands.join(', /')}`);
 	}
@@ -868,7 +881,8 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 
 	// Diverse tool usage in agent mode
 	const toolCount = Object.keys(p.toolCalls.byTool).length;
-	const nonAutoToolCount = Object.keys(p.toolCalls.byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase())).length;
+	// Exclude __slash__ pseudo-entries from real tool counts (they track Claude slash commands, not actual tool calls)
+	const nonAutoToolCount = Object.keys(p.toolCalls.byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase()) && !t.startsWith('__slash__')).length;
 	if ((p.modeUsage.agent + p.modeUsage.cli) >= 10 && nonAutoToolCount >= 3) {
 		agStage = 3;
 	}
@@ -1011,7 +1025,7 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 		cuEvidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos with custom instructions or agents.md`);
 	}
 
-	if (cuStage < 2) { cuTips.push('Create a [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) file with project-specific guidelines'); }
+	if (cuStage < 2) { cuTips.push('Create a [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) or [CLAUDE.md](https://docs.anthropic.com/en/docs/claude-code/memory) file with project-specific guidelines'); }
 	if (cuStage < 3) { cuTips.push('Add [custom instructions](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) to more repositories to standardize your Copilot experience'); }
 	if (cuStage < 4) {
 		const uncustomized = totalRepos - reposWithCustomization;

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -453,9 +453,10 @@ export function parseGitRemoteUrl(gitConfigContent: string): string | undefined 
 /**
  * Check if a tool name indicates it's an MCP (Model Context Protocol) tool.
  * MCP tools are identified by names starting with "mcp." or "mcp_"
+ * Claude Code uses double-underscore format: "mcp__server__tool"
  */
 export function isMcpTool(toolName: string): boolean {
-	return toolName.startsWith('mcp.') || toolName.startsWith('mcp_');
+	return toolName.startsWith('mcp.') || toolName.startsWith('mcp_') || toolName.startsWith('mcp__');
 }
 
 /**
@@ -476,6 +477,7 @@ export function normalizeMcpToolName(toolName: string): string {
 /**
  * Extract server name from an MCP tool name.
  * MCP tool names follow the format: mcp.server.tool or mcp_server_tool
+ * Claude Code uses double-underscore format: mcp__server__tool
  * For example: "mcp.io.github.git.assign_copilot_to_issue" → "GitHub MCP"
  * Uses the display name from toolNames.json (the part before the colon).
  * Falls back to extracting the second segment if no mapping exists.
@@ -496,7 +498,16 @@ export function extractMcpServerName(toolName: string, toolNameMap: { [key: stri
 		return 'GitHub MCP (Remote)';
 	}
 
-	// Generic fallback: extract from tool name structure
+	// Claude Code double-underscore format: mcp__server__tool
+	// e.g. "mcp__github__create_issue" → "github"
+	if (toolName.startsWith('mcp__')) {
+		const withoutPrefix = toolName.slice('mcp__'.length);
+		const serverEnd = withoutPrefix.indexOf('__');
+		const serverName = serverEnd >= 0 ? withoutPrefix.slice(0, serverEnd) : withoutPrefix;
+		return serverName || 'unknown';
+	}
+
+	// Generic fallback: extract from tool name structure (mcp_ or mcp.)
 	const withoutPrefix = toolName.replace(/^mcp[._]/, '');
 	const parts = withoutPrefix.split(/[._]/);
 	return parts[0] || 'unknown';

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -263,3 +263,44 @@ test('getCandidatePaths paths are consistent with discover candidatePaths', asyn
         }
     }
 });
+
+// ---------------------------------------------------------------------------
+// extractClaudeSlashCommand — slash command detection
+// ---------------------------------------------------------------------------
+
+import { extractClaudeSlashCommand } from '../../src/adapters/claudeCodeAdapter';
+
+test('extractClaudeSlashCommand: returns command name for allowed slash commands', () => {
+    assert.equal(extractClaudeSlashCommand('/review'), 'review');
+    assert.equal(extractClaudeSlashCommand('/bug'), 'bug');
+    assert.equal(extractClaudeSlashCommand('/think'), 'think');
+    assert.equal(extractClaudeSlashCommand('/compact'), 'compact');
+    assert.equal(extractClaudeSlashCommand('/pr_comments'), 'pr_comments');
+});
+
+test('extractClaudeSlashCommand: returns null for unknown commands', () => {
+    assert.equal(extractClaudeSlashCommand('/unknown'), null);
+    assert.equal(extractClaudeSlashCommand('/init'), null);
+    assert.equal(extractClaudeSlashCommand('/memory'), null);
+});
+
+test('extractClaudeSlashCommand: returns null for non-slash messages', () => {
+    assert.equal(extractClaudeSlashCommand('can you review my code'), null);
+    assert.equal(extractClaudeSlashCommand(''), null);
+    assert.equal(extractClaudeSlashCommand(null), null);
+});
+
+test('extractClaudeSlashCommand: handles string with trailing text', () => {
+    assert.equal(extractClaudeSlashCommand('/review this file'), 'review');
+    assert.equal(extractClaudeSlashCommand('/bug fix the null pointer'), 'bug');
+});
+
+test('extractClaudeSlashCommand: handles array content blocks', () => {
+    const content = [{ type: 'text', text: '/review' }];
+    assert.equal(extractClaudeSlashCommand(content), 'review');
+});
+
+test('extractClaudeSlashCommand: ignores slash commands not at the start', () => {
+    assert.equal(extractClaudeSlashCommand('some text\n/review'), null);
+    assert.equal(extractClaudeSlashCommand('prefix /review'), null);
+});

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -467,3 +467,24 @@ test('getRepoDisplayName: handles SSH URL with .git', () => {
         const result = getRepoDisplayName('git@github.com:owner/repo.git');
         assert.equal(result, 'owner/repo');
 });
+
+// ── Claude Code MCP double-underscore format ──────────────────────────────
+
+test('isMcpTool: mcp__ double-underscore prefix (Claude Code format) returns true', () => {
+        assert.equal(isMcpTool('mcp__github__create_issue'), true);
+        assert.equal(isMcpTool('mcp__filesystem__read_file'), true);
+});
+
+test('isMcpTool: regular tool without mcp__ prefix returns false', () => {
+        assert.equal(isMcpTool('github__create_issue'), false);
+        assert.equal(isMcpTool('__slash__review'), false);
+});
+
+test('extractMcpServerName: mcp__server__tool format extracts server name', () => {
+        assert.equal(extractMcpServerName('mcp__github__create_issue'), 'github');
+        assert.equal(extractMcpServerName('mcp__filesystem__read_file'), 'filesystem');
+});
+
+test('extractMcpServerName: mcp__server__multi__part__tool extracts only first server segment', () => {
+        assert.equal(extractMcpServerName('mcp__my_server__tool__with__parts'), 'my_server');
+});


### PR DESCRIPTION
## Summary

This PR improves the fluency spiderweb scoring for users who only use Claude Code or Claude Desktop Cowork, by surfacing prompt engineering signals and customization data that were previously invisible to the scorer.

## Changes

### Bug Fixes
- **\workspaceHelpers.ts\**: \isMcpTool()\ now detects \mcp__\ double-underscore format (Claude Code MCP). Previously only \mcp.\ and \mcp_\ were recognized.
- **\workspaceHelpers.ts\**: \xtractMcpServerName()\ now correctly parses \mcp__server__tool\ format. Previously returned 'unknown' for all Claude Code MCP tools.
- **\cli/src/helpers.ts\**: \ClaudeDesktopAdapter\ constructor was missing 3 required args. Now passes \isMcpTool\, \xtractMcpServerName\, and token estimator.

### Claude Slash Command Tracking (Prompt Engineering axis)
- \claudeCodeAdapter.ts\: Added \xtractClaudeSlashCommand()\ + \CLAUDE_SLASH_ALLOWLIST\ (\/review\, \/bug\, \/think\, \/compact\, \/pr_comments\). Slash commands stored as \__slash__<cmd>\ in \	oolCalls.byTool\ without incrementing \	oolCalls.total\.
- \claudeDesktopAdapter.ts\: Reuses shared slash command detection.
- \maturityScoring.ts\: Both scorers recognize \__slash__*\ as Prompt Engineering evidence and exclude them from \
onAutoToolCount\.

### CLAUDE.md Customization Support
- \maturityScoring.ts\: Stage 1 tips + evidence mention CLAUDE.md alongside copilot-instructions.md.
- \cli/src/helpers.ts\: \uildCustomizationMatrix()\ now detects Claude Code workspaces via JSONL \cwd\ field and checks for \CLAUDE.md\.
- Duplicate \uildCustomizationMatrix\ removed from \luency.ts\ and \ll.ts\.

### Tests
- 4 new tests for \mcp__\ format in \workspaceHelpers.test.ts\
- 7 new tests for \xtractClaudeSlashCommand\ in \cosystemAdapters.test.ts\
- All 145 tests pass.