### PR TITLE
fix: prevent duplicate loading sessions in status bar

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -269,6 +269,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// In-flight command tracker — prevents concurrent execution of the same webview command
 	private readonly _inFlightCommands = new Set<string>();
 
+	// In-flight updateTokenStats promise — coalesces concurrent callers onto the same run
+	private _updateTokenStatsInFlight: Promise<DetailedStats | undefined> | undefined;
+
 	// Cache mapping workspaceStorageId -> resolved workspace folder path (or undefined if not resolvable)
 	private _workspaceIdToFolderCache: Map<string, string | undefined> = new Map();
 
@@ -1428,6 +1431,22 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	public async updateTokenStats(silent: boolean = false): Promise<DetailedStats | undefined> {
+		// Coalesce concurrent callers onto the same in-flight run to prevent
+		// multiple executions from racing to update the status bar simultaneously.
+		if (this._updateTokenStatsInFlight) {
+			this.log('updateTokenStats already in progress, coalescing onto existing run');
+			return this._updateTokenStatsInFlight;
+		}
+
+		this._updateTokenStatsInFlight = this._runUpdateTokenStats(silent);
+		try {
+			return await this._updateTokenStatsInFlight;
+		} finally {
+			this._updateTokenStatsInFlight = undefined;
+		}
+	}
+
+	private async _runUpdateTokenStats(silent: boolean): Promise<DetailedStats | undefined> {
 		try {
 			this.log('Updating token stats...');
 			const { stats: detailedStats, dailyStats } = await this.calculateDetailedStats(silent ? undefined : (completed, total) => {


### PR DESCRIPTION
## Problem

When the extension first loads, `updateTokenStats()` runs in the background and shows progress in the status bar (`Analyzing Logs: 72%`). If the user clicks the status bar item during this initial load, `showDetails()` finds no cached stats (`lastDetailedStats` is still `undefined`) and starts a **second** concurrent call to `updateTokenStats()`. Both calls race to update the status bar with independent progress counters, causing the flickering alternating percentages (70 / 91 / 72 / 92 …).

## Fix

**Promise coalescing** on `updateTokenStats()`: if a run is already in-flight, any new caller receives the existing promise rather than starting a second scan.

- Added `_updateTokenStatsInFlight` field to track the current in-flight promise  
- `updateTokenStats()` returns the existing promise immediately if one is running  
- Actual implementation moved to private `_runUpdateTokenStats()` (no other behavioural changes)

Only one execution updates the status bar at a time; all concurrent callers get the same result when it completes.