### PR TITLE
feat: dual-publish VS Code extension under new AI Engineering Fluency ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       version: ${{ steps.extract_version.outputs.tag_version }}
       tag_name: ${{ steps.tag_name.outputs.tag_name }}
       vsix_file: ${{ steps.vsix_filename.outputs.vsix_file }}
+      legacy_vsix_file: ${{ steps.vsix_filename.outputs.legacy_vsix_file }}
     
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -259,21 +260,44 @@ jobs:
       working-directory: vscode-extension
       run: npx vsce package
       
+    - name: Create legacy VSIX (copilot-token-tracker)
+      if: inputs.vs_only != true
+      working-directory: vscode-extension
+      run: |
+        node -e "
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+          pkg.name = 'copilot-token-tracker';
+          fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+        "
+        npx vsce package
+        node -e "
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+          pkg.name = 'ai-engineering-fluency';
+          fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+        "
+
     - name: Get VSIX filename
       if: inputs.vs_only != true
       id: vsix_filename
       working-directory: vscode-extension
       run: |
-        VSIX_FILE=$(find . -maxdepth 1 -name "*.vsix" -exec basename {} \; | head -n 1)
+        VSIX_FILE=$(find . -maxdepth 1 -name "ai-engineering-fluency-*.vsix" -exec basename {} \; | head -n 1)
+        LEGACY_VSIX_FILE=$(find . -maxdepth 1 -name "copilot-token-tracker-*.vsix" -exec basename {} \; | head -n 1)
         echo "vsix_file=$VSIX_FILE" >> "$GITHUB_OUTPUT"
-        echo "VSIX file: $VSIX_FILE"
+        echo "legacy_vsix_file=$LEGACY_VSIX_FILE" >> "$GITHUB_OUTPUT"
+        echo "Primary VSIX: $VSIX_FILE"
+        echo "Legacy VSIX:  $LEGACY_VSIX_FILE"
 
     - name: Upload VSIX as workflow artifact
       if: inputs.vs_only != true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: vsix-package
-        path: vscode-extension/${{ steps.vsix_filename.outputs.vsix_file }}
+        path: |
+          vscode-extension/${{ steps.vsix_filename.outputs.vsix_file }}
+          vscode-extension/${{ steps.vsix_filename.outputs.legacy_vsix_file }}
         retention-days: 90
         
     - name: Create Release
@@ -289,15 +313,16 @@ jobs:
         
         # Create release (skip if it already exists — e.g. re-running after a downstream job failure)
         TAG="${{ steps.tag_name.outputs.tag_name }}"
+        PRIMARY_VSIX="vscode-extension/${{ steps.vsix_filename.outputs.vsix_file }}"
+        LEGACY_VSIX="vscode-extension/${{ steps.vsix_filename.outputs.legacy_vsix_file }}"
         if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-          echo "ℹ️ Release $TAG already exists — uploading VSIX with --clobber"
-          gh release upload "$TAG" \
-            vscode-extension/${{ steps.vsix_filename.outputs.vsix_file }} --clobber 2>&1 | tee /tmp/release_output.txt
+          echo "ℹ️ Release $TAG already exists — uploading VSIXs with --clobber"
+          gh release upload "$TAG" "$PRIMARY_VSIX" "$LEGACY_VSIX" --clobber 2>&1 | tee /tmp/release_output.txt
         else
           gh release create "$TAG" \
             --title "VS Code Extension v${{ steps.extract_version.outputs.tag_version }}" \
             --notes-file /tmp/release_notes.md \
-            vscode-extension/${{ steps.vsix_filename.outputs.vsix_file }} 2>&1 | tee /tmp/release_output.txt
+            "$PRIMARY_VSIX" "$LEGACY_VSIX" 2>&1 | tee /tmp/release_output.txt
         fi
 
     - name: Release Summary
@@ -368,7 +393,7 @@ jobs:
           "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=3.0-preview.1" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json;api-version=3.0-preview.1" \
-          -d '{"filters":[{"criteria":[{"filterType":7,"value":"RobBos.copilot-token-tracker"}]}],"flags":512}' \
+          -d '{"filters":[{"criteria":[{"filterType":7,"value":"RobBos.ai-engineering-fluency"}]}],"flags":512}' \
           | jq -r '.results[0].extensions[0].versions[0].version // empty')
 
         if [ -z "$MARKETPLACE_VERSION" ]; then
