### PR TITLE
feat: add deploy_to_test workflow_dispatch input

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -10,6 +10,11 @@ on:
       - "sharing-server/**"
       - ".github/workflows/sharing-server-deploy.yml"
   workflow_dispatch:
+    inputs:
+      deploy_to_test:
+        description: 'Deploy main branch to the test environment instead of production'
+        type: boolean
+        default: false
 
 # One deploy per branch at a time — prevents concurrent Terraform runs from
 # conflicting on the same remote state file (state blob already locked errors).
@@ -42,8 +47,10 @@ jobs:
 
       - name: Compute deployment parameters
         id: env
+        env:
+          FORCE_TEST: ${{ inputs.deploy_to_test }}
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/main" && "$FORCE_TEST" != "true" ]]; then
             {
               echo "app_name=sharing-server-prod"
               echo "state_key=sharing-server/prod.tfstate"


### PR DESCRIPTION
## Summary

Adds a `deploy_to_test` boolean input to the `workflow_dispatch` trigger on the **Deploy Sharing Server** workflow.

### What changed

- `workflow_dispatch` now exposes a `deploy_to_test` boolean input (default: `false`)
- The `setup` job passes the input as an env var (`FORCE_TEST`) and checks it alongside `github.ref`
- When `deploy_to_test: true` is selected in the UI, a manual run from `main` routes to the **testing** environment (same slug+hash naming as branch deployments) instead of production

### Behaviour matrix

| Trigger | `deploy_to_test` | Environment |
|---|---|---|
| Push to `main` | n/a | production |
| Push to any other branch | n/a | testing |
| Manual dispatch from `main` | `false` (default) | production |
| Manual dispatch from `main` | `true` | testing |
| Manual dispatch from any branch | either | testing |