### PR TITLE
fix: show Configure Backend button when backend storage info is unavailable

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1014,6 +1014,12 @@ function renderBackendStoragePanel(
       <div class="info-box">
         <div class="info-box-title">☁️ Backend Storage</div>
         <div>Backend storage information is not available. This may be a temporary issue.</div>
+        <div class="button-group" style="margin-top: 12px;">
+          <button class="button" id="btn-configure-backend">
+            <span>🔧</span>
+            <span>Configure Backend</span>
+          </button>
+        </div>
       </div>
     `;
   }


### PR DESCRIPTION
## Problem

When the Diagnostics panel opens, it renders immediately with \ackendStorageInfo: null\ (loading state), then populates via an async data load. If that load fails or errors out silently, the ☁️ Backend Storage tab is left showing only:

> Backend storage information is not available. This may be a temporary issue.

…with no way to navigate to the Backend configuration page.

## Fix

Add a **Configure Backend** button to the fallback state. It reuses the existing \tn-configure-backend\ id that \setupBackendButtonHandlers()\ already wires to the \configureBackend\ VS Code command — so no JS changes are needed, the button just works.

Before: static error message, no escape hatch.
After: same message + a 🔧 Configure Backend button.