### PR TITLE
Add GitHub Copilot AI-Credit pricing alongside provider pricing

### DIFF
--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -107,9 +107,9 @@ function printPeriodStats(
 	console.log(`  Avg tokens/session:    ${chalk.bold(formatTokens(stats.avgTokensPerSession))}`);
 
 	if (options.cost && stats.estimatedCost > 0) {
-		console.log(`  Estimated cost (API):  ${chalk.green('$' + stats.estimatedCost.toFixed(4))}`);
+		console.log(`  Estimated cost (est.): ${chalk.green('$' + stats.estimatedCost.toFixed(4))}  ${chalk.dim('(provider API rates)')}`);
 		if ((stats.estimatedCostCopilot ?? 0) > 0) {
-			console.log(`  Estimated cost (Copilot): ${chalk.green('$' + (stats.estimatedCostCopilot ?? 0).toFixed(4))}`);
+			console.log(`  Estimated cost (TBB):  ${chalk.green('$' + (stats.estimatedCostCopilot ?? 0).toFixed(4))}  ${chalk.dim('(Copilot AI Credits)')}`);
 		}
 	}
 

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -107,7 +107,10 @@ function printPeriodStats(
 	console.log(`  Avg tokens/session:    ${chalk.bold(formatTokens(stats.avgTokensPerSession))}`);
 
 	if (options.cost && stats.estimatedCost > 0) {
-		console.log(`  Estimated cost:        ${chalk.green('$' + stats.estimatedCost.toFixed(4))}`);
+		console.log(`  Estimated cost (API):  ${chalk.green('$' + stats.estimatedCost.toFixed(4))}`);
+		if ((stats.estimatedCostCopilot ?? 0) > 0) {
+			console.log(`  Estimated cost (Copilot): ${chalk.green('$' + (stats.estimatedCostCopilot ?? 0).toFixed(4))}`);
+		}
 	}
 
 	// Model breakdown

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -437,6 +437,7 @@ export async function calculateDetailedStats(
 		period.treesEquivalent = period.co2 / CO2_ABSORPTION_PER_TREE_PER_YEAR;
 		period.waterUsage = (period.tokens / 1000) * WATER_USAGE_PER_1K_TOKENS;
 		period.estimatedCost = calculateEstimatedCost(period.modelUsage, modelPricing);
+		period.estimatedCostCopilot = calculateEstimatedCost(period.modelUsage, modelPricing, 'copilot');
 	}
 
 	return {

--- a/vscode-extension/src/README.md
+++ b/vscode-extension/src/README.md
@@ -46,11 +46,44 @@ Contains pricing information for AI models, including input and output token cos
       "cacheCreationCostPerMillion": 2.1875,
       "category": "Model category",
       "tier": "standard|premium|unknown",
-      "multiplier": 1
+      "multiplier": 1,
+      "copilotPricing": {
+        "inputCostPerMillion": 1.75,
+        "cachedInputCostPerMillion": 0.175,
+        "cacheCreationCostPerMillion": 2.1875,
+        "outputCostPerMillion": 14.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     }
   }
 }
 ```
+
+**Provider vs. GitHub Copilot pricing**
+
+The top-level `inputCostPerMillion` / `outputCostPerMillion` / cache fields
+represent the **direct provider/API price** (OpenAI, Anthropic, Google, xAI, …).
+The optional `copilotPricing` block represents **GitHub Copilot's published
+per-token AI Credit rates**
+(<https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing>,
+1 AI credit = $0.01). Both are computed in parallel by `calculateEstimatedCost`:
+
+```ts
+calculateEstimatedCost(usage, pricing);             // provider/API cost (default)
+calculateEstimatedCost(usage, pricing, 'copilot');  // GitHub Copilot AI-Credit cost
+```
+
+When a model has no `copilotPricing` block the `'copilot'` source falls back to
+the provider rates as a proxy — this means the Copilot cost is never
+*under-reported* due to a missing entry, it just won't reflect the (often
+identical) GitHub-published rate explicitly.
+
+> ℹ️ **Caching note.** Copilot Chat session logs do not (yet) expose a
+> cached-read / cache-creation token breakdown, so the Copilot cost falls back
+> to the full input rate for those sources. Adapters that *do* surface cache
+> tokens (Claude Desktop, Claude Code, OpenCode) automatically benefit from the
+> reduced cached-input rates in `copilotPricing`.
 
 **Cache pricing fields (optional):**
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1332,7 +1332,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📅 Today  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.today.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost :             | $ ${detailedStats.today.estimatedCost.toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (API) :       | $ ${detailedStats.today.estimatedCost.toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (Copilot) :   | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.today.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.today.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.today.sessions} |\n`);
@@ -1345,7 +1346,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📊 Last 30 Days  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.last30Days.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost :             | $ ${detailedStats.last30Days.estimatedCost.toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (API) :       | $ ${detailedStats.last30Days.estimatedCost.toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (Copilot) :   | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.last30Days.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.last30Days.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.last30Days.sessions} |\n`);
@@ -1811,6 +1813,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const lastMonthCost = this.calculateEstimatedCost(lastMonthStats.modelUsage);
 		const last30DaysCost = this.calculateEstimatedCost(last30DaysStats.modelUsage);
 
+		const todayCostCopilot = this.calculateEstimatedCost(todayStats.modelUsage, 'copilot');
+		const monthCostCopilot = this.calculateEstimatedCost(monthStats.modelUsage, 'copilot');
+		const lastMonthCostCopilot = this.calculateEstimatedCost(lastMonthStats.modelUsage, 'copilot');
+		const last30DaysCostCopilot = this.calculateEstimatedCost(last30DaysStats.modelUsage, 'copilot');
+
 		const result: DetailedStats = {
 			today: {
 				tokens: todayStats.tokens,
@@ -1825,7 +1832,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 				co2: todayCo2,
 				treesEquivalent: todayCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: todayWater,
-				estimatedCost: todayCost
+				estimatedCost: todayCost,
+				estimatedCostCopilot: todayCostCopilot
 			},
 			month: {
 				tokens: monthStats.tokens,
@@ -1840,7 +1848,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 				co2: monthCo2,
 				treesEquivalent: monthCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: monthWater,
-				estimatedCost: monthCost
+				estimatedCost: monthCost,
+				estimatedCostCopilot: monthCostCopilot
 			},
 			lastMonth: {
 				tokens: lastMonthStats.tokens,
@@ -1855,7 +1864,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 				co2: lastMonthCo2,
 				treesEquivalent: lastMonthCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: lastMonthWater,
-				estimatedCost: lastMonthCost
+				estimatedCost: lastMonthCost,
+				estimatedCostCopilot: lastMonthCostCopilot
 			},
 			last30Days: {
 				tokens: last30DaysStats.tokens,
@@ -1870,7 +1880,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 				co2: last30DaysCo2,
 				treesEquivalent: last30DaysCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: last30DaysWater,
-				estimatedCost: last30DaysCost
+				estimatedCost: last30DaysCost,
+				estimatedCostCopilot: last30DaysCostCopilot
 			},
 			lastUpdated: now
 		};
@@ -3825,8 +3836,8 @@ usageAnalysis: undefined
 		return { responseText, thinkingText, toolCalls, mcpTools };
 	}
 
-	public calculateEstimatedCost(modelUsage: ModelUsage): number {
-		return _calculateEstimatedCost(modelUsage, this.modelPricing);
+	public calculateEstimatedCost(modelUsage: ModelUsage, pricingSource: 'provider' | 'copilot' = 'provider'): number {
+		return _calculateEstimatedCost(modelUsage, this.modelPricing, pricingSource);
 	}
 
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1332,8 +1332,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📅 Today  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.today.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.today.estimatedCost.toFixed(4)} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.today.estimatedCost.toFixed(2)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.today.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.today.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.today.sessions} |\n`);
@@ -1346,8 +1346,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📊 Last 30 Days  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.last30Days.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.last30Days.estimatedCost.toFixed(4)} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.last30Days.estimatedCost.toFixed(2)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.last30Days.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.last30Days.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.last30Days.sessions} |\n`);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1332,8 +1332,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📅 Today  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.today.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (API) :       | $ ${detailedStats.today.estimatedCost.toFixed(4)} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (Copilot) :   | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.today.estimatedCost.toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.today.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.today.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.today.sessions} |\n`);
@@ -1346,8 +1346,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📊 Last 30 Days  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.last30Days.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (API) :       | $ ${detailedStats.last30Days.estimatedCost.toFixed(4)} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (Copilot) :   | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.last30Days.estimatedCost.toFixed(4)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(4)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.last30Days.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.last30Days.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.last30Days.sessions} |\n`);
@@ -1356,6 +1356,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			// Footer
 			tooltip.appendMarkdown('\n---\n');
 			tooltip.appendMarkdown('*Cost estimates based on actual input/output token ratios.*  \n');
+			tooltip.appendMarkdown('*(est.) = provider API market rates, for reference only.*  \n');
+			tooltip.appendMarkdown('*(TBB) = Copilot AI Credit rates — what Copilot will bill you.*  \n');
 			tooltip.appendMarkdown('*Updates automatically every 5 minutes.*');
 
 			this.statusBarItem.tooltip = tooltip;

--- a/vscode-extension/src/modelPricing.json
+++ b/vscode-extension/src/modelPricing.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Model pricing data - costs per million tokens for input and output",
+  "description": "Model pricing data - costs per million tokens. Each model has direct provider/API pricing at the top level (used as a reference); models billed through GitHub Copilot AI Credits also include a `copilotPricing` block reflecting GitHub's published per-token rates (1 AI credit = $0.01).",
   "metadata": {
-    "lastUpdated": "2026-04-24",
+    "lastUpdated": "2026-04-27",
     "sources": [
       {
         "name": "OpenAI API Pricing",
@@ -42,6 +42,12 @@
         "url": "https://openrouter.ai",
         "retrievedDate": "2026-03-30",
         "note": "Cross-provider pricing aggregator used for verification"
+      },
+      {
+        "name": "GitHub Copilot Models and Pricing",
+        "url": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "retrievedDate": "2026-04-27",
+        "note": "Source for the `copilotPricing` per-model block (GitHub AI Credit per-token rates)"
       }
     ],
     "disclaimer": "GitHub Copilot uses these models but pricing may differ from direct API usage. These are reference prices for cost estimation purposes only."
@@ -67,7 +73,14 @@
       "outputCostPerMillion": 2.0,
       "category": "GPT-5 models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "copilotPricing": {
+        "inputCostPerMillion": 0.25,
+        "cachedInputCostPerMillion": 0.025,
+        "outputCostPerMillion": 2.0,
+        "releaseStatus": "GA",
+        "category": "Lightweight"
+      }
     },
     "gpt-5.1": {
       "inputCostPerMillion": 1.25,
@@ -102,14 +115,28 @@
       "outputCostPerMillion": 14.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "copilotPricing": {
+        "inputCostPerMillion": 1.75,
+        "cachedInputCostPerMillion": 0.175,
+        "outputCostPerMillion": 14.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "gpt-5.2-codex": {
       "inputCostPerMillion": 1.75,
       "outputCostPerMillion": 14.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "copilotPricing": {
+        "inputCostPerMillion": 1.75,
+        "cachedInputCostPerMillion": 0.175,
+        "outputCostPerMillion": 14.0,
+        "releaseStatus": "GA",
+        "category": "Powerful"
+      }
     },
     "gpt-5.2-pro": {
       "inputCostPerMillion": 21.0,
@@ -123,7 +150,14 @@
       "outputCostPerMillion": 14.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "copilotPricing": {
+        "inputCostPerMillion": 1.75,
+        "cachedInputCostPerMillion": 0.175,
+        "outputCostPerMillion": 14.0,
+        "releaseStatus": "GA",
+        "category": "Powerful"
+      }
     },
     "gpt-5.4": {
       "inputCostPerMillion": 2.50,
@@ -132,7 +166,14 @@
       "category": "GPT-5 models",
       "tier": "premium",
       "multiplier": 1,
-      "displayNames": ["GPT-5.4"]
+      "displayNames": ["GPT-5.4"],
+      "copilotPricing": {
+        "inputCostPerMillion": 2.50,
+        "cachedInputCostPerMillion": 0.25,
+        "outputCostPerMillion": 15.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "gpt-5.4-mini": {
       "inputCostPerMillion": 0.75,
@@ -141,7 +182,30 @@
       "category": "GPT-5 models",
       "tier": "standard",
       "multiplier": 0,
-      "displayNames": ["GPT-5.4 mini"]
+      "displayNames": ["GPT-5.4 mini"],
+      "copilotPricing": {
+        "inputCostPerMillion": 0.75,
+        "cachedInputCostPerMillion": 0.075,
+        "outputCostPerMillion": 4.5,
+        "releaseStatus": "GA",
+        "category": "Lightweight"
+      }
+    },
+    "gpt-5.4-nano": {
+      "inputCostPerMillion": 0.20,
+      "cachedInputCostPerMillion": 0.02,
+      "outputCostPerMillion": 1.25,
+      "category": "GPT-5 models",
+      "tier": "standard",
+      "multiplier": 0,
+      "displayNames": ["GPT-5.4 nano"],
+      "copilotPricing": {
+        "inputCostPerMillion": 0.20,
+        "cachedInputCostPerMillion": 0.02,
+        "outputCostPerMillion": 1.25,
+        "releaseStatus": "GA",
+        "category": "Lightweight"
+      }
     },
     "gpt-4": {
       "inputCostPerMillion": 3.0,
@@ -158,7 +222,14 @@
       "category": "GPT-4 models",
       "tier": "standard",
       "multiplier": 0,
-      "displayNames": ["GPT-4.1"]
+      "displayNames": ["GPT-4.1"],
+      "copilotPricing": {
+        "inputCostPerMillion": 2.0,
+        "cachedInputCostPerMillion": 0.5,
+        "outputCostPerMillion": 8.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "gpt-4.1-mini": {
       "inputCostPerMillion": 0.4,
@@ -230,7 +301,15 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 1,
-      "displayNames": ["Claude Sonnet 4"]
+      "displayNames": ["Claude Sonnet 4"],
+      "copilotPricing": {
+        "inputCostPerMillion": 3.0,
+        "cachedInputCostPerMillion": 0.3,
+        "cacheCreationCostPerMillion": 3.75,
+        "outputCostPerMillion": 15.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "claude-sonnet-4.5": {
       "inputCostPerMillion": 3.0,
@@ -239,7 +318,15 @@
       "cacheCreationCostPerMillion": 3.75,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "copilotPricing": {
+        "inputCostPerMillion": 3.0,
+        "cachedInputCostPerMillion": 0.3,
+        "cacheCreationCostPerMillion": 3.75,
+        "outputCostPerMillion": 15.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "claude-sonnet-4.6": {
       "inputCostPerMillion": 3.0,
@@ -249,7 +336,15 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 3,
-      "displayNames": ["Claude Sonnet 4.6"]
+      "displayNames": ["Claude Sonnet 4.6"],
+      "copilotPricing": {
+        "inputCostPerMillion": 3.0,
+        "cachedInputCostPerMillion": 0.3,
+        "cacheCreationCostPerMillion": 3.75,
+        "outputCostPerMillion": 15.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "claude-haiku": {
       "inputCostPerMillion": 0.25,
@@ -267,7 +362,15 @@
       "cacheCreationCostPerMillion": 1.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 0.33
+      "multiplier": 0.33,
+      "copilotPricing": {
+        "inputCostPerMillion": 1.0,
+        "cachedInputCostPerMillion": 0.1,
+        "cacheCreationCostPerMillion": 1.25,
+        "outputCostPerMillion": 5.0,
+        "releaseStatus": "GA",
+        "category": "Versatile"
+      }
     },
     "claude-opus-4.1": {
       "inputCostPerMillion": 15.0,
@@ -285,7 +388,15 @@
       "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 3
+      "multiplier": 3,
+      "copilotPricing": {
+        "inputCostPerMillion": 5.0,
+        "cachedInputCostPerMillion": 0.5,
+        "cacheCreationCostPerMillion": 6.25,
+        "outputCostPerMillion": 25.0,
+        "releaseStatus": "GA",
+        "category": "Powerful"
+      }
     },
     "claude-opus-4.6": {
       "inputCostPerMillion": 5.0,
@@ -294,7 +405,33 @@
       "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 3
+      "multiplier": 3,
+      "copilotPricing": {
+        "inputCostPerMillion": 5.0,
+        "cachedInputCostPerMillion": 0.5,
+        "cacheCreationCostPerMillion": 6.25,
+        "outputCostPerMillion": 25.0,
+        "releaseStatus": "GA",
+        "category": "Powerful"
+      }
+    },
+    "claude-opus-4.7": {
+      "inputCostPerMillion": 5.0,
+      "outputCostPerMillion": 25.0,
+      "cachedInputCostPerMillion": 0.5,
+      "cacheCreationCostPerMillion": 6.25,
+      "category": "Claude models (Anthropic)",
+      "tier": "premium",
+      "multiplier": 3,
+      "displayNames": ["Claude Opus 4.7"],
+      "copilotPricing": {
+        "inputCostPerMillion": 5.0,
+        "cachedInputCostPerMillion": 0.5,
+        "cacheCreationCostPerMillion": 6.25,
+        "outputCostPerMillion": 25.0,
+        "releaseStatus": "GA",
+        "category": "Powerful"
+      }
     },
     "claude-opus-4.6-(fast-mode)-(preview)": {
       "inputCostPerMillion": 5.0,
@@ -303,7 +440,15 @@
       "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 30
+      "multiplier": 30,
+      "copilotPricing": {
+        "inputCostPerMillion": 30.0,
+        "cachedInputCostPerMillion": 3.0,
+        "cacheCreationCostPerMillion": 37.5,
+        "outputCostPerMillion": 150.0,
+        "releaseStatus": "Public preview",
+        "category": "Powerful"
+      }
     },
     "claude-opus-4.6-fast": {
       "inputCostPerMillion": 5.0,
@@ -312,7 +457,15 @@
       "cacheCreationCostPerMillion": 6.25,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 30
+      "multiplier": 30,
+      "copilotPricing": {
+        "inputCostPerMillion": 30.0,
+        "cachedInputCostPerMillion": 3.0,
+        "cacheCreationCostPerMillion": 37.5,
+        "outputCostPerMillion": 150.0,
+        "releaseStatus": "Public preview",
+        "category": "Powerful"
+      }
     },
     "o3-mini": {
       "inputCostPerMillion": 1.10,
@@ -360,7 +513,14 @@
       "category": "Google Gemini models",
       "tier": "premium",
       "multiplier": 1,
-      "displayNames": ["Gemini 2.5 Pro"]
+      "displayNames": ["Gemini 2.5 Pro"],
+      "copilotPricing": {
+        "inputCostPerMillion": 1.25,
+        "cachedInputCostPerMillion": 0.125,
+        "outputCostPerMillion": 10.0,
+        "releaseStatus": "GA",
+        "category": "Powerful"
+      }
     },
     "gemini-2.5-flash": {
       "inputCostPerMillion": 0.30,
@@ -395,7 +555,14 @@
       "outputCostPerMillion": 3.0,
       "category": "Google Gemini models",
       "tier": "premium",
-      "multiplier": 0.33
+      "multiplier": 0.33,
+      "copilotPricing": {
+        "inputCostPerMillion": 0.50,
+        "cachedInputCostPerMillion": 0.05,
+        "outputCostPerMillion": 3.0,
+        "releaseStatus": "Public preview",
+        "category": "Lightweight"
+      }
     },
     "gemini-3-pro": {
       "inputCostPerMillion": 2.0,
@@ -419,7 +586,14 @@
       "category": "Google Gemini models",
       "tier": "premium",
       "multiplier": 1,
-      "displayNames": ["Gemini 3.1 Pro", "Gemini 3.1 Pro (Preview)"]
+      "displayNames": ["Gemini 3.1 Pro", "Gemini 3.1 Pro (Preview)"],
+      "copilotPricing": {
+        "inputCostPerMillion": 2.0,
+        "cachedInputCostPerMillion": 0.20,
+        "outputCostPerMillion": 12.0,
+        "releaseStatus": "Public preview",
+        "category": "Powerful"
+      }
     },
     "gemini-3.1-flash-lite": {
       "inputCostPerMillion": 0.25,
@@ -434,21 +608,42 @@
       "outputCostPerMillion": 1.50,
       "category": "xAI Grok models",
       "tier": "premium",
-      "multiplier": 0.25
+      "multiplier": 0.25,
+      "copilotPricing": {
+        "inputCostPerMillion": 0.20,
+        "cachedInputCostPerMillion": 0.02,
+        "outputCostPerMillion": 1.50,
+        "releaseStatus": "GA",
+        "category": "Lightweight"
+      }
     },
     "raptor-mini": {
       "inputCostPerMillion": 0.25,
       "outputCostPerMillion": 2.0,
       "category": "GitHub Copilot fine-tuned models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "copilotPricing": {
+        "inputCostPerMillion": 0.25,
+        "cachedInputCostPerMillion": 0.025,
+        "outputCostPerMillion": 2.0,
+        "releaseStatus": "Public preview",
+        "category": "Versatile"
+      }
     },
     "goldeneye": {
       "inputCostPerMillion": 0.00,
       "outputCostPerMillion": 0.00,
       "category": "GitHub Copilot fine-tuned models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "copilotPricing": {
+        "inputCostPerMillion": 1.25,
+        "cachedInputCostPerMillion": 0.125,
+        "outputCostPerMillion": 10.0,
+        "releaseStatus": "Public preview",
+        "category": "Powerful"
+      }
     }
   }
 }

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -535,14 +535,32 @@ export function getModelTier(modelId: string, modelPricing: { [key: string]: Mod
  *        + cachedReadTokens × cachedInputCostPerMillion (fallback: inputCostPerMillion)
  *        + cacheCreationTokens × cacheCreationCostPerMillion (fallback: inputCostPerMillion)
  *        + outputTokens × outputCostPerMillion
+ *
  * @param modelUsage Object with model names as keys and token counts as values
+ * @param modelPricing Pricing table keyed by model id
+ * @param pricingSource 'provider' (default) uses the top-level provider/API rates;
+ *                      'copilot' uses each model's `copilotPricing` block when present,
+ *                      and falls back to provider rates for models without one.
  * @returns Estimated cost in USD
  */
-export function calculateEstimatedCost(modelUsage: ModelUsage, modelPricing: { [key: string]: ModelPricing } = {}): number {
+export function calculateEstimatedCost(
+	modelUsage: ModelUsage,
+	modelPricing: { [key: string]: ModelPricing } = {},
+	pricingSource: 'provider' | 'copilot' = 'provider'
+): number {
 	let totalCost = 0;
 
 	for (const [model, usage] of Object.entries(modelUsage)) {
-		const pricing = modelPricing[model] ?? modelPricing['gpt-4o-mini'];
+		const baseEntry = modelPricing[model] ?? modelPricing['gpt-4o-mini'];
+		if (!baseEntry) {
+			continue;
+		}
+
+		// Pick which rate set to use. For 'copilot', prefer the model's copilotPricing
+		// block; if absent, fall back to the provider/API rates as a proxy.
+		const pricing = pricingSource === 'copilot' && baseEntry.copilotPricing
+			? baseEntry.copilotPricing
+			: baseEntry;
 
 		const cachedRead = usage.cachedReadTokens ?? 0;
 		const cacheCreation = usage.cacheCreationTokens ?? 0;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -18,6 +18,15 @@ export interface ModelUsage {
   };
 }
 
+export interface CopilotPricing {
+  inputCostPerMillion: number;
+  outputCostPerMillion: number;
+  cachedInputCostPerMillion?: number;
+  cacheCreationCostPerMillion?: number;
+  releaseStatus?: string;       // e.g. "GA" or "Public preview"
+  category?: string;            // GitHub Copilot capability category (Lightweight / Versatile / Powerful)
+}
+
 export interface ModelPricing {
   inputCostPerMillion: number;
   outputCostPerMillion: number;
@@ -27,6 +36,12 @@ export interface ModelPricing {
   tier?: "standard" | "premium" | "unknown";
   multiplier?: number;
   displayNames?: string[];
+  /**
+   * GitHub Copilot AI-Credit per-token pricing (1 credit = $0.01).
+   * Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
+   * When omitted the top-level provider/API rates are used as a fallback proxy.
+   */
+  copilotPricing?: CopilotPricing;
 }
 
 export interface EditorUsage {
@@ -57,6 +72,12 @@ export interface PeriodStats {
   treesEquivalent: number;
   waterUsage: number;
   estimatedCost: number;
+  /**
+   * Estimated cost using GitHub Copilot AI-Credit per-token rates (when available
+   * for a given model). Optional/additive so existing fixtures don't need updating.
+   * Falls back to provider/API pricing for models without `copilotPricing`.
+   */
+  estimatedCostCopilot?: number;
 }
 
 export interface DetailedStats {

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -29,6 +29,7 @@ type PeriodStats = {
 	treesEquivalent: number;
 	waterUsage: number;
 	estimatedCost: number;
+	estimatedCostCopilot?: number;
 };
 
 type DetailedStats = {
@@ -92,6 +93,7 @@ function render(stats: DetailedStats): void {
 	const projectedCo2 = calculateProjection(stats.last30Days.co2);
 	const projectedWater = calculateProjection(stats.last30Days.waterUsage);
 	const projectedCost = calculateProjection(stats.last30Days.estimatedCost);
+	const projectedCostCopilot = calculateProjection(stats.last30Days.estimatedCostCopilot ?? 0);
 	const projectedTrees = calculateProjection(stats.last30Days.treesEquivalent);
 
 	renderShell(root, stats, {
@@ -100,6 +102,7 @@ function render(stats: DetailedStats): void {
 		projectedCo2,
 		projectedWater,
 		projectedCost,
+		projectedCostCopilot,
 		projectedTrees
 	});
 
@@ -115,6 +118,7 @@ function renderShell(
 		projectedCo2: number;
 		projectedWater: number;
 		projectedCost: number;
+		projectedCostCopilot?: number;
 		projectedTrees: number;
 	}
 ): void {
@@ -181,6 +185,7 @@ function buildMetricsSection(
 		projectedCo2: number;
 		projectedWater: number;
 		projectedCost: number;
+		projectedCostCopilot?: number;
 		projectedTrees: number;
 	}
 ): HTMLElement {
@@ -219,7 +224,8 @@ function buildMetricsSection(
 		{ label: 'Tokens (user estimated)', icon: '📝', color: '#b39ddb', today: formatCompact(stats.today.estimatedTokens), last30Days: formatCompact(stats.last30Days.estimatedTokens), lastMonth: formatCompact(stats.lastMonth.estimatedTokens), projected: '—' },
 		{ label: 'Service overhead %', icon: '☁️', color: '#90a4ae', today: (stats.today.actualTokens || 0) > 0 ? formatPercent(((stats.today.tokens - stats.today.estimatedTokens) / stats.today.tokens) * 100) : '—', last30Days: (stats.last30Days.actualTokens || 0) > 0 ? formatPercent(((stats.last30Days.tokens - stats.last30Days.estimatedTokens) / stats.last30Days.tokens) * 100) : '—', lastMonth: (stats.lastMonth.actualTokens || 0) > 0 ? formatPercent(((stats.lastMonth.tokens - stats.lastMonth.estimatedTokens) / stats.lastMonth.tokens) * 100) : '—', projected: '—' },
 		{ label: 'Thinking tokens', icon: '🧠', color: '#a78bfa', today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: '—' },
-		{ label: 'Estimated cost', icon: '🪙', color: '#ffd166', today: formatCost(stats.today.estimatedCost), last30Days: formatCost(stats.last30Days.estimatedCost), lastMonth: formatCost(stats.lastMonth.estimatedCost), projected: formatCost(projections.projectedCost) },
+		{ label: 'Estimated cost (API)', icon: '🪙', color: '#ffd166', today: formatCost(stats.today.estimatedCost), last30Days: formatCost(stats.last30Days.estimatedCost), lastMonth: formatCost(stats.lastMonth.estimatedCost), projected: formatCost(projections.projectedCost) },
+		{ label: 'Estimated cost (Copilot)', icon: '🟢', color: '#7ce38b', today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) },
 		{ label: 'Sessions', icon: '📅', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
 		{ label: 'Average interactions/session', icon: '💬', color: '#8ce0ff', today: formatNumber(stats.today.avgInteractionsPerSession), last30Days: formatNumber(stats.last30Days.avgInteractionsPerSession), lastMonth: formatNumber(stats.lastMonth.avgInteractionsPerSession), projected: '—' },
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' }

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -219,13 +219,23 @@ function buildMetricsSection(
 	table.append(thead);
 
 	const tbody = document.createElement('tbody');
-	const rows: Array<{ label: string; icon: string; color?: string; today: string; last30Days: string; lastMonth: string; projected: string }> = [
+	const rows: Array<{ label: string; labelTooltip?: string; icon: string; color?: string; today: string; last30Days: string; lastMonth: string; projected: string }> = [
 		{ label: 'Tokens (total)', icon: '🟣', color: '#c37bff', today: formatCompact(stats.today.tokens), last30Days: formatCompact(stats.last30Days.tokens), lastMonth: formatCompact(stats.lastMonth.tokens), projected: formatCompact(projections.projectedTokens) },
 		{ label: 'Tokens (user estimated)', icon: '📝', color: '#b39ddb', today: formatCompact(stats.today.estimatedTokens), last30Days: formatCompact(stats.last30Days.estimatedTokens), lastMonth: formatCompact(stats.lastMonth.estimatedTokens), projected: '—' },
 		{ label: 'Service overhead %', icon: '☁️', color: '#90a4ae', today: (stats.today.actualTokens || 0) > 0 ? formatPercent(((stats.today.tokens - stats.today.estimatedTokens) / stats.today.tokens) * 100) : '—', last30Days: (stats.last30Days.actualTokens || 0) > 0 ? formatPercent(((stats.last30Days.tokens - stats.last30Days.estimatedTokens) / stats.last30Days.tokens) * 100) : '—', lastMonth: (stats.lastMonth.actualTokens || 0) > 0 ? formatPercent(((stats.lastMonth.tokens - stats.lastMonth.estimatedTokens) / stats.lastMonth.tokens) * 100) : '—', projected: '—' },
 		{ label: 'Thinking tokens', icon: '🧠', color: '#a78bfa', today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: '—' },
-		{ label: 'Estimated cost (API)', icon: '🪙', color: '#ffd166', today: formatCost(stats.today.estimatedCost), last30Days: formatCost(stats.last30Days.estimatedCost), lastMonth: formatCost(stats.lastMonth.estimatedCost), projected: formatCost(projections.projectedCost) },
-		{ label: 'Estimated cost (Copilot)', icon: '🟢', color: '#7ce38b', today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) },
+		{
+			label: 'Estimated cost (est.)',
+			labelTooltip: 'Based on public provider API rates — for comparison only. This is not what you are billed.',
+			icon: '🪙', color: '#ffd166',
+			today: formatCost(stats.today.estimatedCost), last30Days: formatCost(stats.last30Days.estimatedCost), lastMonth: formatCost(stats.lastMonth.estimatedCost), projected: formatCost(projections.projectedCost)
+		},
+		{
+			label: 'Estimated cost (TBB)',
+			labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. TBB = To Be Billed.',
+			icon: '🟢', color: '#7ce38b',
+			today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0)
+		},
 		{ label: 'Sessions', icon: '📅', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
 		{ label: 'Average interactions/session', icon: '💬', color: '#8ce0ff', today: formatNumber(stats.today.avgInteractionsPerSession), last30Days: formatNumber(stats.last30Days.avgInteractionsPerSession), lastMonth: formatNumber(stats.lastMonth.avgInteractionsPerSession), projected: '—' },
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' }
@@ -241,6 +251,14 @@ function buildMetricsSection(
 		if (row.color) { iconSpan.style.color = row.color; }
 		const textSpan = document.createElement('span');
 		textSpan.textContent = row.label;
+		if (row.labelTooltip) {
+			labelWrapper.title = row.labelTooltip;
+			labelWrapper.style.cursor = 'help';
+			const hintSpan = document.createElement('span');
+			hintSpan.textContent = ' ℹ️';
+			hintSpan.style.cssText = 'font-size:0.75em; opacity:0.6;';
+			textSpan.append(hintSpan);
+		}
 		labelWrapper.append(iconSpan, textSpan);
 		labelTd.append(labelWrapper);
 

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -92,13 +92,13 @@ export function formatCompact(value: number): string {
 }
 
 /**
- * Formats a number as a USD cost with 4 decimal places.
+ * Formats a number as a USD cost with 2 decimal places.
  */
 export function formatCost(value: number): string {
 	return new Intl.NumberFormat(currentLocale, {
 		style: 'currency',
 		currency: 'USD',
-		minimumFractionDigits: 4,
-		maximumFractionDigits: 4
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2
 	}).format(value);
 }

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -207,6 +207,61 @@ test('calculateEstimatedCost: uses fallback pricing for unknown models', () => {
         assert.ok(Math.abs(cost - 0.00075) < 0.0001);
 });
 
+test('calculateEstimatedCost: copilot source uses copilotPricing block when present', () => {
+        const modelUsage = { 'gpt-x': { inputTokens: 1_000_000, outputTokens: 1_000_000 } };
+        const pricing = {
+                'gpt-x': {
+                        inputCostPerMillion: 1.0,
+                        outputCostPerMillion: 2.0,
+                        copilotPricing: { inputCostPerMillion: 5.0, outputCostPerMillion: 10.0 }
+                }
+        };
+        const providerCost = calculateEstimatedCost(modelUsage, pricing);
+        const copilotCost = calculateEstimatedCost(modelUsage, pricing, 'copilot');
+        assert.ok(Math.abs(providerCost - 3.0) < 1e-9);   // 1 + 2
+        assert.ok(Math.abs(copilotCost - 15.0) < 1e-9);   // 5 + 10
+});
+
+test('calculateEstimatedCost: copilot source falls back to provider pricing when copilotPricing missing', () => {
+        const modelUsage = { 'gpt-y': { inputTokens: 1_000_000, outputTokens: 1_000_000 } };
+        const pricing = { 'gpt-y': { inputCostPerMillion: 1.0, outputCostPerMillion: 2.0 } };
+        const providerCost = calculateEstimatedCost(modelUsage, pricing);
+        const copilotCost = calculateEstimatedCost(modelUsage, pricing, 'copilot');
+        assert.equal(providerCost, copilotCost);
+});
+
+test('calculateEstimatedCost: copilot source applies cached + cache-creation rates from copilotPricing', () => {
+        const modelUsage = {
+                'claude-x': {
+                        inputTokens: 1_000_000,         // total input
+                        outputTokens: 1_000_000,
+                        cachedReadTokens: 400_000,
+                        cacheCreationTokens: 100_000
+                }
+        };
+        const pricing = {
+                'claude-x': {
+                        inputCostPerMillion: 3.0,
+                        cachedInputCostPerMillion: 0.3,
+                        cacheCreationCostPerMillion: 3.75,
+                        outputCostPerMillion: 15.0,
+                        copilotPricing: {
+                                inputCostPerMillion: 6.0,
+                                cachedInputCostPerMillion: 0.6,
+                                cacheCreationCostPerMillion: 7.5,
+                                outputCostPerMillion: 30.0
+                        }
+                }
+        };
+        const cost = calculateEstimatedCost(modelUsage, pricing, 'copilot');
+        // uncached = 500_000 → 0.5*6 = 3.0
+        // cached read = 400_000 → 0.4*0.6 = 0.24
+        // cache creation = 100_000 → 0.1*7.5 = 0.75
+        // output = 1_000_000 → 1.0*30 = 30.0
+        // total = 33.99
+        assert.ok(Math.abs(cost - 33.99) < 1e-9);
+});
+
 // ── getTotalTokensFromModelUsage ────────────────────────────────────────
 
 test('getTotalTokensFromModelUsage: sums input and output across models', () => {

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -82,16 +82,16 @@ test('formatNumber: adds thousand separators', () => {
 
 // ── formatCost ──────────────────────────────────────────────────────────
 
-test('formatCost: formats as USD with 4 decimal places', () => {
+test('formatCost: formats as USD with 2 decimal places', () => {
 	setFormatLocale('en-US');
 	const result = formatCost(1.23456789);
 	assert.ok(result.includes('$'), 'should contain dollar sign');
-	assert.ok(result.includes('1.2346'), 'should round to 4 decimal places');
+	assert.ok(result.includes('1.23'), 'should round to 2 decimal places');
 });
 
 test('formatCost: zero cost', () => {
 	setFormatLocale('en-US');
 	const result = formatCost(0);
 	assert.ok(result.includes('$'), 'should contain dollar sign');
-	assert.ok(result.includes('0.0000'), 'should show four decimal zeros');
+	assert.ok(result.includes('0.00'), 'should show two decimal zeros');
 });


### PR DESCRIPTION
## Why

GitHub published per-token Copilot AI-Credit pricing
(<https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing>).
Today the extension only stores direct **provider/API** pricing as a proxy. This
PR makes both pricing models first-class so the app can show "what the API would
cost" *and* "what GitHub Copilot will actually bill you in AI Credits", side by
side.

## What

- **`modelPricing.json`**
  - New optional `copilotPricing` block per model with the GitHub-published
    rates (`inputCostPerMillion`, `cachedInputCostPerMillion`,
    `cacheCreationCostPerMillion` for Anthropic, `outputCostPerMillion`,
    plus `releaseStatus` and `category` metadata).
  - Added missing models: **`claude-opus-4.7`**, **`gpt-5.4-nano`**.
  - Differentiated **Opus 4.6 fast-mode** Copilot rates (6× provider).
  - New source URL + bumped `lastUpdated`.
- **`types.ts`** — new `CopilotPricing` interface; `ModelPricing.copilotPricing?`;
  `PeriodStats.estimatedCostCopilot?` (additive, so existing fixtures keep working).
- **`tokenEstimation.calculateEstimatedCost`** — new
  `pricingSource: 'provider' | 'copilot'` arg. Falls back to provider rates
  when `copilotPricing` is missing, so unmapped models are never under-reported.
- **`extension.ts`** — computes both costs for all four periods; status-bar
  tooltip now shows `Estimated cost (API)` and `Estimated cost (Copilot)`.
- **Webview details panel** — dedicated `Estimated cost (Copilot)` row with its
  own colour and projection.
- **CLI `usage`** — prints both API and Copilot estimated cost.
- **README** — documents the new field, fallback behaviour, and the caching
  caveat (Copilot Chat session logs don't yet expose cached-read /
  cache-creation token breakdowns, so cache-aware Copilot rates only apply for
  adapters that do — Claude Desktop, Claude Code, OpenCode).
- **Tests** — new unit tests for the `pricingSource` path: copilot block used
  when present, fallback to provider when absent, cache-aware copilot rates.

## Verification

- `npm run compile` — clean (vscode-extension)
- `npm run build` — clean (cli)
- `npm run test:node` — all suites pass, including the new
  `calculateEstimatedCost: copilot ...` tests
- `node scripts/validate-json.js` — all 15 JSON files valid

## Notes

The two pricing sets are *very* close for most models — the biggest difference
today is Opus 4.6 fast-mode (Copilot 6×) and the addition of explicit
cached-input rates for several OpenAI models. As GitHub adjusts AI-Credit rates
in future, only `copilotPricing` blocks need updating; provider rates stay as
the API-cost reference.