@@ -397,20 +422,23 @@ jobs:
       working-directory: vscode-extension
       run: npm ci
 
-    - name: Download VSIX from release
+    - name: Download VSIXs from release
       id: download_vsix
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         TAG_NAME="${{ needs.release.outputs.tag_name }}"
-        echo "Downloading VSIX from release $TAG_NAME..."
+        echo "Downloading VSIXs from release $TAG_NAME..."
         gh release download "$TAG_NAME" \
           --repo "${{ github.repository }}" \
           --pattern "*.vsix" \
           --dir .
-        VSIX_FILE=$(find . -maxdepth 1 -name "*.vsix" -exec basename {} \; | head -n 1)
-        echo "Downloaded: $VSIX_FILE"
-        echo "vsix_file=$VSIX_FILE" >> "$GITHUB_OUTPUT"
+        PRIMARY_VSIX=$(find . -maxdepth 1 -name "ai-engineering-fluency-*.vsix" -exec basename {} \; | head -n 1)
+        LEGACY_VSIX=$(find . -maxdepth 1 -name "copilot-token-tracker-*.vsix" -exec basename {} \; | head -n 1)
+        echo "Primary VSIX: $PRIMARY_VSIX"
+        echo "Legacy VSIX:  $LEGACY_VSIX"
+        echo "vsix_file=$PRIMARY_VSIX" >> "$GITHUB_OUTPUT"
+        echo "legacy_vsix_file=$LEGACY_VSIX" >> "$GITHUB_OUTPUT"
 
     - name: Publish to VS Code Marketplace
       id: publish
@@ -427,6 +455,11 @@ jobs:
         echo "Publishing ${{ steps.download_vsix.outputs.vsix_file }} to VS Code Marketplace..."
         npx vsce publish \
           --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
+          --pat "$VSCE_PAT"
+        
+        echo "Publishing ${{ steps.download_vsix.outputs.legacy_vsix_file }} to VS Code Marketplace (legacy ID)..."
+        npx vsce publish \
+          --packagePath "${{ steps.download_vsix.outputs.legacy_vsix_file }}" \
           --pat "$VSCE_PAT"
 
     - name: Publish to Open VSX Registry
@@ -445,6 +478,11 @@ jobs:
           --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
           -p "$OPEN_VSX_TOKEN"
 
+        echo "Publishing ${{ steps.download_vsix.outputs.legacy_vsix_file }} to Open VSX Registry (legacy ID)..."
+        npx --yes ovsx publish \
+          --packagePath "${{ steps.download_vsix.outputs.legacy_vsix_file }}" \
+          -p "$OPEN_VSX_TOKEN"
+
     - name: Publish Summary
       if: always()
       run: |
@@ -452,9 +490,9 @@ jobs:
           echo "# 🚀 VS Code Marketplace"
           echo ""
           if [ "${{ steps.publish.outcome }}" == "success" ]; then
-            echo "✅ Extension v${{ needs.release.outputs.version }} published to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker)"
+            echo "✅ Extension v${{ needs.release.outputs.version }} published to the [VS Code Marketplace (new ID)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency) and [legacy ID](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker)"
           elif [ "${{ steps.version_check.outcome }}" == "failure" ]; then
-            echo "⏭️ Publish skipped — v${{ needs.release.outputs.version }} is already live on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker)."
+            echo "⏭️ Publish skipped — v${{ needs.release.outputs.version }} is already live on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency)."
             echo ""
             echo "Bump the version in \`vscode-extension/package.json\` before publishing again."
           else
@@ -467,7 +505,7 @@ jobs:
           echo "# 🌐 Open VSX Registry"
           echo ""
           if [ "${{ steps.publish_open_vsx.outcome }}" == "success" ]; then
