### PR TITLE
chore: bump versions for release (vscode-extension v0.4.0, cli v0.1.0)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,32 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-04
+
+### ✨ Features & Improvements
+- Added Gemini CLI support as a trackable ecosystem
+- Added JetBrains adapter to CLI ecosystem registry
+- Added Mistral Vibe session support
+- Added weekly/monthly chart periods and fixed usage analysis routing
+- Added GitHub Copilot AI-Credit pricing alongside provider pricing
+- Added dedicated CLI interaction mode in Usage Analysis (#659)
+- Added macOS path support for Claude Desktop Cowork sessions (#714)
+- Improved fluency spiderweb chart for Claude-only users
+- Renamed cost labels: (API) → (est.) and (Copilot) → (TBB) with explainer tooltips
+- Display CO2 in kg when ≥ 1000g for readability
+
+### 🐛 Bug Fixes
+- Fixed: align token counting with VS Code extension
+- Fixed: use actual tokens for all periods; increased session timeout to 120s
+- Fixed: prefer `actualTokens` from `session.shutdown` over estimates
+- Fixed: use UTC date boundaries for period attribution
+- Fixed: extract per-model usage from `session.shutdown` events
+- Fixed: populate estimated cost data in chart view for all periods
+
+### 🔧 Maintenance
+- Migrated to IEcosystemAdapter registry pattern for improved extensibility
+- Bumped cache version to 3 to reflect SessionData shape changes
+
 ## [0.0.14] - 2026-04-30
 
 ### ✨ Features & Improvements

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.15",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.0.15",
+      "version": "0.1.0",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.0.15",
+  "version": "0.1.0",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,30 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-04
+
+### Features and Improvements
+- Added Gemini CLI support as a trackable ecosystem
+- Added JetBrains IDE Copilot session discovery with ask/agent mode detection, per-turn model tracking, and tooltips for data limits
+- Added Copilot PR chat context references detection — surfaces #pr context in session log viewer (#760)
+- Added Path Analyzer tab to diagnostics panel (#713)
+- Added Editor Mode summary card to log viewer
+- Added daily auto-sync of model multipliers from github-copilot-model-notifier (#718)
+- Dual-publish VS Code extension under new AI Engineering Fluency marketplace ID (#731)
+- Added detection of legacy copilot-token-tracker extension with prompt to uninstall and migration notice
+- Added friendly display names for mcp_context7, mcp_microsoftdocs, Slidev, Copilot CLI built-in tools, and JetBrains tools (#723, #726)
+- Added missing friendly names for additional tools (#771)
+- Surface subagent count in log viewer; fixed subagent tool-result token estimation (#720)
+- Added weekly/monthly chart periods and fixed usage analysis routing
+
+### Bug Fixes
+- Fixed: only suppress deprecation notice on explicit Dismiss
+- Fixed: show correct editor name for eco sessions in diagnostics directory table
+- Fixed: eco-session token count in diagnostics matches file viewer
+- Fixed: replace hardcoded dark backgrounds in log viewer with theme CSS variables (#716)
+- Fixed: populate estimated cost data in chart view for all periods
+- Fixed: cost estimate reason display
+
 ## [0.3.0] - 2026-04-30
 
 ### Features and Improvements

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-token-tracker",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-token-tracker",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers and updates changelogs for components that have changed since their last release tags.

| Component | Old version | New version | Bump type |
|-----------|-------------|-------------|-----------|
| VS Code extension | v0.3.3 | v0.4.0 | minor |
| CLI | v0.0.15 | v0.1.0 | minor |
| Visual Studio extension | v1.0.11 | — | skipped (no changes) |

### Changes included

**VS Code extension (v0.4.0):** JetBrains IDE Copilot session discovery, Gemini CLI support, Copilot PR chat context detection, Path Analyzer diagnostics tab, Editor Mode summary card, daily model-multiplier sync, dual-publish under new AI Engineering Fluency marketplace ID, legacy extension migration prompt, and numerous friendly tool name additions.

**CLI (v0.1.0):** Gemini CLI, JetBrains, and Mistral Vibe ecosystem support; weekly/monthly chart periods; GitHub Copilot AI-Credit pricing; dedicated CLI interaction mode; multiple token-counting accuracy fixes; full adapter-registry refactor.

---

### After merging, run these workflows:

#### 1. VS Code Extension
- Go to **Actions → Extensions - Release → Run workflow** (on \main\)
- Publishes VS Code extension **v0.4.0** to the VS Code Marketplace

#### 2. CLI
- Go to **Actions → CLI - Publish to npm and GitHub → Run workflow** (on \main\)
- Publishes **@rajbos/ai-engineering-fluency@0.1.0** to npm