### PR TITLE
fix: count subagent tool results in token estimation + show subagent count in log viewer

### DIFF
--- a/.github/instructions/cli.instructions.md
+++ b/.github/instructions/cli.instructions.md
@@ -58,6 +58,7 @@ When adding support for a new editor or data source, wire it into **both** `vsco
 - [ ] `cli/src/helpers.ts` — import, factory, singleton, detection, stat routing, processSessionFile block, usageAnalysis deps
 - [ ] `cli/src/commands/stats.ts` — `getEditorDisplayName()` entry
 - [ ] `cli/README.md` — "Data Sources" section updated
+- [ ] `docs/vscode-extension/README.md` — add the new editor to the "Supported editors shown in the chart" list in the **Chart View** section
 - [ ] `npm run build` passes (from `cli/`)
 - [ ] CLI `stats` command shows the new editor in the session list
 - [ ] Token counts are non-zero and plausible

--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -163,5 +163,12 @@ Current adapter set (9):
 
 **Adapter ordering matters**: register more-specific adapters first. `CopilotChatAdapter` and `CopilotCliAdapter` are registered **last** in `this.ecosystems`.
 
+### Checklist when adding a new adapter
+
+- [ ] Add adapter class under `vscode-extension/src/adapters/`
+- [ ] Register adapter in `extension.ts` `this.ecosystems` (before Copilot adapters)
+- [ ] `docs/vscode-extension/README.md` — add the new editor to the "Supported editors shown in the chart" list in the **Chart View** section
+- [ ] Also update the CLI side — see `.github/instructions/cli.instructions.md`
+
 **`handles()` for CopilotChat/Cli currently returns `false`**: discovery is owned by the adapters, but per-session parsing is still routed through the existing fallback path in `extension.ts` (`countInteractionsInSession`, `estimateTokensFromSession`, `getSessionFileDataCached`). A future PR can flip `handles()` to use the exported `isCopilotChatSessionPath` / `isCopilotCliSessionPath` predicates once the JSON parser helpers are extracted from `extension.ts`. When you flip `handles()`, also fix `_detectEditorSource(filePath, (p) => !!this.findEcosystem(p))` at extension.ts:~3224 — the predicate must check `?.id === 'opencode'` (or use `getEditorTypeFromPath` convention) so that VS Code paths are still labeled "VS Code", not "OpenCode".
 

--- a/docs/vscode-extension/README.md
+++ b/docs/vscode-extension/README.md
@@ -123,6 +123,42 @@ For detailed scoring rules, see [Fluency Levels Documentation](../FLUENCY-LEVELS
 
 ---
 
+## Session Log Viewer
+
+The extension includes a session log viewer for inspecting individual Copilot Chat or Copilot CLI session files in detail.
+
+**To open:** In the **Diagnostics** view → session files tab, click the **📄 View** link next to any session.
+
+### What you see
+
+Each chat turn is shown as a card with:
+- Input, output, and (where applicable) thinking token counts
+- The model used
+- A summary of tool calls and sub-agent activity
+
+### Sub-Agent tracking
+
+When a turn launched sub-agents, the summary card shows:
+
+> 🤖 Sub-Agents: N started · M tool calls
+
+Sub-agent tool rows are displayed with friendly names:
+- `task` → **Sub-Agent**
+- `read_agent` → **Sub-Agent (read)**
+- `write_agent` → **Sub-Agent (write)**
+- `list_agents` → **Sub-Agent (list)**
+
+Each sub-agent row also shows a green **↑N ↓M tokens** badge with the estimated input/output token usage for that specific sub-agent invocation.
+
+### Tool call pill filters
+
+Each turn with tool calls shows clickable pill badges (e.g. `read_file: 3`, `🤖 Sub-Agents: 2`). Clicking a pill:
+- Opens the tool calls panel for that turn if it is not already open
+- Filters the list to show only tool rows of that type
+- Click the same pill again to clear the filter and show all rows
+
+---
+
 ## Usage Analysis Dashboard
 
 The extension includes a comprehensive usage analysis dashboard that helps you understand how you interact with GitHub Copilot.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6922,6 +6922,31 @@ ${hashtag}`;
             await vscode.env.openExternal(vscode.Uri.parse(issueUrl));
           });
           break;
