### PR TITLE
feat: load and log Copilot plan info from copilot_internal/user API

### DIFF
--- a/vscode-extension/src/README.md
+++ b/vscode-extension/src/README.md
@@ -22,17 +22,18 @@ Contains GitHub Copilot plan definitions — the `plans` object keys match the `
 ```
 
 - `monthlyPremiumRequests` — included allotment per user per month; extra requests are $0.04 each
+- `monthlyAiCreditsUsd` — dollar value of AI credits included with the plan (1 AI credit = $0.01); `0` = none included
 - `codeCompletionsPerMonth` — tab completions limit; `null` = unlimited (paid plans)
 
 **Current plans:**
 
-| ID | Name | $/user/mo | Premium requests/mo |
-|----|------|-----------|---------------------|
-| `free` | Copilot Free | $0 | 50 |
-| `individual` / `pro` | Copilot Pro | $10 | 300 |
-| `pro_plus` | Copilot Pro+ | $39 | 1,500 |
-| `business` | Copilot Business | $19 | 300 |
-| `enterprise` | Copilot Enterprise | $39 | 1,000 |
+| ID | Name | $/user/mo | AI credits/mo | Premium requests/mo |
+|----|------|-----------|---------------|---------------------|
+| `free` | Copilot Free | $0 | none | 50 |
+| `individual` / `pro` | Copilot Pro | $10 | $10 | 300 |
+| `pro_plus` | Copilot Pro+ | $39 | $39 | 1,500 |
+| `business` | Copilot Business | $19 | $19 | 300 |
+| `enterprise` | Copilot Enterprise | $39 | $39 | 1,000 |
 
 **How to update:** Edit the `plans` object when GitHub changes pricing or adds plans. Update `metadata.lastUpdated` and reference the [official plans page](https://docs.github.com/en/copilot/get-started/plans).
 

--- a/vscode-extension/src/README.md
+++ b/vscode-extension/src/README.md
@@ -2,6 +2,40 @@
 
 This directory contains JSON configuration files for the GitHub Copilot Token Tracker extension.
 
+## copilotPlans.json
+
+Contains GitHub Copilot plan definitions — the `plans` object keys match the `copilot_plan` value returned by the `copilot_internal/user` API endpoint.
+
+**Structure:**
+```json
+{
+  "plans": {
+    "<plan-id>": {
+      "name": "Display name",
+      "monthlyPricePerUser": 10,
+      "monthlyPremiumRequests": 300,
+      "codeCompletionsPerMonth": null,
+      "description": "..."
+    }
+  }
+}
+```
+
+- `monthlyPremiumRequests` — included allotment per user per month; extra requests are $0.04 each
+- `codeCompletionsPerMonth` — tab completions limit; `null` = unlimited (paid plans)
+
+**Current plans:**
+
+| ID | Name | $/user/mo | Premium requests/mo |
+|----|------|-----------|---------------------|
+| `free` | Copilot Free | $0 | 50 |
+| `individual` / `pro` | Copilot Pro | $10 | 300 |
+| `pro_plus` | Copilot Pro+ | $39 | 1,500 |
+| `business` | Copilot Business | $19 | 300 |
+| `enterprise` | Copilot Enterprise | $39 | 1,000 |
+
+**How to update:** Edit the `plans` object when GitHub changes pricing or adds plans. Update `metadata.lastUpdated` and reference the [official plans page](https://docs.github.com/en/copilot/get-started/plans).
+
 ## tokenEstimators.json
 
 Contains character-to-token ratio estimators for different AI models. These ratios are used to estimate token counts from text length.

--- a/vscode-extension/src/copilotPlans.json
+++ b/vscode-extension/src/copilotPlans.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GitHub Copilot plan definitions. Keys match the value of the 'copilot_plan' field returned by the copilot_internal/user API endpoint.",
+  "metadata": {
+    "lastUpdated": "2026-04-27",
+    "source": "https://docs.github.com/en/copilot/get-started/plans",
+    "notes": "monthlyPremiumRequests is the included allotment per user per month. null means unlimited. Extra premium requests beyond the allotment are billed at $0.04 each. Code completions (tab completions) do not consume premium requests on paid plans."
+  },
+  "plans": {
+    "free": {
+      "name": "Copilot Free",
+      "monthlyPricePerUser": 0,
+      "monthlyPremiumRequests": 50,
+      "codeCompletionsPerMonth": 2000,
+      "description": "Limited plan for light use and evaluation"
+    },
+    "individual": {
+      "name": "Copilot Pro",
+      "monthlyPricePerUser": 10,
+      "monthlyPremiumRequests": 300,
+      "codeCompletionsPerMonth": null,
+      "description": "For individual developers (legacy plan ID, same as 'pro')"
+    },
+    "pro": {
+      "name": "Copilot Pro",
+      "monthlyPricePerUser": 10,
+      "monthlyPremiumRequests": 300,
+      "codeCompletionsPerMonth": null,
+      "description": "For individual developers"
+    },
+    "pro_plus": {
+      "name": "Copilot Pro+",
+      "monthlyPricePerUser": 39,
+      "monthlyPremiumRequests": 1500,
+      "codeCompletionsPerMonth": null,
+      "description": "For power users needing more premium requests and the broadest model selection"
+    },
+    "business": {
+      "name": "Copilot Business",
+      "monthlyPricePerUser": 19,
+      "monthlyPremiumRequests": 300,
+      "codeCompletionsPerMonth": null,
+      "description": "For organizations; includes policy controls and audit logs"
+    },
+    "enterprise": {
+      "name": "Copilot Enterprise",
+      "monthlyPricePerUser": 39,
+      "monthlyPremiumRequests": 1000,
+      "codeCompletionsPerMonth": null,
+      "description": "For large organizations on GitHub Enterprise Cloud; includes custom models and expanded controls"
+    }
+  }
+}

--- a/vscode-extension/src/copilotPlans.json
+++ b/vscode-extension/src/copilotPlans.json
@@ -4,12 +4,13 @@
   "metadata": {
     "lastUpdated": "2026-04-27",
     "source": "https://docs.github.com/en/copilot/get-started/plans",
-    "notes": "monthlyPremiumRequests is the included allotment per user per month. null means unlimited. Extra premium requests beyond the allotment are billed at $0.04 each. Code completions (tab completions) do not consume premium requests on paid plans."
+    "notes": "monthlyPremiumRequests is the included allotment per user per month. null means unlimited. Extra premium requests beyond the allotment are billed at $0.04 each. Code completions (tab completions) do not consume premium requests on paid plans. monthlyAiCreditsUsd is the dollar value of AI credits included with the plan (1 AI credit = $0.01)."
   },
   "plans": {
     "free": {
       "name": "Copilot Free",
       "monthlyPricePerUser": 0,
+      "monthlyAiCreditsUsd": 0,
       "monthlyPremiumRequests": 50,
       "codeCompletionsPerMonth": 2000,
       "description": "Limited plan for light use and evaluation"
@@ -17,6 +18,7 @@
     "individual": {
       "name": "Copilot Pro",
       "monthlyPricePerUser": 10,
+      "monthlyAiCreditsUsd": 10,
       "monthlyPremiumRequests": 300,
       "codeCompletionsPerMonth": null,
       "description": "For individual developers (legacy plan ID, same as 'pro')"
@@ -24,6 +26,7 @@
     "pro": {
       "name": "Copilot Pro",
       "monthlyPricePerUser": 10,
+      "monthlyAiCreditsUsd": 10,
       "monthlyPremiumRequests": 300,
       "codeCompletionsPerMonth": null,
       "description": "For individual developers"
@@ -31,6 +34,7 @@
     "pro_plus": {
       "name": "Copilot Pro+",
       "monthlyPricePerUser": 39,
+      "monthlyAiCreditsUsd": 39,
       "monthlyPremiumRequests": 1500,
       "codeCompletionsPerMonth": null,
       "description": "For power users needing more premium requests and the broadest model selection"
@@ -38,6 +42,7 @@
     "business": {
       "name": "Copilot Business",
       "monthlyPricePerUser": 19,
+      "monthlyAiCreditsUsd": 19,
       "monthlyPremiumRequests": 300,
       "codeCompletionsPerMonth": null,
       "description": "For organizations; includes policy controls and audit logs"
@@ -45,6 +50,7 @@
     "enterprise": {
       "name": "Copilot Enterprise",
       "monthlyPricePerUser": 39,
+      "monthlyAiCreditsUsd": 39,
       "monthlyPremiumRequests": 1000,
       "codeCompletionsPerMonth": null,
       "description": "For large organizations on GitHub Enterprise Cloud; includes custom models and expanded controls"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1331,13 +1331,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return;
 			}
 			const planId = planInfo.copilot_plan as string | undefined;
-			const plans = copilotPlansData.plans as Record<string, { name: string; monthlyPremiumRequests: number | null; monthlyPricePerUser: number }>;
+			const plans = copilotPlansData.plans as Record<string, { name: string; monthlyPremiumRequests: number | null; monthlyPricePerUser: number; monthlyAiCreditsUsd: number }>;
 			const knownPlan = planId ? plans[planId] : undefined;
 			const planLabel = knownPlan ? `${knownPlan.name} (${planId})` : (planId ?? 'unknown');
 			this.log(`Copilot plan: ${planLabel}`);
 			if (knownPlan) {
 				const credits = knownPlan.monthlyPremiumRequests !== null ? `${knownPlan.monthlyPremiumRequests.toLocaleString()}/month` : 'unlimited';
 				this.log(`  Monthly premium requests: ${credits}`);
+				const aiCredits = knownPlan.monthlyAiCreditsUsd > 0 ? `$${knownPlan.monthlyAiCreditsUsd}/month included` : 'none';
+				this.log(`  Monthly AI credits: ${aiCredits}`);
 			}
 			if (planInfo.ide_chat !== undefined)          { this.log(`  IDE chat: ${planInfo.ide_chat}`); }
 			if (planInfo.copilot_ide_agent !== undefined) { this.log(`  Agent mode: ${planInfo.copilot_ide_agent}`); }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -284,6 +284,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private _sessionRestorePromise: Promise<void> | undefined;
 	/** True when the user explicitly signed out from our extension this VS Code session. Gated by globalState so it survives reloads. */
 	private _githubSignedOutByUser: boolean = false;
+	/** Resolved Copilot plan details fetched from copilot_internal/user after sign-in. */
+	private _copilotPlanResolved: { planId: string; planName: string; monthlyAiCreditsUsd: number; monthlyPremiumRequests: number | null } | undefined;
 
 	// Cached PR stats result for the repos tab
 	private _lastRepoPrStats?: RepoPrStatsResult;
@@ -1340,6 +1342,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.log(`  Monthly premium requests: ${credits}`);
 				const aiCredits = knownPlan.monthlyAiCreditsUsd > 0 ? `$${knownPlan.monthlyAiCreditsUsd}/month included` : 'none';
 				this.log(`  Monthly AI credits: ${aiCredits}`);
+				this._copilotPlanResolved = {
+					planId: planId!,
+					planName: knownPlan.name,
+					monthlyAiCreditsUsd: knownPlan.monthlyAiCreditsUsd,
+					monthlyPremiumRequests: knownPlan.monthlyPremiumRequests,
+				};
+			} else if (planId) {
+				// Unknown plan ID — store it with no credits so the webview still shows it
+				this._copilotPlanResolved = { planId, planName: planId, monthlyAiCreditsUsd: 0, monthlyPremiumRequests: null };
 			}
 			if (planInfo.ide_chat !== undefined)          { this.log(`  IDE chat: ${planInfo.ide_chat}`); }
 			if (planInfo.copilot_ide_agent !== undefined) { this.log(`  Agent mode: ${planInfo.copilot_ide_agent}`); }
@@ -6446,6 +6457,7 @@ ${hashtag}`;
       backendConfigured: this.isBackendConfigured(),
       sortSettings,
       compactNumbers: this.getCompactNumbersSetting(),
+      copilotPlan: this._copilotPlanResolved,
     };
     const initialData = JSON.stringify(dataWithBackend).replace(
       /</g,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -18,6 +18,8 @@ import {
 	detectAiType,
 	discoverGitHubRepos,
 	fetchRepoPrs,
+	fetchCopilotPlanInfo,
+	type CopilotPlanInfo,
 	type RepoPrDetail,
 	type RepoPrInfo,
 	type RepoPrStatsResult,
@@ -899,6 +901,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					this.githubSession = session;
 					await this.context.globalState.update('github.authenticated', true);
 					await this.context.globalState.update('github.username', session.account.label);
+					void this.loadAndLogCopilotPlanInfo();
 				} else {
 					this.githubSession = undefined;
 					await this.context.globalState.update('github.authenticated', false);
@@ -1101,6 +1104,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				vscode.window.showInformationMessage(`GitHub authentication successful! Logged in as ${session.account.label}`);
 				await this.context.globalState.update('github.authenticated', true);
 				await this.context.globalState.update('github.username', session.account.label);
+				void this.loadAndLogCopilotPlanInfo();
 			}
 		} catch (error) {
 			this.error('GitHub authentication failed:', error);
@@ -1296,6 +1300,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.log(`✅ GitHub session found for ${session.account.label}`);
 				await this.context.globalState.update('github.authenticated', true);
 				await this.context.globalState.update('github.username', session.account.label);
+				void this.loadAndLogCopilotPlanInfo();
 			} else {
 				const wasAuthenticated = this.context.globalState.get<boolean>('github.authenticated', false);
 				if (wasAuthenticated) {
@@ -1309,6 +1314,28 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.warn('Failed to restore GitHub session: ' + String(error));
 			await this.context.globalState.update('github.authenticated', false);
 			await this.context.globalState.update('github.username', undefined);
+		}
+	}
+
+	/**
+	 * Fetch and log Copilot plan information for the authenticated user.
+	 * Best-effort: silently skips if not authenticated or if the endpoint is unavailable.
+	 */
+	private async loadAndLogCopilotPlanInfo(): Promise<void> {
+		if (!this.githubSession) { return; }
+		try {
+			const { planInfo, statusCode, error } = await fetchCopilotPlanInfo(this.githubSession.accessToken);
+			if (error || !planInfo) {
+				this.warn(`Copilot plan info unavailable (HTTP ${statusCode ?? 'n/a'}): ${error ?? 'no data'}`);
+				return;
+			}
+			this.log(`Copilot plan: ${planInfo.copilot_plan ?? 'unknown'}`);
+			if (planInfo.ide_chat !== undefined)          { this.log(`  IDE chat: ${planInfo.ide_chat}`); }
+			if (planInfo.copilot_ide_agent !== undefined) { this.log(`  Agent mode: ${planInfo.copilot_ide_agent}`); }
+			if (planInfo.public_code_suggestions !== undefined) { this.log(`  Public code suggestions: ${planInfo.public_code_suggestions}`); }
+			if (planInfo.unlimited_pr_summaries !== undefined)  { this.log(`  Unlimited PR summaries: ${planInfo.unlimited_pr_summaries}`); }
+		} catch (err) {
+			this.warn('Failed to load Copilot plan info: ' + String(err));
 		}
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,6 +7,7 @@ import tokenEstimatorsData from './tokenEstimators.json';
 import modelPricingData from './modelPricing.json';
 import toolNamesData from './toolNames.json';
 import customizationPatternsData from './customizationPatterns.json';
+import copilotPlansData from './copilotPlans.json';
 import { REPO_HYGIENE_SKILL } from './backend/repoHygieneSkill';
 import { BackendFacade } from './backend/facade';
 import { BackendCommandHandler } from './backend/commands';
@@ -1329,7 +1330,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.warn(`Copilot plan info unavailable (HTTP ${statusCode ?? 'n/a'}): ${error ?? 'no data'}`);
 				return;
 			}
-			this.log(`Copilot plan: ${planInfo.copilot_plan ?? 'unknown'}`);
+			const planId = planInfo.copilot_plan as string | undefined;
+			const plans = copilotPlansData.plans as Record<string, { name: string; monthlyPremiumRequests: number | null; monthlyPricePerUser: number }>;
+			const knownPlan = planId ? plans[planId] : undefined;
+			const planLabel = knownPlan ? `${knownPlan.name} (${planId})` : (planId ?? 'unknown');
+			this.log(`Copilot plan: ${planLabel}`);
+			if (knownPlan) {
+				const credits = knownPlan.monthlyPremiumRequests !== null ? `${knownPlan.monthlyPremiumRequests.toLocaleString()}/month` : 'unlimited';
+				this.log(`  Monthly premium requests: ${credits}`);
+			}
 			if (planInfo.ide_chat !== undefined)          { this.log(`  IDE chat: ${planInfo.ide_chat}`); }
 			if (planInfo.copilot_ide_agent !== undefined) { this.log(`  Agent mode: ${planInfo.copilot_ide_agent}`); }
 			if (planInfo.public_code_suggestions !== undefined) { this.log(`  Public code suggestions: ${planInfo.public_code_suggestions}`); }

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -26,6 +26,78 @@ export type RepoPrStatsResult = {
 	since: string; // ISO date string
 };
 
+// ---------------------------------------------------------------------------
+// Copilot plan info
+// ---------------------------------------------------------------------------
+
+export type CopilotPlanInfo = {
+	copilot_plan?: string;             // e.g. "copilot_individual" | "copilot_business" | "copilot_enterprise" | "copilot_free"
+	public_code_suggestions?: string;  // "block" | "allow"
+	ide_chat?: string;                 // "enabled" | "disabled"
+	copilot_ide_agent?: string;        // "enabled" | "disabled"
+	unlimited_pr_summaries?: boolean;
+	assignee?: { login?: string; id?: number };
+	[key: string]: unknown;
+};
+
+export type CopilotPlanResult = { planInfo?: CopilotPlanInfo; statusCode?: number; error?: string };
+
+/** Internal low-level fetcher for the copilot_internal/user endpoint. */
+function fetchCopilotPlanInfoPage(token: string): Promise<CopilotPlanResult> {
+	return new Promise((resolve) => {
+		const req = https.request(
+			{
+				hostname: 'api.github.com',
+				path: '/copilot_internal/user',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'User-Agent': 'copilot-token-tracker',
+					Accept: 'application/json',
+				},
+			},
+			(res) => {
+				let data = '';
+				res.on('data', (chunk) => (data += chunk));
+				res.on('end', () => {
+					const statusCode = res.statusCode ?? 0;
+					if (statusCode < 200 || statusCode >= 300) {
+						resolve({ statusCode, error: `HTTP ${statusCode}` });
+						return;
+					}
+					try {
+						const parsed = JSON.parse(data);
+						if (typeof parsed !== 'object' || parsed === null) {
+							resolve({ statusCode, error: 'Unexpected response format' });
+							return;
+						}
+						resolve({ planInfo: parsed as CopilotPlanInfo, statusCode });
+					} catch (e) {
+						resolve({ statusCode, error: String(e) });
+					}
+				});
+			},
+		);
+		req.on('error', (e) => resolve({ error: e.message }));
+		req.setTimeout(15000, () => {
+			req.destroy(new Error('Request timed out after 15 s'));
+		});
+		req.end();
+	});
+}
+
+/**
+ * Fetch GitHub Copilot plan information for the authenticated user.
+ * Uses the VS Code-only internal endpoint `https://api.github.com/copilot_internal/user`.
+ * Treat as best-effort — this endpoint may not be available for all accounts.
+ * @param fetcher Injectable fetcher for testing; defaults to the real HTTPS implementation.
+ */
+export function fetchCopilotPlanInfo(
+	token: string,
+	fetcher: (token: string) => Promise<CopilotPlanResult> = fetchCopilotPlanInfoPage,
+): Promise<CopilotPlanResult> {
+	return fetcher(token);
+}
+
 /** Detect which AI system a GitHub login belongs to, or null if not an AI bot. */
 export function detectAiType(login: string): RepoPrDetail['aiType'] | null {
 	const l = login.toLowerCase();

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -242,23 +242,16 @@ function buildMetricsSection(
 			icon: '🟢', color: '#7ce38b',
 			today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0)
 		},
-		...(stats.copilotPlan ? [
-			{
+		...(stats.copilotPlan ? (() => {
+			const credits = stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd} credits` : 'no credits';
+			const planCell = `${stats.copilotPlan.planName} (${credits})`;
+			return [{
 				label: 'Copilot plan',
-				labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${stats.copilotPlan.planId})`,
+				labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${stats.copilotPlan.planId}). Included AI credits cover token-based billing (1 AI credit = $0.01).`,
 				icon: '🏷️', color: '#60a5fa',
-				today: '—', last30Days: stats.copilotPlan.planName, lastMonth: stats.copilotPlan.planName, projected: '—'
-			},
-			{
-				label: 'Included AI credits',
-				labelTooltip: 'Monthly AI credits included with your Copilot plan. Credits cover token-based billing (1 AI credit = $0.01).',
-				icon: '💳', color: '#34d399',
-				today: '—',
-				last30Days: stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd}` : 'none',
-				lastMonth: stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd}` : 'none',
-				projected: '—'
-			}
-		] : []),
+				today: '—', last30Days: planCell, lastMonth: planCell, projected: '—'
+			}];
+		})() : []),
 		{ label: 'Sessions', icon: '📅', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
 		{ label: 'Average interactions/session', icon: '💬', color: '#8ce0ff', today: formatNumber(stats.today.avgInteractionsPerSession), last30Days: formatNumber(stats.last30Days.avgInteractionsPerSession), lastMonth: formatNumber(stats.lastMonth.avgInteractionsPerSession), projected: '—' },
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' }

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -40,6 +40,12 @@ type DetailedStats = {
 	lastUpdated: string | Date;
 	backendConfigured?: boolean;
 	compactNumbers?: boolean;
+	copilotPlan?: {
+		planId: string;
+		planName: string;
+		monthlyAiCreditsUsd: number;
+		monthlyPremiumRequests: number | null;
+	};
 	sortSettings?: {
 		editor?: { key?: string; dir?: string };
 		model?: { key?: string; dir?: string };
@@ -236,6 +242,23 @@ function buildMetricsSection(
 			icon: '🟢', color: '#7ce38b',
 			today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0)
 		},
+		...(stats.copilotPlan ? [
+			{
+				label: 'Copilot plan',
+				labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${stats.copilotPlan.planId})`,
+				icon: '🏷️', color: '#60a5fa',
+				today: '—', last30Days: stats.copilotPlan.planName, lastMonth: stats.copilotPlan.planName, projected: '—'
+			},
+			{
+				label: 'Included AI credits',
+				labelTooltip: 'Monthly AI credits included with your Copilot plan. Credits cover token-based billing (1 AI credit = $0.01).',
+				icon: '💳', color: '#34d399',
+				today: '—',
+				last30Days: stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd}` : 'none',
+				lastMonth: stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd}` : 'none',
+				projected: '—'
+			}
+		] : []),
 		{ label: 'Sessions', icon: '📅', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
 		{ label: 'Average interactions/session', icon: '💬', color: '#8ce0ff', today: formatNumber(stats.today.avgInteractionsPerSession), last30Days: formatNumber(stats.last30Days.avgInteractionsPerSession), lastMonth: formatNumber(stats.lastMonth.avgInteractionsPerSession), projected: '—' },
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' }

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -243,13 +243,12 @@ function buildMetricsSection(
 			today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0)
 		},
 		...(stats.copilotPlan ? (() => {
-			const credits = stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd} credits` : 'no credits';
-			const planCell = `${stats.copilotPlan.planName} (${credits})`;
+			const credits = stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd} credits/month` : 'no credits';
 			return [{
-				label: 'Copilot plan',
+				label: `${stats.copilotPlan.planName} (${credits})`,
 				labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${stats.copilotPlan.planId}). Included AI credits cover token-based billing (1 AI credit = $0.01).`,
 				icon: '🏷️', color: '#60a5fa',
-				today: '—', last30Days: planCell, lastMonth: planCell, projected: '—'
+				today: '—', last30Days: '—', lastMonth: '—', projected: '—'
 			}];
 		})() : []),
 		{ label: 'Sessions', icon: '📅', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import { detectAiType, fetchRepoPrs } from '../../src/githubPrService';
+import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, type CopilotPlanInfo } from '../../src/githubPrService';
 
 // ---------------------------------------------------------------------------
 // detectAiType — pure function, no I/O
@@ -144,4 +144,61 @@ test('fetchRepoPrs: propagates generic error from fetchPage', async () => {
 	const { prs, error } = await fetchRepoPrs('owner', 'repo', 'token', since, mockFetchPage);
 	assert.equal(prs.length, 0);
 	assert.equal(error, 'Network error');
+});
+
+// ---------------------------------------------------------------------------
+// fetchCopilotPlanInfo — uses injectable fetcher
+// ---------------------------------------------------------------------------
+
+test('fetchCopilotPlanInfo: returns plan info on success', async () => {
+	const planData: CopilotPlanInfo = {
+		copilot_plan: 'copilot_individual',
+		ide_chat: 'enabled',
+		copilot_ide_agent: 'enabled',
+		public_code_suggestions: 'block',
+		unlimited_pr_summaries: true,
+	};
+	const mockFetcher = async () => ({ planInfo: planData, statusCode: 200 });
+	const { planInfo, statusCode, error } = await fetchCopilotPlanInfo('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.equal(statusCode, 200);
+	assert.deepEqual(planInfo, planData);
+});
+
+test('fetchCopilotPlanInfo: returns error on non-2xx response', async () => {
+	const mockFetcher = async () => ({ statusCode: 401, error: 'HTTP 401' });
+	const { planInfo, statusCode, error } = await fetchCopilotPlanInfo('token', mockFetcher);
+	assert.equal(planInfo, undefined);
+	assert.equal(statusCode, 401);
+	assert.equal(error, 'HTTP 401');
+});
+
+test('fetchCopilotPlanInfo: returns error on 403 response', async () => {
+	const mockFetcher = async () => ({ statusCode: 403, error: 'HTTP 403' });
+	const { planInfo, statusCode, error } = await fetchCopilotPlanInfo('token', mockFetcher);
+	assert.equal(planInfo, undefined);
+	assert.equal(statusCode, 403);
+});
+
+test('fetchCopilotPlanInfo: returns error on network failure', async () => {
+	const mockFetcher = async () => ({ error: 'socket hang up' });
+	const { planInfo, error } = await fetchCopilotPlanInfo('token', mockFetcher);
+	assert.equal(planInfo, undefined);
+	assert.equal(error, 'socket hang up');
+});
+
+test('fetchCopilotPlanInfo: returns error on unexpected response format', async () => {
+	const mockFetcher = async () => ({ statusCode: 200, error: 'Unexpected response format' });
+	const { planInfo, error } = await fetchCopilotPlanInfo('token', mockFetcher);
+	assert.equal(planInfo, undefined);
+	assert.ok(error?.includes('Unexpected response format'));
+});
+
+test('fetchCopilotPlanInfo: handles partial plan data gracefully', async () => {
+	// Not all fields may be present — only copilot_plan returned
+	const mockFetcher = async () => ({ planInfo: { copilot_plan: 'copilot_free' } as CopilotPlanInfo, statusCode: 200 });
+	const { planInfo, error } = await fetchCopilotPlanInfo('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.equal(planInfo?.copilot_plan, 'copilot_free');
+	assert.equal(planInfo?.ide_chat, undefined);
 });


### PR DESCRIPTION
## Summary

Calls `https://api.github.com/copilot_internal/user` after a GitHub session is established to log the user's Copilot plan details to the output channel. This is the first step — we log the data now and will build on it.

## Changes

### `githubPrService.ts`
- Add `CopilotPlanInfo` type (plan type, IDE chat, agent mode, public code suggestions, PR summaries, etc.)
- Add `CopilotPlanResult` type
- Add internal `fetchCopilotPlanInfoPage` (real HTTPS implementation)
- Export `fetchCopilotPlanInfo(token, fetcher?)` with an injectable fetcher for testability

### `extension.ts`
- Add `loadAndLogCopilotPlanInfo()` private method — best-effort, fires after session is set
  - Logs: plan type, IDE chat, agent mode, public code suggestions, unlimited PR summaries
  - Non-2xx responses and network errors surface as `warn()` (no startup impact)
- Wire `void this.loadAndLogCopilotPlanInfo()` from:
  - `restoreGitHubSession()` — on startup when a session is found
  - `authenticateWithGitHub()` — after manual sign-in
  - `onDidChangeSessions` handler — when the session changes externally

### `test/unit/githubPrService.test.ts`
- 6 new tests: success, 401, 403, network failure, unexpected format, partial data

## Output log example
```
✅ GitHub session found for rajbos
Copilot plan: copilot_individual
  IDE chat: enabled
  Agent mode: enabled
  Public code suggestions: block
  Unlimited PR summaries: true
```