### PR TITLE
chore: bump Visual Studio extension to v1.0.12

### DIFF
--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.11"
+              Version="1.0.12"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>


### PR DESCRIPTION
Version 1.0.11 already exists on the VS Marketplace (VsixPub0029). Bumps vsixmanifest to 1.0.12.