### PR TITLE
chore(vscode): bump version to 0.4.4

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-05-05
+
+### Bug Fixes
+- Fixed Cowork (Claude) token over-count caused by duplicate `requestId` entries in `buildTurns` — each request is now counted exactly once (#790)
+- Fixed sharing server sync being skipped when Azure Storage sync fails — both backends now sync independently (#789)
+
 ## [0.4.3] - 2026-05-05
 
 ### Bug Fixes

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## VS Code Extension v0.4.4 Release

Bumps the VS Code extension version to `0.4.4` and updates the changelog.

### What's new in 0.4.4

**Bug Fixes**
- Fixed Cowork (Claude) token over-count caused by duplicate `requestId` entries in `buildTurns` — each request is now counted exactly once (#790)
- Fixed sharing server sync being skipped when Azure Storage sync fails — both backends now sync independently (#789)

---

Once merged, trigger the [Release workflow](https://github.com/rajbos/ai-engineering-fluency/actions/workflows/release.yml) via `workflow_dispatch` to build and publish to the VS Code Marketplace.