### PR TITLE
fix: disable installed extension when running in debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
 			"request": "launch",
 			"preLaunchTask": "esbuild",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}/vscode-extension"
+				"--extensionDevelopmentPath=${workspaceFolder}/vscode-extension",
+				"--disable-extension",
+				"RobBos.ai-engineering-fluency"
 			],
 			"outFiles": [
 				"${workspaceFolder}/vscode-extension/dist/**/*.js"


### PR DESCRIPTION
## Problem

When the extension `RobBos.ai-engineering-fluency` is already installed in VS Code and the user presses F5 to run/debug it, both instances activate simultaneously. This causes:

1. **`command 'aiEngineeringFluency.refresh' already exists`** — the installed extension registered the command first, and the debug extension tries to register the same one.
2. **`Cannot register 'copilotTokenTracker.backend.backend'. This property is already registered.`** — same issue with configuration contributions.

## Fix

Add `--disable-extension RobBos.ai-engineering-fluency` to the Extension Development Host launch args in `.vscode/launch.json`. This is the standard VS Code approach: the EDH disables the installed copy of the same extension when running in development mode, eliminating the duplicate registration conflicts.