### PR TITLE
feat: add Path Analyzer tab to diagnostics panel

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,4 +1,4 @@
-﻿import * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -3579,6 +3579,16 @@ usageAnalysis: undefined
 					if (ev.type === 'tool.execution_complete' && typeof ev.data?.model === 'string') {
 						cliSessionModel = ev.data.model;
 						break;
+					}
+					// JetBrains / generic: model in assistant.turn_start.data.model
+					if (ev.type === 'assistant.turn_start' && typeof ev.data?.model === 'string') {
+						cliSessionModel = ev.data.model;
+						break;
+					}
+					// Fallback: session.start.data.model (not selectedModel)
+					if (ev.type === 'session.start' && typeof ev.data?.model === 'string' && !cliModelFound) {
+						cliSessionModel = ev.data.model;
+						cliModelFound = true;
 					}
 				} catch { /* skip */ }
 			}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6952,6 +6952,62 @@ ${hashtag}`;
             }
           });
           break;
+        case "pickFolder":
+          await this.dispatch('pickFolder:diagnostics', async () => {
+            const uris = await vscode.window.showOpenDialog({
+              canSelectFiles: false,
+              canSelectFolders: true,
+              canSelectMany: false,
+              openLabel: "Select Folder to Analyze",
+            });
+            if (uris && uris.length > 0 && this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+              this.diagnosticsPanel.webview.postMessage({
+                command: "folderPicked",
+                folderPath: uris[0].fsPath,
+              });
+            }
+          });
+          break;
+        case "analyzeFolder":
+          await this.dispatch('analyzeFolder:diagnostics', async () => {
+            const { folderPath, toolType } = message as { folderPath: string; toolType: string };
+            if (!folderPath) {
+              if (this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+                this.diagnosticsPanel.webview.postMessage({
+                  command: "folderAnalysisResult",
+                  error: "No folder path provided.",
+                  files: [],
+                  totalScanned: 0,
+                  parseErrors: 0,
+                  truncated: false,
+                  folderPath: "",
+                  toolType: toolType ?? "auto",
+                });
+              }
+              return;
+            }
+            try {
+              await fs.promises.access(folderPath);
+            } catch {
+              if (this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+                this.diagnosticsPanel.webview.postMessage({
+                  command: "folderAnalysisResult",
+                  error: `Folder not found or not accessible: ${folderPath}`,
+                  files: [],
+                  totalScanned: 0,
+                  parseErrors: 0,
+                  truncated: false,
+                  folderPath,
+                  toolType: toolType ?? "auto",
+                });
+              }
+              return;
+            }
+            if (this.diagnosticsPanel) {
+              await this.analyzeFolderPath(this.diagnosticsPanel, folderPath, toolType ?? "auto");
+            }
+          });
+          break;
       }
     });
 
@@ -7223,6 +7279,129 @@ ${hashtag}`;
     } catch (err) {
       // Panel may have been disposed
       this.log("Could not send session files to panel (may be closed)");
+    }
+  }
+
+  /**
+   * Analyze a custom folder for session files belonging to any of the supported AI tools.
+   * Scans recursively up to depth 5, max 500 files.
+   * Does NOT touch the cache — reads each file once and calls countInteractionsInSession
+   * and estimateTokensFromSession directly with preloaded content.
+   */
+  private async analyzeFolderPath(
+    panel: vscode.WebviewPanel,
+    folderPath: string,
+    toolType: string,
+  ): Promise<void> {
+    const MAX_FILES = 500;
+    const MAX_DEPTH = 5;
+
+    // Determine which extensions to accept
+    const jsonOnly = ["claude-code"];
+    const jsonlOnly = ["continue", "opencode", "mistral-vibe", "claude-desktop"];
+    let allowJson = true;
+    let allowJsonl = true;
+    if (jsonOnly.includes(toolType)) {
+      allowJson = false;
+      allowJsonl = true;
+    } else if (jsonlOnly.includes(toolType)) {
+      allowJson = true;
+      allowJsonl = false;
+    }
+
+    const results: Array<{
+      file: string;
+      size: number;
+      modified: string;
+      interactions: number;
+      tokens: number;
+      actualTokens: number;
+    }> = [];
+    let totalScanned = 0;
+    let parseErrors = 0;
+    let truncated = false;
+
+    // Recursive scan helper
+    const scan = async (dir: string, depth: number): Promise<void> => {
+      if (totalScanned >= MAX_FILES) {
+        truncated = true;
+        return;
+      }
+      if (depth > MAX_DEPTH) { return; }
+
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+
+      for (const entry of entries) {
+        if (totalScanned >= MAX_FILES) {
+          truncated = true;
+          break;
+        }
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await scan(full, depth + 1);
+        } else if (entry.isFile()) {
+          const isJson = entry.name.endsWith(".json");
+          const isJsonl = entry.name.endsWith(".jsonl");
+          if ((isJson && allowJson) || (isJsonl && allowJsonl)) {
+            totalScanned++;
+
+            let stat: fs.Stats;
+            try {
+              stat = await fs.promises.stat(full);
+            } catch {
+              parseErrors++;
+              continue;
+            }
+
+            let content: string;
+            try {
+              content = await fs.promises.readFile(full, "utf8");
+            } catch {
+              parseErrors++;
+              results.push({
+                file: full,
+                size: stat.size,
+                modified: stat.mtime.toISOString(),
+                interactions: 0,
+                tokens: 0,
+                actualTokens: 0,
+              });
+              continue;
+            }
+
+            const interactions = await this.countInteractionsInSession(full, content);
+            const tokenResult = await this.estimateTokensFromSession(full, content);
+
+            results.push({
+              file: full,
+              size: stat.size,
+              modified: stat.mtime.toISOString(),
+              interactions,
+              tokens: tokenResult.tokens,
+              actualTokens: tokenResult.actualTokens,
+            });
+          }
+        }
+      }
+    };
+
+    await scan(folderPath, 0);
+
+    if (this.isPanelOpen(panel)) {
+      panel.webview.postMessage({
+        command: "folderAnalysisResult",
+        files: results,
+        totalScanned,
+        parseErrors,
+        truncated,
+        folderPath,
+        toolType,
+      });
     }
   }
 

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -102,6 +102,15 @@ type DiagnosticsViewState = {
   activeSubtab?: string;
 };
 
