### PR TITLE
chore: bump versions for release (vscode-extension, cli, visualstudio-extension)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.8"
+              Version="1.0.9"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for all three components in preparation for their next releases.

| Component | Old version | New version | Bump type |
|-----------|-------------|-------------|-----------|
| VS Code extension | v0.1.4 | v0.2.0 | minor |
| CLI | v0.0.10 | v0.0.11 | patch |
| Visual Studio extension | v1.0.8 | v1.0.9 | patch |

### After merging, run these workflows:

#### 1. VS Code Extension
- **Actions → Extensions - Release (\elease.yml\) → Run workflow** (on \main\)
- Publishes VS Code extension **v0.2.0** to the VS Code Marketplace

#### 2. CLI
- **Actions → CLI - Publish to npm and GitHub (\cli-publish.yml\) → Run workflow** (on \main\)
- Publishes **@rajbos/ai-engineering-fluency@0.0.11** to npm

#### 3. Visual Studio Extension
- **Actions → Visual Studio Extension - Build & Package (\isualstudio-build.yml\) → Run workflow** (on \main\)
- Set \publish_marketplace: true\ to publish **v1.0.9** to the Visual Studio Marketplace