### PR TITLE
feat: scan workspaceStorage debug-logs directories for session files

### DIFF
--- a/vscode-extension/src/adapters/copilotChatAdapter.ts
+++ b/vscode-extension/src/adapters/copilotChatAdapter.ts
@@ -11,6 +11,10 @@
  *   - workspaceStorage/<hash>/github.copilot-chat/chatSessions/        (Linux case-sensitive variant)
  *   - workspaceStorage/<hash>/GitHub.copilot/chatSessions/             (unified extension, VS Code 1.117+)
  *   - workspaceStorage/<hash>/github.copilot/chatSessions/             (Linux case-sensitive variant)
+ *   - workspaceStorage/<hash>/GitHub.copilot-chat/debug-logs/          (debug logs, e.g. devcontainer layout)
+ *   - workspaceStorage/<hash>/github.copilot-chat/debug-logs/          (Linux case-sensitive variant)
+ *   - workspaceStorage/<hash>/GitHub.copilot/debug-logs/               (unified extension debug logs)
+ *   - workspaceStorage/<hash>/github.copilot/debug-logs/               (Linux case-sensitive variant)
  *   - globalStorage/emptyWindowChatSessions/                           (legacy)
  *   - globalStorage/{GitHub,github}.copilot-chat/**                    (both casings, recursive)
  *   - globalStorage/{GitHub,github}.copilot/**                         (unified extension, both casings)
@@ -249,11 +253,16 @@ export function isCopilotChatSessionPath(filePath: string): boolean {
 	const norm = filePath.replace(/\\/g, '/');
 	if (!/\.jsonl?$/.test(norm)) { return false; }
 
-	// workspaceStorage/<hash>/chatSessions/<file>
+	// workspaceStorage/<hash>/chatSessions/<file>  (legacy)
+	if (/\/workspaceStorage\/[^/]+\/chatSessions\/[^/]+$/.test(norm)) {
+		return true;
+	}
+	// workspaceStorage/<hash>/{extension}/chatSessions/<file>
 	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/chatSessions\/[^/]+$/.test(norm)) {
 		return true;
 	}
-	if (/\/workspaceStorage\/[^/]+\/chatSessions\/[^/]+$/.test(norm)) {
+	// workspaceStorage/<hash>/{extension}/debug-logs/<file>
+	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/debug-logs\/[^/]+$/.test(norm)) {
 		return true;
 	}
 	// globalStorage/emptyWindowChatSessions/<file>
@@ -376,7 +385,7 @@ export class CopilotChatAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 		await runWithConcurrency(foundPaths, async (codeUserPath) => {
 			const pathName = path.basename(path.dirname(codeUserPath));
 
-			// workspaceStorage/<hash>/{,GitHub.copilot-chat/,github.copilot-chat/,GitHub.copilot/,github.copilot/}chatSessions/
+			// workspaceStorage/<hash>/{,GitHub.copilot-chat/,github.copilot-chat/,GitHub.copilot/,github.copilot/}{chatSessions/,debug-logs/}
 			const workspaceStoragePath = path.join(codeUserPath, 'workspaceStorage');
 			try {
 				if (await pathExists(workspaceStoragePath)) {
@@ -388,6 +397,10 @@ export class CopilotChatAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 							path.join(workspaceStoragePath, workspaceDir, 'github.copilot-chat', 'chatSessions'),
 							path.join(workspaceStoragePath, workspaceDir, 'GitHub.copilot', 'chatSessions'),
 							path.join(workspaceStoragePath, workspaceDir, 'github.copilot', 'chatSessions'),
+							path.join(workspaceStoragePath, workspaceDir, 'GitHub.copilot-chat', 'debug-logs'),
+							path.join(workspaceStoragePath, workspaceDir, 'github.copilot-chat', 'debug-logs'),
+							path.join(workspaceStoragePath, workspaceDir, 'GitHub.copilot', 'debug-logs'),
+							path.join(workspaceStoragePath, workspaceDir, 'github.copilot', 'debug-logs'),
 						];
 						for (const chatSessionsPath of candidates) {
 							try {

--- a/vscode-extension/test/unit/copilotChatAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotChatAdapter.test.ts
@@ -73,6 +73,13 @@ test('isCopilotChatSessionPath: recognises emptyWindowChatSessions and globalSto
     assert.ok(isCopilotChatSessionPath('/x/User/globalStorage/github.copilot-chat/foo/bar.json'));
 });
 
+test('isCopilotChatSessionPath: recognises debug-logs layout (both casings)', () => {
+    assert.ok(isCopilotChatSessionPath('/x/User/workspaceStorage/abc/GitHub.copilot-chat/debug-logs/s1.json'));
+    assert.ok(isCopilotChatSessionPath('/x/User/workspaceStorage/abc/github.copilot-chat/debug-logs/s1.jsonl'));
+    assert.ok(isCopilotChatSessionPath('/x/User/workspaceStorage/abc/GitHub.copilot/debug-logs/s1.json'));
+    assert.ok(isCopilotChatSessionPath('/x/User/workspaceStorage/abc/github.copilot/debug-logs/s1.jsonl'));
+});
+
 test('isCopilotChatSessionPath: rejects non-session and unrelated paths', () => {
     assert.equal(isCopilotChatSessionPath('/x/User/globalStorage/GitHub.copilot-chat/embeddings.json'), false);
     assert.equal(isCopilotChatSessionPath('/x/User/globalStorage/GitHub.copilot-chat/foo/cache.json'), false);
@@ -207,4 +214,20 @@ test('CopilotChatAdapter.discover: candidatePaths matches getCandidatePaths()', 
     const result = await adapter.discover(() => { /* noop */ });
     const dis = result.candidatePaths.map(c => c.path).sort();
     assert.deepEqual(sync, dis);
