### PR TITLE
chore: bump versions for release (vscode-extension)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps the version number for the VS Code extension, which has changed since its last release tag (\scode/v0.3.0\).

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.3.2 | v0.3.3 |

### After merging, run these workflows:

#### VS Code Extension
- Go to **Actions → Extensions - Release → Run workflow** (on \main\)
- This publishes VS Code extension **v0.3.3** to the VS Code Marketplace