### PR TITLE
fix: use esbuild as preLaunchTask so F5 debug always works

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
-			"preLaunchTask": "npm compile",
+			"preLaunchTask": "esbuild",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}/vscode-extension"
 			],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,19 @@
       "problemMatcher": []
     },
     {
+      "label": "esbuild",
+      "type": "shell",
+      "command": "node esbuild.js",
+      "options": {
+        "cwd": "${workspaceFolder}/vscode-extension"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "watch",
       "dependsOn": ["npm: watch:tsc", "npm: watch:esbuild"],
       "presentation": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,8 +5,8 @@
   "tasks": [
     {
       "label": "npm compile",
-      "type": "npm",
-      "script": "compile",
+      "type": "shell",
+      "command": "npm run compile",
       "options": {
         "cwd": "${workspaceFolder}/vscode-extension"
       },
@@ -15,7 +15,7 @@
         "isDefault": true
       },
       "presentation": {
-        "reveal": "silent"
+        "reveal": "always"
       },
       "problemMatcher": []
     },


### PR DESCRIPTION
## Why

Pressing F5 to debug the VS Code extension always shows a "Waiting for preLaunchTask 'npm compile'..." popup, and the task terminal appears empty. The root cause: the `compile` script chains `tsc --noEmit && eslint src && node esbuild.js`. Any TypeScript or ESLint error silently breaks the chain before esbuild runs, so `dist/` is never built. With `reveal: "silent"` the errors are hidden, making the terminal look empty and leaving VS Code stuck waiting.

## What changed

**`.vscode/tasks.json`**
- Added a new `"esbuild"` task that runs `node esbuild.js` directly -- fast (~1s), no type-checking, never blocked by lint errors.
- Changed the existing `"npm compile"` task from `type: "npm"` to `type: "shell"` and set `reveal: "always"` so build errors are visible when running the full compile.

**`.vscode/launch.json`**
- Changed `preLaunchTask` from `"npm compile"` to `"esbuild"`.

The full `npm compile` task (tsc + eslint + esbuild) remains as the default build task (`Ctrl+Shift+B`) for catching errors before committing. It just no longer blocks F5.