### PR TITLE
chore(vscode): bump VS Code extension to v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ void --install-extension RobBos.ai-engineering-fluency
 
 📖 [Full VS Code extension documentation](docs/vscode-extension/README.md)
 
+> **Previously known as `copilot-token-tracker` (deprecated):** [![legacy installs](https://badgen.net/vs-marketplace/i/RobBos.copilot-token-tracker)](https://marketplace.visualstudio.com/items?itemName=RobBos.copilot-token-tracker) — If you still have it installed, the extension will prompt you to migrate.
+
 ---
 
 ### 🐦 JetBrains IDE Plugin

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 
 Real-time token usage in the status bar, fluency score dashboard, usage analysis, cloud sync, and more. Works with all Chromium-based VS Code forks — VS Code, Windsurf, Cursor, VSCodium, Trae, Kiro, Void, and more.
 
-[![Install - VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency) [![VS Code installs](https://img.shields.io/visual-studio-marketplace/i/RobBos.ai-engineering-fluency?label=VS%20Code%20installs)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency) [![Install - Windsurf (Open VSX)](https://img.shields.io/badge/Install-Windsurf-00B4D8?logo=open-vsx)](https://open-vsx.org/extension/RobBos/ai-engineering-fluency) [![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/ai-engineering-fluency?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/ai-engineering-fluency)
+[![Install - VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency) [![VS Code installs](https://badgen.net/vs-marketplace/i/RobBos.ai-engineering-fluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency) [![Install - Windsurf (Open VSX)](https://img.shields.io/badge/Install-Windsurf-00B4D8?logo=open-vsx)](https://open-vsx.org/extension/RobBos/ai-engineering-fluency) [![Open VSX installs](https://img.shields.io/open-vsx/dt/RobBos/ai-engineering-fluency?label=Open%20VSX%20installs)](https://open-vsx.org/extension/RobBos/ai-engineering-fluency)
 
 ```bash
 # Install from the VS Code Marketplace
@@ -87,9 +87,11 @@ void --install-extension RobBos.ai-engineering-fluency
 
 ---
 
-### 🐦 JetBrains IDE Plugin (awaiting JetBrains Marketplace approval)
+### 🐦 JetBrains IDE Plugin
 
 Token usage and fluency dashboards inside any JetBrains IDE (IntelliJ IDEA, Rider, PyCharm, WebStorm, GoLand, RubyMine, CLion, …). Built as a thin Kotlin/JCEF host that reuses the same webview bundles as the VS Code extension and the same bundled CLI as the Visual Studio extension.
+
+[![Install - JetBrains](https://img.shields.io/badge/Install-JetBrains-000000?logo=jetbrains)](https://plugins.jetbrains.com/plugin/31580-ai-engineering-fluency) [![JetBrains installs](https://img.shields.io/jetbrains/plugin/d/31580?label=JetBrains%20installs)](https://plugins.jetbrains.com/plugin/31580-ai-engineering-fluency)
 
 📖 [JetBrains plugin docs](jetbrains-plugin/README.md) · [Debugging guide](jetbrains-plugin/DEBUGGING-GUIDE.md)
 
@@ -99,7 +101,7 @@ Token usage and fluency dashboards inside any JetBrains IDE (IntelliJ IDEA, Ride
 
 Token usage tracking inside Visual Studio 2022+, reading Copilot Chat session files directly.
 
-[![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/RobBos.AIEngineeringFluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.AIEngineeringFluency)
+[![Visual Studio Marketplace Installs](https://badgen.net/vs-marketplace/i/RobBos.AIEngineeringFluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.AIEngineeringFluency)
 
 📖 [Full Visual Studio extension documentation](docs/visual-studio/README.md)
 

--- a/docs/vscode-extension/README.md
+++ b/docs/vscode-extension/README.md
@@ -6,7 +6,7 @@ Track your AI Engineering Fluency — daily and monthly token usage, cost estima
 
 ## Install
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/RobBos.ai-engineering-fluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency)
+[![VS Code Marketplace](https://badgen.net/vs-marketplace/v/RobBos.ai-engineering-fluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency)
 
 Search for **"AI Engineering Fluency"** in the VS Code Extensions panel, or install via the Marketplace link above.
 

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-05
+
+### Fixes
+- Fixed README badges: replaced retired vsmarketplacebadges.dev with shields.io
+- Updated all VS Code install links and commands to the current extension ID (`ai-engineering-fluency`)
+- Disabled legacy `copilot-token-tracker` VSIX creation and publishing in the release workflow (migration flow complete)
+
 ## [0.4.0] - 2026-05-04
 
 ### Features and Improvements

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -6,7 +6,7 @@ Track your AI Engineering Fluency — daily and monthly token usage, cost estima
 
 ## Install
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/RobBos.ai-engineering-fluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency)
+[![VS Code Marketplace](https://badgen.net/vs-marketplace/v/RobBos.ai-engineering-fluency)](https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency)
 
 Search for **"AI Engineering Fluency"** in the VS Code Extensions panel, or install via the Marketplace link above.
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "copilot-token-tracker",
-  "version": "0.4.0",
+  "name": "ai-engineering-fluency",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "copilot-token-tracker",
-      "version": "0.4.0",
+      "name": "ai-engineering-fluency",
+      "version": "0.4.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Why

v0.4.0 was already live on the VS Code Marketplace when the release workflow ran. This bumps to **0.4.1** so the next publish can proceed.

## What's in 0.4.1

- Fixed README badges (retired `vsmarketplacebadges.dev` → `shields.io`)
- Updated all VS Code install links/commands to the current extension ID (`ai-engineering-fluency`)
- Disabled legacy `copilot-token-tracker` VSIX creation and publishing in the release workflow (migration flow complete)

## After merging

Trigger **Actions → Extensions - Release → Run workflow** (on `main`) to publish v0.4.1.