+        case "reportNewEditorPath":
+          if (message.path) {
+            await this.dispatch('reportNewEditorPath:diagnostics', async () => {
+              const rawPath: string = message.path;
+              const home = os.homedir();
+              const anonymizedPath = rawPath.startsWith(home) ? rawPath.replace(home, '~') : rawPath;
+              const title = encodeURIComponent('New editor support: unknown session path found');
+              const body = encodeURIComponent([
+                '## Unknown editor session path found',
+                '',
+                'The extension found a session file at a path it does not recognise:',
+                '',
+                '```',
+                anonymizedPath,
+                '```',
+                '',
+                '**Which editor or tool does this path belong to?**',
+                '',
+                'Please describe the editor/tool and how you installed it so we can add support for it.',
+              ].join('\n'));
+              const issueUrl = `${this.getRepositoryUrl()}/issues/new?title=${title}&body=${body}&labels=${encodeURIComponent('new-editor-support')}`;
+              await vscode.env.openExternal(vscode.Uri.parse(issueUrl));
+            });
+          }
+          break;
         case "openSessionFile":
           if (message.file) {
             await this.dispatch('openSessionFile:diagnostics', async () => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -171,7 +171,7 @@ type LocalViewRegressionCase = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 43; // Fix eco-session token count in diagnostics path
+	private static readonly CACHE_VERSION = 44; // Add tool.execution_complete token counting for CLI sessions
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -3517,6 +3517,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private async getSessionLogData(sessionFile: string): Promise<SessionLogData> {
 		const details = await this.getSessionFileDetails(sessionFile);
 		const turns: ChatTurn[] = [];
+		let subAgentsStarted: number | undefined;
 
 		try {
 // Delegate to ecosystem adapter if available
@@ -3751,7 +3752,9 @@ usageAnalysis: undefined
 
 					// Handle CLI tool calls (tool.execution_start is the actual event type in current CLI format)
 					const CLI_SUB_AGENT_TOOLS = new Set(['task', 'read_agent', 'write_agent', 'list_agents']);
-					if ((event.type === 'tool.call' || event.type === 'tool.result' || event.type === 'tool.execution_start') && turns.length > 0) {
+					if ((event.type === 'tool.call' || event.type === 'tool.result' || event.type === 'tool.execution_start')
+					&& turns.length > 0
+					&& !event.data?.parentToolCallId) {
 						const lastTurn = turns[turns.length - 1];
 						const toolName = event.data?.toolName || event.toolName || 'unknown';
 						const isSubAgent = CLI_SUB_AGENT_TOOLS.has(toolName);
@@ -3789,6 +3792,11 @@ usageAnalysis: undefined
 						const serverName = event.data?.mcpServer || 'unknown';
 						const toolName = event.data?.toolName || event.toolName || 'unknown';
 						lastTurn.mcpTools.push({ server: serverName, tool: toolName });
+					}
+
+					// Count distinct subagent sessions launched
+					if (event.type === 'subagent.started') {
+						subAgentsStarted = (subAgentsStarted ?? 0) + 1;
 					}
 				} catch {
 					// Skip malformed lines
@@ -3897,7 +3905,8 @@ usageAnalysis: undefined
 			lastInteraction: details.lastInteraction,
 			turns,
 			usageAnalysis,
-			actualTokens: sessionCache?.actualTokens || 0
+			actualTokens: sessionCache?.actualTokens || 0,
+			...(subAgentsStarted !== undefined ? { subAgentsStarted } : {})
 		};
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3711,6 +3711,9 @@ usageAnalysis: undefined
 				} catch { /* skip */ }
 			}
 
+			// Track output tokens per subagent (keyed by parentToolCallId)
+			const subAgentOutputTokenMap = new Map<string, number>();
+
 			for (const line of lines) {
 				try {
 					const event = JSON.parse(line);
@@ -3744,10 +3747,16 @@ usageAnalysis: undefined
 					}
 
 					// Handle CLI assistant response
-					if (event.type === 'assistant.message' && event.data?.content && turns.length > 0) {
-						const lastTurn = turns[turns.length - 1];
-						lastTurn.assistantResponse += event.data.content;
-						lastTurn.outputTokensEstimate = this.estimateTokensFromText(lastTurn.assistantResponse, lastTurn.model || 'gpt-4o');
+					if (event.type === 'assistant.message' && event.data?.content) {
+						if (event.data.parentToolCallId) {
+							// Subagent response — accumulate output tokens keyed by parent tool call
+							const prev = subAgentOutputTokenMap.get(event.data.parentToolCallId) ?? 0;
+							subAgentOutputTokenMap.set(event.data.parentToolCallId, prev + this.estimateTokensFromText(event.data.content, cliSessionModel));
+						} else if (turns.length > 0) {
+							const lastTurn = turns[turns.length - 1];
+							lastTurn.assistantResponse += event.data.content;
+							lastTurn.outputTokensEstimate = this.estimateTokensFromText(lastTurn.assistantResponse, lastTurn.model || 'gpt-4o');
+						}
 					}
 
 					// Handle CLI tool calls (tool.execution_start is the actual event type in current CLI format)
@@ -3764,12 +3773,15 @@ usageAnalysis: undefined
 							const serverName = this.extractMcpServerName(toolName);
 							lastTurn.mcpTools.push({ server: serverName, tool: toolName });
 						} else if (isSubAgent) {
-							lastTurn.toolCalls.push({
+							const subAgentCallId: string | undefined = event.data?.toolCallId;
+							const subAgentEntry: any = {
 								toolName,
 								arguments: event.data?.arguments ? JSON.stringify(event.data.arguments) : undefined,
 								result: undefined,
 								isSubAgent: true,
-							});
+							};
+							if (subAgentCallId) { subAgentEntry._callId = subAgentCallId; }
+							lastTurn.toolCalls.push(subAgentEntry);
 						} else {
 							// Add to regular tool calls (skip duplicate execution_start events per toolCallId)
 							const callId: string | undefined = event.data?.toolCallId;
@@ -3800,6 +3812,30 @@ usageAnalysis: undefined
 					}
 				} catch {
 					// Skip malformed lines
+				}
+			}
+
+			// Attach subagent token estimates to sub-agent tool call entries
+			if (subAgentOutputTokenMap.size > 0) {
+				for (const turn of turns) {
+					for (const tc of turn.toolCalls as any[]) {
+						if (tc.isSubAgent && tc._callId) {
+							const outputTokens = subAgentOutputTokenMap.get(tc._callId) ?? 0;
+							let inputTokens = 0;
+							if (tc.arguments) {
+								try {
+									const args = JSON.parse(tc.arguments);
+									const prompt = typeof args?.prompt === 'string' ? args.prompt : tc.arguments;
+									inputTokens = this.estimateTokensFromText(prompt, cliSessionModel);
+								} catch {
+									inputTokens = this.estimateTokensFromText(tc.arguments, cliSessionModel);
+								}
+							}
+							if (outputTokens > 0 || inputTokens > 0) {
+								tc.subAgentTokens = { input: inputTokens, output: outputTokens };
+							}
+						}
+					}
 				}
 			}
 		}

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -112,8 +112,12 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 				totalTokens += estimateTokensFromText(event.data.content);
 			} else if (event.type === 'assistant.message' && event.data?.content) {
 				totalTokens += estimateTokensFromText(event.data.content);
-			} else if (event.type === 'tool.result' && event.data?.output) {
-				totalTokens += estimateTokensFromText(event.data.output);
+			} else if (event.type === 'tool.execution_complete' && event.data?.result) {
+				const result = event.data.result;
+				// Prefer detailedContent (captures full subagent prompt for task launches)
+				const text = typeof result.detailedContent === 'string' ? result.detailedContent
+					: typeof result.content === 'string' ? result.content : '';
+				if (text) { totalTokens += estimateTokensFromText(text); }
 			} else if (event.content) {
 				// Fallback for other formats that might have content
 				totalTokens += estimateTokensFromText(event.content);

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -445,6 +445,8 @@ export interface SessionLogData {
   usageAnalysis?: SessionUsageAnalysis;
   /** Session-level actual token count from LLM API (e.g. session.shutdown in CLI format). 0 when unavailable. */
   actualTokens?: number;
+  /** Number of distinct subagent sessions started (CLI format only, from subagent.started events). */
+  subAgentsStarted?: number;
 }
 
 // Local summary type for customization files (mirrors webview/shared/contextRefUtils.ts)

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -418,7 +418,7 @@ export interface ChatTurn {
   userMessage: string;
   assistantResponse: string;
   model: string | null;
-  toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string }[];
+  toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string; subAgentTokens?: { input: number; output: number } }[];
   contextReferences: ContextReferenceUsage;
   mcpTools: { server: string; tool: string }[];
   inputTokensEstimate: number;

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -691,6 +691,7 @@ function renderSessionTable(
 							<td>${formatDate(sf.lastInteraction)}</td>
 							<td>
 								<a href="#" class="view-formatted-link" data-file="${encodeURIComponent(sf.file)}" title="View formatted JSONL file">📄 View</a>
+								${(sf.editorName || sf.editorSource || "Unknown") === "Unknown" ? ` <a href="#" class="report-editor-link" data-path="${encodeURIComponent(sf.file)}" title="Report this unknown path so we can add editor support">📢 Report</a>` : ""}
 							</td>
 						</tr>
 					`,
@@ -1089,7 +1090,7 @@ function renderLayout(data: DiagnosticsData): void {
 					<td title="${escapeHtml(sf.dir)}">${escapeHtml(display)}</td>
 				<td><span class="${getEditorBadgeClass(editorName)}">${getEditorIcon(editorName)} ${escapeHtml(editorName)}</span></td>
 					<td>${sf.count}</td>
-					<td><a href="#" class="reveal-link" data-path="${encodeURIComponent(sf.dir)}">Open directory</a></td>
+					<td><a href="#" class="reveal-link" data-path="${encodeURIComponent(sf.dir)}">Open directory</a>${editorName === "Unknown" ? ` <a href="#" class="report-editor-link" data-path="${encodeURIComponent(sf.dir)}" title="Report this unknown path so we can add editor support">📢 Report</a>` : ""}</td>
 				</tr>`;
       },
     );
