### PR TITLE
Add dev.ps1 convenience script for VS Code extension development

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+# Quick dev setup for the VS Code extension: install deps, compile, then open VS Code.
+
+Push-Location "$PSScriptRoot/vscode-extension"
+
+try {
+    npm ci && npm run compile
+    if ($LASTEXITCODE -eq 0) {
+        code .
+    } else {
+        Write-Error "Build failed — VS Code will not be opened."
+    }
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Why

Setting up the VS Code extension for local development requires three manual steps every time: changing into the subfolder, installing dependencies, compiling, and opening VS Code. This script bundles all of that into a single command from the repo root.

## What

Adds `dev.ps1` to the repo root. Running `./dev.ps1` will:

1. `npm ci` -- install/sync dependencies in `vscode-extension/`
2. `npm run compile` -- build the extension
3. `code .` -- open VS Code in the `vscode-extension/` folder (only if the build succeeded)

Uses `Push-Location`/`Pop-Location` so the caller's working directory is preserved after the script exits.