### PR TITLE
fix(release): rename legacy VSIX display name and flip publish order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,7 @@ jobs:
           const fs = require('fs');
           const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
           pkg.name = 'copilot-token-tracker';
+          pkg.displayName = 'GitHub Copilot Token Tracker';
           fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
         "
         npx vsce package
@@ -275,6 +276,7 @@ jobs:
           const fs = require('fs');
           const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
           pkg.name = 'ai-engineering-fluency';
+          pkg.displayName = 'AI Engineering Fluency';
           fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
         "
 
@@ -452,14 +454,16 @@ jobs:
           exit 1
         fi
         
-        echo "Publishing ${{ steps.download_vsix.outputs.vsix_file }} to VS Code Marketplace..."
-        npx vsce publish \
-          --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
-          --pat "$VSCE_PAT"
-        
+        # Publish legacy first to release the "AI Engineering Fluency" display name,
+        # then publish the new extension which claims it.
         echo "Publishing ${{ steps.download_vsix.outputs.legacy_vsix_file }} to VS Code Marketplace (legacy ID)..."
         npx vsce publish \
           --packagePath "${{ steps.download_vsix.outputs.legacy_vsix_file }}" \
+          --pat "$VSCE_PAT"
+
+        echo "Publishing ${{ steps.download_vsix.outputs.vsix_file }} to VS Code Marketplace..."
+        npx vsce publish \
+          --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
           --pat "$VSCE_PAT"
 
     - name: Publish to Open VSX Registry
@@ -473,14 +477,16 @@ jobs:
           exit 1
         fi
 
-        echo "Publishing ${{ steps.download_vsix.outputs.vsix_file }} to Open VSX Registry..."
-        npx --yes ovsx publish \
-          --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
-          -p "$OPEN_VSX_TOKEN"
-
+        # Publish legacy first to release the "AI Engineering Fluency" display name,
+        # then publish the new extension which claims it.
         echo "Publishing ${{ steps.download_vsix.outputs.legacy_vsix_file }} to Open VSX Registry (legacy ID)..."
         npx --yes ovsx publish \
           --packagePath "${{ steps.download_vsix.outputs.legacy_vsix_file }}" \
+          -p "$OPEN_VSX_TOKEN"
+
+        echo "Publishing ${{ steps.download_vsix.outputs.vsix_file }} to Open VSX Registry..."
+        npx --yes ovsx publish \
+          --packagePath "${{ steps.download_vsix.outputs.vsix_file }}" \
           -p "$OPEN_VSX_TOKEN"
 
     - name: Publish Summary


### PR DESCRIPTION
## Problem

The `release.yml` publish job was failing with:
> `This extension display name is taken. Please try a different one.`

The old `RobBos.copilot-token-tracker` extension holds the display name **"AI Engineering Fluency"** on the VS Code Marketplace. When the workflow tried to publish the new `RobBos.ai-engineering-fluency` extension with the same display name, the marketplace rejected it.

## Fix

1. **Rename the legacy VSIX display name at build time** — when building the `copilot-token-tracker` VSIX, also set `displayName` to `"GitHub Copilot Token Tracker"`. This frees up the `"AI Engineering Fluency"` name on the marketplace.

2. **Flip the publish order** — publish the legacy extension first (which releases the display name), then publish the new `ai-engineering-fluency` extension which claims it. Applied to both the VS Code Marketplace and Open VSX Registry publish steps.

After this merges, re-run the `Extensions - Release` workflow with `publish_marketplace: true` to complete the publish.