### PR TITLE
fix: replace hardcoded dark backgrounds in log viewer with theme CSS variables

### DIFF
--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -49,7 +49,7 @@ body {
 	justify-content: center;
 	font-size: 18px;
 	background: var(--bg-tertiary);
-	border: 2px solid #2a2a30;
+	border: 2px solid var(--border-subtle);
 	box-shadow: 0 2px 4px var(--shadow-color);
 }
 
@@ -316,12 +316,12 @@ body {
 
 .user-message .message-text {
 	border-left: 4px solid #60a5fa;
-	background: linear-gradient(135deg, #1e293b 0%, #22222a 100%);
+	background: var(--bg-tertiary);
 }
 
 .assistant-message .message-text {
 	border-left: 4px solid #7c3aed;
-	background: linear-gradient(135deg, #1e1e2a 0%, #22222a 100%);
+	background: var(--bg-tertiary);
 }
 
 /* Shared collapse arrow for details/summary panels */
@@ -430,7 +430,7 @@ details[open] > summary .collapse-arrow {
 	text-align: left;
 	padding: 8px 12px;
 	background: var(--bg-tertiary);
-	border-bottom: 2px solid #4a4a5a;
+	border-bottom: 2px solid var(--border-subtle);
 	color: var(--text-secondary);
 	font-weight: 600;
 	font-size: 12px;
@@ -536,7 +536,7 @@ details[open] > summary .collapse-arrow {
 /* MCP tools */
 .turn-mcp {
 	margin: 0 16px 14px;
-	background: linear-gradient(135deg, #1e2e1e 0%, #1a261a 100%);
+	background: var(--bg-secondary);
 	border: 1px solid #3a5a3a;
 	border-radius: 8px;
 	padding: 14px;
@@ -581,8 +581,8 @@ details[open] > summary .collapse-arrow {
 /* Context References - detail panel */
 .turn-context-details {
 	margin-bottom: 14px;
-	background: linear-gradient(135deg, #2a2535 0%, #252530 100%);
-	border: 1px solid #4a4a5a;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-subtle);
 	border-radius: 8px;
 	padding: 14px;
 	box-shadow: 0 2px 8px rgb(0, 0, 0, 0.2);
@@ -624,7 +624,7 @@ details[open] > summary .collapse-arrow {
 .context-refs-table td {
 	padding: 8px 12px;
 	text-align: left;
-	border-bottom: 1px solid #334155;
+	border-bottom: 1px solid var(--border-subtle);
 }
 
 .context-refs-table th {
@@ -633,7 +633,7 @@ details[open] > summary .collapse-arrow {
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.5px;
-	background: #1e293b;
+	background: var(--bg-tertiary);
 }
 
 .context-refs-table td {
@@ -641,7 +641,7 @@ details[open] > summary .collapse-arrow {
 }
 
 .context-refs-table tbody tr:hover {
-	background: #1e293b;
+	background: var(--list-hover-bg);
 }
 
 .context-refs-table .count-cell {
@@ -701,8 +701,8 @@ details[open] > summary .collapse-arrow {
 /* Context References - collapsible panel */
 .turn-context-refs {
 	margin: 0 16px 14px;
-	background: linear-gradient(135deg, #2a2535 0%, #252530 100%);
-	border: 1px solid #4a4a5a;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-subtle);
 	border-radius: 8px;
 	padding: 12px 14px;
 	box-shadow: 0 2px 8px rgb(0, 0, 0, 0.2);
@@ -790,15 +790,15 @@ details[open] > summary .collapse-arrow {
 .footer {
 	margin-top: 16px;
 	padding-top: 12px;
-	border-top: 1px solid #2a2a30;
+	border-top: 1px solid var(--border-subtle);
 	font-size: 11px;
-	color: #666;
+	color: var(--text-muted);
 }
 
 /* Actual LLM Usage - per turn */
 .turn-actual-usage {
 	margin: 0 16px 14px;
-	background: linear-gradient(135deg, #1a2530 0%, #1a2028 100%);
+	background: var(--bg-secondary);
 	border: 1px solid #2a5a6a;
 	border-radius: 8px;
 	padding: 12px 14px;
@@ -832,13 +832,13 @@ details[open] > summary .collapse-arrow {
 }
 
 .actual-usage-summary:hover {
-	color: #fff;
+	color: var(--text-primary);
 }
 
 .actual-usage-header-inline {
 	font-size: 13px;
 	font-weight: 700;
-	color: #fff;
+	color: var(--text-primary);
 	text-transform: uppercase;
 	letter-spacing: 0.5px;
 }
@@ -909,16 +909,16 @@ details[open] > summary .collapse-arrow {
 .usage-comparison-table td {
 	padding: 8px 12px;
 	text-align: left;
-	border-bottom: 1px solid #334155;
+	border-bottom: 1px solid var(--border-subtle);
 }
 
 .usage-comparison-table th {
-	color: #94a3b8;
+	color: var(--text-secondary);
 	font-weight: 600;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.5px;
-	background: #1e293b;
+	background: var(--bg-tertiary);
 }
 
 .usage-comparison-table .count-cell {
@@ -927,7 +927,7 @@ details[open] > summary .collapse-arrow {
 }
 
 .usage-total-row {
-	border-top: 2px solid #475569;
+	border-top: 2px solid var(--border-subtle);
 }
 
 .usage-total-row td {
@@ -985,16 +985,16 @@ details[open] > summary .collapse-arrow {
 .prompt-breakdown-table td {
 	padding: 8px 12px;
 	text-align: left;
-	border-bottom: 1px solid #334155;
+	border-bottom: 1px solid var(--border-subtle);
 }
 
 .prompt-breakdown-table th {
-	color: #94a3b8;
+	color: var(--text-secondary);
 	font-weight: 600;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.5px;
-	background: #1e293b;
+	background: var(--bg-tertiary);
 }
 
 .prompt-breakdown-table .count-cell {
@@ -1005,7 +1005,7 @@ details[open] > summary .collapse-arrow {
 .bar-cell {
 	width: 100%;
 	height: 14px;
-	background: #1e293b;
+	background: var(--bg-tertiary);
 	border-radius: 4px;
 	overflow: hidden;
 	min-width: 80px;
@@ -1028,7 +1028,7 @@ details[open] > summary .collapse-arrow {
 /* Actual usage summary card highlight */
 .actual-usage-card {
 	border-color: #2a5a6a;
-	background: linear-gradient(135deg, #1a2530 0%, #1a2028 100%);
+	background: var(--bg-secondary);
 }
 
 .actual-usage-card .summary-value {
@@ -1037,7 +1037,7 @@ details[open] > summary .collapse-arrow {
 
 /* Session-level actual usage panel */
 .session-actual-usage {
-	background: linear-gradient(135deg, #1a2530 0%, #1a2028 100%);
+	background: var(--bg-secondary);
 	border: 1px solid #2a5a6a;
 	border-radius: 12px;
 	padding: 20px 24px;
@@ -1048,7 +1048,7 @@ details[open] > summary .collapse-arrow {
 .session-usage-header {
 	font-size: 16px;
 	font-weight: 700;
-	color: #fff;
+	color: var(--text-primary);
 	margin-bottom: 16px;
 	padding-bottom: 12px;
 	border-bottom: 2px solid #2a5a6a;


### PR DESCRIPTION
## Problem

The log viewer webview had many hardcoded dark hex/gradient backgrounds that looked broken when VS Code was using a light theme — large sections appeared dark-on-light instead of following the editor theme.

## Fix

Replaced all hardcoded dark backgrounds and colors in `vscode-extension/src/webview/logviewer/styles.css` with CSS variables from `theme.css`:

- `.mode-icon` border
- `.user-message` / `.assistant-message` background gradients → `var(--bg-tertiary)`
- `.turn-mcp`, `.turn-context-refs`, `.turn-context-details` → `var(--bg-secondary)`
- `.turn-actual-usage`, `.actual-usage-card`, `.session-actual-usage` → `var(--bg-secondary)`
- All table header/row backgrounds → `var(--bg-tertiary)` / `var(--border-subtle)`
- Hardcoded `#fff` text colors → `var(--text-primary)`
- Footer border/color → `var(--border-subtle)` / `var(--text-muted)`

Intentional accent colors (context badge, progress bar fills, colored left borders) are preserved.