### PR TITLE
fix: use absolute URL for logo in VS Code extension README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,9 @@ jobs:
     - name: Create VSIX package
       if: inputs.vs_only != true
       working-directory: vscode-extension
-      run: npx vsce package
+      # --baseImagesUrl ensures relative image paths in README.md resolve correctly
+      # on the marketplace for this monorepo (extension root ≠ repo root).
+      run: npx vsce package --baseImagesUrl https://raw.githubusercontent.com/rajbos/ai-engineering-fluency/main/vscode-extension
       
     # Legacy VSIX creation disabled — migration flow is complete, no longer publishing copilot-token-tracker.
     # - name: Create legacy VSIX (copilot-token-tracker)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # AI Engineering Fluency — VS Code Extension
 
-![AI Engineering Fluency](assets/logo.png)
+![AI Engineering Fluency](https://raw.githubusercontent.com/rajbos/ai-engineering-fluency/main/vscode-extension/assets/logo.png)
 
 Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and productivity insights directly inside VS Code. Reads local session logs and displays today's and monthly usage in the status bar, with rich detail views and optional cloud sync.
 


### PR DESCRIPTION
## Problem

The main logo image is missing on both the VS Code Marketplace and OpenVSX Marketplace, while screenshots display correctly.

**Root cause:** The logo used a relative path in the README:
\\\md
![AI Engineering Fluency](assets/logo.png)
\\\

In a monorepo, \sce\ resolves relative image paths from the **repo root**, not the extension subdirectory. So the marketplace looks for \/assets/logo.png\ at the repo root, which doesn't exist — the logo is actually at \scode-extension/assets/logo.png\. Screenshots already used absolute \aw.githubusercontent.com\ URLs (which is why they worked).

## Fix

1. **README.md** — change logo to an absolute URL (same pattern as screenshots):
   \\\md
   ![AI Engineering Fluency](https://raw.githubusercontent.com/rajbos/ai-engineering-fluency/main/vscode-extension/assets/logo.png)
   \\\

2. **release.yml** — add \--baseImagesUrl\ to \sce package\ as a safety net so any future relative image paths also resolve correctly for this monorepo.

The fix applies to both VS Code Marketplace and OpenVSX (same VSIX, same issue).