### PR TITLE
fix: don't pass custom domain to branch test environments

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -349,7 +349,10 @@ jobs:
           TF_VAR_github_org_check_token: ${{ secrets.ORG_CHECK_TOKEN }}
           TF_VAR_admin_github_logins: ${{ vars.SHARING_ADMIN_GITHUB_LOGINS }}
           TF_VAR_min_replicas:        ${{ needs.setup.outputs.min_replicas }}
-          TF_VAR_custom_domain:       ${{ vars.SHARING_CUSTOM_DOMAIN }}
+          # Only pass custom domain to stable environments — branch test envs use the ACA FQDN.
+          # Passing a custom domain to a branch env causes cert creation to fail (CNAME points
+          # to the stable env's ACA FQDN, not the branch env).
+          TF_VAR_custom_domain:       ${{ needs.setup.outputs.allow_custom_domain == 'true' && vars.SHARING_CUSTOM_DOMAIN || '' }}
         run: terraform plan -out=tfplan
 
       - name: Terraform apply
@@ -367,7 +370,7 @@ jobs:
           TF_VAR_github_org_check_token: ${{ secrets.ORG_CHECK_TOKEN }}
           TF_VAR_admin_github_logins: ${{ vars.SHARING_ADMIN_GITHUB_LOGINS }}
           TF_VAR_min_replicas:        ${{ needs.setup.outputs.min_replicas }}
-          TF_VAR_custom_domain:       ${{ vars.SHARING_CUSTOM_DOMAIN }}
+          TF_VAR_custom_domain:       ${{ needs.setup.outputs.allow_custom_domain == 'true' && vars.SHARING_CUSTOM_DOMAIN || '' }}
         run: terraform apply -auto-approve tfplan
 
       - name: Health check


### PR DESCRIPTION
## Problem

Branch test environments have `allow_custom_domain=false` set by the setup job, but the Terraform **plan** and **apply** steps were always passing `TF_VAR_custom_domain: ${{ vars.SHARING_CUSTOM_DOMAIN }}` unconditionally.

Since `SHARING_CUSTOM_DOMAIN` is configured on the `testing` GitHub environment (`ai-fluency-server-test.devopsjournal.io`), **every** branch test deployment tried to create a managed cert, which failed with:

```
400 Bad Request: RequireCustomHostnameInEnvironment: Creating managed certificate requires
hostname 'ai-fluency-server-test.devopsjournal.io' added as a custom hostname to a container
app or route in environment 'sharing-test-<slug>-env'
```

The CNAME for `ai-fluency-server-test.devopsjournal.io` points to the **stable test env**'s ACA FQDN, not a branch env — so cert provisioning can never succeed for branch envs.

Observed in run [#25188392457](https://github.com/rajbos/ai-engineering-fluency/actions/runs/25188392457) triggered from branch `rajbos/jetbrains-extension-plan`.

## Fix

Gate `TF_VAR_custom_domain` on `allow_custom_domain` in both Terraform plan and apply steps:

```yaml
TF_VAR_custom_domain: ${{ needs.setup.outputs.allow_custom_domain == 'true' && vars.SHARING_CUSTOM_DOMAIN || '' }}
```

Branch test envs now always receive an empty `TF_VAR_custom_domain`, so Terraform skips cert/hostname resources entirely and uses the ACA-generated FQDN (which already has Azure TLS).