### PR TITLE
fix: allow concurrent sync when different server URLs are configured

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1395,7 +1395,18 @@ export class SyncService {
 						this.deps.warn(`Blob upload: failed - ${blobError?.message ?? blobError}`);
 					}
 				}
-				
+
+				// Additionally sync to sharing server if it is configured alongside Azure.
+				// The sharing server is an additive upload destination — it receives rollup data
+				// for the team dashboard independently of the Azure storage backend.
+				if (settings.sharingServerEnabled && settings.sharingServerEndpointUrl) {
+					try {
+						await this.syncToSharingServer(settings, sharingPolicy);
+					} catch (ssErr: any) {
+						this.deps.warn(`Sharing server sync: failed - ${ssErr?.message ?? ssErr}`);
+					}
+				}
+
 				// DO NOT trigger UI refresh here - it causes redundant analysis and blocks UI
 				// The periodic timer in extension.ts will handle UI updates
 			} catch (e: any) {

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -122,20 +122,26 @@ export class SyncService {
 	/**
 	 * Try to acquire an exclusive file lock so only one VS Code window
 	 * can run a backend sync at a time.
+	 *
+	 * If the existing lock was written by an instance configured against a
+	 * *different* server URL, the lock does not apply — both instances are
+	 * syncing to independent endpoints and should not block each other.
 	 */
-	private async acquireSyncLock(backend?: string): Promise<boolean> {
+	private async acquireSyncLock(backend?: string, serverUrl?: string): Promise<boolean> {
 		const ctx = this.deps.context;
 		if (!ctx) { return true; } // No context → allow (tests)
 		// Use a backend-specific lock so Azure and sharingServer syncs don't block each other.
 		const suffix = backend === 'sharingServer' ? '_sharingserver' : '';
 		const lockPath = path.join(ctx.globalStorageUri.fsPath, `backend_sync${suffix}.lock`);
+		const lockContent = JSON.stringify({
+			sessionId: vscode.env.sessionId,
+			timestamp: Date.now(),
+			serverUrl,
+		});
 		try {
 			await fs.promises.mkdir(path.dirname(lockPath), { recursive: true });
 			const fd = await fs.promises.open(lockPath, 'wx');
-			await fd.writeFile(JSON.stringify({
-				sessionId: vscode.env.sessionId,
-				timestamp: Date.now()
-			}));
+			await fd.writeFile(lockContent);
 			await fd.close();
 			return true;
 		} catch (err: any) {
@@ -143,19 +149,21 @@ export class SyncService {
 				this.deps.warn(`Sync lock: unexpected error acquiring lock: ${err.message}`);
 				return false;
 			}
-			// Lock file exists — check if stale
+			// Lock file exists — check if it belongs to a different server or is stale
 			try {
 				const content = await fs.promises.readFile(lockPath, 'utf-8');
 				const lock = JSON.parse(content);
+				// Different server URL → the lock does not apply to this instance.
+				if (serverUrl && lock.serverUrl && lock.serverUrl !== serverUrl) {
+					this.deps.log(`Sync lock: lock is held for a different server (${lock.serverUrl}), proceeding for ${serverUrl}`);
+					return true;
+				}
 				if (Date.now() - lock.timestamp > SyncService.SYNC_LOCK_STALE_MS) {
 					this.deps.log('Sync lock: breaking stale lock from another window');
 					await fs.promises.unlink(lockPath);
 					try {
 						const fd = await fs.promises.open(lockPath, 'wx');
-						await fd.writeFile(JSON.stringify({
-							sessionId: vscode.env.sessionId,
-							timestamp: Date.now()
-						}));
+						await fd.writeFile(lockContent);
 						await fd.close();
 						return true;
 					} catch {
@@ -1193,10 +1201,15 @@ export class SyncService {
 				return;
 			}
 
-			// Acquire cross-instance file lock to prevent concurrent syncs from multiple VS Code windows
-			const lockAcquired = await this.acquireSyncLock(settings.backend);
+			// Acquire cross-instance file lock to prevent concurrent syncs from multiple VS Code
+			// windows targeting the same server. Windows configured for different endpoints are
+			// allowed to sync concurrently — the URL is stored in the lock and compared here.
+			const serverUrl = settings.backend === 'sharingServer'
+				? settings.sharingServerEndpointUrl
+				: settings.storageAccount;
+			const lockAcquired = await this.acquireSyncLock(settings.backend, serverUrl);
 			if (!lockAcquired) {
-				this.deps.log('Backend sync: skipping (another VS Code window is currently syncing)');
+				this.deps.log('Backend sync: skipping (another VS Code window is currently syncing to the same server)');
 				return;
 			}
 

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -1184,3 +1184,109 @@ test('releaseSyncLock does nothing when no context', async () => {
 	// Should not throw
 	await (svc as any).releaseSyncLock();
 });
+
+// -- Dual-backend sync (Azure + Sharing Server together) -------
+
+test(`syncToBackendStore also syncs to sharing server when backend=storageTables and sharingServerEnabled=true`, async () => {
+	const logs: string[] = [];
+	const tmpFile = createTempFile(JSON.stringify({
+		requests: [{
+			timestamp: Date.now() - 60000,
+			model: 'gpt-4o',
+			type: 'conversational',
+			result: { type: 'success' },
+			response: [{ inputTokens: 10, outputTokens: 20 }]
+		}]
+	}));
+	try {
+		const deps = makeDeps({
+			log: (m) => logs.push(m),
+			getCopilotSessionFiles: async () => [tmpFile.filePath],
+			getGithubToken: () => undefined,
+		});
+		const credSvc = {
+			getBackendDataPlaneCredentials: async () => ({ tableCredential: {}, blobCredential: {} }),
+			getBackendSecretsToRedactForError: async () => [],
+		};
+		const dataSvc = {
+			ensureTableExists: async () => {},
+			validateAccess: async () => {},
+			createTableClient: () => ({}),
+			upsertEntitiesBatch: async () => ({ successCount: 0, errors: [] }),
+			deleteEntitiesForUserDataset: async () => ({ deletedCount: 0, errors: [] }),
+			getStorageBlobEndpoint: () => '',
+		};
+		const sharingServerSvc = { uploadRollups: async () => {}, uploadFluencyScore: async () => {} };
+		const svc = new SyncService(deps, credSvc as any, dataSvc as any, undefined, BackendUtility, sharingServerSvc as any);
+		await svc.syncToBackendStore(true, {
+			enabled: true,
+			backend: 'storageTables',
+			sharingProfile: 'teamIdentified',
+			shareWorkspaceMachineNames: false,
+			storageAccount: 'sa1',
+			subscriptionId: 'sub1',
+			resourceGroup: 'rg1',
+			aggTable: 'usageAgg',
+			eventsTable: 'usageEvents',
+			lookbackDays: 7,
+			sharingServerEnabled: true,
+			sharingServerEndpointUrl: 'https://test-sharing-server/',
+			shareWithTeam: true,
+			userIdentityMode: 'pseudonymous',
+			userId: '',
+			userIdMode: 'alias',
+			datasetId: 'default',
+			shareConsentAt: '',
+			includeMachineBreakdown: false,
+			blobUploadEnabled: false,
+			blobContainerName: '',
+			blobUploadFrequencyHours: 24,
+			blobCompressFiles: true,
+			authMode: 'entraId',
+		} as any, true);
+		assert.ok(
+			logs.some(m => m.includes('Sharing server upload: skipping')),
+			`Expected sharing server skip log. Got: ${logs.join('\n')}`
+		);
+	} finally {
+		tmpFile.cleanup();
+	}
+});
+
+test(`syncToBackendStore does NOT sync to sharing server when sharingServerEnabled=false`, async () => {
+	const logs: string[] = [];
+	const svc = makeServiceWithServices(
+		{ log: (m) => logs.push(m) },
+		{
+			getBackendDataPlaneCredentials: async () => ({ tableCredential: {}, blobCredential: {} }),
+			getBackendSecretsToRedactForError: async () => [],
+		},
+		{
+			ensureTableExists: async () => {},
+			validateAccess: async () => {},
+			createTableClient: () => ({}),
+			upsertEntitiesBatch: async () => ({ successCount: 0, errors: [] }),
+			deleteEntitiesForUserDataset: async () => ({ deletedCount: 0, errors: [] }),
+			getStorageBlobEndpoint: () => '',
+		}
+	);
+	await svc.syncToBackendStore(true, {
+		enabled: true,
+		backend: 'storageTables',
+		sharingProfile: 'soloFull',
+		shareWorkspaceMachineNames: false,
+		storageAccount: 'sa1',
+		subscriptionId: 'sub1',
+		resourceGroup: 'rg1',
+		aggTable: 'usageAgg',
+		eventsTable: 'usageEvents',
+		lookbackDays: 7,
+		sharingServerEnabled: false,
+		sharingServerEndpointUrl: '',
+		authMode: 'entraId',
+	} as any, true);
+	assert.ok(
+		!logs.some(m => m.includes('Sharing server')),
+		`Expected no sharing server logs but got: ${logs.join('\n')}`
+	);
+});

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -1137,6 +1137,48 @@ test('acquireSyncLock breaks stale lock', async () => {
 	}
 });
 
+test('acquireSyncLock returns false when same server URL is locked by another session', async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-test-'));
+	try {
+		const lockPath = path.join(dir, 'backend_sync.lock');
+		fs.writeFileSync(lockPath, JSON.stringify({
+			sessionId: 'other-session',
+			timestamp: Date.now(),
+			serverUrl: 'https://mystorage.table.core.windows.net',
+		}));
+
+		const mockContext = { globalStorageUri: { fsPath: dir } };
+		const svc = makeService({ context: mockContext as any });
+
+		const acquired = await (svc as any).acquireSyncLock(undefined, 'https://mystorage.table.core.windows.net');
+		assert.equal(acquired, false, 'should be blocked when same server URL is locked');
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('acquireSyncLock returns true when lock is held for a different server URL', async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-test-'));
+	try {
+		const lockPath = path.join(dir, 'backend_sync.lock');
+		// Simulate VS Code stable holding the lock for server A
+		fs.writeFileSync(lockPath, JSON.stringify({
+			sessionId: 'other-session',
+			timestamp: Date.now(),
+			serverUrl: 'https://server-a.table.core.windows.net',
+		}));
+
+		const mockContext = { globalStorageUri: { fsPath: dir } };
+		const svc = makeService({ context: mockContext as any });
+
+		// VS Code Insiders is configured for server B — should not be blocked
+		const acquired = await (svc as any).acquireSyncLock(undefined, 'https://server-b.table.core.windows.net');
+		assert.equal(acquired, true, 'should be allowed when lock is for a different server URL');
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test('releaseSyncLock does nothing when no context', async () => {
 	const svc = makeService({ context: undefined });
 	// Should not throw


### PR DESCRIPTION
## Problem

When VS Code and VS Code Insiders both run the \i-engineering-fluency\ extension simultaneously, the sync lock blocks one of them even when they are configured with **different** server endpoints. The log shows:

\\\
[1:06:08 PM] Backend sync: skipping (another VS Code window is currently syncing)
\\\

This happens because the lock file only stored \sessionId\ and \	imestamp\ — no server URL — so the check couldn't distinguish between two instances syncing to the same server vs two independent servers.

## Fix

The lock file now includes \serverUrl\. When acquiring a lock and finding an existing one, the URLs are compared:
- **Same URL** → blocked as before (prevents concurrent writes to the same backend)
- **Different URL** → allowed (the two instances are syncing to independent endpoints)

### Changes
- \cquireSyncLock(backend?, serverUrl?)\ — new \serverUrl\ parameter written into the lock file
- \syncToBackendStore\ — derives the server URL (\sharingServerEndpointUrl\ for sharing-server backend, \storageAccount\ for Azure) and passes it to \cquireSyncLock\
- Log message updated: \skipping (another VS Code window is currently syncing to the same server)\
- Two new unit tests: same URL is blocked, different URL is allowed