+type FolderFileResult = {
+  file: string;
+  size: number;
+  modified: string;
+  interactions: number;
+  tokens: number;
+  actualTokens: number;
+};
+
 declare function acquireVsCodeApi<TState = DiagnosticsViewState>(): {
   postMessage: (message: unknown) => void;
   setState: (newState: TState) => void;
@@ -1038,6 +1047,149 @@ function renderBackendStoragePanel(
   `;
 }
 
+function renderFolderAnalyzerTab(): string {
+  return `
+    <div class="info-box">
+      <div class="info-box-title">🔬 Path Analyzer</div>
+      <div>
+        Analyze any folder to find session files and inspect their content.
+        This helps troubleshoot why the extension isn't finding your AI tool's session files,
+        or verify that files from another OS would be recognized.
+      </div>
+    </div>
+    <div class="section">
+      <div class="section-title">📁 Folder Selection</div>
+      <div class="folder-input-row">
+        <input
+          type="text"
+          id="folder-path-input"
+          class="folder-input"
+          placeholder="Paste a folder path here, e.g. /Users/you/.claude/projects/abc123"
+        />
+        <button class="button secondary" id="btn-browse-folder">📂 Browse…</button>
+      </div>
+      <div style="margin-top: 14px;">
+        <label style="font-size: 12px; color: var(--text-secondary); display: block; margin-bottom: 6px;">
+          Tool type (determines which file types to scan):
+        </label>
+        <select id="tool-type-select" class="tool-type-select">
+          <option value="auto">🔍 Auto-detect (all JSON / JSONL files)</option>
+          <option value="copilot-chat">💙 GitHub Copilot Chat (VS Code)</option>
+          <option value="copilot-cli">🤖 GitHub Copilot CLI</option>
+          <option value="claude-code">🟣 Claude Code (.jsonl only)</option>
+          <option value="continue">⚡ Continue</option>
+          <option value="opencode">🟢 OpenCode (JSON format only — DB not supported)</option>
+          <option value="mistral-vibe">🔥 Mistral Vibe</option>
+          <option value="claude-desktop">🖥️ Claude Desktop</option>
+        </select>
+      </div>
+      <div style="margin-top: 16px;">
+        <button class="button" id="btn-analyze-folder">🔍 Analyze</button>
+      </div>
+    </div>
+    <div id="folder-analysis-results"></div>
+  `;
+}
+
+function renderFolderAnalysisResults(
+  files: FolderFileResult[],
+  totalScanned: number,
+  parseErrors: number,
+  truncated: boolean,
+  folderPath: string,
+): string {
+  const sessionFiles = files.filter(f => f.interactions > 0 || f.tokens > 0);
+  const totalInteractions = files.reduce((sum, f) => sum + f.interactions, 0);
+  const totalTokens = files.reduce((sum, f) => sum + f.tokens, 0);
+
+  const sorted = [...files].sort((a, b) => {
+    const aScore = a.interactions * 1000 + a.tokens;
+    const bScore = b.interactions * 1000 + b.tokens;
+    return bScore - aScore;
+  });
+
+  const truncatedWarning = truncated
+    ? `<div class="info-box" style="margin-bottom: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);">
+        <div>⚠️ Scan limit reached (500 files). Results may be incomplete. Try a more specific subfolder.</div>
+      </div>`
+    : "";
+
+  const emptyState = `
+    <div style="padding: 32px; text-align: center; color: var(--text-muted);">
+      <div style="font-size: 36px; margin-bottom: 12px;">📭</div>
+      <div style="font-size: 14px;">No matching files found in this folder.</div>
+      <div style="font-size: 12px; margin-top: 8px;">Try a different folder path or tool type.</div>
+    </div>`;
+
+  const tableRows = sorted.map((f, idx) => {
+    const hasData = f.interactions > 0 || f.tokens > 0;
+    const rel = f.file.startsWith(folderPath)
+      ? f.file.slice(folderPath.length).replace(/^[/\\]/, "")
+      : getFileName(f.file);
+    const interactionsCell = f.interactions > 0
+      ? `<strong>${f.interactions}</strong>`
+      : `<span style="color: var(--text-muted);">0</span>`;
+    const tokensCell = f.tokens > 0
+      ? `<strong title="${f.tokens.toLocaleString()} tokens">${formatTokenCount(f.tokens)}</strong>`
+      : `<span style="color: var(--text-muted);">0</span>`;
+    return `
+      <tr style="${hasData ? "" : "opacity: 0.45;"}">
+        <td>${idx + 1}</td>
+        <td title="${escapeHtml(f.file)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 420px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(rel)}</td>
+        <td>${formatFileSize(f.size)}</td>
+        <td>${interactionsCell}</td>
+        <td>${tokensCell}</td>
+        <td>${formatDate(f.modified)}</td>
+      </tr>`;
+  }).join("");
+
+  return `
+    <div class="section" style="margin-top: 0;">
+      <div class="section-title">📊 Analysis Results</div>
+      ${truncatedWarning}
+      <div class="summary-cards">
+        <div class="summary-card">
+          <div class="summary-label">📄 Files Scanned</div>
+          <div class="summary-value">${totalScanned}${truncated ? "+" : ""}</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">✅ With Sessions</div>
+          <div class="summary-value">${sessionFiles.length}</div>
+          <div style="font-size: 11px; color: var(--text-muted);">${files.length - sessionFiles.length} empty / unknown</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">💬 Interactions</div>
+          <div class="summary-value">${totalInteractions}</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">🪙 Tokens</div>
+          <div class="summary-value" title="${totalTokens.toLocaleString()} tokens">${formatTokenCount(totalTokens)}</div>
+        </div>
+        ${parseErrors > 0 ? `
+        <div class="summary-card" style="border-left: 3px solid #d97706;">
+          <div class="summary-label">⚠️ Unreadable</div>
+          <div class="summary-value" style="color: #d97706;">${parseErrors}</div>
+        </div>` : ""}
+      </div>
+      ${files.length === 0 ? emptyState : `
+        <div class="table-container" style="margin-top: 12px; max-height: 420px;">
+          <table class="session-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>File</th>
+                <th>Size</th>
+                <th>Interactions</th>
+                <th>Tokens</th>
+                <th>Last Modified</th>
+              </tr>
+            </thead>
+            <tbody>${tableRows}</tbody>
+          </table>
+        </div>`}
+    </div>`;
+}
+
 function renderLayout(data: DiagnosticsData): void {
   const root = document.getElementById("root");
   if (!root) {
@@ -1153,6 +1305,7 @@ function renderLayout(data: DiagnosticsData): void {
 				<button class="tab" data-tab="backend">☁️ Backend Storage</button>
 				<button class="tab" data-tab="github">🔑 GitHub Auth</button>
 				<button class="tab" data-tab="display">⚙️ Settings</button>
+				<button class="tab" data-tab="path-analyzer">🔬 Path Analyzer</button>
 				${data.isDebugMode ? '<button class="tab" data-tab="debug">🐛 Debug</button>' : ''}
 			</div>
 
@@ -1267,6 +1420,9 @@ function renderLayout(data: DiagnosticsData): void {
 				</div>
 			</div>
 			${data.isDebugMode ? renderDebugTab(data.globalStateCounters) : ''}
+			<div id="tab-path-analyzer" class="tab-content">
+				${renderFolderAnalyzerTab()}
+			</div>
 		</div>
 	`;
 
@@ -1591,6 +1747,36 @@ function renderLayout(data: DiagnosticsData): void {
           }
         }
       }
