### PR TITLE
Fix cost estimate reason

### DIFF
--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -535,7 +535,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 				labels: period.labels,
 				datasets: [
 					{
-						label: 'Est. Cost (USD)',
+						label: 'Est. Cost (TBB)',
 						data: period.costData,
 						backgroundColor: 'rgba(34, 197, 94, 0.6)',
 						borderColor: 'rgba(34, 197, 94, 1)',
@@ -563,7 +563,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 						position: 'left' as const,
 						grid: { color: gridColor },
 						ticks: { color: textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` },
-						title: { display: true, text: 'Estimated Cost (USD)', color: textColor, font: { size: 12, weight: 'bold' as const } }
+						title: { display: true, text: 'Estimated Cost (TBB)', color: textColor, font: { size: 12, weight: 'bold' as const } }
 					}
 				}
 			}


### PR DESCRIPTION
This pull request makes a minor update to the cost chart labeling in the `vscode-extension/src/webview/chart/main.ts` file. The estimated cost units have been changed from USD to TBB(Token Based Billing) in both the dataset label and the axis title to reflect a different currency or unit.

- Chart label update:
  * Changed the dataset label from 'Est. Cost (USD)' to 'Est. Cost (TBB)' in the cost chart configuration.

- Axis title update:
  * Changed the y-axis title from 'Estimated Cost (USD)' to 'Estimated Cost (TBB)' to match the new unit.