### PR TITLE
feat: detect and surface Copilot PR chat context references (#pr)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2070,6 +2070,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				changes: 0,
 				outputPanel: 0,
 				problemsPanel: 0,
+				pullRequest: 0,
 				byKind: {},
 				copilotInstructions: 0,
 				agentsMd: 0,
@@ -2192,6 +2193,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 								changes: 0,
 								outputPanel: 0,
 								problemsPanel: 0,
+								pullRequest: 0,
 								byKind: {},
 								copilotInstructions: 0,
 								agentsMd: 0,
@@ -2899,6 +2901,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				changes: 0,
 				outputPanel: 0,
 				problemsPanel: 0,
+				pullRequest: 0,
 				byKind: {},
 				copilotInstructions: 0,
 				agentsMd: 0,
@@ -3049,7 +3052,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				contextReferences: {
 					file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
 					workspace: 0, terminal: 0, vscode: 0,
-					terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0,
+					terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0,
 					// Extended fields expected by SessionUsageAnalysis in the webview
 					byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {}
 				},
@@ -3110,7 +3113,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			contextReferences: {
 				file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
 				workspace: 0, terminal: 0, vscode: 0,
-				terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0,
+				terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0,
 				byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {}
 			},
 			firstInteraction: null,

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -615,7 +615,7 @@ export function createEmptyContextRefs(): ContextReferenceUsage {
 	return {
 		file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
 		workspace: 0, terminal: 0, vscode: 0,
-		terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0,
+		terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0,
 		byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {}
 	};
 }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -254,6 +254,7 @@ export interface ContextReferenceUsage {
   changes: number; // #changes references
   outputPanel: number; // #outputPanel references
   problemsPanel: number; // #problemsPanel references
+  pullRequest: number; // #pr / #pullRequest references (Copilot PR chat, April 2026)
 // contentReferences tracking from session logs
   byKind: { [kind: string]: number }; // Count by reference kind
   copilotInstructions: number; // .github/copilot-instructions.md

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -84,6 +84,7 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 	period.contextReferences.changes += analysis.contextReferences.changes || 0;
 	period.contextReferences.outputPanel += analysis.contextReferences.outputPanel || 0;
 	period.contextReferences.problemsPanel += analysis.contextReferences.problemsPanel || 0;
+	period.contextReferences.pullRequest += analysis.contextReferences.pullRequest || 0;
 
 	// Merge contentReferences counts
 	period.contextReferences.copilotInstructions += analysis.contextReferences.copilotInstructions || 0;
@@ -310,9 +311,20 @@ export function analyzeContextReferences(text: string, refs: ContextReferenceUsa
 	}
 
 	// Count #problemsPanel references
-	const problemsPanelMatches = text.match(/#problemsPanel/gi);
+	const problemsPanelMatches = text.match(/#problemsPanel\b/gi);
 	if (problemsPanelMatches) {
 		refs.problemsPanel += problemsPanelMatches.length;
+	}
+
+	// Count #pr and #pullRequest references (Copilot PR chat, April 2026)
+	// Use word boundaries to avoid matching #problemsPanel or #pullRequestReview etc.
+	const prMatches = text.match(/#pr\b/gi);
+	if (prMatches) {
+		refs.pullRequest += prMatches.length;
+	}
+	const pullRequestMatches = text.match(/#pullRequest\b/gi);
+	if (pullRequestMatches) {
+		refs.pullRequest += pullRequestMatches.length;
 	}
 
 	// Count @workspace references
@@ -363,6 +375,13 @@ export function analyzeContentReferences(contentReferences: any[], refs: Context
 			reference = contentRef.reference;
 		} else if (kind === 'inlineReference' && contentRef.inlineReference) {
 			reference = contentRef.inlineReference;
+		}
+
+		// Pull request context references (Copilot PR chat, April 2026)
+		// These appear as contentRef.kind === 'pullRequest' with PR metadata inside
+		if (kind === 'pullRequest') {
+			refs.pullRequest++;
+			continue;
 		}
 
 		// Process the reference if found

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -138,6 +138,7 @@ function getContextRefBadges(refs: ContextReferenceUsage): string {
 	if ((refs.changes || 0) > 0) { badges.push(`<span class="context-ref-item">#changes: <strong>${refs.changes}</strong></span>`); }
 	if ((refs.outputPanel || 0) > 0) { badges.push(`<span class="context-ref-item">#outputPanel: <strong>${refs.outputPanel}</strong></span>`); }
 	if ((refs.problemsPanel || 0) > 0) { badges.push(`<span class="context-ref-item">#problemsPanel: <strong>${refs.problemsPanel}</strong></span>`); }
+	if ((refs.pullRequest || 0) > 0) { badges.push(`<span class="context-ref-item">#pr: <strong>${refs.pullRequest}</strong></span>`); }
 	if (refs.implicitSelection > 0) { badges.push(`<span class="context-ref-item context-ref-implicit">implicit: <strong>${refs.implicitSelection}</strong></span>`); }
 	return badges.join('');
 }

--- a/vscode-extension/src/webview/shared/contextRefUtils.ts
+++ b/vscode-extension/src/webview/shared/contextRefUtils.ts
@@ -17,6 +17,7 @@ export type ContextReferenceUsage = {
 	changes: number;
 	outputPanel: number;
 	problemsPanel: number;
+	pullRequest: number; // #pr / #pullRequest references (Copilot PR chat, April 2026)
 	byKind: { [kind: string]: number };
 	copilotInstructions: number;
 	agentsMd: number;
@@ -80,7 +81,7 @@ export function getTotalContextRefs(refs: ContextReferenceUsage): number {
 	return refs.file + refs.selection + refs.implicitSelection + refs.symbol + refs.codebase +
 		refs.workspace + refs.terminal + refs.vscode + refs.copilotInstructions + refs.agentsMd +
 		(refs.terminalLastCommand || 0) + (refs.terminalSelection || 0) + (refs.clipboard || 0) +
-		(refs.changes || 0) + (refs.outputPanel || 0) + (refs.problemsPanel || 0);
+		(refs.changes || 0) + (refs.outputPanel || 0) + (refs.problemsPanel || 0) + (refs.pullRequest || 0);
 }
 
 /**
@@ -94,13 +95,13 @@ export function getImplicitContextRefs(refs: ContextReferenceUsage): number {
 /**
  * Calculate the count of explicit (user-initiated) context references.
  * Explicit refs are user-initiated: #file, #selection, #symbol, #codebase, @workspace, @terminal, @vscode,
- * #terminalLastCommand, #terminalSelection, #clipboard, #changes, #outputPanel, #problemsPanel
+ * #terminalLastCommand, #terminalSelection, #clipboard, #changes, #outputPanel, #problemsPanel, #pr
  */
 export function getExplicitContextRefs(refs: ContextReferenceUsage): number {
 	return refs.file + refs.selection + refs.symbol + refs.codebase +
 		refs.workspace + refs.terminal + refs.vscode +
 		(refs.terminalLastCommand || 0) + (refs.terminalSelection || 0) + (refs.clipboard || 0) +
-		(refs.changes || 0) + (refs.outputPanel || 0) + (refs.problemsPanel || 0);
+		(refs.changes || 0) + (refs.outputPanel || 0) + (refs.problemsPanel || 0) + (refs.pullRequest || 0);
 }
 
 /**
@@ -127,6 +128,7 @@ export function getContextRefsSummary(refs: ContextReferenceUsage, abbreviated =
 		if ((refs.changes || 0) > 0) { parts.push(`#chg: ${refs.changes}`); }
 		if ((refs.outputPanel || 0) > 0) { parts.push(`#out: ${refs.outputPanel}`); }
 		if ((refs.problemsPanel || 0) > 0) { parts.push(`#prob: ${refs.problemsPanel}`); }
+		if ((refs.pullRequest || 0) > 0) { parts.push(`#pr: ${refs.pullRequest}`); }
 		if (refs.copilotInstructions > 0) { parts.push(`📋 inst: ${refs.copilotInstructions}`); }
 		if (refs.agentsMd > 0) { parts.push(`🤖 ag: ${refs.agentsMd}`); }
 	} else {
@@ -145,6 +147,7 @@ export function getContextRefsSummary(refs: ContextReferenceUsage, abbreviated =
 		if ((refs.changes || 0) > 0) { parts.push(`#changes: ${refs.changes}`); }
 		if ((refs.outputPanel || 0) > 0) { parts.push(`#outputPanel: ${refs.outputPanel}`); }
 		if ((refs.problemsPanel || 0) > 0) { parts.push(`#problemsPanel: ${refs.problemsPanel}`); }
+		if ((refs.pullRequest || 0) > 0) { parts.push(`#pr: ${refs.pullRequest}`); }
 		if (refs.copilotInstructions > 0) { parts.push(`📋 instructions: ${refs.copilotInstructions}`); }
 		if (refs.agentsMd > 0) { parts.push(`🤖 agents: ${refs.agentsMd}`); }
 	}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -404,6 +404,7 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 		changes: coerceNumber(refs?.changes),
 		outputPanel: coerceNumber(refs?.outputPanel),
 		problemsPanel: coerceNumber(refs?.problemsPanel),
+		pullRequest: coerceNumber(refs?.pullRequest),
 		byKind: refs?.byKind ?? {},
 		copilotInstructions: coerceNumber(refs?.copilotInstructions),
 		agentsMd: coerceNumber(refs?.agentsMd),
@@ -1201,6 +1202,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 						<div class="stat-card" title="Uncommitted git changes"><div class="stat-label">📝 #changes</div><div class="stat-value">${stats.last30Days.contextReferences.changes || 0}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${stats.today.contextReferences.changes || 0}</div></div>
 						<div class="stat-card" title="Output panel contents"><div class="stat-label">📤 #outputPanel</div><div class="stat-value">${stats.last30Days.contextReferences.outputPanel || 0}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${stats.today.contextReferences.outputPanel || 0}</div></div>
 						<div class="stat-card" title="Problems panel contents"><div class="stat-label">⚠️ #problemsPanel</div><div class="stat-value">${stats.last30Days.contextReferences.problemsPanel || 0}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${stats.today.contextReferences.problemsPanel || 0}</div></div>
+						<div class="stat-card" title="Pull request context references (#pr / #pullRequest) — Copilot PR chat understanding, review, and summary"><div class="stat-label">🔀 #pr</div><div class="stat-value">${stats.last30Days.contextReferences.pullRequest || 0}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${stats.today.contextReferences.pullRequest || 0}</div></div>
 						<div class="stat-card" title="copilot-instructions.md file references detected in session logs"><div class="stat-label">📋 Copilot Instructions</div><div class="stat-value">${stats.last30Days.contextReferences.copilotInstructions}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${stats.today.contextReferences.copilotInstructions}</div></div>
 						<div class="stat-card" title="agents.md file references detected in session logs"><div class="stat-label">🤖 Agents.md</div><div class="stat-value">${stats.last30Days.contextReferences.agentsMd}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${stats.today.contextReferences.agentsMd}</div></div>
 						<div class="stat-card" style="background: var(--list-active-bg); border: 2px solid var(--border-color); color: var(--list-active-fg);"><div class="stat-label" style="color: var(--list-active-fg); opacity: 0.85;">📊 Total References</div><div class="stat-value" style="color: var(--list-active-fg);">${last30DaysTotalRefs}</div><div style="font-size: 10px; color: var(--list-active-fg); opacity: 0.75; margin-top: 4px;">Today: ${todayTotalRefs}</div></div>

--- a/vscode-extension/test/unit/maturityScoring.test.ts
+++ b/vscode-extension/test/unit/maturityScoring.test.ts
@@ -42,7 +42,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
             file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
             workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0,
             terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0,
-            problemsPanel: 0, byKind: {}, byPath: {}, copilotInstructions: 0, agentsMd: 0,
+            problemsPanel: 0, pullRequest: 0, byKind: {}, byPath: {}, copilotInstructions: 0, agentsMd: 0,
         },
         mcpTools: { total: 0, byServer: {}, byTool: {} },
         modelSwitching: {

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -28,7 +28,7 @@ function emptyRefs(): ContextReferenceUsage {
         file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
         workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0,
         terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0,
-        problemsPanel: 0, byKind: {}, byPath: {}, copilotInstructions: 0, agentsMd: 0,
+        problemsPanel: 0, pullRequest: 0, byKind: {}, byPath: {}, copilotInstructions: 0, agentsMd: 0,
     };
 }
 
@@ -276,6 +276,25 @@ test('analyzeContextReferences: counts #problemsPanel references', () => {
     assert.equal(refs.problemsPanel, 1);
 });
 
+test('analyzeContextReferences: counts #pr references', () => {
+    const refs = emptyRefs();
+    analyzeContextReferences('review #pr changes', refs);
+    assert.equal(refs.pullRequest, 1);
+});
+
+test('analyzeContextReferences: counts #pullRequest references', () => {
+    const refs = emptyRefs();
+    analyzeContextReferences('summarize #pullRequest please', refs);
+    assert.equal(refs.pullRequest, 1);
+});
+
+test('analyzeContextReferences: #pr does not match #problemsPanel', () => {
+    const refs = emptyRefs();
+    analyzeContextReferences('check #problemsPanel', refs);
+    assert.equal(refs.pullRequest, 0);
+    assert.equal(refs.problemsPanel, 1);
+});
+
 test('analyzeContextReferences: accumulates on existing counts', () => {
     const refs = emptyRefs();
     refs.file = 2;
@@ -408,6 +427,24 @@ test('analyzeContentReferences: handles inlineReference kind with fsPath', () =>
         { kind: 'inlineReference', inlineReference: { fsPath: '/src/component.ts' } },
     ], refs);
     assert.equal(refs.file, 1);
+});
+
+test('analyzeContentReferences: increments pullRequest for pullRequest kind', () => {
+    const refs = emptyRefs();
+    analyzeContentReferences([
+        { kind: 'pullRequest', pullRequest: { number: 42, title: 'My PR' } },
+    ], refs);
+    assert.equal(refs.pullRequest, 1);
+    assert.equal(refs.byKind['pullRequest'], 1);
+});
+
+test('analyzeContentReferences: multiple pullRequest entries accumulate', () => {
+    const refs = emptyRefs();
+    analyzeContentReferences([
+        { kind: 'pullRequest', pullRequest: { number: 1 } },
+        { kind: 'pullRequest', pullRequest: { number: 2 } },
+    ], refs);
+    assert.equal(refs.pullRequest, 2);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds detection and surfacing of pull request context references in Copilot chat sessions, based on the [GitHub Copilot PR chat improvements (April 2026)](https://github.blog/changelog/2026-04-23-copilot-chat-improvements-for-pull-requests/).

Users can now attach pull request context in VS Code Copilot chat via `#pr` or `#pullRequest`, enabling PR understanding, review, and summarization. This PR tracks those references as a new `pullRequest` counter in `ContextReferenceUsage`.

## Changes

### Detection
- **Text regex**: `/#pr\b/gi` and `/#pullRequest\b/gi` in `analyzeContextReferences()` — `\b` word boundary prevents false matches on `#problemsPanel`
- **Structured refs**: `kind === 'pullRequest'` branch in `analyzeContentReferences()` for when structured `contentReferences` are present in the log

### Aggregation
- `mergeUsageAnalysis()` sums `pullRequest` across sessions with `|| 0` for backward-compatible cache reads
- `createEmptyContextRefs()` initialized with `pullRequest: 0`

### Surfacing
- **Usage Analysis webview**: new `🔀 #pr` stat card in the context references section
- **Log Viewer**: `#pr` badge in per-turn context reference display
- **contextRefUtils**: `getTotalContextRefs`, `getExplicitContextRefs`, `getContextRefsSummary` all include the new field

### Tests
- 5 new unit tests: `#pr` detection, `#pullRequest` detection, no false-positive on `#problemsPanel`, `contentReferences kind=pullRequest` structured detection, multiple PR entries accumulate

## All 40 unit tests pass ✅