### PR TITLE
fix: still run sharing server sync when Azure sync fails

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1413,6 +1413,15 @@ export class SyncService {
 				// Keep local mode functional.
 				const secretsToRedact = await this.credentialService.getBackendSecretsToRedactForError(settings);
 				this.deps.warn(`Backend sync: ${safeStringifyError(e, secretsToRedact)}`);
+
+				// Azure sync failed — still attempt the sharing server sync if configured.
+				if (settings.sharingServerEnabled && settings.sharingServerEndpointUrl) {
+					try {
+						await this.syncToSharingServer(settings, sharingPolicy);
+					} catch (ssErr: any) {
+						this.deps.warn(`Sharing server sync: failed - ${ssErr?.message ?? ssErr}`);
+					}
+				}
 			} finally {
 				this.backendSyncInProgress = false;
 				await this.releaseSyncLock(settings.backend);

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -1059,6 +1059,69 @@ test('syncToBackendStore handles ensureTableExists or validateAccess failure gra
 	assert.ok(warns.some(m => m.includes('network error')));
 });
 
+test('syncToBackendStore still attempts sharing server sync when Azure sync fails', async () => {
+	const logs: string[] = [];
+	const warns: string[] = [];
+	const sharingServerSvc = { uploadRollups: async () => {}, uploadFluencyScore: async () => {} };
+	const svc = new SyncService(
+		makeDeps({
+			log: (m) => logs.push(m),
+			warn: (m) => warns.push(m),
+			getGithubToken: () => undefined,
+		}),
+		{
+			getBackendDataPlaneCredentials: async () => ({
+				tableCredential: {},
+				blobCredential: {},
+				secretsToRedact: [],
+			}),
+			getBackendSecretsToRedactForError: async () => [],
+		} as any,
+		{
+			ensureTableExists: async () => { throw new Error('Azure connection failed'); },
+			validateAccess: async () => {},
+			createTableClient: () => ({}),
+			upsertEntitiesBatch: async () => ({ successCount: 0, errors: [] }),
+			getStorageBlobEndpoint: () => '',
+		} as any,
+		undefined,
+		BackendUtility,
+		sharingServerSvc as any,
+	);
+	await svc.syncToBackendStore(true, {
+		enabled: true,
+		backend: 'storageTables',
+		sharingProfile: 'teamIdentified',
+		shareWorkspaceMachineNames: false,
+		storageAccount: 'sa1',
+		subscriptionId: 'sub1',
+		resourceGroup: 'rg1',
+		aggTable: 'usageAgg',
+		eventsTable: 'usageEvents',
+		lookbackDays: 7,
+		sharingServerEnabled: true,
+		sharingServerEndpointUrl: 'https://test-sharing-server/',
+		shareWithTeam: true,
+		userIdentityMode: 'pseudonymous',
+		userId: '',
+		userIdMode: 'alias',
+		datasetId: 'default',
+		shareConsentAt: '',
+		includeMachineBreakdown: false,
+		blobUploadEnabled: false,
+		blobContainerName: '',
+		blobUploadFrequencyHours: 24,
+		blobCompressFiles: true,
+		authMode: 'entraId',
+	} as any, true);
+	assert.ok(warns.some(m => m.includes('Azure connection failed')), `Expected Azure error in warns. Got: ${warns.join('\n')}`);
+	// Sharing server sync should still be attempted (no GitHub token → skipping log appears)
+	assert.ok(
+		logs.some(m => m.includes('Sharing server upload: skipping')),
+		`Expected sharing server sync attempt even after Azure failure. Logs: ${logs.join('\n')}`
+	);
+});
+
 // ── Sync lock management ─────────────────────────────────────────────────
 
 test('acquireSyncLock succeeds when no context is provided', async () => {


### PR DESCRIPTION
## Problem

When the Azure backend sync throws an exception (network error, auth failure, etc.), execution jumps to the outer `catch` block — which previously only logged the error and exited. This caused the sharing server sync to be skipped entirely, even when `sharingServerEnabled=true`.

## Fix

Added the sharing server sync block to the `catch` path so it is always attempted when `sharingServerEnabled=true`, regardless of whether the Azure sync succeeded or failed.

```
Normal path:  Azure sync succeeds → sharing server sync ✓
Error path:   Azure sync throws   → log error → sharing server sync ✓  (was: ✗)
```

## Test

Added a unit test `syncToBackendStore still attempts sharing server sync when Azure sync fails` that:
- Makes `ensureTableExists` throw `'Azure connection failed'`
- Verifies the error is logged
- Verifies the sharing server sync is still attempted (detected via the "skipping" log when no GitHub token is present)