### PR TITLE
fix: add macOS ARM64 support to JetBrains plugin (fixes #775)

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -131,7 +131,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   build-cli-macos-x64:
     name: Build CLI (macOS x64)
-    runs-on: macos-13   # last Intel (x64) macOS runner available on GitHub Actions
+    runs-on: macos-15-intel   # Intel (x64) macOS runner; macos-13 is no longer available
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -77,11 +77,11 @@ jobs:
           retention-days: 1
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Step 1b — CLI binary: macOS
+  # Step 1b — CLI binary: macOS ARM64 (Apple Silicon)
   # ─────────────────────────────────────────────────────────────────────────────
-  build-cli-macos:
-    name: Build CLI (macOS)
-    runs-on: macos-latest
+  build-cli-macos-arm64:
+    name: Build CLI (macOS ARM64)
+    runs-on: macos-15   # pinned Apple Silicon runner (M-series); do not use macos-latest (label shifts)
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -104,25 +104,75 @@ jobs:
         working-directory: cli
         run: node esbuild.js --production
 
-      - name: Build macOS SEA binary
+      - name: Build macOS ARM64 SEA binary
         working-directory: cli
         run: |
           node --experimental-sea-config sea-config.json
-          cp "$(which node)" dist/copilot-token-tracker-macos
-          npx --yes postject dist/copilot-token-tracker-macos NODE_SEA_BLOB dist/sea-prep.blob \
+          cp "$(which node)" dist/copilot-token-tracker-macos-arm64
+          npx --yes postject dist/copilot-token-tracker-macos-arm64 NODE_SEA_BLOB dist/sea-prep.blob \
             --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 \
             --macho-segment-name NODE_SEA
-          chmod +x dist/copilot-token-tracker-macos
+          chmod +x dist/copilot-token-tracker-macos-arm64
 
       - name: Smoke-test the binary
         working-directory: cli
-        run: dist/copilot-token-tracker-macos --version
+        run: dist/copilot-token-tracker-macos-arm64 --version
 
-      - name: Upload macOS CLI artifact
+      - name: Upload macOS ARM64 CLI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cli-macos
-          path: cli/dist/copilot-token-tracker-macos
+          name: cli-macos-arm64
+          path: cli/dist/copilot-token-tracker-macos-arm64
+          retention-days: 1
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 1c — CLI binary: macOS x64 (Intel)
+  # Note: macos-13 is the last available Intel macOS runner on GitHub Actions.
+  # ─────────────────────────────────────────────────────────────────────────────
+  build-cli-macos-x64:
+    name: Build CLI (macOS x64)
+    runs-on: macos-13   # last Intel (x64) macOS runner available on GitHub Actions
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install CLI dependencies
+        working-directory: cli
+        run: npm ci
+
+      - name: Build production bundle
+        working-directory: cli
+        run: node esbuild.js --production
+
+      - name: Build macOS x64 SEA binary
+        working-directory: cli
+        run: |
+          node --experimental-sea-config sea-config.json
+          cp "$(which node)" dist/copilot-token-tracker-macos-x64
+          npx --yes postject dist/copilot-token-tracker-macos-x64 NODE_SEA_BLOB dist/sea-prep.blob \
+            --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 \
+            --macho-segment-name NODE_SEA
+          chmod +x dist/copilot-token-tracker-macos-x64
+
+      - name: Smoke-test the binary
+        working-directory: cli
+        run: dist/copilot-token-tracker-macos-x64 --version
+
+      - name: Upload macOS x64 CLI artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cli-macos-x64
+          path: cli/dist/copilot-token-tracker-macos-x64
           retention-days: 1
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -214,7 +264,7 @@ jobs:
   build-and-publish:
     name: Build and Publish Plugin
     runs-on: ubuntu-latest
-    needs: [build-cli-windows, build-cli-macos, build-cli-linux, build-webview]
+    needs: [build-cli-windows, build-cli-macos-arm64, build-cli-macos-x64, build-cli-linux, build-webview]
     permissions:
       contents: write   # needed to create GitHub release on tag push
 
@@ -248,16 +298,17 @@ jobs:
           mkdir -p cli/dist vscode-extension/dist/webview
 
           # CLI binaries (sql-wasm.wasm is the same on all platforms; one copy suffices)
-          cp artifacts/cli-windows/copilot-token-tracker.exe  cli/dist/
-          cp artifacts/cli-windows/sql-wasm.wasm              cli/dist/
-          cp artifacts/cli-macos/copilot-token-tracker-macos  cli/dist/
-          cp artifacts/cli-linux/copilot-token-tracker-linux  cli/dist/
+          cp artifacts/cli-windows/copilot-token-tracker.exe      cli/dist/
+          cp artifacts/cli-windows/sql-wasm.wasm                  cli/dist/
+          cp artifacts/cli-macos-arm64/copilot-token-tracker-macos-arm64  cli/dist/
+          cp artifacts/cli-macos-x64/copilot-token-tracker-macos-x64      cli/dist/
+          cp artifacts/cli-linux/copilot-token-tracker-linux       cli/dist/
 
           # Webview JS bundles (built by vscode-extension)
           cp artifacts/webview-bundles/*  vscode-extension/dist/webview/
 
           # Make unix binaries executable
-          chmod +x cli/dist/copilot-token-tracker-macos cli/dist/copilot-token-tracker-linux
+          chmod +x cli/dist/copilot-token-tracker-macos-arm64 cli/dist/copilot-token-tracker-macos-x64 cli/dist/copilot-token-tracker-linux
 
           echo ""
           echo "=== cli/dist ==="
@@ -305,6 +356,26 @@ jobs:
           fi
           SIZE=$(du -sh "$ZIP" | cut -f1)
           echo "✅ Plugin ZIP: $ZIP ($SIZE)"
+
+      - name: Assert all CLI bundles are present in the ZIP
+        run: |
+          ZIP=$(find jetbrains-plugin/build/distributions/ -name "*.zip" | head -1)
+          MISSING=()
+          for ENTRY in \
+            "cli-bundle/win-x64/copilot-token-tracker.exe" \
+            "cli-bundle/darwin-arm64/copilot-token-tracker" \
+            "cli-bundle/darwin-x64/copilot-token-tracker" \
+            "cli-bundle/linux-x64/copilot-token-tracker"; do
+            if ! unzip -l "$ZIP" | grep -q "$ENTRY"; then
+              MISSING+=("$ENTRY")
+            fi
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "❌ Missing CLI bundle entries in plugin ZIP:"
+            for M in "${MISSING[@]}"; do echo "  - $M"; done
+            exit 1
+          fi
+          echo "✅ All CLI bundles present in plugin ZIP"
 
       - name: Publish to JetBrains Marketplace
         # Publish on tag push, or on workflow_dispatch when explicitly requested

--- a/jetbrains-plugin/README.md
+++ b/jetbrains-plugin/README.md
@@ -80,17 +80,22 @@ Or, equivalently, use the orchestrator:
 
 ### macOS / Linux CLI binaries
 
-Out of the box `cli/bundle-exe.ps1` only produces the Windows `.exe`. To
-ship a fully cross-platform plugin, the bundle script must be extended to
-also emit:
+The CI pipeline in `.github/workflows/jetbrains-publish.yml` produces all
+platform binaries automatically:
 
-* `cli/dist/copilot-token-tracker-macos`
-* `cli/dist/copilot-token-tracker-linux`
+| OS | Runner | Output file |
+|----|--------|-------------|
+| macOS ARM64 (Apple Silicon) | `macos-15` | `copilot-token-tracker-macos-arm64` |
+| macOS x64 (Intel) | `macos-13` | `copilot-token-tracker-macos-x64` |
+| Linux x64 | `ubuntu-latest` | `copilot-token-tracker-linux` |
 
-These are produced via Node SEA + `postject` against the matching Node
-binary downloads. CI is the natural place to do this (one job per OS,
-artifacts uploaded into the plugin resources). Until then, the Gradle build
-silently omits the missing binaries and the plugin only works on Windows.
+`CliBridge.kt` detects the JVM runtime architecture at startup and selects
+`darwin-arm64` for ARM64 JVMs (Apple Silicon running IntelliJ natively) or
+`darwin-x64` for x64 JVMs (Intel Macs, or Apple Silicon running IntelliJ
+under Rosetta 2).
+
+Until then, the Gradle build silently omits any missing binary and the plugin
+surfaces a clear error message if the user's OS/arch is not covered.
 
 ## Running and debugging
 

--- a/jetbrains-plugin/build.gradle.kts
+++ b/jetbrains-plugin/build.gradle.kts
@@ -72,16 +72,17 @@ intellijPlatform {
 // Copies the prebuilt artefacts produced by the other monorepo projects into
 // the resources directory so they end up on the plugin classpath:
 //
-//   vscode-extension/dist/webview/*.js                  -> resources/webview/
-//   visualstudio-extension/.../vscode-shim.js           -> resources/webview/
-//   cli/dist/copilot-token-tracker.exe (+ sql-wasm.wasm) -> resources/cli-bundle/win-x64/
-//   cli/dist/copilot-token-tracker-macos                -> resources/cli-bundle/darwin-x64/
-//   cli/dist/copilot-token-tracker-linux                -> resources/cli-bundle/linux-x64/
+//   vscode-extension/dist/webview/*.js                      -> resources/webview/
+//   visualstudio-extension/.../vscode-shim.js               -> resources/webview/
+//   cli/dist/copilot-token-tracker.exe (+ sql-wasm.wasm)    -> resources/cli-bundle/win-x64/
+//   cli/dist/copilot-token-tracker-macos-arm64              -> resources/cli-bundle/darwin-arm64/
+//   cli/dist/copilot-token-tracker-macos-x64                -> resources/cli-bundle/darwin-x64/
+//   cli/dist/copilot-token-tracker-linux                    -> resources/cli-bundle/linux-x64/
 //
-// The macOS/Linux binaries are produced by an extended bundle-exe script (see
-// jetbrains-plugin/README.md). Missing files are tolerated so the plugin can
-// still build with only the OS bundles that are currently available — at
-// runtime CliBridge surfaces a clear error if the user's OS isn't covered.
+// The macOS/Linux binaries are produced by the CI pipeline (see jetbrains-publish.yml).
+// Missing files are tolerated so the plugin can still build with only the OS bundles
+// that are currently available — at runtime CliBridge surfaces a clear error if the
+// user's OS isn't covered.
 // ─────────────────────────────────────────────────────────────────────────────
 
 val prepareBundledAssets by tasks.registering(Copy::class) {
@@ -108,9 +109,16 @@ val prepareBundledAssets by tasks.registering(Copy::class) {
         include("copilot-token-tracker.exe", "sql-wasm.wasm")
         into("cli-bundle/win-x64")
     }
+    // ARM64 macOS binary — built on an ARM64 runner (macos-15) by CI.
     from("$repoRoot/cli/dist") {
-        include("copilot-token-tracker-macos", "sql-wasm.wasm")
-        rename("copilot-token-tracker-macos", "copilot-token-tracker")
+        include("copilot-token-tracker-macos-arm64", "sql-wasm.wasm")
+        rename("copilot-token-tracker-macos-arm64", "copilot-token-tracker")
+        into("cli-bundle/darwin-arm64")
+    }
+    // Intel x64 macOS binary — built on an x64 runner (macos-13) by CI.
+    from("$repoRoot/cli/dist") {
+        include("copilot-token-tracker-macos-x64", "sql-wasm.wasm")
+        rename("copilot-token-tracker-macos-x64", "copilot-token-tracker")
         into("cli-bundle/darwin-x64")
     }
     from("$repoRoot/cli/dist") {

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -1,6 +1,8 @@
 package com.github.rajbos.aiengineeringfluency
 
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.createDirectories
 import java.io.IOException
@@ -138,6 +140,14 @@ object CliBridge {
      * Returns the path to the extracted CLI binary, extracting it on first use.
      * Cached for the lifetime of the IDE so repeated calls are cheap.
      */
+
+    /** Plugin version string, used to version the extraction directory so upgrades don't reuse stale binaries. */
+    private val pluginVersion: String by lazy {
+        PluginManagerCore.getPlugin(PluginId.getId("com.github.rajbos.ai-engineering-fluency"))
+            ?.version
+            ?: "unknown"
+    }
+
     private fun ensureExtracted(): Path {
         cachedExePath?.let { return it }
         synchronized(this) {
@@ -147,7 +157,9 @@ object CliBridge {
             val exeName = if (SystemInfo.isWindows) "copilot-token-tracker.exe" else "copilot-token-tracker"
             val resourcePrefix = "/cli-bundle/$osDir"
 
-            val targetDir = Path.of(System.getProperty("java.io.tmpdir"), "ai-engineering-fluency", osDir)
+            // Include plugin version in the path so each upgrade extracts a fresh copy
+            // instead of reusing a potentially stale binary from a previous version.
+            val targetDir = Path.of(System.getProperty("java.io.tmpdir"), "ai-engineering-fluency", pluginVersion, osDir)
             targetDir.createDirectories()
 
             val exePath = copyResource("$resourcePrefix/$exeName", targetDir.resolve(exeName))
@@ -195,9 +207,21 @@ object CliBridge {
 
     private fun osBundleDir(): String = when {
         SystemInfo.isWindows -> "win-x64"
-        SystemInfo.isMac -> "darwin-x64"   // x64 binary runs on Apple Silicon under Rosetta until we ship arm64
+        SystemInfo.isMac -> if (isArm64Runtime()) "darwin-arm64" else "darwin-x64"
         SystemInfo.isLinux -> "linux-x64"
         else -> throw IllegalStateException("Unsupported OS: ${SystemInfo.OS_NAME}")
+    }
+
+    /**
+     * Returns true when this JVM process is running as an ARM64 (aarch64) binary.
+     *
+     * On Apple Silicon Macs running IntelliJ under Rosetta 2, [System.getProperty]
+     * returns "x86_64", so the x64 CLI bundle is correctly selected in that scenario.
+     * Only a natively-running ARM64 JVM returns "aarch64" here.
+     */
+    private fun isArm64Runtime(): Boolean {
+        val arch = System.getProperty("os.arch", "")
+        return arch.equals("aarch64", ignoreCase = true) || arch.equals("arm64", ignoreCase = true)
     }
 
     /**


### PR DESCRIPTION
## Problem

Issue #775: The JetBrains plugin fails on macOS with:
```
Error loading Copilot usage data
java.lang.IllegalStateException: Bundled CLI not found at classpath:/cli-bundle/darwin-x64/copilot-token-tracker — this OS may not be supported by this build of the plugin
```

## Root Causes

1. **Wrong architecture**: `CliBridge.kt` always selected `darwin-x64` for all Mac users. Modern Macs (Apple Silicon, M1/M2/M3/M4) run IntelliJ as a native ARM64 JVM — there was no `darwin-arm64` bundle in the plugin JAR.

2. **Mislabelled binary**: The CI workflow used `macos-latest` (now an ARM64 runner since ~late 2025) but stored the binary under `darwin-x64`, putting an ARM64 binary in the wrong slot.

3. **Stale extraction cache**: The temp extraction path was shared across plugin versions, so a stale binary from an older version could survive an upgrade.

## Changes

### `CliBridge.kt`
- Detect runtime JVM architecture via `System.getProperty("os.arch")` and select `darwin-arm64` for ARM64 JVMs or `darwin-x64` for x64 JVMs
- Correctly handles Apple Silicon Macs running IntelliJ under Rosetta 2 (which report `x86_64`, so the x64 bundle is used — the right behaviour)
- Version the temp extraction directory with the plugin version to force fresh extraction on upgrade

### `.github/workflows/jetbrains-publish.yml`
- Split macOS build into two jobs:
  - `build-cli-macos-arm64` on `macos-15` (pinned Apple Silicon runner)
  - `build-cli-macos-x64` on `macos-13` (last available Intel macOS runner)
- Added a packaging assertion step that verifies all four CLI bundles are present in the plugin ZIP before publishing

### `jetbrains-plugin/build.gradle.kts`
- Bundle `darwin-arm64` from `copilot-token-tracker-macos-arm64`
- Bundle `darwin-x64` from `copilot-token-tracker-macos-x64` (was `copilot-token-tracker-macos`)

### `jetbrains-plugin/README.md`
- Document the dual-arch macOS build setup

## Testing

After merging, re-publish via `jetbrains-publish.yml` → the packaging assertion will verify both macOS bundles are present before the plugin reaches the marketplace.