@@ -1838,6 +1839,17 @@ function renderLayout(data: DiagnosticsData): void {
           (link as HTMLElement).getAttribute("data-path") || "",
         );
         vscode.postMessage({ command: "revealPath", path });
+      });
+    });
+
+    // Report unknown editor path handlers
+    document.querySelectorAll(".report-editor-link").forEach((link) => {
+      link.addEventListener("click", (e) => {
+        e.preventDefault();
+        const path = decodeURIComponent(
+          (link as HTMLElement).getAttribute("data-path") || "",
+        );
+        vscode.postMessage({ command: "reportNewEditorPath", path });
       });
     });
   }

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -25,7 +25,7 @@ type ChatTurn = {
 	userMessage: string;
 	assistantResponse: string;
 	model: string | null;
-	toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string }[];
+	toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string; subAgentTokens?: { input: number; output: number } }[];
 	contextReferences: ContextReferenceUsage;
 	mcpTools: { server: string; tool: string }[];
 	inputTokensEstimate: number;
@@ -463,8 +463,9 @@ function renderTurnCard(turn: ChatTurn): string {
 							${turn.toolCalls.map((tc, idx) => `
 								<tr class="tool-row${tc.isSubAgent ? ' sub-agent-row' : ''}" data-tool-name="${tc.isSubAgent ? '__subagent__' : escapeHtml(lookupToolName(tc.toolName))}">
 									<td class="tool-name-cell">
-										<span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(tc.isSubAgent ? `🤖 ${tc.toolName}` : lookupToolName(tc.toolName))}</span>
+										<span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(tc.isSubAgent ? ({'task':'🤖 Sub-Agent','read_agent':'🤖 Sub-Agent (read)','write_agent':'🤖 Sub-Agent (write)','list_agents':'🤖 Sub-Agent (list)'}[tc.toolName] || `🤖 ${tc.toolName}`) : lookupToolName(tc.toolName))}</span>
 										${tc.isSubAgent && tc.subAgentModel ? `<span class="sub-agent-model-badge">${escapeHtml(tc.subAgentModel)}</span>` : ''}
+										${tc.isSubAgent && tc.subAgentTokens ? `<span class="sub-agent-tokens">↑${tc.subAgentTokens.input.toLocaleString()} ↓${tc.subAgentTokens.output.toLocaleString()} tokens</span>` : ''}
 										${tc.arguments && !tc.isSubAgent ? `<details class="tool-details"><summary>Arguments</summary><pre>${escapeHtml(tc.arguments)}</pre></details>` : ''}
 										${tc.result && !tc.isSubAgent ? `<details class="tool-details"><summary>Result</summary><pre>${escapeHtml(truncateText(tc.result, 500))}</pre></details>` : ''}
 									</td>
@@ -862,6 +863,15 @@ function renderLayout(data: SessionLogData): void {
 				rows.forEach(row => {
 					row.style.display = row.getAttribute('data-tool-name') === filter ? '' : 'none';
 				});
+			}
+		});
+	});
+
+	// Prevent <details> from toggling when a filter pill inside <summary> is clicked
+	document.querySelectorAll<HTMLElement>('summary.tool-calls-summary').forEach(summary => {
+		summary.addEventListener('click', (e) => {
+			if ((e.target as HTMLElement).closest('.tool-summary-item, .sub-agent-summary-item')) {
+				e.preventDefault();
 			}
 		});
 	});

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -62,6 +62,8 @@ type SessionLogData = {
 	usageAnalysis?: SessionUsageAnalysis;
 	/** Session-level actual token count from LLM API (e.g. CLI session.shutdown). 0 when unavailable. */
 	actualTokens?: number;
+	/** Number of subagent sessions started (CLI format only). */
+	subAgentsStarted?: number;
 	compactNumbers?: boolean;
 };
 
@@ -666,10 +668,12 @@ function renderLayout(data: SessionLogData): void {
 					<div class="summary-value">${effortDefaultLabel}</div>
 					<div class="summary-sub">${effortSummary}${sessionEffort.switchCount > 0 ? ` · ${sessionEffort.switchCount} switch${sessionEffort.switchCount !== 1 ? 'es' : ''}` : ''}</div>
 				</div>` : ''}
-				${totalSubAgentCalls > 0 ? `<div class="summary-card">
-					<div class="summary-label">🤖 Sub-Agent Calls</div>
-					<div class="summary-value">${totalSubAgentCalls}</div>
-					<div class="summary-sub">Agent mode sub-agent invocations</div>
+				${(totalSubAgentCalls > 0 || (data.subAgentsStarted ?? 0) > 0) ? `<div class="summary-card">
+					<div class="summary-label">🤖 Sub-Agents</div>
+					<div class="summary-value">${data.subAgentsStarted ?? totalSubAgentCalls}</div>
+					<div class="summary-sub">${data.subAgentsStarted !== undefined
+						? `${data.subAgentsStarted} started · ${totalSubAgentCalls} tool calls`
+						: 'Agent mode sub-agent invocations'}</div>
 				</div>` : ''}
 				<div class="summary-card">
 					<div class="summary-label">🔧 Tool Calls</div>

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -438,10 +438,10 @@ function renderTurnCard(turn: ChatTurn): string {
 		});
 		
 		const toolSummary = Object.entries(toolCounts)
-			.map(([name, count]) => `<span class="tool-summary-item">${escapeHtml(name)}: <strong>${count}</strong></span>`)
+			.map(([name, count]) => `<span class="tool-summary-item" data-tool-filter="${escapeHtml(name)}" data-turn="${turn.turnNumber}" title="Click to filter by ${escapeHtml(name)}">${escapeHtml(name)}: <strong>${count}</strong></span>`)
 			.join('');
 		const subAgentSummary = subAgentCallsInTurn.length > 0
-			? `<span class="sub-agent-summary-item">🤖 Sub-Agents: <strong>${subAgentCallsInTurn.length}</strong></span>`
+			? `<span class="sub-agent-summary-item" data-tool-filter="__subagent__" data-turn="${turn.turnNumber}" title="Click to filter sub-agent calls">🤖 Sub-Agents: <strong>${subAgentCallsInTurn.length}</strong></span>`
 			: '';
 		
 		toolCallsHtml = `
@@ -461,7 +461,7 @@ function renderTurnCard(turn: ChatTurn): string {
 						</thead>
 						<tbody>
 							${turn.toolCalls.map((tc, idx) => `
-								<tr class="tool-row${tc.isSubAgent ? ' sub-agent-row' : ''}">
+								<tr class="tool-row${tc.isSubAgent ? ' sub-agent-row' : ''}" data-tool-name="${tc.isSubAgent ? '__subagent__' : escapeHtml(lookupToolName(tc.toolName))}">
 									<td class="tool-name-cell">
 										<span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(tc.isSubAgent ? `🤖 ${tc.toolName}` : lookupToolName(tc.toolName))}</span>
 										${tc.isSubAgent && tc.subAgentModel ? `<span class="sub-agent-model-badge">${escapeHtml(tc.subAgentModel)}</span>` : ''}
@@ -832,6 +832,37 @@ function renderLayout(data: SessionLogData): void {
 			const turnNumber = parseInt(link.getAttribute('data-turn') || '0', 10);
 			const toolCallIdx = parseInt(link.getAttribute('data-toolcall') || '0', 10);
 			vscode.postMessage({ command: 'showToolCallPretty', turnNumber, toolCallIdx });
+		});
+	});
+
+	// Tool pill filter: clicking a pill filters the tool rows in that turn
+	document.querySelectorAll<HTMLElement>('.tool-summary-item[data-tool-filter], .sub-agent-summary-item[data-tool-filter]').forEach(pill => {
+		pill.addEventListener('click', (e) => {
+			e.stopPropagation(); // prevent <details> toggle
+			const turnNumber = pill.getAttribute('data-turn');
+			const filter = pill.getAttribute('data-tool-filter');
+			const isActive = pill.classList.contains('active');
+
+			const turnCard = document.querySelector<HTMLElement>(`.turn-card[data-turn="${turnNumber}"]`);
+			if (!turnCard) { return; }
+
+			// Clear active state from all pills in this turn
+			turnCard.querySelectorAll<HTMLElement>('.tool-summary-item, .sub-agent-summary-item').forEach(p => p.classList.remove('active'));
+
+			const rows = turnCard.querySelectorAll<HTMLElement>('tr.tool-row');
+			const detailsEl = turnCard.querySelector<HTMLDetailsElement>('details.tool-calls-details');
+
+			if (isActive) {
+				// Second click: clear filter, show all rows
+				rows.forEach(row => { row.style.display = ''; });
+			} else {
+				// Activate filter
+				pill.classList.add('active');
+				if (detailsEl) { detailsEl.open = true; }
+				rows.forEach(row => {
+					row.style.display = row.getAttribute('data-tool-name') === filter ? '' : 'none';
+				});
+			}
 		});
 	});
 

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -839,7 +839,6 @@ function renderLayout(data: SessionLogData): void {
 	// Tool pill filter: clicking a pill filters the tool rows in that turn
 	document.querySelectorAll<HTMLElement>('.tool-summary-item[data-tool-filter], .sub-agent-summary-item[data-tool-filter]').forEach(pill => {
 		pill.addEventListener('click', (e) => {
-			e.stopPropagation(); // prevent <details> toggle
 			const turnNumber = pill.getAttribute('data-turn');
 			const filter = pill.getAttribute('data-tool-filter');
 			const isActive = pill.classList.contains('active');

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -403,6 +403,19 @@ details[open] > summary .collapse-arrow {
 	padding: 2px 8px;
 	border-radius: 4px;
 	white-space: nowrap;
+	cursor: pointer;
+	transition: background 0.15s, border-color 0.15s;
+}
+
+.tool-summary-item:hover {
+	background: rgb(192, 132, 252, 0.22);
+	border-color: rgb(192, 132, 252, 0.6);
+}
+
+.tool-summary-item.active {
+	background: rgb(192, 132, 252, 0.35);
+	border-color: rgb(192, 132, 252, 0.85);
+	outline: 1px solid rgb(192, 132, 252, 0.5);
 }
 
 .tool-summary-item strong {
@@ -474,6 +487,17 @@ details[open] > summary .collapse-arrow {
 	font-size: 11px;
 	background: rgba(99, 102, 241, 0.18);
 	color: #a5b4fc;
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.sub-agent-summary-item:hover {
+	background: rgba(99, 102, 241, 0.32);
+}
+
+.sub-agent-summary-item.active {
+	background: rgba(99, 102, 241, 0.5);
+	outline: 1px solid rgba(99, 102, 241, 0.8);
 }
 
 .tool-name-cell {

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -479,6 +479,17 @@ details[open] > summary .collapse-arrow {
 	vertical-align: middle;
 }
 
+.sub-agent-tokens {
+	display: inline-block;
+	margin-left: 8px;
+	padding: 1px 7px;
+	border-radius: 10px;
+	font-size: 11px;
+	background: rgba(34, 197, 94, 0.1);
+	color: #86efac;
+	vertical-align: middle;
+}
+
 .sub-agent-summary-item {
 	display: inline-block;
 	margin-left: 6px;

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -421,10 +421,42 @@ test('estimateTokensFromJsonlSession: counts assistant.message tokens', () => {
         assert.ok(result.tokens > 0);
 });
 
-test('estimateTokensFromJsonlSession: counts tool.result tokens', () => {
+test('estimateTokensFromJsonlSession: does not count legacy tool.result tokens', () => {
+        // tool.result is the old dead event type — it should no longer count
         const content = JSON.stringify({ type: 'tool.result', data: { output: 'tool output data' } });
         const result = estimateTokensFromJsonlSession(content);
+        assert.equal(result.tokens, 0);
+});
+
+test('estimateTokensFromJsonlSession: counts tool.execution_complete content tokens', () => {
+        const content = JSON.stringify({
+                type: 'tool.execution_complete',
+                data: { result: { content: 'file contents here' } }
+        });
+        const result = estimateTokensFromJsonlSession(content);
         assert.ok(result.tokens > 0);
+});
+
+test('estimateTokensFromJsonlSession: prefers detailedContent over content in tool.execution_complete', () => {
+        const shortContent = 'short';
+        const longDetailedContent = 'a'.repeat(400); // much longer — should give more tokens
+        const eventWithBoth = JSON.stringify({
+                type: 'tool.execution_complete',
+                data: { result: { content: shortContent, detailedContent: longDetailedContent } }
+        });
+        const eventWithShort = JSON.stringify({
+                type: 'tool.execution_complete',
+                data: { result: { content: shortContent } }
+        });
+        const resultBoth = estimateTokensFromJsonlSession(eventWithBoth);
+        const resultShort = estimateTokensFromJsonlSession(eventWithShort);
+        assert.ok(resultBoth.tokens > resultShort.tokens, 'detailedContent should be used when present');
+});
+
+test('estimateTokensFromJsonlSession: skips tool.execution_complete when result is missing', () => {
+        const content = JSON.stringify({ type: 'tool.execution_complete', data: {} });
+        const result = estimateTokensFromJsonlSession(content);
+        assert.equal(result.tokens, 0);
 });
 
 test('estimateTokensFromJsonlSession: uses session.shutdown actual tokens', () => {


### PR DESCRIPTION
## Summary

Fixes two issues with subagent sessions in the CLI token tracker:

### 1. Fix dead token estimation code (`tokenEstimation.ts`)
- Replaced dead `tool.result` event check with correct `tool.execution_complete` event
- Result tokens are now read from `result.detailedContent` (preferred, captures full subagent prompt for `task` launches) with fallback to `result.content`
- Bumped `CACHE_VERSION` 43→44 to invalidate stale estimates

### 2. Show subagent count in log viewer (`extension.ts`, `types.ts`, `logviewer/main.ts`)
- Added `subAgentsStarted?: number` to `SessionLogData` interface
- CLI JSONL parser now counts `subagent.started` events and surfaces the count in the session data
- Log viewer "🤖 Sub-Agents" summary card now shows the semantically correct count (subagents started) with a breakdown: `N started · M tool calls`

### 3. Fix CLI parser subagent pollution bug (`extension.ts`)
- Tool call events with `parentToolCallId` (belonging to subagents) are now filtered out from the parent turn's tool list, preventing subagent's own tool calls from inflating the parent session's tool count

### Tests
- Replaced stale `tool.result` test with new `tool.execution_complete` tests covering:
  - Basic content counting
  - `detailedContent` preference over `content` when both present
  - Missing `result` field (no crash, 0 tokens)
  - Legacy `tool.result` events now correctly return 0 tokens

All 46 test files pass.