### PR TITLE
chore: bump versions for release (vscode-extension, cli)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Last tag | Old version | New version |
|-----------|----------|-------------|-------------|
| VS Code extension | \scode/v0.2.1\ | 0.2.1 | 0.2.2 |
| CLI | \cli/v0.0.8\ | 0.0.12 | 0.0.13 |

> Visual Studio extension skipped — no \s/v*\ tag exists and no changes detected in \isualstudio-extension/\ relative to \origin/main\.

---

### After merging, run these workflows:

#### 1. VS Code Extension
- Go to **Actions → Extensions - Release → Run workflow** (on \main\)
- Publishes VS Code extension **v0.2.2** to the VS Code Marketplace

#### 2. CLI
- Go to **Actions → CLI - Publish to npm and GitHub → Run workflow** (on \main\)
- Publishes **@rajbos/ai-engineering-fluency@0.0.13** to npm