### PR TITLE
fix(release): use unique display name for legacy VSIX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
           const fs = require('fs');
           const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
           pkg.name = 'copilot-token-tracker';
-          pkg.displayName = 'RobBos Copilot Token Tracker';
+          pkg.displayName = 'AI Engineering Fluency (Deprecated)';
           fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
         "
         npx vsce package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
           const fs = require('fs');
           const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
           pkg.name = 'copilot-token-tracker';
-          pkg.displayName = 'GitHub Copilot Token Tracker';
+          pkg.displayName = 'RobBos Copilot Token Tracker';
           fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
         "
         npx vsce package


### PR DESCRIPTION
Follow-up to #763: \GitHub Copilot Token Tracker\ is already claimed by another publisher on the VS Code Marketplace. Changing the legacy \copilot-token-tracker\ VSIX display name to \RobBos Copilot Token Tracker\ instead, which is publisher-scoped and guaranteed unique.