### PR TITLE
feat: add DNS drift detection to sharing server deploy workflow

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -391,6 +391,56 @@ jobs:
           echo "❌ Health check failed after 2 minutes"
           exit 1
 
+      - name: DNS drift check
+        if: steps.prereqs.outputs.configured == 'true' && needs.setup.outputs.allow_custom_domain == 'true'
+        working-directory: sharing-server/infra
+        env:
+          CUSTOM_DOMAIN: ${{ needs.setup.outputs.allow_custom_domain == 'true' && vars.SHARING_CUSTOM_DOMAIN || '' }}
+        run: |
+          if [[ -z "$CUSTOM_DOMAIN" ]]; then
+            echo "No custom domain configured — skipping DNS drift check."
+            exit 0
+          fi
+
+          ACA_FQDN=$(terraform output -raw aca_fqdn)
+
+          # Resolve the CNAME chain for the custom domain (dig follows CNAMEs).
+          # We only care about the final CNAME target, not the A record.
+          RESOLVED=$(dig +short CNAME "$CUSTOM_DOMAIN" 2>/dev/null | sed 's/\.$//')
+
+          if [[ -z "$RESOLVED" ]]; then
+            echo "::warning::DNS drift: no CNAME record found for ${CUSTOM_DOMAIN}. Expected CNAME → ${ACA_FQDN}"
+            {
+              echo ""
+              echo "## ⚠️ DNS Drift Detected"
+              echo ""
+              echo "No CNAME record found for \`${CUSTOM_DOMAIN}\`."
+              echo ""
+              echo "**Expected CNAME target:** \`${ACA_FQDN}\`"
+              echo ""
+              echo "Add or update the CNAME record at your DNS provider:"
+              echo "\`\`\`"
+              echo "CNAME ${CUSTOM_DOMAIN} → ${ACA_FQDN}"
+              echo "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$RESOLVED" != "$ACA_FQDN" ]]; then
+            echo "::warning::DNS drift: ${CUSTOM_DOMAIN} CNAME → ${RESOLVED} but expected → ${ACA_FQDN}"
+            {
+              echo ""
+              echo "## ⚠️ DNS Drift Detected"
+              echo ""
+              echo "| | Value |"
+              echo "|---|---|"
+              echo "| Custom domain | \`${CUSTOM_DOMAIN}\` |"
+              echo "| Current CNAME target | \`${RESOLVED}\` |"
+              echo "| Expected CNAME target | \`${ACA_FQDN}\` |"
+              echo ""
+              echo "Update the CNAME record at your DNS provider to point to \`${ACA_FQDN}\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ DNS OK: ${CUSTOM_DOMAIN} CNAME → ${ACA_FQDN}"
+          fi
+
       - name: Output deployment summary
         if: steps.prereqs.outputs.configured == 'true'
         working-directory: sharing-server/infra


### PR DESCRIPTION
## What

Adds a **DNS drift check** step to the sharing server deploy workflow. After each deployment to an environment with a custom domain, it resolves the CNAME and compares it against the Terraform-managed ACA FQDN.

## Why

We deployed the latest `main` to the test environment but the custom domain (`ai-fluency-server-test.devopsjournal.io`) was still pointing to an old per-branch ACA app (`sharing-test-rajbos-azure...`) instead of the stable `sharing-server-test` environment. This meant the deploy succeeded but the site showed stale code — no footer, no admin dashboard updates.

This check would have immediately surfaced the mismatch as a workflow warning + job summary table.

## How it works

- Runs after the health check, only on environments with `allow_custom_domain == true` and a `SHARING_CUSTOM_DOMAIN` configured
- Uses `dig +short CNAME` to resolve the current DNS target
- Compares against `terraform output -raw aca_fqdn`
- If mismatched: emits `::warning::` annotation + writes a drift table to the job summary
- If missing: warns about missing CNAME
- If OK: logs ✅

The step is non-blocking (warning only, not failure) — DNS drift doesn't mean the deploy failed, just that traffic isn't reaching the new deployment yet.