+    } else if (message.command === "folderPicked") {
+      const input = document.getElementById("folder-path-input") as HTMLInputElement | null;
+      if (input && message.folderPath) {
+        input.value = message.folderPath;
+        input.style.borderColor = "";
+      }
+    } else if (message.command === "folderAnalysisResult") {
+      const btn = document.getElementById("btn-analyze-folder") as HTMLButtonElement | null;
+      if (btn) {
+        btn.disabled = false;
+        btn.innerHTML = "<span>🔍</span><span>Analyze</span>";
+      }
+      const resultsDiv = document.getElementById("folder-analysis-results");
+      if (resultsDiv) {
+        if (message.error) {
+          resultsDiv.innerHTML = `
+            <div class="info-box" style="border-color: #d97706; background: rgba(217,119,6,0.08); margin-top: 12px;">
+              <div class="info-box-title">⚠️ Analysis Error</div>
+              <div>${escapeHtml(message.error)}</div>
+            </div>`;
+        } else {
+          resultsDiv.innerHTML = renderFolderAnalysisResults(
+            message.files || [],
+            message.totalScanned || 0,
+            message.parseErrors || 0,
+            message.truncated || false,
+            message.folderPath || "",
+          );
+        }
+      }
     }
   });
 
@@ -1881,6 +2067,50 @@ function renderLayout(data: DiagnosticsData): void {
     }
   }
 