+});
+
+test('CopilotChatAdapter.discover: finds session files in debug-logs directory', async (t) => {
+    const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cca-debuglogs-'));
+    t.after(async () => { await fs.promises.rm(tmp, { recursive: true, force: true }); });
+
+    // Build a minimal fake VS Code user layout with a debug-logs directory
+    const wsHash = '6493a5e29947913b6a67738025aa3374';
+    const debugLogsDir = path.join(tmp, 'workspaceStorage', wsHash, 'GitHub.copilot-chat', 'debug-logs');
+    await fs.promises.mkdir(debugLogsDir, { recursive: true });
+    await fs.promises.writeFile(path.join(debugLogsDir, 'session-debug.jsonl'), '{"type":"chat"}\n');
+
+    // Verify isCopilotChatSessionPath accepts the file
+    const sessionFile = path.join(debugLogsDir, 'session-debug.jsonl');
+    assert.ok(isCopilotChatSessionPath(sessionFile),
+        `isCopilotChatSessionPath should accept debug-logs path: ${sessionFile}`);
 });


### PR DESCRIPTION
## Problem

In devcontainer setups, VS Code's Copilot Chat extension stores debug/session log files under:

\\\
~/.vscode-server/data/User/workspaceStorage/<id>/GitHub.copilot-chat/debug-logs/
\\\

The extension only scanned \chatSessions/\ subdirectories, so these files were silently skipped.

## Changes

- **\copilotChatAdapter.ts\**: Add \debug-logs\ to the \candidates\ list inside \discover()\ for all four extension-name casings (\GitHub.copilot-chat\, \github.copilot-chat\, \GitHub.copilot\, \github.copilot\). Update \isCopilotChatSessionPath()\ to recognise these paths. Update doc comment.
- **\copilotChatAdapter.test.ts\**: New test for \isCopilotChatSessionPath\ covering all four \debug-logs\ casings, and a new \discover()\ test that creates a synthetic \debug-logs\ layout and asserts the predicate accepts it.

All 18 unit tests pass.