### PR TITLE
fix: populate estimated cost data in chart view for all periods

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -777,7 +777,10 @@ export function buildChartPayload(labels: string[], days: DailyEntry[], allDaysM
 		const totalTokens = tokensData.reduce((a, b) => a + b, 0);
 		const totalSessions = sessionsData.reduce((a, b) => a + b, 0);
 		const periodCount = buckets.length;
-		return { labels: bLabels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets: [], periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData: [], totalCost: 0, avgCostPerPeriod: 0 };
+		const costData = entries.map(e => calculateEstimatedCost(e.modelUsage, modelPricing));
+		const totalCost = costData.reduce((a, b) => a + b, 0);
+		const avgCostPerPeriod = periodCount > 0 ? totalCost / periodCount : 0;
+		return { labels: bLabels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets: [], periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod };
 	};
 
 	const mergeEntry = (target: DailyEntry, src: DailyEntry) => {

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -535,7 +535,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 				labels: period.labels,
 				datasets: [
 					{
-						label: 'Est. Cost (TBB)',
+						label: 'Est. Cost (USD)',
 						data: period.costData,
 						backgroundColor: 'rgba(34, 197, 94, 0.6)',
 						borderColor: 'rgba(34, 197, 94, 1)',


### PR DESCRIPTION
## Problem

The chart's **💰 Est. Cost** view was always empty (showing zeros) in the JetBrains extension (and VS Code extension). The \uildPeriodFromEntries\ function in \cli/src/helpers.ts\ hardcoded \costData: [], totalCost: 0, avgCostPerPeriod: 0\ for all period aggregations (day/week/month).

## Fix

In \uildPeriodFromEntries\, calculate actual cost data using the already-imported \calculateEstimatedCost\ function and the \modelPricing\ data already available in scope:

- \costData\ — per-period estimated cost derived from each entry's \modelUsage\
- \	otalCost\ — sum of all \costData\ values
- \vgCostPerPeriod\ — \	otalCost / periodCount\

Also updated the chart dataset label from \'Est. Cost (TBB)'\ (to-be-built) to \'Est. Cost (USD)'\ now that the data is populated.

## Changes

- \cli/src/helpers.ts\ — compute cost fields in \uildPeriodFromEntries\
- \scode-extension/src/webview/chart/main.ts\ — update dataset label from TBB to USD