### PR TITLE
feat: add target_app workflow_dispatch input to update named test environments

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -15,6 +15,10 @@ on:
         description: 'Deploy main branch to the test environment instead of production'
         type: boolean
         default: false
+      target_app:
+        description: 'Target an existing test app by name (e.g. sharing-test-rajbos-azurecf0d7e). Implies deploy_to_test. Leave blank to use branch-derived name.'
+        type: string
+        default: ''
 
 # One deploy per branch at a time — prevents concurrent Terraform runs from
 # conflicting on the same remote state file (state blob already locked errors).
@@ -48,9 +52,21 @@ jobs:
       - name: Compute deployment parameters
         id: env
         env:
-          FORCE_TEST: ${{ inputs.deploy_to_test }}
+          FORCE_TEST:  ${{ inputs.deploy_to_test }}
+          TARGET_APP:  ${{ inputs.target_app }}
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" && "$FORCE_TEST" != "true" ]]; then
+          # A named target_app always routes to the test environment.
+          if [[ -n "$TARGET_APP" ]]; then
+            # Strip the "sharing-test-" prefix to get the suffix used in the state key.
+            SUFFIX="${TARGET_APP#sharing-test-}"
+            {
+              echo "app_name=${TARGET_APP}"
+              echo "state_key=sharing-server/test-${SUFFIX}.tfstate"
+              echo "environment=testing"
+              echo "is_prod=false"
+              echo "min_replicas=0"
+            } >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" && "$FORCE_TEST" != "true" ]]; then
             {
               echo "app_name=sharing-server-prod"
               echo "state_key=sharing-server/prod.tfstate"

--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -15,10 +15,6 @@ on:
         description: 'Deploy main branch to the test environment instead of production'
         type: boolean
         default: false
-      target_app:
-        description: 'Target an existing test app by name (e.g. sharing-test-rajbos-azurecf0d7e). Implies deploy_to_test. Leave blank to use branch-derived name.'
-        type: string
-        default: ''
 
 # One deploy per branch at a time — prevents concurrent Terraform runs from
 # conflicting on the same remote state file (state blob already locked errors).
@@ -53,20 +49,8 @@ jobs:
         id: env
         env:
           FORCE_TEST:  ${{ inputs.deploy_to_test }}
-          TARGET_APP:  ${{ inputs.target_app }}
         run: |
-          # A named target_app always routes to the test environment.
-          if [[ -n "$TARGET_APP" ]]; then
-            # Strip the "sharing-test-" prefix to get the suffix used in the state key.
-            SUFFIX="${TARGET_APP#sharing-test-}"
-            {
-              echo "app_name=${TARGET_APP}"
-              echo "state_key=sharing-server/test-${SUFFIX}.tfstate"
-              echo "environment=testing"
-              echo "is_prod=false"
-              echo "min_replicas=0"
-            } >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.ref }}" == "refs/heads/main" && "$FORCE_TEST" != "true" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/main" && "$FORCE_TEST" != "true" ]]; then
             {
               echo "app_name=sharing-server-prod"
               echo "state_key=sharing-server/prod.tfstate"


### PR DESCRIPTION
## Problem

`ai-fluency-server-test.devopsjournal.io` is a persistent test environment (`sharing-test-rajbos-azurecf0d7e`) created from the `rajbos/azure-aca-terraform-deploy` branch. The existing `deploy_to_test` input always computes a branch-derived app name, so running it from `main` creates a **new** ACA (`sharing-test-main0d6e40`) instead of updating the existing persistent one.

## Solution

Add a `target_app` workflow_dispatch input. When provided, it bypasses the branch-name computation and targets the specified existing test ACA directly — deriving the Terraform state key from the app name suffix.

## Usage

To update the persistent test environment with the latest main code:
1. Go to Actions → Deploy Sharing Server → Run workflow  
2. Branch: `main`
3. `target_app`: `sharing-test-rajbos-azurecf0d7e`

This preserves all existing data in that environment while updating to the latest container image.