-            echo "✅ Extension v${{ needs.release.outputs.version }} published to the [Open VSX Registry](https://open-vsx.org/extension/RobBos/copilot-token-tracker)"
+            echo "✅ Extension v${{ needs.release.outputs.version }} published to the [Open VSX Registry](https://open-vsx.org/extension/RobBos/ai-engineering-fluency)"
           elif [ "${{ steps.publish_open_vsx.outcome }}" == "skipped" ]; then
             echo "⏭️ Open VSX publish skipped."
           else

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "copilot-token-tracker",
+  "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
   "version": "0.3.0",

--- a/vscode-extension/publish.ps1
+++ b/vscode-extension/publish.ps1
@@ -7,11 +7,18 @@
 # Use this script only when you need to manually publish a pre-built VSIX
 # (e.g., re-publishing after a marketplace upload failure).
 #
+# The extension is published under two IDs (dual-publish):
+#   - RobBos.ai-engineering-fluency  (new/primary ID)
+#   - RobBos.copilot-token-tracker   (legacy ID – kept for existing users)
+#
 # Usage:
-#   .\publish.ps1 -VsixPath ".\copilot-token-tracker-0.0.18.vsix"
+#   .\publish.ps1 -VsixPath ".\ai-engineering-fluency-0.3.0.vsix"
+#   .\publish.ps1 -LegacyVsixPath ".\copilot-token-tracker-0.3.0.vsix"
+#   .\publish.ps1  # auto-detect both VSIXs in the current directory
 
 param(
-    [string]$VsixPath  # Path to the .vsix downloaded from the GitHub release
+    [string]$VsixPath,        # Path to the primary (ai-engineering-fluency) .vsix
+    [string]$LegacyVsixPath   # Path to the legacy (copilot-token-tracker) .vsix
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,15 +31,25 @@ $owner        = "rajbos"
 $repo         = "github-copilot-token-usage"
 $publisherName = "RobBos"
 
-# ── Resolve / prompt for VSIX path ───────────────────────────────────────────
+# ── Resolve / prompt for primary VSIX path ───────────────────────────────────
 if ([string]::IsNullOrWhiteSpace($VsixPath)) {
-    # Default: look for a matching VSIX in the current directory
-    $defaultVsix = ".\copilot-token-tracker-$version.vsix"
+    $defaultVsix = ".\ai-engineering-fluency-$version.vsix"
     if (Test-Path $defaultVsix) {
         $VsixPath = $defaultVsix
-        Write-Host "Found VSIX: $VsixPath" -ForegroundColor Green
+        Write-Host "Found primary VSIX: $VsixPath" -ForegroundColor Green
     } else {
-        $VsixPath = Read-Host "Enter path to the .vsix downloaded from the GitHub release"
+        $VsixPath = Read-Host "Enter path to the primary (ai-engineering-fluency) .vsix"
+    }
+}
+
+# ── Resolve legacy VSIX path (optional) ──────────────────────────────────────
+if ([string]::IsNullOrWhiteSpace($LegacyVsixPath)) {
+    $defaultLegacy = ".\copilot-token-tracker-$version.vsix"
+    if (Test-Path $defaultLegacy) {
+        $LegacyVsixPath = $defaultLegacy
+        Write-Host "Found legacy VSIX:  $LegacyVsixPath" -ForegroundColor Green
+    } else {
+        Write-Host "⚠️  Legacy VSIX not found at $defaultLegacy — will only publish primary ID." -ForegroundColor Yellow
     }
 }
 
@@ -118,20 +135,33 @@ if ([string]::IsNullOrWhiteSpace($pat)) {
     Write-Host "✅ VSCE_PAT environment variable found." -ForegroundColor Green
 }
 
-# ── Step 4: Publish the downloaded VSIX ──────────────────────────────────────
-Write-Host "`nPublishing $VsixPath to the VS Code Marketplace..." -ForegroundColor Cyan
+# ── Step 4: Publish the primary VSIX (ai-engineering-fluency) ────────────────
+Write-Host "`nPublishing $VsixPath to the VS Code Marketplace (primary ID)..." -ForegroundColor Cyan
 npx vsce publish --packagePath $VsixPath --pat $pat
 
-if ($LASTEXITCODE -eq 0) {
-    Write-Host "`n✅ Extension published successfully!" -ForegroundColor Green
-    Write-Host "It may take a few minutes to appear in the marketplace." -ForegroundColor Gray
-    Write-Host ""
-    Write-Host "📝 Commit and push the updated CHANGELOG.md:" -ForegroundColor Cyan
-    Write-Host "   git add CHANGELOG.md" -ForegroundColor Gray
-    Write-Host "   git commit -m 'chore: sync changelog for $expectedTag'" -ForegroundColor Gray
-    Write-Host "   git push" -ForegroundColor Gray
-} else {
-    Write-Host "`n❌ Publishing failed. Check the error messages above." -ForegroundColor Red
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "`n❌ Publishing primary VSIX failed. Check the error messages above." -ForegroundColor Red
     exit 1
 }
+Write-Host "✅ Primary extension published successfully!" -ForegroundColor Green
 
+# ── Step 5: Publish the legacy VSIX (copilot-token-tracker) ──────────────────
+if (-not [string]::IsNullOrWhiteSpace($LegacyVsixPath) -and (Test-Path $LegacyVsixPath)) {
+    Write-Host "`nPublishing $LegacyVsixPath to the VS Code Marketplace (legacy ID)..." -ForegroundColor Cyan
+    npx vsce publish --packagePath $LegacyVsixPath --pat $pat
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "✅ Legacy extension published successfully!" -ForegroundColor Green
+    } else {
+        Write-Host "⚠️  Legacy VSIX publish failed — primary was already published. Check errors above." -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "⚠️  Skipping legacy VSIX publish (not found)." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "It may take a few minutes to appear in the marketplace." -ForegroundColor Gray
+Write-Host ""
+Write-Host "📝 Commit and push the updated CHANGELOG.md:" -ForegroundColor Cyan
+Write-Host "   git add CHANGELOG.md" -ForegroundColor Gray
+Write-Host "   git commit -m 'chore: sync changelog for $expectedTag'" -ForegroundColor Gray
+Write-Host "   git push" -ForegroundColor Gray

--- a/vscode-extension/src/backend/copyConfig.ts
+++ b/vscode-extension/src/backend/copyConfig.ts
@@ -74,7 +74,7 @@ export async function copyBackendConfigToClipboard(settings: BackendSettings): P
 				includeMachineBreakdown: settings.includeMachineBreakdown
 			},
 			machineId: '<redacted>', // Fully redact machineId
-			extensionVersion: vscode.extensions.getExtension('RobBos.copilot-token-tracker')?.packageJSON?.version || 'unknown',
+			extensionVersion: (vscode.extensions.getExtension('RobBos.ai-engineering-fluency') ?? vscode.extensions.getExtension('RobBos.copilot-token-tracker'))?.packageJSON?.version || 'unknown',
 			note: 'This config does NOT include secrets (Storage Shared Key), machineId, sessionId, or home directory. Share safely.'
 		};
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5112,7 +5112,7 @@ private async resetDismissedFluencyTips(): Promise<void> {
  */
 private async shareToSocialMedia(platform: 'linkedin' | 'bluesky' | 'mastodon'): Promise<void> {
 	const scores = await this.calculateMaturityScores();
-	const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker';
+	const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency';
 	const hashtag = '#CopilotFluencyScore';
 	
 	// Build share text with stats
@@ -6511,7 +6511,7 @@ ${hashtag}`;
     // Extension Information
     report.push("## Extension Information");
     report.push(
-      `Extension Version: ${vscode.extensions.getExtension("RobBos.copilot-token-tracker")?.packageJSON.version || "Unknown"}`,
+      `Extension Version: ${(vscode.extensions.getExtension("RobBos.ai-engineering-fluency") ?? vscode.extensions.getExtension("RobBos.copilot-token-tracker"))?.packageJSON.version || "Unknown"}`,
     );
     report.push(`VS Code Version: ${vscode.version}`);
     report.push("");
@@ -7613,27 +7613,30 @@ ${hashtag}`;
     // Try to locate the actual storage file (state DB) for the extension global state
     let storageFilePath: string | null = null;
     try {
-      const extensionId = "RobBos.copilot-token-tracker";
+      // Check both IDs so the diagnostic works whether the user installed the new or legacy extension ID
+      const extensionIds = ["RobBos.ai-engineering-fluency", "RobBos.copilot-token-tracker"];
       const userPaths = getVSCodeUserPaths();
-      for (const userPath of userPaths) {
-        try {
-          const candidate = path.join(userPath, "globalStorage", extensionId);
-          if (fs.existsSync(candidate)) {
-            const files = fs.readdirSync(candidate);
-            // Look for likely state files
-            const match = files.find(
-              (f) =>
-                f.includes("state") ||
-                f.endsWith(".vscdb") ||
-                f.endsWith(".json"),
-            );
-            if (match) {
-              storageFilePath = path.join(candidate, match);
-              break;
+      outer: for (const userPath of userPaths) {
+        for (const extId of extensionIds) {
+          try {
+            const candidate = path.join(userPath, "globalStorage", extId);
+            if (fs.existsSync(candidate)) {
+              const files = fs.readdirSync(candidate);
+              // Look for likely state files
+              const match = files.find(
+                (f) =>
+                  f.includes("state") ||
+                  f.endsWith(".vscdb") ||
+                  f.endsWith(".json"),
+              );
+              if (match) {
+                storageFilePath = path.join(candidate, match);
+                break outer;
+              }
             }
+          } catch (e) {
+            // ignore path access errors
           }
-        } catch (e) {
-          // ignore path access errors
         }
       }
     } catch (e) {

--- a/vscode-extension/test/integration/extension.test.ts
+++ b/vscode-extension/test/integration/extension.test.ts
@@ -14,12 +14,12 @@ suite('Extension Test Suite', () => {
 	});
 
 	test('Extension should be present', () => {
-		const extension = vscode.extensions.getExtension('RobBos.copilot-token-tracker');
+		const extension = vscode.extensions.getExtension('RobBos.ai-engineering-fluency');
 		assert.ok(extension, 'Extension should be installed');
 	});
 
 	test('Commands should be registered', async () => {
-		const extension = vscode.extensions.getExtension('RobBos.copilot-token-tracker');
+		const extension = vscode.extensions.getExtension('RobBos.ai-engineering-fluency');
 		if (extension && !extension.isActive) {
 			await extension.activate();
 		}

--- a/vscode-extension/test/unit/vscode-shim-register.ts
+++ b/vscode-extension/test/unit/vscode-shim-register.ts
@@ -269,7 +269,7 @@ function attachMock(target: any): void {
 
 	target.extensions = target.extensions ?? {};
 	target.extensions.getExtension = target.extensions.getExtension ?? ((id: string) => {
-		if (id === 'RobBos.copilot-token-tracker') {
+		if (id === 'RobBos.ai-engineering-fluency' || id === 'RobBos.copilot-token-tracker') {
 			return { packageJSON: { version: '0.0.0-test' } };
 		}
 		return state.extensions[id] as any;


### PR DESCRIPTION
## Summary

Renames the VS Code extension's marketplace ID from `RobBos.copilot-token-tracker` to `RobBos.ai-engineering-fluency` while keeping the legacy ID active — existing users continue to receive updates.

## How it works

The release workflow now builds and packages the extension **twice** (one compile, two `vsce package` runs):

| VSIX | Marketplace ID | Audience |
|---|---|---|
| `ai-engineering-fluency-{version}.vsix` | `RobBos.ai-engineering-fluency` | New installs, search by name |
| `copilot-token-tracker-{version}.vsix` | `RobBos.copilot-token-tracker` | Existing users — keeps auto-updates working |

Both VSIXs are:
- Uploaded to the GitHub release
- Published to VS Code Marketplace
- Published to Open VSX Registry

## Changes

- **`vscode-extension/package.json`** — `name`: `copilot-token-tracker` → `ai-engineering-fluency`
- **`release.yml`** — add legacy VSIX build step; upload/publish both; update version-check URL to new ID
- **`extension.ts`** — `getExtension()` and marketplace URL updated; storage path lookup searches both IDs
- **`copyConfig.ts`** — `getExtension()` fallback for both IDs
- **`integration test` + `vscode shim`** — updated to new primary extension ID
- **`publish.ps1`** — auto-detects and publishes both VSIXs for manual fallback runs

## Visual Studio

No change needed — already published under `AIEngineeringFluency.VS.RobBos`, never published under the old ID.