### PR TITLE
fix(cli): align token counting with VS Code extension

### DIFF
--- a/cli/src/cliCache.ts
+++ b/cli/src/cliCache.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import type { SessionData } from './helpers';
 
 /** Bump this when the SessionData shape changes to force a full re-parse. */
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
 
 /** Maximum number of entries to keep in the cache file. */
 const MAX_CACHE_ENTRIES = 2000;

--- a/cli/src/commands/diagnostics.ts
+++ b/cli/src/commands/diagnostics.ts
@@ -4,7 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as path from 'path';
-import { discoverSessionFiles, getDiagnosticPaths, processSessionFile, fmt, formatTokens } from '../helpers';
+import { discoverSessionFiles, getDiagnosticPaths, processSessionFile, effectiveTokens, fmt, formatTokens } from '../helpers';
 
 interface LocationStats {
 	label: string;
@@ -159,10 +159,10 @@ export const diagnosticsCommand = new Command('diagnostics')
 			if (data && data.tokens > 0) {
 				loc.sessions++;
 				loc.interactions += data.interactions;
-				loc.tokens += data.tokens;
+				loc.tokens += effectiveTokens(data);
 				totalSessions++;
 				totalInteractions += data.interactions;
-				totalTokens += data.tokens;
+				totalTokens += effectiveTokens(data);
 			}
 		}
 
@@ -204,7 +204,7 @@ export const diagnosticsCommand = new Command('diagnostics')
 		console.log(`  Total files found:      ${chalk.bold(fmt(totalFiles))}`);
 		console.log(`  Files with data:        ${chalk.bold(fmt(totalSessions))}`);
 		console.log(`  Total chat turns:       ${chalk.bold(fmt(totalInteractions))}`);
-		console.log(`  Total tokens (est.):    ${chalk.bold.yellow(formatTokens(totalTokens))}`);
+		console.log(`  Total tokens:           ${chalk.bold.yellow(formatTokens(totalTokens))}`);
 
 		if (missing.length > 0) {
 			console.log();

--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -3,7 +3,7 @@
  */
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { discoverSessionFiles, processSessionFile, getDiagnosticPaths, fmt, formatTokens, getCacheStats } from '../helpers';
+import { discoverSessionFiles, processSessionFile, effectiveTokens, getDiagnosticPaths, fmt, formatTokens, getCacheStats } from '../helpers';
 
 export const statsCommand = new Command('stats')
 	.description('Show overview of discovered session files, sessions, chat turns, and tokens')
@@ -53,7 +53,7 @@ export const statsCommand = new Command('stats')
 			}
 
 			processedCount++;
-			totalTokens += data.tokens;
+			totalTokens += effectiveTokens(data);
 			totalThinkingTokens += data.thinkingTokens;
 			totalInteractions += data.interactions;
 
@@ -62,7 +62,7 @@ export const statsCommand = new Command('stats')
 				editorCounts[data.editorSource] = { files: 0, tokens: 0, interactions: 0 };
 			}
 			editorCounts[data.editorSource].files++;
-			editorCounts[data.editorSource].tokens += data.tokens;
+			editorCounts[data.editorSource].tokens += effectiveTokens(data);
 			editorCounts[data.editorSource].interactions += data.interactions;
 
 			// Track by parent folder
@@ -72,7 +72,7 @@ export const statsCommand = new Command('stats')
 					folderCounts[folder] = { files: 0, tokens: 0 };
 				}
 				folderCounts[folder].files++;
-				folderCounts[folder].tokens += data.tokens;
+				folderCounts[folder].tokens += effectiveTokens(data);
 			}
 
 			// Progress indicator
@@ -90,7 +90,7 @@ export const statsCommand = new Command('stats')
 			console.log(`  Empty/skipped files:        ${chalk.dim(fmt(emptyCount))}`);
 		}
 		console.log(`  Total chat turns:           ${chalk.bold(fmt(totalInteractions))}`);
