### PR TITLE
chore: bump versions for release (vscode-extension 0.3.0, cli 0.0.14)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,20 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.14] - 2026-04-30
+
+### ✨ Features & Improvements
+- Added macOS path support for Claude Desktop Cowork sessions (#714)
+- Added dedicated CLI interaction mode in Usage Analysis (#659)
+- Added GitHub Copilot AI-Credit pricing alongside provider pricing
+- Added Mistral Vibe session support
+- Improved fluency spiderweb chart for Claude-only users
+- Renamed cost labels: `(API)` → `(est.)` and `(Copilot)` → `(TBB)` with explainer tooltips
+- Display CO2 in kg when ≥ 1000g for readability
+
+### 🔧 Maintenance
+- Migrated to IEcosystemAdapter registry pattern for improved extensibility
+
 ## [0.0.8] - 2026-04-11
 
 ### ✨ Features & Improvements

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,8 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-30
+
 ### Features and Improvements
-- Added "💰 Est. Cost" view to the chart page: shows estimated daily/weekly/monthly API cost based on per-model token usage and provider pricing data
+- Added "💰 Est. Cost" view to the chart page: shows estimated daily/weekly/monthly API cost based on per-model token usage and provider pricing data (#703)
+- Added first-value onboarding empty-state guidance and Scoring Guide panel (#710)
+- Added macOS path support for Claude Desktop Cowork sessions (#714)
+
+### Bug Fixes
+- Fixed: show Configure Backend button when backend storage info is unavailable
+- Fixed: exclude suppressed tools from unknown tools alert banner
 
 ## [0.1.1] - 2026-04-10
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-token-tracker",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release Prep

### VS Code Extension: 0.2.2 → 0.3.0

#### ✨ Features & Improvements
- Added "💰 Est. Cost" view to the chart page: shows estimated daily/weekly/monthly API cost based on per-model token usage and provider pricing data (#703)
- Added first-value onboarding empty-state guidance and Scoring Guide panel (#710)
- Added macOS path support for Claude Desktop Cowork sessions (#714)

#### 🐛 Bug Fixes
- Fixed: show Configure Backend button when backend storage info is unavailable
- Fixed: exclude suppressed tools from unknown tools alert banner

---

### CLI: 0.0.13 → 0.0.14 (CHANGELOG update only — package.json was already at 0.0.14)

#### ✨ Features & Improvements
- Added macOS path support for Claude Desktop Cowork sessions (#714)
- Added dedicated CLI interaction mode in Usage Analysis (#659)
- Added GitHub Copilot AI-Credit pricing alongside provider pricing
- Added Mistral Vibe session support
- Improved fluency spiderweb chart for Claude-only users
- Renamed cost labels: `(API)` → `(est.)` and `(Copilot)` → `(TBB)` with explainer tooltips
- Display CO2 in kg when ≥ 1000g for readability

#### 🔧 Maintenance
- Migrated to IEcosystemAdapter registry pattern for improved extensibility

---

After merging:
1. Trigger the **Extensions - Release** workflow (`release.yml`) via `workflow_dispatch` to publish the VS Code extension to the marketplace and create the `vscode/v0.3.0` tag + GitHub release.
2. Push tag `cli/v0.0.14` to trigger the **CLI - Publish to npm** workflow (`cli-publish.yml`).