+  function setupFolderAnalyzerHandlers(): void {
+    document.getElementById("btn-browse-folder")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "pickFolder" });
+    });
+
+    document.getElementById("btn-analyze-folder")?.addEventListener("click", () => {
+      const input = document.getElementById("folder-path-input") as HTMLInputElement | null;
+      const select = document.getElementById("tool-type-select") as HTMLSelectElement | null;
+      const folderPath = input?.value.trim() ?? "";
+
+      if (!folderPath) {
+        if (input) {
+          input.style.borderColor = "#d97706";
+          input.focus();
+        }
+        return;
+      }
+      if (input) {
+        input.style.borderColor = "";
+      }
+
+      const btn = document.getElementById("btn-analyze-folder") as HTMLButtonElement | null;
+      if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = "<span>⏳</span><span>Analyzing…</span>";
+      }
+
+      const resultsDiv = document.getElementById("folder-analysis-results");
+      if (resultsDiv) {
+        resultsDiv.innerHTML = `
+          <div class="analyzer-loading">
+            <span class="spinner" style="width:18px;height:18px;border:2px solid var(--link-color);border-top-color:transparent;border-radius:50%;display:inline-block;animation:spin 0.7s linear infinite;"></span>
+            <span>Scanning files…</span>
+          </div>`;
+      }
+
+      vscode.postMessage({
+        command: "analyzeFolder",
+        folderPath,
+        toolType: select?.value ?? "auto",
+      });
+    });
+  }
+
   document.getElementById("btn-clear-cache")?.addEventListener("click", () => {
     const btn = document.getElementById(
       "btn-clear-cache",
@@ -2005,6 +2235,7 @@ function renderLayout(data: DiagnosticsData): void {
   setupFileLinks();
   setupStorageLinkHandlers();
   setupGitHubAuthHandlers();
+  setupFolderAnalyzerHandlers();
 
   // Restore active tab from saved state, with fallback to default
   const savedState = vscode.getState();

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -402,6 +402,9 @@ function getEditorBadgeClass(editor: string): string {
   if (lower.includes("visual studio")) {
     return "editor-badge editor-badge-vs";
   }
+  if (lower.includes("jetbrains")) {
+    return "editor-badge editor-badge-jetbrains";
+  }
   if (lower.includes("mistral")) {
     return "editor-badge editor-badge-mistral-vibe";
   }
@@ -413,6 +416,9 @@ function getEditorBadgeClass(editor: string): string {
 
 function getEditorIcon(editor: string): string {
   const lower = editor.toLowerCase();
+  if (lower.includes("jetbrains") || lower.includes("rider") || lower.includes("intellij")) {
+    return "🟣";
+  }
   if (lower.includes("visual studio")) {
     return "🪟";
   }

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1773,7 +1773,7 @@ function renderLayout(data: DiagnosticsData): void {
             message.totalScanned || 0,
             message.parseErrors || 0,
             message.truncated || false,
-            message.folderPath || "",
+            escapeHtml(String(message.folderPath || "")),
           );
         }
       }

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1105,8 +1105,8 @@ function renderFolderAnalysisResults(
   folderPath: string,
 ): string {
   const sessionFiles = files.filter(f => f.interactions > 0 || f.tokens > 0);
-  const totalInteractions = files.reduce((sum, f) => sum + f.interactions, 0);
-  const totalTokens = files.reduce((sum, f) => sum + f.tokens, 0);
+  const totalInteractions = files.reduce((sum, f) => sum + Number(f.interactions), 0);
+  const totalTokens = files.reduce((sum, f) => sum + Number(f.tokens), 0);
 
   const sorted = [...files].sort((a, b) => {
     const aScore = a.interactions * 1000 + a.tokens;
@@ -1132,11 +1132,13 @@ function renderFolderAnalysisResults(
     const rel = f.file.startsWith(folderPath)
       ? f.file.slice(folderPath.length).replace(/^[/\\]/, "")
       : getFileName(f.file);
-    const interactionsCell = f.interactions > 0
-      ? `<strong>${f.interactions}</strong>`
+    const safeInteractions = Number(f.interactions);
+    const interactionsCell = safeInteractions > 0
+      ? `<strong>${safeInteractions}</strong>`
       : `<span style="color: var(--text-muted);">0</span>`;
-    const tokensCell = f.tokens > 0
-      ? `<strong title="${f.tokens.toLocaleString()} tokens">${formatTokenCount(f.tokens)}</strong>`
+    const safeTokens = Number(f.tokens);
+    const tokensCell = safeTokens > 0
+      ? `<strong title="${safeTokens.toLocaleString()} tokens">${formatTokenCount(safeTokens)}</strong>`
       : `<span style="color: var(--text-muted);">0</span>`;
     return `
       <tr style="${hasData ? "" : "opacity: 0.45;"}">

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1134,17 +1134,17 @@ function renderFolderAnalysisResults(
       : getFileName(f.file);
     const safeInteractions = Number(f.interactions);
     const interactionsCell = safeInteractions > 0
-      ? `<strong>${safeInteractions}</strong>`
+      ? `<strong>${escapeHtml(String(safeInteractions))}</strong>`
       : `<span style="color: var(--text-muted);">0</span>`;
     const safeTokens = Number(f.tokens);
     const tokensCell = safeTokens > 0
-      ? `<strong title="${safeTokens.toLocaleString()} tokens">${formatTokenCount(safeTokens)}</strong>`
+      ? `<strong title="${escapeHtml(String(safeTokens.toLocaleString()))} tokens">${escapeHtml(String(formatTokenCount(safeTokens)))}</strong>`
       : `<span style="color: var(--text-muted);">0</span>`;
     return `
       <tr style="${hasData ? "" : "opacity: 0.45;"}">
         <td>${idx + 1}</td>
         <td title="${escapeHtml(f.file)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 420px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(rel)}</td>
-        <td>${formatFileSize(f.size)}</td>
+        <td>${escapeHtml(String(formatFileSize(f.size)))}</td>
         <td>${interactionsCell}</td>
         <td>${tokensCell}</td>
         <td>${formatDate(f.modified)}</td>
@@ -1158,7 +1158,7 @@ function renderFolderAnalysisResults(
       <div class="summary-cards">
         <div class="summary-card">
           <div class="summary-label">📄 Files Scanned</div>
-          <div class="summary-value">${totalScanned}${truncated ? "+" : ""}</div>
+          <div class="summary-value">${escapeHtml(String(totalScanned))}${truncated ? "+" : ""}</div>
         </div>
         <div class="summary-card">
           <div class="summary-label">✅ With Sessions</div>
@@ -1167,16 +1167,16 @@ function renderFolderAnalysisResults(
         </div>
         <div class="summary-card">
           <div class="summary-label">💬 Interactions</div>
-          <div class="summary-value">${totalInteractions}</div>
+          <div class="summary-value">${escapeHtml(String(totalInteractions))}</div>
         </div>
         <div class="summary-card">
           <div class="summary-label">🪙 Tokens</div>
-          <div class="summary-value" title="${totalTokens.toLocaleString()} tokens">${formatTokenCount(totalTokens)}</div>
+          <div class="summary-value" title="${escapeHtml(String(totalTokens.toLocaleString()))} tokens">${escapeHtml(String(formatTokenCount(totalTokens)))}</div>
         </div>
         ${parseErrors > 0 ? `
         <div class="summary-card" style="border-left: 3px solid #d97706;">
           <div class="summary-label">⚠️ Unreadable</div>
-          <div class="summary-value" style="color: #d97706;">${parseErrors}</div>
+          <div class="summary-value" style="color: #d97706;">${escapeHtml(String(parseErrors))}</div>
         </div>` : ""}
       </div>
       ${files.length === 0 ? emptyState : `

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -550,3 +550,50 @@ background-position: center;
 	font-size: 14px;
 	margin-bottom: 8px;
 }
+
+/* Path Analyzer tab */
+.folder-input-row {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+
+.folder-input {
+	flex: 1;
+	background: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+	border: 1px solid var(--vscode-input-border, var(--border-color));
+	border-radius: 4px;
+	padding: 6px 10px;
+	font-size: 13px;
+	min-width: 0;
+}
+
+.folder-input:focus {
+	outline: 1px solid var(--link-color);
+	border-color: var(--link-color);
+}
+
+.tool-type-select {
+	background: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+	border: 1px solid var(--vscode-input-border, var(--border-color));
+	border-radius: 4px;
+	padding: 6px 10px;
+	font-size: 13px;
+	cursor: pointer;
+	min-width: 280px;
+}
+
+.analyzer-loading {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 20px;
+	color: var(--text-muted);
+	font-size: 13px;
+}
+
+@keyframes spin {
+	to { transform: rotate(360deg); }
+}

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -355,6 +355,7 @@ export function getEditorNameFromRoot(rootPath: string): string {
 	if (!rootPath) { return 'Unknown'; }
 	const lower = rootPath.toLowerCase();
 	// Check obvious markers first
+	if (lower.includes('.copilot/jb') || lower.includes('.copilot\\jb')) { return 'JetBrains'; }
 	if (lower.includes('.copilot') || lower.includes('copilot')) { return 'Copilot CLI'; }
 	if (lower.includes('opencode')) { return 'OpenCode'; }
 	if (lower.includes('.continue')) { return 'Continue'; }
@@ -758,6 +759,7 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
  */
 export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = filePath.toLowerCase().replace(/\\/g, '/');
+	if (lowerPath.includes('/.copilot/jb/')) { return 'JetBrains'; }
 	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
 	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -218,6 +218,14 @@ test('getEditorNameFromRoot: .copilot path returns Copilot CLI', () => {
     assert.equal(getEditorNameFromRoot('C:\\Users\\user\\.copilot\\worktrees\\session'), 'Copilot CLI');
 });
 
+test('getEditorNameFromRoot: .copilot/jb path returns JetBrains', () => {
+    assert.equal(getEditorNameFromRoot('C:\\Users\\user\\.copilot\\jb'), 'JetBrains');
+});
+
+test('getEditorNameFromRoot: .copilot/jb forward-slash path returns JetBrains', () => {
+    assert.equal(getEditorNameFromRoot('/home/user/.copilot/jb'), 'JetBrains');
+});
+
 test('getEditorNameFromRoot: Code Insiders path returns VS Code Insiders', () => {
     assert.equal(getEditorNameFromRoot('C:\\Users\\user\\AppData\\Roaming\\Code - Insiders'), 'VS Code Insiders');
 });
@@ -435,6 +443,15 @@ test('detectEditorSource: code-insiders hyphenated variant detected', () => {
 test('detectEditorSource: Copilot CLI takes priority over code path', () => {
         // .copilot/session-state path should return Copilot CLI, not VS Code
         assert.equal(detectEditorSource('/home/user/.copilot/session-state/session123.json'), 'Copilot CLI');
+});
+
+test('detectEditorSource: JetBrains detected from .copilot/jb path', () => {
+        assert.equal(detectEditorSource('/home/user/.copilot/jb/uuid-1234/partition-0.jsonl'), 'JetBrains');
+});
+
+test('detectEditorSource: JetBrains takes priority over Copilot CLI fallback', () => {
+        // .copilot/jb/ path should return JetBrains, not Copilot CLI
+        assert.notEqual(detectEditorSource('/home/user/.copilot/jb/uuid-1234/partition-0.jsonl'), 'Copilot CLI');
 });
 
 test('detectEditorSource: Claude Code takes priority over code path', () => {


### PR DESCRIPTION
## Summary

Adds a new **🔬 Path Analyzer** tab to the diagnostics panel that helps users troubleshoot why the extension isn't finding their AI tool's session files, or verify that files from another OS would be recognized.

## Features

- **Folder selection** — browse with a native file picker or paste a path manually
- **Tool type selector** — choose from Copilot Chat, Copilot CLI, Claude Code, Continue, OpenCode, Mistral Vibe, Claude Desktop, or Auto-detect
- **Recursive scan** — up to 500 files, max 5 directory levels deep
- **Results table** — shows each file with size, interaction count, token estimate, and last modified date; files with no recognized sessions are dimmed
- **Summary cards** — files scanned, files with sessions, total interactions, total tokens, and unreadable file count
- **Loading state** — spinner + disabled button while analysis runs
- **Error handling** — clear message if folder doesn't exist or isn't accessible, truncation warning at 500 files

## Technical approach

- Uses `countInteractionsInSession()` and `estimateTokensFromSession()` directly with preloaded file content — **bypasses the session cache entirely** to avoid polluting it with custom folder paths
- Extension-side `analyzeFolderPath()` method handles all I/O and posts results back to the webview
- New `pickFolder` / `analyzeFolder` / `folderPicked` / `folderAnalysisResult` message protocol commands
- All 47 unit tests pass ✅