-		console.log(`  Total estimated tokens:     ${chalk.bold.yellow(formatTokens(totalTokens))}`);
+		console.log(`  Total tokens:               ${chalk.bold.yellow(formatTokens(totalTokens))}`);
 		if (totalThinkingTokens > 0) {
 			console.log(`  Thinking tokens (included): ${chalk.dim(formatTokens(totalThinkingTokens))}`);
 		}

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -270,12 +270,136 @@ export interface SessionData {
 	file: string;
 	tokens: number;
 	thinkingTokens: number;
+	/** Actual LLM tokens from session.shutdown or request-level usage data. 0 means unavailable. */
+	actualTokens: number;
 	interactions: number;
 	modelUsage: ModelUsage;
 	lastModified: Date;
 	editorSource: string;
-	/** Per-UTC-day actual token breakdown from shutdown event timestamps. */
-	dailyActualTokens?: Record<string, number>;
+	/**
+	 * Per-UTC-day token fractions, keyed by "YYYY-MM-DD".
+	 * Values sum to 1.0. Built from interaction timestamps extracted from the session file.
+	 * Falls back to { [mtimeDateKey]: 1.0 } when no timestamps are available.
+	 *
+	 * This is the canonical attribution mechanism for all session formats:
+	 *  - Copilot CLI JSONL: from user.message event timestamps
+	 *  - VS Code delta JSONL: from kind:0/1/2 request timestamps
+	 *  - VS Code JSON: from requests[].timestamp fields
+	 *  - Ecosystem adapters: mtime fallback (until adapter implements getDailyFractions)
+	 */
+	dailyFractions: Record<string, number>;
+}
+
+/**
+ * Extract per-UTC-day fractions from session content using interaction timestamps.
+ * Fractions sum to 1.0. Falls back to { [fallbackDateKey]: 1.0 } when no timestamps found.
+ *
+ * Single canonical implementation for all text-based session formats:
+ *  - Copilot CLI JSONL: timestamps on `user.message` events
+ *  - VS Code delta JSONL: timestamps in kind:0 initial state, kind:2 appends, kind:1 updates
+ *  - VS Code JSON: timestamps on request objects
+ *
+ * When adding support for a new session format, extend this function rather than creating
+ * a separate attribution implementation — this keeps all formats consistent.
+ */
+export function extractDailyFractions(content: string, isJsonl: boolean, fallbackDate: Date): Record<string, number> {
+	const fallbackKey = fallbackDate.toISOString().slice(0, 10);
+	const dayCounts: Record<string, number> = {};
+
+	function recordTimestamp(ts: unknown): void {
+		if (ts === undefined || ts === null) { return; }
+		const date = new Date(ts as any);
+		if (!isNaN(date.getTime())) {
+			const key = date.toISOString().slice(0, 10);
+			dayCounts[key] = (dayCounts[key] || 0) + 1;
+		}
+	}
+
+	if (isJsonl) {
+		// Track per-index timestamps for kind:1 updates so we can add them even when kind:2 had no timestamp
+		const requestTsMap: Record<number, unknown> = {};
+
+		const lines = content.trim().split('\n');
+		for (const line of lines) {
+			if (!line.trim()) { continue; }
+			try {
+				const event = JSON.parse(line);
+
+				// Copilot CLI JSONL: user.message events carry the interaction timestamp
+				if (event.type === 'user.message') {
+					const ts = event.timestamp ?? event.ts ?? event.data?.timestamp;
+					recordTimestamp(ts);
+					continue;
+				}
+
+				// VS Code delta JSONL
+				const kind = event.kind;
+				const k: unknown[] = event.k;
+				const v = event.v;
+
+				if (kind === 0 && v?.requests && Array.isArray(v.requests)) {
+					// Initial state — extract timestamps from existing requests
+					for (const req of v.requests) {
+						const ts = req.timestamp ?? req.ts;
+						recordTimestamp(ts);
+					}
+				} else if (kind === 2 && Array.isArray(k) && k[0] === 'requests') {
+					if (Array.isArray(v)) {
+						// Batch append
+						for (const req of v) {
+							const ts = req.timestamp ?? req.ts;
+							recordTimestamp(ts);
+						}
+					} else if (v && typeof v === 'object') {
+						// Single request append — may or may not have timestamp yet
+						const ts = (v as any).timestamp ?? (v as any).ts;
+						if (ts !== undefined) {
+							recordTimestamp(ts);
+						}
+						// Track index for potential kind:1 timestamp update below
+						if (typeof k[1] === 'number') {
+							requestTsMap[k[1]] = ts;
+						}
+					}
+				} else if (kind === 1 && Array.isArray(k) && k.length === 3 && k[0] === 'requests' &&
+						(k[2] === 'timestamp' || k[2] === 'ts') && typeof k[1] === 'number') {
+					// kind:1 updates the timestamp on an existing request
+					const idx = k[1] as number;
+					if (requestTsMap[idx] === undefined) {
+						// First time seeing a timestamp for this request index
+						recordTimestamp(v);
+					}
+					requestTsMap[idx] = v;
+				}
+			} catch { /* skip malformed lines */ }
+		}
+	} else {
+		// VS Code JSON format: requests array with timestamp fields
+		try {
+			const data = JSON.parse(content);
+			if (data.requests && Array.isArray(data.requests)) {
+				for (const req of data.requests) {
+					const ts = req.timestamp ?? req.ts ?? req.result?.timestamp;
+					recordTimestamp(ts);
+				}
+			}
+		} catch { /* skip */ }
+	}
+
+	const total = Object.values(dayCounts).reduce((a, b) => a + b, 0);
+	if (total === 0) {
+		return { [fallbackKey]: 1.0 };
+	}
+	const fractions: Record<string, number> = {};
+	for (const [key, count] of Object.entries(dayCounts)) {
+		fractions[key] = count / total;
+	}
+	return fractions;
+}
+
+/** Returns actual tokens when available (more accurate), else falls back to estimated. */
+export function effectiveTokens(data: SessionData): number {
+	return data.actualTokens > 0 ? data.actualTokens : data.tokens;
 }
 
 /**
@@ -299,14 +423,18 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 				eco.countInteractions(filePath),
 				eco.getModelUsage(filePath),
 			]);
+			const mtimeDateKey = stats.mtime.toISOString().slice(0, 10);
 			const ecoResult: SessionData = {
 				file: filePath,
 				tokens: tokenResult.actualTokens > 0 ? tokenResult.actualTokens : tokenResult.tokens,
 				thinkingTokens: tokenResult.thinkingTokens,
+				actualTokens: tokenResult.actualTokens,
 				interactions,
 				modelUsage,
 				lastModified: stats.mtime,
 				editorSource: getEditorSourceFromPath(filePath),
+				// Ecosystem adapters don't expose per-request timestamps; fall back to mtime
+				dailyFractions: { [mtimeDateKey]: 1.0 },
 			};
 			setCached(filePath, stats.mtimeMs, stats.size, ecoResult);
 			return ecoResult;
@@ -322,9 +450,9 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 
 		let tokens = 0;
 		let thinkingTokens = 0;
+		let actualTokens = 0;
 		let interactions = 0;
 		let fileModelUsage: ModelUsage = {};
-		let fileDailyActualTokens: Record<string, number> | undefined;
 
 		if (isJsonl) {
 			const result = estimateTokensFromJsonlSession(content);
@@ -332,11 +460,9 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 			// matching VS Code's logic: actualTokens > 0 ? actualTokens : estimatedTokens
 			tokens = result.actualTokens > 0 ? result.actualTokens : result.tokens;
 			thinkingTokens = result.thinkingTokens;
+			actualTokens = result.actualTokens;
+			// Use per-model breakdown from session.shutdown events (more accurate than request-level estimates)
 			fileModelUsage = result.modelUsage;
-			// Store per-day breakdown for accurate period attribution of multi-day sessions
-			if (Object.keys(result.dailyActualTokens).length > 0) {
-				fileDailyActualTokens = result.dailyActualTokens;
-			}
 
 			// Count interactions from JSONL
 			const lines = content.trim().split('\n');
@@ -359,19 +485,23 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 			);
 			tokens = result.tokens;
 			thinkingTokens = result.thinkingTokens;
+			actualTokens = result.actualTokens;
 			interactions = result.interactions;
 			fileModelUsage = result.modelUsage as ModelUsage;
 		}
+
+		const dailyFractions = extractDailyFractions(content, isJsonl, stats.mtime);
 
 		const sessionData: SessionData = {
 			file: filePath,
 			tokens,
 			thinkingTokens,
+			actualTokens,
 			interactions,
 			modelUsage: fileModelUsage,
 			lastModified: stats.mtime,
 			editorSource: getEditorSourceFromPath(filePath),
-			dailyActualTokens: fileDailyActualTokens,
+			dailyFractions,
 		};
 		setCached(filePath, stats.mtimeMs, stats.size, sessionData);
 		return sessionData;
@@ -388,13 +518,23 @@ export async function calculateDetailedStats(
 	progressCallback?: (completed: number, total: number) => void
 ): Promise<DetailedStats> {
 	const now = new Date();
+
+	// All period boundaries are UTC date keys (YYYY-MM-DD) to match the VS Code extension's behaviour.
 	const todayUtcKey = now.toISOString().slice(0, 10);
-	const monthUtcStartKey = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0, 10);
-	const lastMonthLastDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0));
-	const lastMonthUtcEndKey = lastMonthLastDay.toISOString().slice(0, 10);
-	const lastMonthUtcStartKey = new Date(Date.UTC(lastMonthLastDay.getUTCFullYear(), lastMonthLastDay.getUTCMonth(), 1)).toISOString().slice(0, 10);
-	const last30DaysUtcStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
-	const last30DaysUtcStartKey = last30DaysUtcStart.toISOString().slice(0, 10);
+
+	const y = now.getUTCFullYear();
+	const m = now.getUTCMonth(); // 0-indexed
+	const monthStartKey = `${y}-${String(m + 1).padStart(2, '0')}-01`;
+
+	// Last month: the month before the current UTC month
+	const lmYear = m === 0 ? y - 1 : y;
+	const lmMonth = m === 0 ? 12 : m; // 1-indexed last month number
+	const lastMonthStartKey = `${lmYear}-${String(lmMonth).padStart(2, '0')}-01`;
+	// lastMonthEndKey is the day before monthStartKey — string comparison handles this naturally
+	// (any date >= lastMonthStartKey && < monthStartKey is in last month)
+
+	const last30DaysDate = new Date(Date.UTC(y, m, now.getUTCDate() - 30));
+	const last30DaysStartKey = last30DaysDate.toISOString().slice(0, 10);
 
 	const periods: {
 		today: PeriodStats;
@@ -420,63 +560,27 @@ export async function calculateDetailedStats(
 			continue;
 		}
 
-		const modifiedUtcKey = data.lastModified.toISOString().slice(0, 10);
+		// Skip sessions that have no relevant days (all older than last month)
+		const hasRelevantDay = Object.keys(data.dailyFractions).some(k => k >= lastMonthStartKey);
+		if (!hasRelevantDay) { continue; }
 
-		// Skip files older than the last month's start
-		if (modifiedUtcKey < lastMonthUtcStartKey) {
-			continue;
+		// Accumulate per-period fractions from the session's daily breakdown
+		let todayFrac = 0;
+		let monthFrac = 0;
+		let lastMonthFrac = 0;
+		let last30DaysFrac = 0;
+
+		for (const [dateKey, fraction] of Object.entries(data.dailyFractions)) {
+			if (dateKey === todayUtcKey) { todayFrac += fraction; }
+			if (dateKey >= monthStartKey) { monthFrac += fraction; }
+			if (dateKey >= lastMonthStartKey && dateKey < monthStartKey) { lastMonthFrac += fraction; }
+			if (dateKey >= last30DaysStartKey) { last30DaysFrac += fraction; }
 		}
 
-		// When per-day actual token breakdown is available (multi-day sessions),
-		// distribute tokens accurately across the days they occurred — matching
-		// VS Code's dailyRollups behavior.
-		if (data.dailyActualTokens && Object.keys(data.dailyActualTokens).length > 1) {
-			let addedToToday = false;
-			let addedToMonth = false;
-			let addedToLastMonth = false;
-			let addedToLast30Days = false;
-
-			for (const [dayKey, dayTokens] of Object.entries(data.dailyActualTokens)) {
-				if (dayKey < lastMonthUtcStartKey) { continue; }
-
-				const dayData: SessionData = {
-					...data,
-					tokens: dayTokens,
-				};
-
-				if (dayKey === todayUtcKey) {
-					aggregateIntoPeriod(periods.today, dayData, !addedToToday);
-					addedToToday = true;
-				}
-				if (dayKey >= monthUtcStartKey) {
-					aggregateIntoPeriod(periods.month, dayData, !addedToMonth);
-					addedToMonth = true;
-				}
-				if (dayKey >= lastMonthUtcStartKey && dayKey <= lastMonthUtcEndKey) {
-					aggregateIntoPeriod(periods.lastMonth, dayData, !addedToLastMonth);
-					addedToLastMonth = true;
-				}
-				if (dayKey >= last30DaysUtcStartKey) {
-					aggregateIntoPeriod(periods.last30Days, dayData, !addedToLast30Days);
-					addedToLast30Days = true;
-				}
-			}
-			continue;
-		}
-
-		// Single-day session (or no daily breakdown): attribute all tokens to mtime day
-		if (modifiedUtcKey === todayUtcKey) {
-			aggregateIntoPeriod(periods.today, data);
-		}
-		if (modifiedUtcKey >= monthUtcStartKey) {
-			aggregateIntoPeriod(periods.month, data);
-		}
-		if (modifiedUtcKey >= lastMonthUtcStartKey && modifiedUtcKey <= lastMonthUtcEndKey) {
-			aggregateIntoPeriod(periods.lastMonth, data);
-		}
-		if (modifiedUtcKey >= last30DaysUtcStartKey) {
-			aggregateIntoPeriod(periods.last30Days, data);
-		}
+		if (todayFrac > 0) { aggregateIntoPeriod(periods.today, data, todayFrac); }
+		if (monthFrac > 0) { aggregateIntoPeriod(periods.month, data, monthFrac); }
+		if (lastMonthFrac > 0) { aggregateIntoPeriod(periods.lastMonth, data, lastMonthFrac); }
+		if (last30DaysFrac > 0) { aggregateIntoPeriod(periods.last30Days, data, last30DaysFrac); }
 	}
 
 	// Compute derived stats
@@ -515,37 +619,37 @@ function createEmptyPeriodStats(): PeriodStats {
 	};
 }
 
-function aggregateIntoPeriod(period: PeriodStats, data: SessionData, countSession = true): void {
-	period.tokens += data.tokens;
-	period.thinkingTokens += data.thinkingTokens;
-	period.estimatedTokens += data.tokens;
-	if (countSession) {
-		period.sessions++;
-	}
+function aggregateIntoPeriod(period: PeriodStats, data: SessionData, fraction: number): void {
+	const displayTok = Math.round(effectiveTokens(data) * fraction);
+	const thinkingTok = Math.round(data.thinkingTokens * fraction);
+	const actualTok = Math.round(data.actualTokens * fraction);
 
-	// Merge model usage
+	period.tokens += displayTok;
+	period.thinkingTokens += thinkingTok;
+	period.estimatedTokens += Math.round(data.tokens * fraction);
+	period.actualTokens += actualTok;
+	period.sessions++;
+
+	// Merge model usage proportionally
 	for (const [model, usage] of Object.entries(data.modelUsage)) {
 		if (!period.modelUsage[model]) {
 			period.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
 		}
-		period.modelUsage[model].inputTokens += usage.inputTokens;
-		period.modelUsage[model].outputTokens += usage.outputTokens;
+		period.modelUsage[model].inputTokens += Math.round(usage.inputTokens * fraction);
+		period.modelUsage[model].outputTokens += Math.round(usage.outputTokens * fraction);
 	}
 
-	// Track interactions
-	if (countSession) {
-		const totalInteractions = period.avgInteractionsPerSession * (period.sessions - 1) + data.interactions;
-		period.avgInteractionsPerSession = period.sessions > 0 ? totalInteractions / period.sessions : 0;
-	}
+	// Track interactions proportionally for the running average
+	const interactions = Math.round(data.interactions * fraction);
+	const totalInteractions = period.avgInteractionsPerSession * (period.sessions - 1) + interactions;
+	period.avgInteractionsPerSession = period.sessions > 0 ? totalInteractions / period.sessions : 0;
 
 	// Editor usage
 	if (!period.editorUsage[data.editorSource]) {
 		period.editorUsage[data.editorSource] = { tokens: 0, sessions: 0 };
 	}
-	period.editorUsage[data.editorSource].tokens += data.tokens;
-	if (countSession) {
-		period.editorUsage[data.editorSource].sessions++;
-	}
+	period.editorUsage[data.editorSource].tokens += displayTok;
+	period.editorUsage[data.editorSource].sessions++;
 }
 
 /**
@@ -674,7 +778,7 @@ interface DailyEntry {
 
 /**
  * Process session files and return per-day stats for the last 30 days.
- * Returns `{ labels, days }` where labels are sorted YYYY-MM-DD strings and
+ * Returns `{ labels, days }` where labels are sorted YYYY-MM-DD strings (UTC) and
  * days are the corresponding aggregated stats.
  */
 export async function calculateDailyStats(sessionFiles: string[]): Promise<{
@@ -683,51 +787,72 @@ export async function calculateDailyStats(sessionFiles: string[]): Promise<{
 	allDaysMap: Map<string, DailyEntry>;
 }> {
 	const now = new Date();
-	const last30DaysStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-	const fmtKey = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+	const last30DaysDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
+	const last30DaysStartKey = last30DaysDate.toISOString().slice(0, 10);
+	const todayKey = now.toISOString().slice(0, 10);
 
 	// Fill in all 31 days (today inclusive) with zeroes so the chart has continuous labels
 	const dailyMap = new Map<string, DailyEntry>();
-	const cursor = new Date(last30DaysStart);
-	while (cursor <= now) {
-		dailyMap.set(fmtKey(new Date(cursor)), { tokens: 0, sessions: 0, modelUsage: {}, editorUsage: {} });
-		cursor.setDate(cursor.getDate() + 1);
+	const cursor = new Date(last30DaysDate);
+	while (cursor.toISOString().slice(0, 10) <= todayKey) {
+		const key = cursor.toISOString().slice(0, 10);
+		dailyMap.set(key, { tokens: 0, sessions: 0, modelUsage: {}, editorUsage: {} });
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
 	}
 
-	// Full historical map (all time) for weekly/monthly chart periods
+	// Full historical map (all time, no age filter) for weekly/monthly chart periods
 	const allDaysMap = new Map<string, DailyEntry>();
 
-	const addToEntry = (map: Map<string, DailyEntry>, dateKey: string, data: { tokens: number; modelUsage: ModelUsage; editorSource: string }) => {
-		if (!map.has(dateKey)) {
-			map.set(dateKey, { tokens: 0, sessions: 0, modelUsage: {}, editorUsage: {} });
-		}
-		const entry = map.get(dateKey)!;
-		entry.tokens += data.tokens;
-		entry.sessions++;
-		for (const [model, usage] of Object.entries(data.modelUsage)) {
-			if (!entry.modelUsage[model]) { entry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
-			entry.modelUsage[model].inputTokens += (usage as any).inputTokens;
-			entry.modelUsage[model].outputTokens += (usage as any).outputTokens;
-		}
-		const editor = data.editorSource;
-		if (!entry.editorUsage[editor]) { entry.editorUsage[editor] = { tokens: 0, sessions: 0 }; }
-		entry.editorUsage[editor].tokens += data.tokens;
-		entry.editorUsage[editor].sessions++;
-	};
+	const sessionResults = await runWithConcurrency(sessionFiles, async (file) => processSessionFile(file));
 
-	for (const file of sessionFiles) {
-		const data = await processSessionFile(file);
+	for (const data of sessionResults) {
 		if (!data || data.tokens === 0 || data.interactions === 0) { continue; }
 
-		const d = data.lastModified;
-		const dateKey = fmtKey(d);
+		const displayTok = effectiveTokens(data);
 
-		// Always add to the full history map
-		addToEntry(allDaysMap, dateKey, data);
+		for (const [dateKey, fraction] of Object.entries(data.dailyFractions)) {
+			const tokForDay = Math.round(displayTok * fraction);
 
-		// Only add to the 30-day map if within window
-		if (data.lastModified >= last30DaysStart && dailyMap.has(dateKey)) {
-			addToEntry(dailyMap, dateKey, data);
+			// 30-day map: only add days within the window
+			const dailyEntry = dailyMap.get(dateKey);
+			if (dailyEntry) {
+				dailyEntry.tokens += tokForDay;
+				dailyEntry.sessions++;
+				for (const [model, usage] of Object.entries(data.modelUsage)) {
+					if (!dailyEntry.modelUsage[model]) {
+						dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+					}
+					dailyEntry.modelUsage[model].inputTokens += Math.round(usage.inputTokens * fraction);
+					dailyEntry.modelUsage[model].outputTokens += Math.round(usage.outputTokens * fraction);
+				}
+				const editor = data.editorSource;
+				if (!dailyEntry.editorUsage[editor]) {
+					dailyEntry.editorUsage[editor] = { tokens: 0, sessions: 0 };
+				}
+				dailyEntry.editorUsage[editor].tokens += tokForDay;
+				dailyEntry.editorUsage[editor].sessions++;
+			}
+
+			// Full history map: always add regardless of age (used for weekly/monthly charts)
+			if (!allDaysMap.has(dateKey)) {
+				allDaysMap.set(dateKey, { tokens: 0, sessions: 0, modelUsage: {}, editorUsage: {} });
+			}
+			const allEntry = allDaysMap.get(dateKey)!;
+			allEntry.tokens += tokForDay;
+			allEntry.sessions++;
+			for (const [model, usage] of Object.entries(data.modelUsage)) {
+				if (!allEntry.modelUsage[model]) {
+					allEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+				}
+				allEntry.modelUsage[model].inputTokens += Math.round(usage.inputTokens * fraction);
+				allEntry.modelUsage[model].outputTokens += Math.round(usage.outputTokens * fraction);
+			}
+			const editor = data.editorSource;
+			if (!allEntry.editorUsage[editor]) {
+				allEntry.editorUsage[editor] = { tokens: 0, sessions: 0 };
+			}
+			allEntry.editorUsage[editor].tokens += tokForDay;
+			allEntry.editorUsage[editor].sessions++;
 		}
 	}
 

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -19,6 +19,7 @@ import { OpenCodeAdapter, CrushAdapter, ContinueAdapter, ClaudeDesktopAdapter, C
 import { isMcpTool, extractMcpServerName } from '../../vscode-extension/src/workspaceHelpers';
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, getModelTier } from '../../vscode-extension/src/tokenEstimation';
+import { extractDailyFractions } from '../../vscode-extension/src/dailyAttribution';
 import type { DetailedStats, PeriodStats, ModelUsage, EditorUsage, SessionFileCache, UsageAnalysisStats, UsageAnalysisPeriod, WorkspaceCustomizationMatrix } from '../../vscode-extension/src/types';
 import { analyzeSessionUsage, mergeUsageAnalysis, calculateModelSwitching, trackEnhancedMetrics } from '../../vscode-extension/src/usageAnalysis';
 import { createEmptyContextRefs } from '../../vscode-extension/src/tokenEstimation';
@@ -302,101 +303,6 @@ export interface SessionData {
  * When adding support for a new session format, extend this function rather than creating
  * a separate attribution implementation — this keeps all formats consistent.
  */
-export function extractDailyFractions(content: string, isJsonl: boolean, fallbackDate: Date): Record<string, number> {
-	const fallbackKey = fallbackDate.toISOString().slice(0, 10);
-	const dayCounts: Record<string, number> = {};
-
-	function recordTimestamp(ts: unknown): void {
-		if (ts === undefined || ts === null) { return; }
-		const date = new Date(ts as any);
-		if (!isNaN(date.getTime())) {
-			const key = date.toISOString().slice(0, 10);
-			dayCounts[key] = (dayCounts[key] || 0) + 1;
-		}
-	}
-
-	if (isJsonl) {
-		// Track per-index timestamps for kind:1 updates so we can add them even when kind:2 had no timestamp
-		const requestTsMap: Record<number, unknown> = {};
-
-		const lines = content.trim().split('\n');
-		for (const line of lines) {
-			if (!line.trim()) { continue; }
-			try {
-				const event = JSON.parse(line);
-
-				// Copilot CLI JSONL: user.message events carry the interaction timestamp
-				if (event.type === 'user.message') {
-					const ts = event.timestamp ?? event.ts ?? event.data?.timestamp;
-					recordTimestamp(ts);
-					continue;
-				}
-
-				// VS Code delta JSONL
-				const kind = event.kind;
-				const k: unknown[] = event.k;
-				const v = event.v;
-
-				if (kind === 0 && v?.requests && Array.isArray(v.requests)) {
-					// Initial state — extract timestamps from existing requests
-					for (const req of v.requests) {
-						const ts = req.timestamp ?? req.ts;
-						recordTimestamp(ts);
-					}
-				} else if (kind === 2 && Array.isArray(k) && k[0] === 'requests') {
-					if (Array.isArray(v)) {
-						// Batch append
-						for (const req of v) {
-							const ts = req.timestamp ?? req.ts;
-							recordTimestamp(ts);
-						}
-					} else if (v && typeof v === 'object') {
-						// Single request append — may or may not have timestamp yet
-						const ts = (v as any).timestamp ?? (v as any).ts;
-						if (ts !== undefined) {
-							recordTimestamp(ts);
-						}
-						// Track index for potential kind:1 timestamp update below
-						if (typeof k[1] === 'number') {
-							requestTsMap[k[1]] = ts;
-						}
-					}
-				} else if (kind === 1 && Array.isArray(k) && k.length === 3 && k[0] === 'requests' &&
-						(k[2] === 'timestamp' || k[2] === 'ts') && typeof k[1] === 'number') {
-					// kind:1 updates the timestamp on an existing request
-					const idx = k[1] as number;
-					if (requestTsMap[idx] === undefined) {
-						// First time seeing a timestamp for this request index
-						recordTimestamp(v);
-					}
-					requestTsMap[idx] = v;
-				}
-			} catch { /* skip malformed lines */ }
-		}
-	} else {
-		// VS Code JSON format: requests array with timestamp fields
-		try {
-			const data = JSON.parse(content);
-			if (data.requests && Array.isArray(data.requests)) {
-				for (const req of data.requests) {
-					const ts = req.timestamp ?? req.ts ?? req.result?.timestamp;
-					recordTimestamp(ts);
-				}
-			}
-		} catch { /* skip */ }
-	}
-
-	const total = Object.values(dayCounts).reduce((a, b) => a + b, 0);
-	if (total === 0) {
-		return { [fallbackKey]: 1.0 };
-	}
-	const fractions: Record<string, number> = {};
-	for (const [key, count] of Object.entries(dayCounts)) {
-		fractions[key] = count / total;
-	}
-	return fractions;
-}
-
 /** Returns actual tokens when available (more accurate), else falls back to estimated. */
 export function effectiveTokens(data: SessionData): number {
 	return data.actualTokens > 0 ? data.actualTokens : data.tokens;
@@ -433,8 +339,7 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 				modelUsage,
 				lastModified: stats.mtime,
 				editorSource: getEditorSourceFromPath(filePath),
-				// Ecosystem adapters don't expose per-request timestamps; fall back to mtime
-				dailyFractions: { [mtimeDateKey]: 1.0 },
+				dailyFractions: (await eco.getDailyFractions?.(filePath)) ?? { [mtimeDateKey]: 1.0 },
 			};
 			setCached(filePath, stats.mtimeMs, stats.size, ecoResult);
 			return ecoResult;

--- a/vscode-extension/src/dailyAttribution.ts
+++ b/vscode-extension/src/dailyAttribution.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared per-UTC-day token attribution logic.
+ *
+ * Extracts a fraction map (`Record<"YYYY-MM-DD", 0..1>`) from any supported session
+ * file format. The fractions sum to 1.0 and represent how many interactions fell on
+ * each calendar day (UTC), so callers can proportionally attribute session tokens to
+ * the correct day rather than lumping everything on the file's mtime date.
+ *
+ * Supported formats:
+ *   - Copilot CLI JSONL   (`type === "user.message"` events with `timestamp`)
+ *   - VS Code delta JSONL  (kind:0 initial state, kind:2 appends, kind:1 timestamp updates)
+ *   - VS Code JSON         (`requests[].timestamp`)
+ */
+
+/**
+ * Derive per-UTC-day fractions from session file content.
+ *
+ * @param content     Raw text content of the session file.
+ * @param isJsonl     True when the file is a JSONL (line-delimited JSON) format.
+ * @param fallbackDate Date to use when no interaction timestamps are found (typically file mtime).
+ * @returns A `Record<"YYYY-MM-DD", number>` where values sum to 1.0.
+ */
+export function extractDailyFractions(content: string, isJsonl: boolean, fallbackDate: Date): Record<string, number> {
+	const fallbackKey = fallbackDate.toISOString().slice(0, 10);
+	const dayCounts: Record<string, number> = {};
+
+	function recordTimestamp(ts: unknown): void {
+		if (ts === undefined || ts === null) { return; }
+		const date = new Date(ts as any);
+		if (!isNaN(date.getTime())) {
+			const key = date.toISOString().slice(0, 10);
+			dayCounts[key] = (dayCounts[key] || 0) + 1;
+		}
+	}
+
+	if (isJsonl) {
+		// Track per-index timestamps for kind:1 updates so we can add them even when kind:2 had no timestamp
+		const requestTsMap: Record<number, unknown> = {};
+
+		const lines = content.trim().split('\n');
+		for (const line of lines) {
+			if (!line.trim()) { continue; }
+			try {
+				const event = JSON.parse(line);
+
+				// Copilot CLI JSONL: user.message events carry the interaction timestamp
+				if (event.type === 'user.message') {
+					const ts = event.timestamp ?? event.ts ?? event.data?.timestamp;
+					recordTimestamp(ts);
+					continue;
+				}
+
+				// VS Code delta JSONL
+				const kind = event.kind;
+				const k: unknown[] = event.k;
+				const v = event.v;
+
+				if (kind === 0 && v?.requests && Array.isArray(v.requests)) {
+					// Initial state — extract timestamps from existing requests
+					for (const req of v.requests) {
+						const ts = req.timestamp ?? req.ts;
+						recordTimestamp(ts);
+					}
+				} else if (kind === 2 && Array.isArray(k) && k[0] === 'requests') {
+					if (Array.isArray(v)) {
+						// Batch append
+						for (const req of v) {
+							const ts = req.timestamp ?? req.ts;
+							recordTimestamp(ts);
+						}
+					} else if (v && typeof v === 'object') {
+						// Single request append — may or may not have timestamp yet
+						const ts = (v as any).timestamp ?? (v as any).ts;
+						if (ts !== undefined) {
+							recordTimestamp(ts);
+						}
+						// Track index for potential kind:1 timestamp update below
+						if (typeof k[1] === 'number') {
+							requestTsMap[k[1]] = ts;
+						}
+					}
+				} else if (kind === 1 && Array.isArray(k) && k.length === 3 && k[0] === 'requests' &&
+						(k[2] === 'timestamp' || k[2] === 'ts') && typeof k[1] === 'number') {
+					// kind:1 updates the timestamp on an existing request
+					const idx = k[1] as number;
+					if (requestTsMap[idx] === undefined) {
+						// First time seeing a timestamp for this request index
+						recordTimestamp(v);
+					}
+					requestTsMap[idx] = v;
+				}
+			} catch { /* skip malformed lines */ }
+		}
+	} else {
+		// VS Code JSON format: requests array with timestamp fields
+		try {
+			const data = JSON.parse(content);
+			if (data.requests && Array.isArray(data.requests)) {
+				for (const req of data.requests) {
+					const ts = req.timestamp ?? req.ts ?? req.result?.timestamp;
+					recordTimestamp(ts);
+				}
+			}
+		} catch { /* skip */ }
+	}
+
+	const total = Object.values(dayCounts).reduce((a, b) => a + b, 0);
+	if (total === 0) {
+		return { [fallbackKey]: 1.0 };
+	}
+	const fractions: Record<string, number> = {};
+	for (const [key, count] of Object.entries(dayCounts)) {
+		fractions[key] = count / total;
+	}
+	return fractions;
+}

--- a/vscode-extension/src/ecosystemAdapter.ts
+++ b/vscode-extension/src/ecosystemAdapter.ts
@@ -79,6 +79,19 @@ export interface IEcosystemAdapter {
 	getRawFileContent?(sessionFile: string): string | undefined;
 
 	/**
+	 * Return per-UTC-day token fractions for accurate multi-day attribution.
+	 *
+	 * When implemented, `processSessionFile` in the CLI uses these fractions instead of
+	 * falling back to file mtime (which would count all session tokens as "today").
+	 * The returned record must have "YYYY-MM-DD" keys whose values sum to 1.0.
+	 *
+	 * Implement this when the adapter's data source contains per-request timestamps
+	 * (e.g. a database with a `created_at` column, or a JSON file with `requests[].timestamp`).
+	 * Adapters that do not implement this method fall back to the mtime date.
+	 */
+	getDailyFractions?(sessionFile: string): Promise<Record<string, number>>;
+
+	/**
 	 * Return data needed for backend sync.
 	 * Only implemented by ecosystems that support sync (OpenCode, Crush).
 	 */


### PR DESCRIPTION
## Problem

The CLI showed ~100M tokens for today while the VS Code extension showed ~25M — a ~4x discrepancy.

## Root Causes

Two independent issues combined to cause the gap:

### 1. Token source mismatch
- **Extension**: prefers `actualTokens` from `session.shutdown` modelMetrics (or `request.result.promptTokens/outputTokens` for VS Code JSON sessions) — these are true LLM API token counts
- **CLI**: always used text-based estimated tokens, which over-count agent sessions by 4x+ because they include raw tool execution content (file reads, search results) that gets processed/compressed before reaching the LLM

### 2. Day attribution (mtime vs. timestamps)
- **Extension**: builds per-UTC-day rollups from actual interaction timestamps, so only today's fraction of a multi-day session counts as "today"
- **CLI**: used file `mtime >= todayStart` (local time), so a long-running session that was touched today had ALL its historical tokens credited to today

## Changes

**`cli/src/helpers.ts`**
- `SessionData` gets two new fields: `actualTokens` (from session.shutdown or request usage) and `dailyFractions` (per-UTC-day fraction map, sums to 1.0)
- New `extractDailyFractions()`: extracts per-day fractions from all three session formats:
  - Copilot CLI JSONL — `user.message` event timestamps  
  - VS Code delta JSONL — kind:0 initial state + kind:2 appends + kind:1 timestamp updates
  - VS Code JSON — `requests[].timestamp`
  - Falls back to `{ [mtimeDateKey]: 1.0 }` when no timestamps found
- Export `effectiveTokens()`: returns `actualTokens` if >0, else `tokens`
- `aggregateIntoPeriod()` accepts a `fraction` param; uses `effectiveTokens` for all token accumulation
- `calculateDetailedStats()`: switched from mtime Date comparisons to UTC string-key period boundaries; uses `dailyFractions` to attribute only the relevant fraction of each session to each period
- `calculateDailyStats()`: switched to UTC date keys; distributes tokens per day using `dailyFractions`

**`cli/src/commands/stats.ts`** + **`diagnostics.ts`**
- Updated to use `effectiveTokens(data)` for all token totals

**`cli/src/cliCache.ts`**
- Cache version bumped from 2 → 3 to invalidate stale cached entries that lack the new fields