### PR TITLE
fix: deduplicate requestId in buildTurns to fix Cowork token over-count

### DIFF
--- a/vscode-extension/src/adapters/claudeDesktopAdapter.ts
+++ b/vscode-extension/src/adapters/claudeDesktopAdapter.ts
@@ -96,11 +96,18 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 			const toolCalls: { toolName: string; arguments?: string }[] = [];
 			const mcpTools: { server: string; tool: string }[] = [];
 
+			// The Cowork JSONL writes one event per content block for each API call,
+			// so multiple events may share the same requestId with identical usage counts.
+			// Deduplicate by requestId to avoid counting tokens multiple times per API call.
+			const seenRequestIds = new Set<string>();
 			for (const ae of pendingAssistantEvents) {
 				const msg = ae.message;
 				if (!model && msg?.model) { model = msg.model; }
+				const reqId = ae.requestId as string | undefined;
+				const isFirstOccurrence = !reqId || !seenRequestIds.has(reqId);
+				if (reqId) { seenRequestIds.add(reqId); }
 				const usage = msg?.usage;
-				if (usage) {
+				if (usage && isFirstOccurrence) {
 					actualInputTokens += (usage.input_tokens || 0) + (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0);
 					actualOutputTokens += usage.output_tokens || 0;
 				}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -176,7 +176,7 @@ type LocalViewRegressionCase = {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 44; // Add tool.execution_complete token counting for CLI sessions
+	private static readonly CACHE_VERSION = 45; // Fix Cowork token double-counting: deduplicate by requestId in buildTurns
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -1,12 +1,14 @@
 /**
  * Unit tests for ecosystem adapters and the IDiscoverableEcosystem interface.
  * Tests cover: isDiscoverable type guard, handles(), getCandidatePaths(),
- * getEditorRoot(), and discover() adapter loop behavior.
+ * getEditorRoot(), discover() adapter loop behavior, and ClaudeDesktopAdapter
+ * buildTurns() token deduplication for Cowork JSONL sessions.
  */
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import * as fs from 'node:fs';
 
 import { isDiscoverable } from '../../src/ecosystemAdapter';
 import type { IEcosystemAdapter } from '../../src/ecosystemAdapter';
@@ -330,4 +332,138 @@ test('extractClaudeSlashCommand: handles array content blocks', () => {
 test('extractClaudeSlashCommand: ignores slash commands not at the start', () => {
     assert.equal(extractClaudeSlashCommand('some text\n/review'), null);
     assert.equal(extractClaudeSlashCommand('prefix /review'), null);
+});
+
+// ---------------------------------------------------------------------------
+// ClaudeDesktopAdapter.buildTurns() — requestId deduplication
+// ---------------------------------------------------------------------------
+
+test('ClaudeDesktopAdapter.buildTurns: counts tokens once per requestId (dedup split content blocks)', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-test-'));
+    const sessionFile = path.join(tmpDir, 'session.jsonl');
+    try {
+        // Simulate Cowork JSONL: one API call (req_001) split into two events —
+        // first event has the thinking block, second has the text block.
+        // Both share the same requestId and identical token counts.
+        const events = [
+            { type: 'user', isSidechain: false, message: { role: 'user', content: 'Hello' } },
+            {
+                type: 'assistant', requestId: 'req_001',
+                message: {
+                    role: 'assistant', stop_reason: 'end_turn',
+                    usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'thinking', thinking: 'thoughts' }],
+                },
+            },
+            {
+                type: 'assistant', requestId: 'req_001',
+                message: {
+                    role: 'assistant', stop_reason: 'end_turn',
+                    usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'text', text: 'Hello there!' }],
+                },
+            },
+        ];
+        fs.writeFileSync(sessionFile, events.map(e => JSON.stringify(e)).join('\n'));
+
+        const { turns } = await claudeDesktopAdapter.buildTurns(sessionFile);
+        assert.equal(turns.length, 1, 'Should produce exactly 1 turn');
+        const turn = turns[0];
+        // Tokens should be counted ONCE (100 input + 50 output = 150), not doubled
+        assert.equal(turn.actualUsage?.promptTokens, 100, 'Input tokens should not be doubled');
+        assert.equal(turn.actualUsage?.completionTokens, 50, 'Output tokens should not be doubled');
+        assert.equal(turn.inputTokensEstimate, 100);
+        assert.equal(turn.outputTokensEstimate, 50);
+        // Text from second event should still be collected
+        assert.equal(turn.assistantResponse, 'Hello there!');
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('ClaudeDesktopAdapter.buildTurns: collects tool calls from all content-block events of same requestId', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-test-'));
+    const sessionFile = path.join(tmpDir, 'session.jsonl');
+    try {
+        // One API call (req_001) split into 3 events: thinking, tool_use A, tool_use B
+        const events = [
+            { type: 'user', isSidechain: false, message: { role: 'user', content: 'Do stuff' } },
+            {
+                type: 'assistant', requestId: 'req_001',
+                message: {
+                    role: 'assistant', stop_reason: 'tool_use',
+                    usage: { input_tokens: 200, output_tokens: 30, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'thinking', thinking: 'planning' }],
+                },
+            },
+            {
+                type: 'assistant', requestId: 'req_001',
+                message: {
+                    role: 'assistant', stop_reason: 'tool_use',
+                    usage: { input_tokens: 200, output_tokens: 30, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'tool_use', id: 'tool_A', name: 'Read', input: { path: '/tmp/a' } }],
+                },
+            },
+            {
+                type: 'assistant', requestId: 'req_001',
+                message: {
+                    role: 'assistant', stop_reason: 'tool_use',
+                    usage: { input_tokens: 200, output_tokens: 30, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'tool_use', id: 'tool_B', name: 'Write', input: { path: '/tmp/b', content: 'x' } }],
+                },
+            },
+        ];
+        fs.writeFileSync(sessionFile, events.map(e => JSON.stringify(e)).join('\n'));
+
+        const { turns } = await claudeDesktopAdapter.buildTurns(sessionFile);
+        assert.equal(turns.length, 1);
+        const turn = turns[0];
+        // Tokens counted once (not 3x)
+        assert.equal(turn.actualUsage?.promptTokens, 200);
+        assert.equal(turn.actualUsage?.completionTokens, 30);
+        // Both tool calls should be present (from events 2 and 3)
+        assert.equal(turn.toolCalls.length, 2, 'Both tool calls should be collected');
+        assert.ok(turn.toolCalls.some(tc => tc.toolName === 'Read'), 'Should include Read tool call');
+        assert.ok(turn.toolCalls.some(tc => tc.toolName === 'Write'), 'Should include Write tool call');
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('ClaudeDesktopAdapter.buildTurns: unique requestIds across turns sum correctly', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cowork-test-'));
+    const sessionFile = path.join(tmpDir, 'session.jsonl');
+    try {
+        // Two user turns, each with one API call (no duplicates)
+        const events = [
+            { type: 'user', isSidechain: false, message: { role: 'user', content: 'Turn 1' } },
+            {
+                type: 'assistant', requestId: 'req_A',
+                message: {
+                    role: 'assistant', stop_reason: 'end_turn',
+                    usage: { input_tokens: 100, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'text', text: 'Response 1' }],
+                },
+            },
+            { type: 'user', isSidechain: false, message: { role: 'user', content: 'Turn 2' } },
+            {
+                type: 'assistant', requestId: 'req_B',
+                message: {
+                    role: 'assistant', stop_reason: 'end_turn',
+                    usage: { input_tokens: 150, output_tokens: 25, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+                    content: [{ type: 'text', text: 'Response 2' }],
+                },
+            },
+        ];
+        fs.writeFileSync(sessionFile, events.map(e => JSON.stringify(e)).join('\n'));
+
+        const { turns } = await claudeDesktopAdapter.buildTurns(sessionFile);
+        assert.equal(turns.length, 2);
+        assert.equal(turns[0].actualUsage?.promptTokens, 100);
+        assert.equal(turns[0].actualUsage?.completionTokens, 20);
+        assert.equal(turns[1].actualUsage?.promptTokens, 150);
+        assert.equal(turns[1].actualUsage?.completionTokens, 25);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
 });


### PR DESCRIPTION
## Root Cause

The Claude Desktop Cowork JSONL format writes **one event per content block** for each API call. A single API response (unique `requestId`) is split into multiple JSONL events:
- Event 1: `thinking` block
- Event 2: `text` block  
- Event 3+: each `tool_use` block

All of these events share the **same `requestId`** and **identical token usage counts**.

`buildTurns()` in `ClaudeDesktopAdapter` was not deduplicating by `requestId`, so it counted tokens **N times** for N content-block events. For a session with many parallel tool calls this could inflate the token count by 2–7x or more.

**Example from a real session:**
- `getTokensFromCoworkSession()` (used by session list) → **3.25M tokens** ✅ correct (deduplicates by requestId)
- `buildTurns()` (used by session detail view) → **7.23M tokens** ❌ overcounted

For the first turn alone: 2 events (thinking + text), each with 42,305+780 = 43,085 tokens → `buildTurns` incorrectly showed **86.2K** instead of **43.1K**.

## Fix

Added a `seenRequestIds` Set inside `emitTurn()`. Token usage is counted only for the **first** event per `requestId`; subsequent events with the same `requestId` still have their content blocks (`text`, `tool_use`) collected, since each event carries a different block type.

Also bumps `CACHE_VERSION` to 45 so cached session token totals are recomputed.

## Tests Added

Three new tests in `ecosystemAdapters.test.ts`:
- thinking+text split events: tokens counted once, text still captured
- thinking+tool_use A+tool_use B split: tokens once, both tools present
- unique requestIds across two turns still sum correctly