### PR TITLE
feat: first-value onboarding empty-state guidance and Scoring Guide panel

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -57,7 +57,7 @@
       },
       {
         "command": "aiEngineeringFluency.showFluencyLevelViewer",
-        "title": "Show Fluency Level Viewer (Debug Only)",
+        "title": "Scoring Guide",
         "category": "AI Engineering Fluency"
       },
       {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -149,6 +149,7 @@ import {
   type ViewRegressionProbeConfig,
   type ViewRegressionProbeSnapshot,
 } from './viewRegression';
+import { determineOnboardingAction } from './onboarding';
 
 type LocalViewRegressionProbeResult = {
   pass: boolean;
@@ -986,12 +987,64 @@ class CopilotTokenTracker implements vscode.Disposable {
 			try {
 				await this.updateTokenStats();
 				this.startBackendSyncAfterInitialAnalysis();
+				await this.checkAndShowOnboarding();
 				await this.showFluencyScoreNewsBanner();
 				await this.showUnknownMcpToolsBanner();
 			} catch (error) {
 				this.error('Error in initial update:', error);
 			}
 		}, 3000);
+	}
+
+	/**
+	 * After the initial scan, decide whether to show onboarding guidance.
+	 * Branches on three cases:
+	 *   1. Returning user (`hasSeenOnboarding` already set) — do nothing.
+	 *   2. Genuine first use (no files, no discovery error) — show welcome notification.
+	 *   3. Discovery failure (no files + adapter error) — route to Diagnostics.
+	 * When data is found, the flag is marked so subsequent runs skip this.
+	 */
+	private async checkAndShowOnboarding(): Promise<void> {
+		const hasSeenOnboarding = this.context.globalState.get<boolean>('hasSeenOnboarding', false);
+		const sessionFilesCount = this.sessionDiscovery.lastDiscoveryFilesCount;
+		const hadDiscoveryError = this.sessionDiscovery.lastDiscoveryHadError;
+
+		// Compute action from pre-update state so the decision is stable.
+		const action = determineOnboardingAction(hasSeenOnboarding, sessionFilesCount, hadDiscoveryError);
+
+		// Mark as seen whenever data is present so future runs skip onboarding.
+		if (sessionFilesCount > 0) {
+			await this.context.globalState.update('hasSeenOnboarding', true);
+		}
+
+		switch (action) {
+			case 'welcome': {
+				const choice = await vscode.window.showInformationMessage(
+					'AI Engineering Fluency tracks your GitHub Copilot usage — token counts, cost estimates, and fluency scores based on how you interact with AI tools.',
+					'Open Fluency Score',
+					'Learn More',
+				);
+				await this.context.globalState.update('hasSeenOnboarding', true);
+				if (choice === 'Open Fluency Score') {
+					await this.showMaturity();
+				} else if (choice === 'Learn More') {
+					await vscode.env.openExternal(vscode.Uri.parse('https://github.com/rajbos/github-copilot-token-usage#supported-editors'));
+				}
+				break;
+			}
+			case 'diagnostics': {
+				const choice = await vscode.window.showWarningMessage(
+					'AI Engineering Fluency: session files could not be found. Open Diagnostics to investigate.',
+					'Open Diagnostics',
+				);
+				if (choice === 'Open Diagnostics') {
+					await this.showDiagnosticReport();
+				}
+				break;
+			}
+			default:
+				break;
+		}
 	}
 
 	/**
@@ -1372,7 +1425,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.setStatusBarText(`$(loading~spin) Analyzing Logs: ${percentage}%`);
 			});
 
-			this.setStatusBarText(`$(symbol-numeric) ${this.formatCompact(detailedStats.today.tokens)} | ${this.formatCompact(detailedStats.last30Days.tokens)}`);
+			if (detailedStats.today.sessions === 0 && detailedStats.last30Days.sessions === 0) {
+				this.setStatusBarText('$(symbol-numeric) No session data yet');
+			} else {
+				this.setStatusBarText(`$(symbol-numeric) ${this.formatCompact(detailedStats.today.tokens)} | ${this.formatCompact(detailedStats.last30Days.tokens)}`);
+			}
 
 			// Create detailed tooltip with improved style
 			const tooltip = new vscode.MarkdownString();
@@ -5477,10 +5534,9 @@ ${hashtag}`;
   }
 
   public async showFluencyLevelViewer(): Promise<void> {
-    const isDebugMode =
-      this.context.extensionMode === vscode.ExtensionMode.Development;
+    const isDebugMode = false;
 
-    this.log("🔍 Opening Fluency Level Viewer");
+    this.log("🔍 Opening Scoring Guide");
 
     // If panel already exists, dispose and recreate with fresh data
     if (this.fluencyLevelViewerPanel) {
@@ -5492,7 +5548,7 @@ ${hashtag}`;
 
     this.fluencyLevelViewerPanel = vscode.window.createWebviewPanel(
       "copilotFluencyLevelViewer",
-      "Fluency Level Viewer",
+      "Scoring Guide",
       { viewColumn: vscode.ViewColumn.One, preserveFocus: true },
       {
         enableScripts: true,
@@ -5529,15 +5585,14 @@ ${hashtag}`;
       return;
     }
 
-    const isDebugMode =
-      this.context.extensionMode === vscode.ExtensionMode.Development;
-    this.log("🔄 Refreshing Fluency Level Viewer");
+    const isDebugMode = false;
+    this.log("🔄 Refreshing Scoring Guide");
     const fluencyLevelData = this.getFluencyLevelData(isDebugMode);
     this.fluencyLevelViewerPanel.webview.html = this.getFluencyLevelViewerHtml(
       this.fluencyLevelViewerPanel.webview,
       fluencyLevelData,
     );
-    this.log("✅ Fluency Level Viewer refreshed");
+    this.log("✅ Scoring Guide refreshed");
   }
 
   private getFluencyLevelData(isDebugMode: boolean): ReturnType<typeof _getFluencyLevelData> {
@@ -5594,7 +5649,7 @@ ${hashtag}`;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta http-equiv="Content-Security-Policy" content="${csp}" />
-		<title>Fluency Level Viewer</title>
+		<title>Scoring Guide</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -1,0 +1,35 @@
+/**
+ * Onboarding / empty-state logic for first-run guidance.
+ *
+ * Kept as a pure function so it can be unit-tested with a mocked extension context
+ * without pulling in the full extension module.
+ */
+
+export type OnboardingAction = 'none' | 'welcome' | 'diagnostics';
+
+/**
+ * Determines what onboarding action to take after the initial session scan.
+ *
+ * @param hasSeenOnboarding  Whether `globalState.get('hasSeenOnboarding')` is true.
+ *                           A returning user whose workspace storage was wiped should
+ *                           never see the welcome flow again.
+ * @param sessionFilesCount  Number of session files discovered in the last scan.
+ * @param hadDiscoveryError  Whether any adapter threw an error during discovery.
+ */
+export function determineOnboardingAction(
+	hasSeenOnboarding: boolean,
+	sessionFilesCount: number,
+	hadDiscoveryError: boolean,
+): OnboardingAction {
+	// Returning user: never show welcome again even if workspace storage was wiped.
+	if (hasSeenOnboarding) { return 'none'; }
+
+	// Files found on first run — proceed normally; caller should mark hasSeenOnboarding.
+	if (sessionFilesCount > 0) { return 'none'; }
+
+	// No files and adapter(s) threw an error: route to Diagnostics.
+	if (hadDiscoveryError) { return 'diagnostics'; }
+
+	// No files, no errors: genuine first use — show welcome notification.
+	return 'welcome';
+}

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -54,9 +54,20 @@ export class SessionDiscovery {
 	private _sessionFilesCacheTime: number = 0;
 	private static readonly SESSION_FILES_CACHE_TTL = 60000;
 
+	/** Whether any adapter threw during the last discovery run. */
+	private _lastDiscoveryHadError = false;
+	/** Number of files returned by the last discovery run (reflects actual result, not just cache). */
+	private _lastDiscoveryFilesCount = 0;
+
 	constructor(deps: SessionDiscoveryDeps) {
 		this.deps = deps;
 	}
+
+	/** Whether any adapter threw an error during the most recent discovery scan. */
+	get lastDiscoveryHadError(): boolean { return this._lastDiscoveryHadError; }
+
+	/** Number of session files found in the most recent discovery scan. */
+	get lastDiscoveryFilesCount(): number { return this._lastDiscoveryFilesCount; }
 
 	clearCache(): void {
 		this._sessionFilesCache = null;
@@ -132,6 +143,10 @@ export class SessionDiscovery {
 			return this._sessionFilesCache;
 		}
 
+		// Reset discovery state for this run.
+		this._lastDiscoveryHadError = false;
+		this._lastDiscoveryFilesCount = 0;
+
 		// Screenshot/demo mode: sample data directory bypasses adapter discovery.
 		const sampleDir = this.deps.sampleDataDirectoryOverride?.()
 			?? vscode.workspace.getConfiguration('aiEngineeringFluency').get<string>('sampleDataDirectory');
@@ -145,6 +160,7 @@ export class SessionDiscovery {
 					this.deps.log(`📸 Sample data mode: using ${sampleFiles.length} file(s) from ${resolvedSampleDir}`);
 					this._sessionFilesCache = sampleFiles;
 					this._sessionFilesCacheTime = now;
+					this._lastDiscoveryFilesCount = sampleFiles.length;
 					return sampleFiles;
 				} else {
 					this.deps.warn(`Sample data directory not found: ${resolvedSampleDir}`);
@@ -164,6 +180,7 @@ export class SessionDiscovery {
 					sessionFiles.push(...result.sessionFiles);
 				} catch (ecoError) {
 					this.deps.warn(`Could not discover ${eco.displayName} sessions: ${ecoError}`);
+					this._lastDiscoveryHadError = true;
 				}
 			}
 
@@ -191,9 +208,12 @@ export class SessionDiscovery {
 
 			this._sessionFilesCache = deduped;
 			this._sessionFilesCacheTime = Date.now();
+			this._lastDiscoveryFilesCount = deduped.length;
 			return deduped;
 		} catch (error) {
 			this.deps.error('Error getting session files:', error);
+			this._lastDiscoveryHadError = true;
+			this._lastDiscoveryFilesCount = sessionFiles.length;
 			return sessionFiles;
 		}
 	}

--- a/vscode-extension/src/webview/fluency-level-viewer/main.ts
+++ b/vscode-extension/src/webview/fluency-level-viewer/main.ts
@@ -143,8 +143,8 @@ function renderLayout(data: FluencyLevelData): void {
 		<div class="container">
 			<div class="header">
 				<div class="header-left">
-					<span class="header-icon">🔍</span>
-					<span class="header-title">Fluency Level Viewer</span>
+					<span class="header-icon">📊</span>
+					<span class="header-title">Scoring Guide</span>
 					${data.isDebugMode ? '<span class="debug-badge">🐛 DEBUG MODE</span>' : ''}
 				</div>
 				<div class="button-row">
@@ -176,7 +176,7 @@ function renderLayout(data: FluencyLevelData): void {
 			</div>
 
 			<div class="footer">
-				🔍 Fluency Level Viewer &middot; ${data.categories.length} categories &middot; 4 stages each
+				📊 Scoring Guide &middot; ${data.categories.length} categories &middot; 4 stages each
 			</div>
 		</div>
 	`;

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -414,7 +414,7 @@ function renderLayout(data: MaturityData): void {
 					This dashboard maps your AI tool usage patterns from the last 30 days to a maturity model with 4 stages across 6 categories.
 					It helps you understand which AI capabilities you already use and suggests areas to explore for greater productivity.
 					<br><br>
-					📖 <a href="https://github.com/rajbos/github-copilot-token-usage/blob/main/docs/FLUENCY-LEVELS.md" class="beta-link">Read the full scoring rules</a> to learn how each category and stage is calculated. <button id="btn-level-viewer-inline" class="inline-action-btn">🔍 Fluency Level Viewer</button>
+					📖 <a href="https://github.com/rajbos/github-copilot-token-usage/blob/main/docs/FLUENCY-LEVELS.md" class="beta-link">Read the full scoring rules</a> to learn how each category and stage is calculated. <button id="btn-level-viewer-inline" class="inline-action-btn">📊 How is my score calculated?</button>
 					<br><br>
 					<strong>Note:</strong> Scores are based on data from session log files. Some features (e.g., inline suggestion acceptance) cannot be tracked via logs.
 				</div>

--- a/vscode-extension/test/unit/onboarding.test.ts
+++ b/vscode-extension/test/unit/onboarding.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import { determineOnboardingAction } from '../../src/onboarding';
+
+test('determineOnboardingAction', async (t) => {
+
+	await t.test('returning user (hasSeenOnboarding=true) always returns none', () => {
+		assert.strictEqual(determineOnboardingAction(true, 0, false), 'none');
+		assert.strictEqual(determineOnboardingAction(true, 0, true), 'none');
+		assert.strictEqual(determineOnboardingAction(true, 5, false), 'none');
+		assert.strictEqual(determineOnboardingAction(true, 5, true), 'none');
+	});
+
+	await t.test('first run with data found returns none', () => {
+		assert.strictEqual(determineOnboardingAction(false, 1, false), 'none');
+		assert.strictEqual(determineOnboardingAction(false, 10, false), 'none');
+		// Even with a discovery error, files found means proceed normally
+		assert.strictEqual(determineOnboardingAction(false, 1, true), 'none');
+	});
+
+	await t.test('genuine first use (no files, no error) returns welcome', () => {
+		assert.strictEqual(determineOnboardingAction(false, 0, false), 'welcome');
+	});
+
+	await t.test('discovery failure (no files, had error) returns diagnostics', () => {
+		assert.strictEqual(determineOnboardingAction(false, 0, true), 'diagnostics');
+	});
+});


### PR DESCRIPTION
## Summary

Implements issue #707: first-value onboarding with empty-state guidance and a Scoring Guide panel available to all users.

## Changes

### Onboarding flow
- New determineOnboardingAction() pure function (src/onboarding.ts) gated on context.globalState.get('hasSeenOnboarding') — returning users never see the welcome flow again even if their workspaceStorage was wiped
- Two separate no-data branches: (1) genuine first use → show welcome notification with setup instructions; (2) discovery failure → show 'check Diagnostics' message
- checkAndShowOnboarding() method wired into scheduleInitialUpdate so it fires once after the 3-second startup delay

### SessionDiscovery improvements
- Tracks lastDiscoveryHadError (set on any per-adapter throw OR outer catch)
- Tracks lastDiscoveryFilesCount (reliable count that works even when outer catch short-circuits cache population)

### Status bar
- Shows 'No session data yet' when sessions === 0 instead of a confusing '0 | 0' token display

### Scoring Guide (was 'Fluency Level Viewer (Debug Only)')
- Renamed command in package.json from 'Show Fluency Level Viewer (Debug Only)' to 'Scoring Guide'
- Removed xtensionMode === Development guard — the panel is now available to all users
- Webview panel title, in-page header, and footer all updated to 'Scoring Guide'
- Maturity panel button updated to '📊 How is my score calculated?'

## Tests
- New unit tests for determineOnboardingAction covering all 4 branches (returning user, first run with data, genuine first use, discovery failure)
- All 46 existing unit tests continue to pass

Closes #707