### PR TITLE
chore: bump versions for release (vscode-extension v0.2.1)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version | Changed since last tag? |
|-----------|-------------|-------------|------------------------|
| VS Code extension | v0.2.0 | **v0.2.1** | ✅ yes (PRs #684, #685 merged after \scode/v0.2.0\ tag) |
| CLI | v0.0.11 | — (no bump needed) | ✅ yes, but CLI workflow self-manages version |
| Visual Studio extension | — (no prior release) | — (no bump needed) | ✅ yes, but version already at 1.0.9 |

### Changes included in VS Code extension v0.2.1

- **PR #684** — new-toolnames-fix
- **PR #685** — Add GitHub Copilot AI-Credit pricing, rename cost labels, reduce cost display precision

---

### After merging, run these workflows:

#### 1. 🟦 VS Code + Visual Studio Extensions (\elease.yml\)
Go to **Actions → Extensions - Release → Run workflow** on \main\ with:
- \create_tag\: ✅ true (default) — creates \scode/v0.2.1\ tag
- \publish_marketplace\: ✅ true (default) — publishes to VS Code Marketplace
- \s_only\: false (default)
- \scode_only\: false (default)

This publishes **VS Code extension v0.2.1** AND the **Visual Studio extension v1.0.9** to their respective marketplaces.

#### 2. 🟨 CLI (\cli-publish.yml\)
The CLI workflow self-manages its version bump. Since \cli/package.json\ is at **0.0.11** and the last published tag is \cli/v0.0.8\, you have two options:

**Option A (recommended — release exactly v0.0.11):**
Push a tag manually after this PR is merged:
\\\ash
git tag cli/v0.0.11 main
git push origin cli/v0.0.11
\\\
This triggers \cli-publish.yml\ automatically, validates \package.json\ is at 0.0.11, publishes to npm, and creates a GitHub release.

**Option B (bump to v0.0.12 and release that):**
Go to **Actions → CLI - Publish to npm and GitHub → Run workflow** on \main\ with:
- \ersion_bump\: \patch\
- \dry_run\: false

This bumps 0.0.11 → 0.0.12, publishes to npm, and opens a follow-up PR for the version bump.