### PR TITLE
fix: team dashboard empty

### DIFF
--- a/vscode-extension/src/backend/services/dataPlaneService.ts
+++ b/vscode-extension/src/backend/services/dataPlaneService.ts
@@ -210,13 +210,13 @@ export class DataPlaneService {
   }): Promise<BackendAggDailyEntityLike[]> {
     const { tableClient, startDayKey, endDayKey } = args;
 
-    // Query all entities in the date range without filtering by dataset
-    // Filter by timestamp to limit the scan
-    const startDate = new Date(startDayKey);
-    const endDate = new Date(endDayKey);
-    endDate.setUTCHours(23, 59, 59, 999); // End of day
-
-    const filter = `Timestamp ge datetime'${startDate.toISOString()}' and Timestamp le datetime'${endDate.toISOString()}'`;
+    // Query all entities in the date range without filtering by dataset.
+    // Filter by the `day` entity field (plain YYYY-MM-DD string).
+    // Filtering by Timestamp (the system write-time property) using the OData `datetime'...'`
+    // type annotation is not supported by Cosmos DB Tables API, which silently returns zero
+    // results. Using the `day` field works reliably across both Azure Storage Tables and
+    // Cosmos DB Tables API.
+    const filter = `day ge '${startDayKey}' and day le '${endDayKey}'`;
 
     this.log(
       `Querying all datasets for date range ${startDayKey} to ${endDayKey}`,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6077,7 +6077,7 @@ ${hashtag}`;
       const userId = (entity.userId ?? "").toString().replace(/^u:/, ""); // Strip u: prefix
       const datasetId = (entity.datasetId ?? "").toString().replace(/^ds:/, ""); // Strip ds: prefix
       const machineId = (entity.machineId ?? "").toString().replace(/^mc:/, ""); // Strip mc: prefix
-      const workspaceId = (entity.workspaceId ?? "").toString();
+      const workspaceId = (entity.workspaceId ?? "").toString().replace(/^w:/, ""); // Strip w: prefix
       const model = (entity.model ?? "").toString().replace(/^m:/, ""); // Strip m: prefix
       const inputTokens = Number.isFinite(Number(entity.inputTokens))
         ? Number(entity.inputTokens)

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6632,6 +6632,28 @@ ${hashtag}`;
     }
     report.push("");
 
+    // Backend Configuration
+    report.push("## Backend Configuration");
+    const settings = this.backend?.getSettings();
+    const githubAuthStatus = this.getGitHubAuthStatus();
+    report.push(`GitHub Authentication: ${githubAuthStatus.authenticated ? `Authenticated (${githubAuthStatus.username || "unknown"})` : "Not Authenticated"}`);
+    if (settings?.sharingServerEnabled) {
+      report.push(`Team Server: Enabled`);
+      report.push(`  - Server URL: ${settings.sharingServerEndpointUrl || "(not set)"}`);
+      if (!githubAuthStatus.authenticated) {
+        report.push(`  - ⚠️ WARNING: GitHub authentication is required for team server sync`);
+      }
+    } else {
+      report.push(`Team Server: Disabled`);
+    }
+    if (settings?.enabled) {
+      report.push(`Azure Storage: Enabled`);
+      report.push(`  - Storage Account: ${settings.storageAccount || "(not set)"}`);
+    } else {
+      report.push(`Azure Storage: Disabled`);
+    }
+    report.push("");
+
     // Session Files Discovery
     report.push("## Session Files Discovery");
     try {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -966,16 +966,17 @@ function renderTeamServerPanel(teamInfo: TeamServerInfo, githubAuth?: GitHubAuth
     </div>
 
     ${githubNotAuthenticated ? `
-    <div style="margin-bottom: 16px; padding: 12px 16px; background: rgba(217, 119, 6, 0.15); border: 1px solid #d97706; border-radius: 6px; display: flex; gap: 10px; align-items: flex-start;">
+    <button id="btn-team-server-auth-warning" style="width: 100%; margin-bottom: 16px; padding: 12px 16px; background: rgba(217, 119, 6, 0.15); border: 1px solid #d97706; border-radius: 6px; display: flex; gap: 10px; align-items: center; cursor: pointer; text-align: left;" title="Click to sign in to GitHub">
       <span style="font-size: 18px; flex-shrink: 0;">⚠️</span>
-      <div>
+      <div style="flex: 1;">
         <div style="color: #fbbf24; font-weight: 600; font-size: 13px; margin-bottom: 4px;">GitHub Authentication Required</div>
         <div style="color: #d4a017; font-size: 12px;">
           Team server sync will not run until you sign in to GitHub.
-          Go to the <strong>GitHub</strong> tab to authenticate.
+          <strong style="color: #fbbf24;">Click here to sign in.</strong>
         </div>
       </div>
-    </div>
+      <span style="color: #fbbf24; font-size: 18px; flex-shrink: 0;">→</span>
+    </button>
     ` : ''}
 
     <div class="summary-cards">
@@ -2029,6 +2030,12 @@ function renderLayout(data: DiagnosticsData): void {
         const currentState = vscode.getState() ?? {};
         vscode.setState({ ...currentState, activeTab: "backend", activeSubtab: "backend-teamserver" });
         vscode.postMessage({ command: "configureTeamServer" });
+      });
+
+    document
+      .getElementById("btn-team-server-auth-warning")
+      ?.addEventListener("click", () => {
+        vscode.postMessage({ command: "authenticateGitHub" });
       });
 
     document

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -948,7 +948,7 @@ function renderAzureStoragePanel(azureInfo: AzureStorageInfo): string {
   `;
 }
 
-function renderTeamServerPanel(teamInfo: TeamServerInfo): string {
+function renderTeamServerPanel(teamInfo: TeamServerInfo, githubAuth?: GitHubAuthStatus): string {
   const statusColor = teamInfo.isConfigured ? "#2d6a4f" : teamInfo.enabled ? "#d97706" : "#666";
   const statusIcon = teamInfo.isConfigured ? "✅" : teamInfo.enabled ? "⚠️" : "⚪";
   const statusText = teamInfo.isConfigured
@@ -957,16 +957,35 @@ function renderTeamServerPanel(teamInfo: TeamServerInfo): string {
       ? "Enabled but Not Configured"
       : "Disabled";
 
+  const githubNotAuthenticated = teamInfo.isConfigured && !githubAuth?.authenticated;
+
   return `
     <div class="info-box">
       <div class="info-box-title">🖥️ Team Server Backend</div>
       <div>Sync your token usage data to a self-hosted team server for team-wide reporting.</div>
     </div>
 
+    ${githubNotAuthenticated ? `
+    <div style="margin-bottom: 16px; padding: 12px 16px; background: rgba(217, 119, 6, 0.15); border: 1px solid #d97706; border-radius: 6px; display: flex; gap: 10px; align-items: flex-start;">
+      <span style="font-size: 18px; flex-shrink: 0;">⚠️</span>
+      <div>
+        <div style="color: #fbbf24; font-weight: 600; font-size: 13px; margin-bottom: 4px;">GitHub Authentication Required</div>
+        <div style="color: #d4a017; font-size: 12px;">
+          Team server sync will not run until you sign in to GitHub.
+          Go to the <strong>GitHub</strong> tab to authenticate.
+        </div>
+      </div>
+    </div>
+    ` : ''}
+
     <div class="summary-cards">
       <div class="summary-card" style="border-left: 4px solid ${statusColor};">
         <div class="summary-label">${statusIcon} Status</div>
         <div class="summary-value" style="font-size: 16px; color: ${statusColor};">${statusText}</div>
+      </div>
+      <div class="summary-card" style="border-left: 4px solid ${githubNotAuthenticated ? '#d97706' : githubAuth?.authenticated ? '#2d6a4f' : '#666'};">
+        <div class="summary-label">${githubNotAuthenticated ? '⚠️' : githubAuth?.authenticated ? '✅' : '⚪'} GitHub Auth</div>
+        <div class="summary-value" style="font-size: 14px; color: ${githubNotAuthenticated ? '#d97706' : githubAuth?.authenticated ? '#2d6a4f' : '#666'};">${githubNotAuthenticated ? 'Not Authenticated' : githubAuth?.authenticated ? escapeHtml(githubAuth.username || 'Authenticated') : 'Not Authenticated'}</div>
       </div>
       <div class="summary-card">
         <div class="summary-label">👥 Sharing Profile</div>
@@ -1030,6 +1049,7 @@ function renderTeamServerPanel(teamInfo: TeamServerInfo): string {
 
 function renderBackendStoragePanel(
   backendInfo: BackendStorageInfo | undefined,
+  githubAuth?: GitHubAuthStatus,
 ): string {
   if (!backendInfo) {
     return `
@@ -1055,7 +1075,7 @@ function renderBackendStoragePanel(
       ${renderAzureStoragePanel(backendInfo.azure)}
     </div>
     <div id="subtab-backend-teamserver" class="subtab-content">
-      ${renderTeamServerPanel(backendInfo.teamServer)}
+      ${renderTeamServerPanel(backendInfo.teamServer, githubAuth)}
     </div>
   `;
 }
@@ -1440,7 +1460,7 @@ function renderLayout(data: DiagnosticsData): void {
 			</div>
 
 			<div id="tab-backend" class="tab-content">
-				${renderBackendStoragePanel(data.backendStorageInfo)}
+				${renderBackendStoragePanel(data.backendStorageInfo, data.githubAuth)}
 			</div>
 
 			<div id="tab-github" class="tab-content">
@@ -1475,6 +1495,9 @@ function renderLayout(data: DiagnosticsData): void {
   // Store data for re-rendering on sort - will be updated when data loads
   let storedDetailedFiles = detailedFiles;
   let isLoading = detailedFiles.length === 0;
+  // Cache backend and auth state so re-renders triggered by either update have both
+  let currentBackendInfo: BackendStorageInfo | undefined = data.backendStorageInfo;
+  let currentGithubAuth: GitHubAuthStatus | undefined = data.githubAuth;
 
   // Listen for messages from the extension (background loading)
   window.addEventListener("message", (event) => {
@@ -1497,6 +1520,10 @@ function renderLayout(data: DiagnosticsData): void {
 
       // Update backend storage info if provided
       if (message.backendStorageInfo) {
+        currentBackendInfo = message.backendStorageInfo;
+        if (message.githubAuth !== undefined) {
+          currentGithubAuth = message.githubAuth;
+        }
         const backendTabContent = document.getElementById("tab-backend");
         if (backendTabContent) {
           // Capture active subtab before re-rendering so we can restore it
@@ -1505,7 +1532,8 @@ function renderLayout(data: DiagnosticsData): void {
             ?? vscode.getState()?.activeSubtab;
 
           backendTabContent.innerHTML = renderBackendStoragePanel(
-            message.backendStorageInfo,
+            currentBackendInfo,
+            currentGithubAuth,
           );
           // Re-attach event listeners for backend buttons
           setupBackendButtonHandlers();
@@ -1696,10 +1724,23 @@ function renderLayout(data: DiagnosticsData): void {
       }
     } else if (message.command === "githubAuthUpdated") {
       // Update GitHub Auth tab with new authentication status
+      currentGithubAuth = message.githubAuth;
       const githubTabContent = document.getElementById("tab-github");
       if (githubTabContent) {
-        githubTabContent.innerHTML = renderGitHubAuthPanel(message.githubAuth);
+        githubTabContent.innerHTML = renderGitHubAuthPanel(currentGithubAuth);
         setupGitHubAuthHandlers();
+      }
+      // Re-render the backend panel so the team server warning reflects the new auth state
+      const backendTabContent = document.getElementById("tab-backend");
+      if (backendTabContent && currentBackendInfo) {
+        const activeSubtabEl = backendTabContent.querySelector(".subtab.active") as HTMLElement | null;
+        const previousSubtab = activeSubtabEl?.getAttribute("data-subtab");
+        backendTabContent.innerHTML = renderBackendStoragePanel(currentBackendInfo, currentGithubAuth);
+        setupBackendButtonHandlers();
+        setupSubtabHandlers();
+        if (previousSubtab) {
+          activateSubtab(previousSubtab);
+        }
       }
     } else if (message.command === "diagnosticDataError") {
       // Show error message

--- a/vscode-extension/test/unit/backend-dataPlaneService.test.ts
+++ b/vscode-extension/test/unit/backend-dataPlaneService.test.ts
@@ -127,6 +127,7 @@ test('listAllEntitiesForRange parses partition and row keys correctly', async ()
 		entities: [{
 			partitionKey: 'myDataset|2024-06-15',
 			rowKey: 'gpt-4o|ws1|m1|user1',
+			day: '2024-06-15',
 			inputTokens: 500,
 			outputTokens: 1000,
 			interactions: 10,
@@ -147,12 +148,34 @@ test('listAllEntitiesForRange parses partition and row keys correctly', async ()
 	assert.equal(result[0].userId, 'user1');
 });
 
+test('listAllEntitiesForRange uses day field range filter (not Timestamp)', async () => {
+	const svc = makeService();
+	let capturedFilter = '';
+	const mockClient: TableClientLike = {
+		async *listEntities(options: any) {
+			capturedFilter = options?.queryOptions?.filter ?? '';
+			yield { partitionKey: 'ds:myds|d:2024-06-15', rowKey: 'm:gpt-4o|w:ws1|mc:m1|u:u1', day: '2024-06-15', inputTokens: 100, outputTokens: 200, interactions: 1 };
+		},
+		upsertEntity: async () => ({}),
+		deleteEntity: async () => ({}),
+	};
+
+	await svc.listAllEntitiesForRange({ tableClient: mockClient, startDayKey: '2024-06-10', endDayKey: '2024-06-20' });
+
+	// Verify the filter uses `day` field (not Timestamp which is incompatible with Cosmos DB Tables API)
+	assert.ok(capturedFilter.includes("day ge '2024-06-10'"), `Expected day ge filter, got: ${capturedFilter}`);
+	assert.ok(capturedFilter.includes("day le '2024-06-20'"), `Expected day le filter, got: ${capturedFilter}`);
+	assert.ok(!capturedFilter.includes('Timestamp'), `Filter should not use Timestamp: ${capturedFilter}`);
+	assert.ok(!capturedFilter.includes("datetime'"), `Filter should not use datetime type annotation: ${capturedFilter}`);
+});
+
 test('listAllEntitiesForRange includes fluency metrics when present', async () => {
 	const svc = makeService();
 	const mockClient = makeMockTableClient({
 		entities: [{
 			partitionKey: 'ds1|2024-06-15',
 			rowKey: 'gpt-4o|ws1|m1|',
+			day: '2024-06-15',
 			inputTokens: 100,
 			outputTokens: 200,
 			interactions: 5,


### PR DESCRIPTION
## Problem

Team dashboards showed no data ("0 Team Members") despite the backend sync running successfully and writing entities every 5 minutes.

**Root cause**: `listAllEntitiesForRange` used an OData `Timestamp` filter with the `datetime'...'` type annotation:
```
Timestamp ge datetime'2026-04-06T00:00:00.000Z' and Timestamp le datetime'2026-05-05T23:59:59.999Z'
```

The `datetime'...'` type annotation syntax **is not supported by Cosmos DB Tables API** — it silently returns zero results instead of an error. Users of Cosmos DB (identifiable by the "created table" log message appearing on every sync cycle instead of "already exists") would always see an empty team dashboard.

## Fix

Replace the Timestamp filter with a `day` field range filter:
```
day ge '2026-04-06' and day le '2026-05-05'
```

The `day` field is stored as a plain `YYYY-MM-DD` string in every entity by `createDailyAggEntity`. Simple OData string comparisons work with both Azure Storage Tables and Cosmos DB Tables API.

**Additional fix**: `workspaceId` in the team dashboard entity processing was missing the `w:` prefix strip. All other dimension prefixes (`u:`, `mc:`, `ds:`, `d:`, `m:`) were correctly stripped but `workspaceId` was not.

## Changes

- `vscode-extension/src/backend/services/dataPlaneService.ts` — Replace `Timestamp ge datetime'...'` filter with `day ge '...' and day le '...'` in `listAllEntitiesForRange`
- `vscode-extension/src/extension.ts` — Add `.replace(/^w:/, "")` to `workspaceId` processing in dashboard entity loop
- `vscode-extension/test/unit/backend-dataPlaneService.test.ts` — Add test verifying the filter uses `day` field (not `Timestamp`); add `day` field to existing test entities

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>