### PR TITLE
chore: bump Visual Studio extension to v1.0.10

### DIFF
--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.9"
+              Version="1.0.10"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>


### PR DESCRIPTION
## Problem
Publishing v1.0.9 to the Visual Studio Marketplace failed because that version already exists (published previously from a release branch).

## Fix
Bump Visual Studio extension version from 1.0.9 → **1.0.10**.

## After merging
Re-run the **Extensions - Release** workflow on \main\ with all defaults to publish both:
- VS Code extension v0.2.1
- Visual Studio extension v1.0.10