### PR TITLE
chore(vscode): bump version to 0.4.2

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,19 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-05
+
+### Bug Fixes
+- Fixed team dashboard showing empty results with Cosmos DB backend — replaced unsupported OData `datetime'...'` filter with `day` field string comparison (#783)
+- Fixed `workspaceId` `w:` prefix not being stripped in extension dashboard entity processing (#783)
+- Fixed logo image URL in VS Code Marketplace README (#782)
+
+### Improvements
+- Team Server diagnostics panel now shows GitHub auth status and a clickable warning banner when backend is configured but GitHub is not authenticated (#783)
+- Added friendly display names for 10 additional tools (#784)
+- Added friendly names for two missing GitHub MCP (Local) tools (#781)
+- Pinned `vsce` and `ovsx` as exact devDependencies for reproducible builds (#785)
+
 ## [0.4.1] - 2026-05-05
 
 ### Fixes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## VS Code Extension — Release 0.4.2

Bumps the version to `0.4.2` and adds a CHANGELOG entry for all fixes merged since `v0.4.1`.

### Changes included in this release

**Bug Fixes**
- Fixed team dashboard showing empty results with Cosmos DB backend — replaced unsupported OData `datetime'...'` filter with `day` field string comparison (#783)
- Fixed `workspaceId` `w:` prefix not being stripped in extension dashboard entity processing (#783)
- Fixed logo image URL in VS Code Marketplace README (#782)

**Improvements**
- Team Server diagnostics panel now shows GitHub auth status and a clickable warning banner when backend is configured but GitHub is not authenticated (#783)
- Added friendly display names for 10 additional tools (#784)
- Added friendly names for two missing GitHub MCP (Local) tools (#781)
- Pinned `vsce` and `ovsx` as exact devDependencies for reproducible builds (#785)

---

After merging, trigger the **Extensions - Release** workflow (`workflow_dispatch`) to build the VSIX, create the GitHub release tag `vscode/v0.4.2`, and publish to the VS Code Marketplace.