### PR TITLE
fix: eco-session token count in diagnostics matches file viewer

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -171,7 +171,7 @@ type LocalViewRegressionCase = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 42; // Use UTC-based daily rollups for consistent token attribution
+	private static readonly CACHE_VERSION = 43; // Fix eco-session token count in diagnostics path
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -3135,28 +3135,39 @@ class CopilotTokenTracker implements vscode.Disposable {
 	/**
 	 * Update or create cache entry with session file details.
 	 * Merges new detail fields with existing cached data if available.
+	 * @param tokenResult - Fresh token data from eco.getTokens(); when provided, takes
+	 *   precedence over any cached token values so eco-session diagnostics always show
+	 *   the correct (actual-API) count rather than a stale or zero value.
 	 */
 	private async updateCacheWithSessionDetails(
 		sessionFile: string,
 		stat: fs.Stats,
-		details: SessionFileDetails
+		details: SessionFileDetails,
+		tokenResult?: { tokens: number; thinkingTokens: number; actualTokens: number }
 	): Promise<void> {
 		// Get existing cache entry if available
 		const existingCache = this.getCachedSessionData(sessionFile);
 
-		// Enrich details with token count from existing cache (populated by main stats calculation).
-		// Prefer actualTokens (real API count) when available; fall back to estimated tokens.
-		details.tokens = existingCache?.actualTokens || existingCache?.tokens || 0;
+		// Prefer fresh token data (eco path supplies this) over any cached value.
+		// For Copilot Chat sessions no tokenResult is provided, so we fall back to
+		// the existing cache that was already populated by getSessionFileDataCached().
+		const resolvedActualTokens = tokenResult?.actualTokens ?? existingCache?.actualTokens;
+		const resolvedTokens = tokenResult?.tokens ?? existingCache?.tokens ?? 0;
+		const resolvedThinkingTokens = tokenResult?.thinkingTokens ?? existingCache?.thinkingTokens;
+		details.tokens = resolvedActualTokens || resolvedTokens || 0;
 
 		// Create or update cache entry
 		const cacheEntry: SessionFileCache = {
-			tokens: existingCache?.tokens || 0,
+			tokens: resolvedTokens,
 			interactions: details.interactions,
 			modelUsage: existingCache?.modelUsage || {},
 			mtime: stat.mtime.getTime(),
 			size: stat.size,
-			actualTokens: existingCache?.actualTokens,
-			thinkingTokens: existingCache?.thinkingTokens,
+			actualTokens: resolvedActualTokens,
+			thinkingTokens: resolvedThinkingTokens,
+			// Preserve existing dailyRollups so this partial update does not discard
+			// the per-day breakdown computed by getSessionFileDataCached().
+			dailyRollups: existingCache?.dailyRollups,
 			usageAnalysis: existingCache?.usageAnalysis || {
 				toolCalls: { total: 0, byTool: {} },
 				modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
@@ -3239,17 +3250,26 @@ class CopilotTokenTracker implements vscode.Disposable {
 			// Handle all non-Copilot-Chat ecosystems via adapter dispatch
 			const eco = this.findEcosystem(sessionFile);
 			if (eco) {
-				const meta = await eco.getMeta(sessionFile);
+				// Fetch meta, tokens, and interaction count in parallel to minimise file-read latency.
+				// getTokens() is the key addition here: it reads the actual API token counts so the
+				// diagnostics view shows the same (correct) total that the file viewer header does.
+				const [meta, tokenResult, interactionCount] = await Promise.all([
+					eco.getMeta(sessionFile),
+					eco.getTokens(sessionFile),
+					eco.countInteractions(sessionFile)
+				]);
 				details.title = meta.title;
 				details.firstInteraction = meta.firstInteraction;
 				details.lastInteraction = meta.lastInteraction;
-				details.interactions = await eco.countInteractions(sessionFile);
+				details.interactions = interactionCount;
 				details.editorRoot = eco.getEditorRoot(sessionFile);
 				details.editorName = eco.displayName;
 				if (meta.workspacePath) {
 					details.repository = path.basename(meta.workspacePath);
 				}
-				await this.updateCacheWithSessionDetails(sessionFile, stat, details);
+				// Pass fresh tokenResult so updateCacheWithSessionDetails stores the correct counts
+				// and does not overwrite a good full-cache entry with a stale/zero token value.
+				await this.updateCacheWithSessionDetails(sessionFile, stat, details, tokenResult);
 				return details;
 			}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7158,6 +7158,9 @@ ${hashtag}`;
 
       // Build folder counts grouped by top-level VS Code user folder (editor roots)
       const dirCounts = new Map<string, number>();
+      // Tracks friendly display names for eco-adapter directories so the directory
+      // table shows "Claude Desktop Cowork" etc. instead of "Unknown".
+      const dirEditorNames = new Map<string, string>();
       const pathModule = require("path");
       const copilotSessionStateDir = pathModule.join(
         os.homedir(),
@@ -7170,6 +7173,7 @@ ${hashtag}`;
         if (eco) {
           const editorRoot = eco.getEditorRoot(file);
           dirCounts.set(editorRoot, (dirCounts.get(editorRoot) || 0) + 1);
+          dirEditorNames.set(editorRoot, eco.displayName);
           continue;
         }
         const parts = file.split(/[\\\/]/);
@@ -7196,7 +7200,7 @@ ${hashtag}`;
         ([dir, count]) => ({
           dir,
           count,
-          editorName: this.getEditorNameFromRoot(dir),
+          editorName: dirEditorNames.get(dir) || this.getEditorNameFromRoot(dir),
         }),
       );
 


### PR DESCRIPTION
## Problem

The diagnostics tab **session files list** (and main screens) showed zero or stale token counts for Claude Desktop Cowork (and other eco-adapter) sessions. Opening the same session in the **file viewer** correctly showed the much higher actual-API token total.

## Root Cause

`getSessionFileDetails()` eco path called `eco.getMeta()` + `eco.countInteractions()` but **never** `eco.getTokens()`.  

`updateCacheWithSessionDetails()` then wrote a cache entry stamped with the current `mtime`/`size` but `tokens=0`.  Any later call to `getSessionFileDataCached()` saw a valid cache hit (mtime+size matched) and returned the stale zero-token data — so the correct tokens were never computed.

The file viewer took a separate path (`buildTurns()`) that reads actual API token counts directly from the JSONL, which is why it always showed the right value.

## Fix

| Change | Why |
|---|---|
| `getSessionFileDetails()` eco path: run `getMeta()`, `getTokens()`, and `countInteractions()` concurrently via `Promise.all()` | Reads actual API tokens and passes them forward; also slightly faster (parallel file reads) |
| `updateCacheWithSessionDetails()`: new optional `tokenResult` param | When fresh token data is supplied, it takes precedence over any cached values — eco sessions always store correct counts |
| Preserve `existingCache.dailyRollups` in partial cache update | Prevents a later full recompute from being silently discarded |
| Bump `CACHE_VERSION` 42 → 43 | Invalidates any poisoned cache entries already on disk |

## Testing

- TypeScript type-check (`tsc --noEmit`): ✅ clean
- Unit tests (`ecosystemAdapters`, `sessionParser`, `claudecode`, `copilotChatAdapter`, `copilotCliAdapter`): ✅ 101 pass, 0 fail