### PR TITLE
chore: bump versions for release (vscode-extension, cli, visualstudio-extension)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.10"
+              Version="1.0.11"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version | Last tag |
|-----------|-------------|-------------|----------|
| VS Code extension | v0.3.1 | v0.3.2 | \scode/v0.3.0\ |
| CLI | v0.0.14 | v0.0.15 | \cli/v0.0.8\ |
| Visual Studio extension | v1.0.10 | v1.0.11 | *(never tagged — first release)* |

---

### After merging, run these workflows:

#### 1. VS Code Extension
- **Actions → Extensions - Release → Run workflow** (on \main\)
- Publishes VS Code extension **v0.3.2** to the VS Code Marketplace

#### 2. CLI
- **Actions → CLI - Publish to npm and GitHub → Run workflow** (on \main\)
- Publishes **@rajbos/ai-engineering-fluency@0.0.15** to npm

#### 3. Visual Studio Extension
- **Actions → Visual Studio Extension - Build & Package → Run workflow** (on \main\)
- Set \publish_marketplace: true\ to publish **v1.0.11** to the Visual Studio Marketplace