### PR TITLE
fix: exclude suppressed tools from unknown tools banner

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1047,7 +1047,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		Object.keys(stats.today.toolCalls.byTool).forEach(tool => allTools.add(tool));
 		Object.keys(stats.last30Days.toolCalls.byTool).forEach(tool => allTools.add(tool));
 		Object.keys(stats.month.toolCalls.byTool).forEach(tool => allTools.add(tool));
-		return Array.from(allTools).filter(tool => !this.toolNameMap[tool] && !this.toolNameMap[tool.toLowerCase()]).sort();
+		const suppressed = new Set<string>(
+			vscode.workspace.getConfiguration('aiEngineeringFluency').get<string[]>('suppressedUnknownTools', [])
+		);
+		return Array.from(allTools).filter(tool => !this.toolNameMap[tool] && !this.toolNameMap[tool.toLowerCase()] && !suppressed.has(tool)).sort();
 	}
 
 	private async showUnknownMcpToolsBanner(): Promise<void> {


### PR DESCRIPTION
## Problem

When the user suppressed an unknown tool (via the Suppress action in Usage Analysis), the unknown tools notification banner would still fire for that tool on the next activation cycle.

This happened because \getUnknownMcpToolsFromStats()\ only filtered out tools present in \	oolNameMap\ — it never checked the \suppressedUnknownTools\ configuration. The webview's \getUnknownTools()\ correctly excludes suppressed tools, but the banner logic did not.

## Fix

Read \suppressedUnknownTools\ from the VS Code configuration in \getUnknownMcpToolsFromStats()\ and exclude suppressed tools from the result, matching the same filter already applied in the webview.