### PR TITLE
fix: handle cert timeout leaving non-Succeeded state in Azure

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -240,7 +240,35 @@ jobs:
             | sed 's/.*= "\(.*\)".*/\1/' || true)
 
           if [[ "$CURRENT_CERT_NAME" == "$EXPECTED_CERT_NAME" ]]; then
-            echo "Cert already TF-managed as '$EXPECTED_CERT_NAME'. No cleanup needed."
+            # Cert is in TF state — verify it actually reached Succeeded in Azure.
+            # A previous apply may have timed out while polling (context deadline exceeded),
+            # leaving the cert in Azure in a non-Succeeded state but still tracked in TF state.
+            # In that case re-applying without cleanup would hit the same timeout again.
+            AZURE_CERT_PROV=$(az containerapp env certificate list \
+              --name "$ENV_NAME" \
+              --resource-group "$TF_VAR_resource_group_name" \
+              --query "[?name=='$EXPECTED_CERT_NAME'].properties.provisioningState | [0]" \
+              -o tsv 2>/dev/null || true)
+
+            if [[ "$AZURE_CERT_PROV" == "Succeeded" ]]; then
+              echo "Cert already TF-managed as '$EXPECTED_CERT_NAME' and Succeeded in Azure. No cleanup needed."
+            else
+              echo "Cert '$EXPECTED_CERT_NAME' is in TF state but Azure provisioning state is '${AZURE_CERT_PROV:-not found}'. Cleaning up so Terraform can recreate it."
+              az containerapp hostname delete \
+                --name "$TF_VAR_app_name" \
+                --resource-group "$TF_VAR_resource_group_name" \
+                --hostname "$TF_VAR_custom_domain" --yes 2>/dev/null || true
+              az containerapp env certificate delete \
+                --name "$ENV_NAME" \
+                --resource-group "$TF_VAR_resource_group_name" \
+                --certificate "$EXPECTED_CERT_NAME" --yes 2>/dev/null || true
+              # Remove all three dependent state entries so Terraform re-runs them in order:
+              # hostname_registration → managed_certificate → cert_binding
+              terraform state rm 'null_resource.hostname_registration[0]' 2>/dev/null || true
+              terraform state rm 'null_resource.cert_binding[0]' 2>/dev/null || true
+              terraform state rm 'azurerm_container_app_environment_managed_certificate.this[0]' 2>/dev/null || true
+              echo "Cleanup done. Terraform will recreate hostname registration, cert, and domain binding from scratch."
+            fi
           else
             # Cert is absent from TF state or has a mismatched name.
             # Before deleting anything, check whether the correctly-named cert already


### PR DESCRIPTION
## Problem

When the managed certificate creation times out (`context deadline exceeded` after 60 min), the cert can be left in Azure in a non-`Succeeded` state while still tracked in Terraform state as `sharing-cert`.

On the next deployment, the reconcile step hit the early-exit branch — `"Cert already TF-managed as 'sharing-cert'. No cleanup needed."` — and proceeded straight to `terraform apply`. This caused the apply to fail again (or stall) because Azure still had the cert in a bad provisioning state.

## Fix

When the cert **is** in TF state as the expected name, the reconcile step now queries Azure's `provisioningState`. If it's not `Succeeded`, it:

1. Deletes the hostname binding from the container app
2. Deletes the cert from the managed environment
3. Removes `null_resource.hostname_registration[0]`, `null_resource.cert_binding[0]`, and `azurerm_container_app_environment_managed_certificate.this[0]` from TF state

This forces Terraform to recreate all three resources in the correct dependency order on the next apply.

## To recover from the current failure

Just re-run the `Deploy Sharing Server` workflow with `deploy_to_test=true` — the reconcile step will now detect the stuck cert and clean it up automatically before the apply.