### PR TITLE
Add explainer video link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Studio, and the command line. All data is read from local session logs — nothing leaves your machine unless you opt in to cloud sync.
 
-[![Build](https://github.com/rajbos/ai-engineering-fluency/actions/workflows/build.yml/badge.svg)](https://github.com/rajbos/ai-engineering-fluency/actions/workflows/build.yml)
+[![Build](https://github.com/rajbos/ai-engineering-fluency/actions/workflows/build.yml/badge.svg)](https://github.com/rajbos/ai-engineering-fluency/actions/workflows/build.yml) [![Watch the Explainer Video](https://img.shields.io/badge/Watch-Explainer%20Video-FF0000?logo=youtube)](https://youtu.be/Odm3wNursCY)
 
 ## Supported AI engineering tools
 


### PR DESCRIPTION
Adds a YouTube badge linking to the explainer video (https://youtu.be/Odm3wNursCY) next to the build badge in the README.