### PR TITLE
fix: change esbuild prelaunch task to type process

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,8 +21,9 @@
     },
     {
       "label": "esbuild",
-      "type": "shell",
-      "command": "node esbuild.js",
+      "type": "process",
+      "command": "node",
+      "args": ["esbuild.js"],
       "options": {
         "cwd": "${workspaceFolder}/vscode-extension"
       },


### PR DESCRIPTION
## Problem

When pressing F5 in VS Code, the "Run Extension" launch config was getting stuck on the `esbuild` prelaunch task -- showing "waiting for prelaunch task" even after the build had clearly completed (the PowerShell prompt returned).

The root cause: VS Code creates a full **interactive PowerShell session** for `type: "shell"` tasks. A custom shell prompt (oh-my-posh/starship) interferes with VS Code's shell integration markers, so VS Code can't reliably detect when the command inside the shell has finished. It keeps waiting indefinitely.

## Fix

Changed the `esbuild` task in `.vscode/tasks.json` from `type: "shell"` to `type: "process"`, running `node` directly with `esbuild.js` as an argument.

```diff
- "type": "shell",
- "command": "node esbuild.js",
+ "type": "process",
+ "command": "node",
+ "args": ["esbuild.js"],
```

VS Code now tracks the Node.js process exit directly -- no shell wrapper, no shell integration quirks, no profile loading delay. The prelaunch task unblocks F5 immediately when the build finishes.