### PR TITLE
feat: Session Efficiency view - PR/session linking with scatter chart

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -61,6 +61,11 @@
         "category": "AI Engineering Fluency"
       },
       {
+        "command": "aiEngineeringFluency.showSessionEfficiency",
+        "title": "Show Session Efficiency",
+        "category": "AI Engineering Fluency"
+      },
+      {
         "command": "aiEngineeringFluency.runLocalViewRegression",
         "title": "Run Local View Regression (Debug Only)",
         "category": "AI Engineering Fluency"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -61,11 +61,6 @@
         "category": "AI Engineering Fluency"
       },
       {
-        "command": "aiEngineeringFluency.showSessionEfficiency",
-        "title": "Show Session Efficiency",
-        "category": "AI Engineering Fluency"
-      },
-      {
         "command": "aiEngineeringFluency.runLocalViewRegression",
         "title": "Run Local View Regression (Debug Only)",
         "category": "AI Engineering Fluency"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5616,6 +5616,15 @@ ${hashtag}`;
     );
     this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(sessions);
     this.sessionEfficiencyPanel.webview.onDidReceiveMessage(async (message) => {
+      if (message.command === 'refresh') {
+        try {
+          const fresh = loadSessionEfficiency();
+          this.sessionEfficiencyPanel!.webview.html = renderSessionEfficiencyHtml(fresh);
+        } catch (err) {
+          this.warn(`Session Efficiency refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        return;
+      }
       await this.dispatchSharedCommand(message.command);
     });
     this.sessionEfficiencyPanel.onDidDispose(() => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,7 +16,7 @@ import * as packageJson from '../package.json';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 import { ConfirmationMessages } from "./backend/ui/messages";
 import { loadSessionEfficiency } from './sessionEfficiency';
-import { renderSessionEfficiencyHtml } from './sessionEfficiencyWebview';
+import { renderSessionEfficiencyHtml, renderSessionEfficiencyLoadingHtml } from './sessionEfficiencyWebview';
 import {
 	detectAiType,
 	discoverGitHubRepos,
@@ -5588,25 +5588,9 @@ ${hashtag}`;
     this.log("📈 Opening Session Efficiency");
     if (this.sessionEfficiencyPanel) {
       this.sessionEfficiencyPanel.reveal(vscode.ViewColumn.One);
-      // Refresh content with the latest scan when re-opening.
-      try {
-        const fresh = loadSessionEfficiency();
-        this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(fresh);
-      } catch (err) {
-        this.warn(`Session Efficiency refresh failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      await this.refreshSessionEfficiencyPanel();
       return;
     }
-
-    let sessions;
-    try {
-      sessions = loadSessionEfficiency();
-    } catch (err) {
-      this.error(`Session Efficiency scan failed: ${err instanceof Error ? err.message : String(err)}`);
-      vscode.window.showErrorMessage(`Session Efficiency: ${err instanceof Error ? err.message : String(err)}`);
-      return;
-    }
-    this.log(`📈 Session Efficiency: scanned ${sessions.length} session(s)`);
 
     this.sessionEfficiencyPanel = vscode.window.createWebviewPanel(
       "copilotSessionEfficiency",
@@ -5614,15 +5598,12 @@ ${hashtag}`;
       { viewColumn: vscode.ViewColumn.One, preserveFocus: true },
       { enableScripts: true, retainContextWhenHidden: true },
     );
-    this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(sessions);
+    // Show spinner immediately so the panel appears right away.
+    this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyLoadingHtml();
+
     this.sessionEfficiencyPanel.webview.onDidReceiveMessage(async (message) => {
       if (message.command === 'refresh') {
-        try {
-          const fresh = loadSessionEfficiency();
-          this.sessionEfficiencyPanel!.webview.html = renderSessionEfficiencyHtml(fresh);
-        } catch (err) {
-          this.warn(`Session Efficiency refresh failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
+        await this.refreshSessionEfficiencyPanel();
         return;
       }
       await this.dispatchSharedCommand(message.command);
@@ -5631,6 +5612,29 @@ ${hashtag}`;
       this.log("📈 Session Efficiency closed");
       this.sessionEfficiencyPanel = undefined;
     });
+
+    // Scan sessions in background so the UI isn't blocked.
+    await this.refreshSessionEfficiencyPanel();
+  }
+
+  private async refreshSessionEfficiencyPanel(): Promise<void> {
+    if (!this.sessionEfficiencyPanel) { return; }
+    this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyLoadingHtml();
+    try {
+      const sessions = await new Promise<ReturnType<typeof loadSessionEfficiency>>((resolve, reject) => {
+        setImmediate(() => {
+          try { resolve(loadSessionEfficiency()); }
+          catch (e) { reject(e); }
+        });
+      });
+      this.log(`📈 Session Efficiency: scanned ${sessions.length} session(s)`);
+      if (this.sessionEfficiencyPanel) {
+        this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(sessions);
+      }
+    } catch (err) {
+      this.warn(`Session Efficiency scan failed: ${err instanceof Error ? err.message : String(err)}`);
+      vscode.window.showErrorMessage(`Session Efficiency: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   private getFluencyLevelData(isDebugMode: boolean): ReturnType<typeof _getFluencyLevelData> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,8 @@ import { TeamServerConfigPanel } from './backend/teamServerConfigPanel';
 import * as packageJson from '../package.json';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 import { ConfirmationMessages } from "./backend/ui/messages";
+import { loadSessionEfficiency } from './sessionEfficiency';
+import { renderSessionEfficiencyHtml } from './sessionEfficiencyWebview';
 import {
 	detectAiType,
 	discoverGitHubRepos,
@@ -247,6 +249,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private dashboardPanel: vscode.WebviewPanel | undefined;
 	private fluencyLevelViewerPanel: vscode.WebviewPanel | undefined;
 	private environmentalPanel: vscode.WebviewPanel | undefined;
+	private sessionEfficiencyPanel: vscode.WebviewPanel | undefined;
 	private outputChannel: vscode.OutputChannel;
 	private lastDetailedStats: DetailedStats | undefined;
 	private lastDailyStats: DailyTokenStats[] | undefined;
@@ -5574,6 +5577,49 @@ ${hashtag}`;
     this.log("✅ Scoring Guide refreshed");
   }
 
+  /**
+   * Open the Session Efficiency view: scans `~/.copilot/session-state/` for
+   * Copilot CLI sessions, classifies them by what was produced (PR, commit,
+   * edit, …) and shows a cost-vs-output scatter so the user can see which
+   * sessions converted tool calls into tangible output and which didn't.
+   */
+  public async showSessionEfficiency(): Promise<void> {
+    this.log("📈 Opening Session Efficiency");
+    if (this.sessionEfficiencyPanel) {
+      this.sessionEfficiencyPanel.reveal(vscode.ViewColumn.One);
+      // Refresh content with the latest scan when re-opening.
+      try {
+        const fresh = loadSessionEfficiency();
+        this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(fresh);
+      } catch (err) {
+        this.warn(`Session Efficiency refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      return;
+    }
+
+    let sessions;
+    try {
+      sessions = loadSessionEfficiency();
+    } catch (err) {
+      this.error(`Session Efficiency scan failed: ${err instanceof Error ? err.message : String(err)}`);
+      vscode.window.showErrorMessage(`Session Efficiency: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    this.log(`📈 Session Efficiency: scanned ${sessions.length} session(s)`);
+
+    this.sessionEfficiencyPanel = vscode.window.createWebviewPanel(
+      "copilotSessionEfficiency",
+      "Session Efficiency",
+      { viewColumn: vscode.ViewColumn.One, preserveFocus: true },
+      { enableScripts: true, retainContextWhenHidden: true },
+    );
+    this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(sessions);
+    this.sessionEfficiencyPanel.onDidDispose(() => {
+      this.log("📈 Session Efficiency closed");
+      this.sessionEfficiencyPanel = undefined;
+    });
+  }
+
   private getFluencyLevelData(isDebugMode: boolean): ReturnType<typeof _getFluencyLevelData> {
 		return _getFluencyLevelData(isDebugMode);
   }
@@ -8492,6 +8538,15 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   );
 
+  // Register the show session efficiency command
+  const showSessionEfficiencyCommand = vscode.commands.registerCommand(
+    "aiEngineeringFluency.showSessionEfficiency",
+    async () => {
+      tokenTracker.log("Show session efficiency command called");
+      await tokenTracker.showSessionEfficiency();
+    },
+  );
+
   const runLocalViewRegressionCommand = vscode.commands.registerCommand(
     "aiEngineeringFluency.runLocalViewRegression",
     async () => {
@@ -8544,6 +8599,7 @@ export async function activate(context: vscode.ExtensionContext) {
     showUsageAnalysisCommand,
     showMaturityCommand,
     showFluencyLevelViewerCommand,
+    showSessionEfficiencyCommand,
     runLocalViewRegressionCommand,
     showDashboardCommand,
     showEnvironmentalCommand,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -445,6 +445,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			showDashboard:          () => this.showDashboard(),
 			showEnvironmental:      () => this.showEnvironmental(),
 			showFluencyLevelViewer: () => this.showFluencyLevelViewer(),
+			showSessionEfficiency:  () => this.showSessionEfficiency(),
 		};
 		const handler = handlers[command];
 		if (!handler) { return false; }
@@ -5614,6 +5615,9 @@ ${hashtag}`;
       { enableScripts: true, retainContextWhenHidden: true },
     );
     this.sessionEfficiencyPanel.webview.html = renderSessionEfficiencyHtml(sessions);
+    this.sessionEfficiencyPanel.webview.onDidReceiveMessage(async (message) => {
+      await this.dispatchSharedCommand(message.command);
+    });
     this.sessionEfficiencyPanel.onDidDispose(() => {
       this.log("📈 Session Efficiency closed");
       this.sessionEfficiencyPanel = undefined;
@@ -8538,14 +8542,8 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   );
 
-  // Register the show session efficiency command
-  const showSessionEfficiencyCommand = vscode.commands.registerCommand(
-    "aiEngineeringFluency.showSessionEfficiency",
-    async () => {
-      tokenTracker.log("Show session efficiency command called");
-      await tokenTracker.showSessionEfficiency();
-    },
-  );
+  // Register the show session efficiency command was removed — the view is
+  // now only reachable via the nav button row in all other panels (no palette entry).
 
   const runLocalViewRegressionCommand = vscode.commands.registerCommand(
     "aiEngineeringFluency.runLocalViewRegression",
@@ -8599,7 +8597,6 @@ export async function activate(context: vscode.ExtensionContext) {
     showUsageAnalysisCommand,
     showMaturityCommand,
     showFluencyLevelViewerCommand,
-    showSessionEfficiencyCommand,
     runLocalViewRegressionCommand,
     showDashboardCommand,
     showEnvironmentalCommand,

--- a/vscode-extension/src/sessionEfficiency.ts
+++ b/vscode-extension/src/sessionEfficiency.ts
@@ -1,0 +1,365 @@
+/**
+ * Session Efficiency analyzer.
+ *
+ * Scans GitHub Copilot CLI session-state directories (events.jsonl) and
+ * extracts per-session "what-was-produced" metrics so the user can compare
+ * cost (tool calls) against output (PRs, commits, file edits).
+ *
+ * NOTE: This intentionally does NOT touch the existing token-tracking pipeline.
+ * It reads the same on-disk files that the CopilotCliAdapter discovers, but
+ * mines them for VCS/PR signals rather than tokens.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCopilotCliSessionStateDir } from './adapters/copilotCliAdapter';
+
+const PR_URL_RE = /github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)/g;
+const CREATED_PR_RE = /Created pull request #(\d+) in ([\w.-]+\/[\w.-]+)/g;
+const ISSUE_URL_RE = /github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)/g;
+const EDIT_TOOLS = new Set(['edit', 'create', 'apply_patch', 'write', 'str_replace_editor']);
+
+export type EfficiencyCategory =
+	| 'shipped'      // Created at least one PR
+	| 'committed'    // Made at least one git commit but no PR
+	| 'issue'        // Created/opened an issue (no PR/commit)
+	| 'edited'       // Edited files but never committed
+	| 'exploratory'  // Few tool calls, no edits — research/Q&A
+	| 'no-pr';       // ≥50 tool calls but no PR/commit/issue/edit on disk
+
+export interface PrRef {
+	repo: string;
+	number: number;
+	source: string;
+	confidence: 1 | 2 | 3;
+}
+
+export interface SessionEfficiency {
+	id: string;
+	repository: string | null;
+	branch: string | null;
+	summary: string | null;
+	createdAt: string;
+	updatedAt: string;
+	model: string | null;
+
+	userTurns: number;
+	assistantTurns: number;
+	toolCalls: number;
+	editCount: number;
+	commitCount: number;
+	filesEdited: number;
+	subagentCount: number;
+
+	prRefs: PrRef[];
+	issueRefs: PrRef[];
+	prsCreated: number;
+	issuesCreated: number;
+
+	output: number;       // composite output score
+	efficiency: number;   // output / cost
+	category: EfficiencyCategory;
+	firstUserMsg: string | null;
+}
+
+interface HarvestResult {
+	refs: PrRef[];
+	issueRefs: PrRef[];
+	stats: {
+		userTurns: number;
+		assistantTurns: number;
+		toolCalls: number;
+		editCount: number;
+		commitCount: number;
+		filesEdited: number;
+		subagentCount: number;
+		firstUserMsg: string | null;
+		firstTs: string | null;
+		lastTs: string | null;
+		model: string | null;
+	};
+}
+
+function safeJson(line: string): any {
+	try { return JSON.parse(line); } catch { return null; }
+}
+
+function loadWorkspace(dir: string): Record<string, string> | null {
+	// workspace.yaml is a flat key/value file (id, repository, branch, summary,
+	// created_at, updated_at, …). We only need top-level scalars, so a minimal
+	// parser avoids pulling in a YAML dependency.
+	const wp = path.join(dir, 'workspace.yaml');
+	if (!fs.existsSync(wp)) {return null;}
+	let txt: string;
+	try { txt = fs.readFileSync(wp, 'utf8'); } catch { return null; }
+	const out: Record<string, string> = {};
+	for (const rawLine of txt.split(/\r?\n/)) {
+		// Skip nested keys, list entries, and comments.
+		if (!rawLine || /^\s/.test(rawLine) || rawLine.startsWith('#') || rawLine.startsWith('-')) {continue;}
+		const m = /^([A-Za-z_][\w-]*)\s*:\s*(.*)$/.exec(rawLine);
+		if (!m) {continue;}
+		let v = m[2].trim();
+		// Strip optional surrounding quotes.
+		if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+			v = v.slice(1, -1);
+		}
+		out[m[1]] = v;
+	}
+	return out;
+}
+
+function* iterLines(file: string): IterableIterator<string> {
+	// Stream-style line read without pulling whole file into JS array.
+	const data = fs.readFileSync(file, 'utf8');
+	let start = 0;
+	for (let i = 0; i < data.length; i++) {
+		if (data.charCodeAt(i) === 10) {
+			const line = data.slice(start, i);
+			start = i + 1;
+			if (line.length > 0) {yield line;}
+		}
+	}
+	if (start < data.length) {
+		const line = data.slice(start);
+		if (line.length > 0) {yield line;}
+	}
+}
+
+function harvestFromEventsFile(file: string): HarvestResult {
+	const refs = new Map<string, PrRef>();
+	const issueRefs = new Map<string, PrRef>();
+	const toolCallNames = new Map<string, { name: string; args: any }>();
+	const editedFiles = new Set<string>();
+	let toolCalls = 0;
+	let userTurns = 0;
+	let assistantTurns = 0;
+	let editCount = 0;
+	let commitCount = 0;
+	let subagentCount = 0;
+	let firstUserMsg: string | null = null;
+	let firstTs: string | null = null;
+	let lastTs: string | null = null;
+	let model: string | null = null;
+
+	const upsert = (
+		map: Map<string, PrRef>,
+		repo: string,
+		num: number,
+		source: string,
+		confidence: 1 | 2 | 3,
+	) => {
+		const key = `${repo}#${num}`;
+		const cur = map.get(key);
+		if (!cur || confidence > cur.confidence) {
+			map.set(key, { repo, number: num, source, confidence });
+		}
+	};
+
+	for (const line of iterLines(file)) {
+		const ev = safeJson(line);
+		if (!ev) {continue;}
+		if (!firstTs) {firstTs = ev.timestamp;}
+		lastTs = ev.timestamp;
+
+		const t = ev.type;
+		const d = ev.data || {};
+
+		if (t === 'session.start') {model = d.selectedModel || model;}
+		if (t === 'user.message') {
+			userTurns++;
+			if (!firstUserMsg && d.content) {firstUserMsg = String(d.content).slice(0, 240);}
+		}
+		if (t === 'assistant.turn_end') {assistantTurns++;}
+		if (t === 'tool.execution_complete' || t === 'tool.execution_start') {toolCalls++;}
+		if (t === 'subagent.started') {subagentCount++;}
+
+		if (t === 'tool.execution_start') {
+			if (d.toolCallId && d.toolName) {
+				toolCallNames.set(d.toolCallId, { name: d.toolName, args: d.arguments || {} });
+			}
+			if (d.toolName === 'open_pr_session') {
+				const a = d.arguments || {};
+				if (a.pr_number && a.repo_full_name) {
+					upsert(refs, a.repo_full_name, a.pr_number, 'open_pr_session', 2);
+				}
+			}
+			if (d.toolName === 'open_issue_session') {
+				const a = d.arguments || {};
+				if (a.issue_number && a.repo_full_name) {
+					upsert(issueRefs, a.repo_full_name, a.issue_number, 'open_issue_session', 2);
+				}
+			}
+		}
+
+		if (t === 'tool.execution_complete') {
+			const result = d.result || {};
+			const success = result.success !== false;
+			// `tool.execution_complete` does not always carry toolName — correlate via toolCallId.
+			const meta = toolCallNames.get(d.toolCallId) || { name: undefined, args: {} };
+			const toolName: string | undefined = d.toolName || meta.name;
+			const args = d.arguments || meta.args || {};
+			const text = [
+				typeof result.content === 'string' ? result.content : null,
+				typeof result.detailedContent === 'string' ? result.detailedContent : null,
+				typeof result === 'string' ? result : null,
+			].filter(Boolean).join('\n');
+
+			if (success && toolName && EDIT_TOOLS.has(toolName)) {
+				editCount++;
+				if (args && typeof args.path === 'string') {editedFiles.add(args.path);}
+			}
+			if (success && toolName === 'powershell') {
+				const cmd = (args && args.command) || '';
+				if (typeof cmd === 'string' && /\bgit\s+commit\b/.test(cmd)) {commitCount++;}
+			}
+
+			if (toolName === 'create_pull_request' && success) {
+				for (const m of text.matchAll(CREATED_PR_RE)) {
+					upsert(refs, m[2], parseInt(m[1], 10), 'create_pull_request', 3);
+				}
+				for (const m of text.matchAll(PR_URL_RE)) {
+					upsert(refs, `${m[1]}/${m[2]}`, parseInt(m[3], 10), 'create_pull_request', 3);
+				}
+			} else if (toolName === 'powershell' && /gh\s+pr\s+create/.test(JSON.stringify(args))) {
+				for (const m of text.matchAll(PR_URL_RE)) {
+					upsert(refs, `${m[1]}/${m[2]}`, parseInt(m[3], 10), 'gh_pr_create', 2);
+				}
+			} else {
+				for (const m of text.matchAll(PR_URL_RE)) {
+					upsert(refs, `${m[1]}/${m[2]}`, parseInt(m[3], 10), toolName || 'tool_output', 1);
+				}
+			}
+
+			if (toolName === 'powershell' && /gh\s+issue\s+create/.test(JSON.stringify(args)) && success) {
+				for (const m of text.matchAll(ISSUE_URL_RE)) {
+					upsert(issueRefs, `${m[1]}/${m[2]}`, parseInt(m[3], 10), 'gh_issue_create', 2);
+				}
+			} else {
+				for (const m of text.matchAll(ISSUE_URL_RE)) {
+					upsert(issueRefs, `${m[1]}/${m[2]}`, parseInt(m[3], 10), toolName || 'tool_output', 1);
+				}
+			}
+		}
+	}
+
+	return {
+		refs: [...refs.values()],
+		issueRefs: [...issueRefs.values()],
+		stats: {
+			userTurns,
+			assistantTurns,
+			toolCalls,
+			editCount,
+			commitCount,
+			filesEdited: editedFiles.size,
+			subagentCount,
+			firstUserMsg,
+			firstTs,
+			lastTs,
+			model,
+		},
+	};
+}
+
+function classify(
+	prsCreated: number,
+	issuesCreated: number,
+	commitCount: number,
+	editCount: number,
+	toolCalls: number,
+): EfficiencyCategory {
+	if (prsCreated > 0) {return 'shipped';}
+	if (commitCount > 0) {return 'committed';}
+	if (issuesCreated > 0) {return 'issue';}
+	if (editCount > 0) {return 'edited';}
+	return toolCalls > 50 ? 'no-pr' : 'exploratory';
+}
+
+function buildSession(dir: string, info: HarvestResult, ws: any): SessionEfficiency {
+	const stats = info.stats;
+	const prsCreated = info.refs.filter(r => r.confidence >= 2).length;
+	const issuesCreated = info.issueRefs.filter(r => r.confidence >= 2).length;
+	const output =
+		prsCreated * 10 +
+		issuesCreated * 3 +
+		stats.commitCount * 4 +
+		stats.filesEdited;
+	const cost = stats.toolCalls;
+	const efficiency = cost > 0 ? output / cost : 0;
+	const category = classify(prsCreated, issuesCreated, stats.commitCount, stats.editCount, stats.toolCalls);
+
+	return {
+		id: (ws && ws.id) || path.basename(dir),
+		repository: (ws && ws.repository) || null,
+		branch: (ws && ws.branch) || null,
+		summary: (ws && ws.summary) || null,
+		createdAt: String((ws && ws.created_at) || stats.firstTs || ''),
+		updatedAt: String((ws && ws.updated_at) || stats.lastTs || ''),
+		model: stats.model,
+		userTurns: stats.userTurns,
+		assistantTurns: stats.assistantTurns,
+		toolCalls: stats.toolCalls,
+		editCount: stats.editCount,
+		commitCount: stats.commitCount,
+		filesEdited: stats.filesEdited,
+		subagentCount: stats.subagentCount,
+		prRefs: info.refs,
+		issueRefs: info.issueRefs,
+		prsCreated,
+		issuesCreated,
+		output,
+		efficiency,
+		category,
+		firstUserMsg: stats.firstUserMsg,
+	};
+}
+
+/**
+ * Scan all sessions in `~/.copilot/session-state/` and return per-session
+ * efficiency data. Returns an empty array if the directory does not exist
+ * (e.g. user does not use the Copilot CLI).
+ */
+export function loadSessionEfficiency(rootDir?: string): SessionEfficiency[] {
+	const root = rootDir || getCopilotCliSessionStateDir();
+	if (!fs.existsSync(root)) {return [];}
+	const out: SessionEfficiency[] = [];
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(root, { withFileTypes: true });
+	} catch { return out; }
+
+	for (const e of entries) {
+		if (!e.isDirectory()) {continue;}
+		// Session dirs are UUIDs (8-4-4-4-12). Skip non-uuid subdirs.
+		if (!/^[0-9a-f]{8}-/i.test(e.name)) {continue;}
+		const dir = path.join(root, e.name);
+		const ws = loadWorkspace(dir);
+		const eventsFile = path.join(dir, 'events.jsonl');
+		let info: HarvestResult = {
+			refs: [],
+			issueRefs: [],
+			stats: {
+				userTurns: 0, assistantTurns: 0, toolCalls: 0,
+				editCount: 0, commitCount: 0, filesEdited: 0, subagentCount: 0,
+				firstUserMsg: null, firstTs: null, lastTs: null, model: null,
+			},
+		};
+		if (fs.existsSync(eventsFile)) {
+			try { info = harvestFromEventsFile(eventsFile); }
+			catch { /* ignore unreadable files */ }
+		}
+		// Skip empty sessions (no events and no workspace metadata).
+		if (!ws && info.stats.toolCalls === 0 && info.stats.userTurns === 0) {continue;}
+		out.push(buildSession(dir, info, ws));
+	}
+	return out;
+}
+
+/** Aggregate counts by category — handy for summary panels. */
+export function categoryCounts(sessions: SessionEfficiency[]): Record<EfficiencyCategory, number> {
+	const out: Record<EfficiencyCategory, number> = {
+		shipped: 0, committed: 0, issue: 0, edited: 0, exploratory: 0, 'no-pr': 0,
+	};
+	for (const s of sessions) {out[s.category]++;}
+	return out;
+}

--- a/vscode-extension/src/sessionEfficiency.ts
+++ b/vscode-extension/src/sessionEfficiency.ts
@@ -58,6 +58,7 @@ export interface SessionEfficiency {
 
 	output: number;       // composite output score
 	efficiency: number;   // output / cost
+	aiCredits: number;    // AI credits used (from session.shutdown modelMetrics); 0 if not available
 	category: EfficiencyCategory;
 	firstUserMsg: string | null;
 }
@@ -73,6 +74,7 @@ interface HarvestResult {
 		commitCount: number;
 		filesEdited: number;
 		subagentCount: number;
+		aiCredits: number;
 		firstUserMsg: string | null;
 		firstTs: string | null;
 		lastTs: string | null;
@@ -136,6 +138,7 @@ function harvestFromEventsFile(file: string): HarvestResult {
 	let editCount = 0;
 	let commitCount = 0;
 	let subagentCount = 0;
+	let aiCredits = 0;
 	let firstUserMsg: string | null = null;
 	let firstTs: string | null = null;
 	let lastTs: string | null = null;
@@ -165,6 +168,16 @@ function harvestFromEventsFile(file: string): HarvestResult {
 		const d = ev.data || {};
 
 		if (t === 'session.start') {model = d.selectedModel || model;}
+		if (t === 'session.shutdown') {
+			// Sum AI credits used across all models from the shutdown summary.
+			const metrics = d.modelMetrics;
+			if (metrics && typeof metrics === 'object') {
+				for (const key of Object.keys(metrics)) {
+					const cost = metrics[key]?.requests?.cost;
+					if (typeof cost === 'number') {aiCredits += cost;}
+				}
+			}
+		}
 		if (t === 'user.message') {
 			userTurns++;
 			if (!firstUserMsg && d.content) {firstUserMsg = String(d.content).slice(0, 240);}
@@ -253,6 +266,7 @@ function harvestFromEventsFile(file: string): HarvestResult {
 			commitCount,
 			filesEdited: editedFiles.size,
 			subagentCount,
+			aiCredits,
 			firstUserMsg,
 			firstTs,
 			lastTs,
@@ -309,6 +323,7 @@ function buildSession(dir: string, info: HarvestResult, ws: any): SessionEfficie
 		issuesCreated,
 		output,
 		efficiency,
+		aiCredits: stats.aiCredits,
 		category,
 		firstUserMsg: stats.firstUserMsg,
 	};
@@ -340,7 +355,7 @@ export function loadSessionEfficiency(rootDir?: string): SessionEfficiency[] {
 			issueRefs: [],
 			stats: {
 				userTurns: 0, assistantTurns: 0, toolCalls: 0,
-				editCount: 0, commitCount: 0, filesEdited: 0, subagentCount: 0,
+				editCount: 0, commitCount: 0, filesEdited: 0, subagentCount: 0, aiCredits: 0,
 				firstUserMsg: null, firstTs: null, lastTs: null, model: null,
 			},
 		};

--- a/vscode-extension/src/sessionEfficiency.ts
+++ b/vscode-extension/src/sessionEfficiency.ts
@@ -13,6 +13,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getCopilotCliSessionStateDir } from './adapters/copilotCliAdapter';
+import modelPricingData from './modelPricing.json';
+import type { ModelPricing } from './types';
+
+const PRICING: Record<string, ModelPricing> = modelPricingData.pricing as Record<string, ModelPricing>;
 
 const PR_URL_RE = /github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)/g;
 const CREATED_PR_RE = /Created pull request #(\d+) in ([\w.-]+\/[\w.-]+)/g;
@@ -32,6 +36,16 @@ export interface PrRef {
 	number: number;
 	source: string;
 	confidence: 1 | 2 | 3;
+}
+
+/** Per-model token usage and calculated cost from a session.shutdown event. */
+export interface ModelMetricSummary {
+	model: string;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	costUsd: number;
 }
 
 export interface SessionEfficiency {
@@ -57,8 +71,9 @@ export interface SessionEfficiency {
 	issuesCreated: number;
 
 	output: number;       // composite output score
-	efficiency: number;   // output / cost
-	aiCredits: number;    // AI credits used (from session.shutdown modelMetrics); 0 if not available
+	efficiency: number;   // output / cost (tool calls)
+	estimatedCostUsd: number;  // token-based dollar cost from session.shutdown metrics; 0 if unavailable
+	modelMetrics: ModelMetricSummary[];  // per-model breakdown for tooltip
 	category: EfficiencyCategory;
 	firstUserMsg: string | null;
 }
@@ -74,7 +89,7 @@ interface HarvestResult {
 		commitCount: number;
 		filesEdited: number;
 		subagentCount: number;
-		aiCredits: number;
+		modelMetrics: ModelMetricSummary[];
 		firstUserMsg: string | null;
 		firstTs: string | null;
 		lastTs: string | null;
@@ -127,6 +142,27 @@ function* iterLines(file: string): IterableIterator<string> {
 	}
 }
 
+/**
+ * Calculate dollar cost for one model's token usage using Copilot pricing rates.
+ * Falls back to provider rates when copilotPricing is absent.
+ */
+function calcModelCostUsd(
+	modelKey: string,
+	inputTokens: number,
+	outputTokens: number,
+	cacheReadTokens: number,
+	cacheWriteTokens: number,
+): number {
+	const base = PRICING[modelKey];
+	if (!base) {return 0;}
+	const p = base.copilotPricing ?? base;
+	const uncached = Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens);
+	return (uncached / 1_000_000) * p.inputCostPerMillion
+		+ (cacheReadTokens / 1_000_000) * (p.cachedInputCostPerMillion ?? p.inputCostPerMillion)
+		+ (cacheWriteTokens / 1_000_000) * (p.cacheCreationCostPerMillion ?? p.inputCostPerMillion)
+		+ (outputTokens / 1_000_000) * p.outputCostPerMillion;
+}
+
 function harvestFromEventsFile(file: string): HarvestResult {
 	const refs = new Map<string, PrRef>();
 	const issueRefs = new Map<string, PrRef>();
@@ -138,7 +174,7 @@ function harvestFromEventsFile(file: string): HarvestResult {
 	let editCount = 0;
 	let commitCount = 0;
 	let subagentCount = 0;
-	let aiCredits = 0;
+	const modelMetrics: ModelMetricSummary[] = [];
 	let firstUserMsg: string | null = null;
 	let firstTs: string | null = null;
 	let lastTs: string | null = null;
@@ -169,12 +205,18 @@ function harvestFromEventsFile(file: string): HarvestResult {
 
 		if (t === 'session.start') {model = d.selectedModel || model;}
 		if (t === 'session.shutdown') {
-			// Sum AI credits used across all models from the shutdown summary.
+			// Extract per-model token usage and compute dollar cost from the shutdown summary.
 			const metrics = d.modelMetrics;
 			if (metrics && typeof metrics === 'object') {
 				for (const key of Object.keys(metrics)) {
-					const cost = metrics[key]?.requests?.cost;
-					if (typeof cost === 'number') {aiCredits += cost;}
+					const mu = metrics[key];
+					const u = mu?.usage || {};
+					const inTok  = typeof u.inputTokens     === 'number' ? u.inputTokens     : 0;
+					const outTok = typeof u.outputTokens    === 'number' ? u.outputTokens    : 0;
+					const cache  = typeof u.cacheReadTokens === 'number' ? u.cacheReadTokens : 0;
+					const cacheW = typeof u.cacheWriteTokens === 'number' ? u.cacheWriteTokens : 0;
+					const costUsd = calcModelCostUsd(key, inTok, outTok, cache, cacheW);
+					modelMetrics.push({ model: key, inputTokens: inTok, outputTokens: outTok, cacheReadTokens: cache, cacheWriteTokens: cacheW, costUsd });
 				}
 			}
 		}
@@ -266,7 +308,7 @@ function harvestFromEventsFile(file: string): HarvestResult {
 			commitCount,
 			filesEdited: editedFiles.size,
 			subagentCount,
-			aiCredits,
+			modelMetrics,
 			firstUserMsg,
 			firstTs,
 			lastTs,
@@ -323,7 +365,8 @@ function buildSession(dir: string, info: HarvestResult, ws: any): SessionEfficie
 		issuesCreated,
 		output,
 		efficiency,
-		aiCredits: stats.aiCredits,
+		estimatedCostUsd: stats.modelMetrics.reduce((s, m) => s + m.costUsd, 0),
+		modelMetrics: stats.modelMetrics,
 		category,
 		firstUserMsg: stats.firstUserMsg,
 	};
@@ -355,7 +398,7 @@ export function loadSessionEfficiency(rootDir?: string): SessionEfficiency[] {
 			issueRefs: [],
 			stats: {
 				userTurns: 0, assistantTurns: 0, toolCalls: 0,
-				editCount: 0, commitCount: 0, filesEdited: 0, subagentCount: 0, aiCredits: 0,
+				editCount: 0, commitCount: 0, filesEdited: 0, subagentCount: 0, modelMetrics: [],
 				firstUserMsg: null, firstTs: null, lastTs: null, model: null,
 			},
 		};

--- a/vscode-extension/src/sessionEfficiency.ts
+++ b/vscode-extension/src/sessionEfficiency.ts
@@ -174,7 +174,7 @@ function harvestFromEventsFile(file: string): HarvestResult {
 	let editCount = 0;
 	let commitCount = 0;
 	let subagentCount = 0;
-	const modelMetrics: ModelMetricSummary[] = [];
+	const modelMetricsMap = new Map<string, ModelMetricSummary>();
 	let firstUserMsg: string | null = null;
 	let firstTs: string | null = null;
 	let lastTs: string | null = null;
@@ -206,17 +206,27 @@ function harvestFromEventsFile(file: string): HarvestResult {
 		if (t === 'session.start') {model = d.selectedModel || model;}
 		if (t === 'session.shutdown') {
 			// Extract per-model token usage and compute dollar cost from the shutdown summary.
+			// Multiple shutdown events (checkpoints/resumes) are aggregated per model.
 			const metrics = d.modelMetrics;
 			if (metrics && typeof metrics === 'object') {
 				for (const key of Object.keys(metrics)) {
 					const mu = metrics[key];
 					const u = mu?.usage || {};
-					const inTok  = typeof u.inputTokens     === 'number' ? u.inputTokens     : 0;
-					const outTok = typeof u.outputTokens    === 'number' ? u.outputTokens    : 0;
-					const cache  = typeof u.cacheReadTokens === 'number' ? u.cacheReadTokens : 0;
+					const inTok  = typeof u.inputTokens      === 'number' ? u.inputTokens      : 0;
+					const outTok = typeof u.outputTokens     === 'number' ? u.outputTokens     : 0;
+					const cache  = typeof u.cacheReadTokens  === 'number' ? u.cacheReadTokens  : 0;
 					const cacheW = typeof u.cacheWriteTokens === 'number' ? u.cacheWriteTokens : 0;
 					const costUsd = calcModelCostUsd(key, inTok, outTok, cache, cacheW);
-					modelMetrics.push({ model: key, inputTokens: inTok, outputTokens: outTok, cacheReadTokens: cache, cacheWriteTokens: cacheW, costUsd });
+					const existing = modelMetricsMap.get(key);
+					if (existing) {
+						existing.inputTokens     += inTok;
+						existing.outputTokens    += outTok;
+						existing.cacheReadTokens += cache;
+						existing.cacheWriteTokens += cacheW;
+						existing.costUsd         += costUsd;
+					} else {
+						modelMetricsMap.set(key, { model: key, inputTokens: inTok, outputTokens: outTok, cacheReadTokens: cache, cacheWriteTokens: cacheW, costUsd });
+					}
 				}
 			}
 		}
@@ -308,7 +318,7 @@ function harvestFromEventsFile(file: string): HarvestResult {
 			commitCount,
 			filesEdited: editedFiles.size,
 			subagentCount,
-			modelMetrics,
+			modelMetrics: [...modelMetricsMap.values()],
 			firstUserMsg,
 			firstTs,
 			lastTs,

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -1,0 +1,334 @@
+/**
+ * Webview HTML for the Session Efficiency view.
+ *
+ * The webview ships the full session list as a JSON blob inlined into the
+ * page (no external fetch — VS Code webviews don't have file:// access by
+ * default). All rendering happens client-side so filtering and sorting feel
+ * snappy.
+ */
+
+import type { SessionEfficiency } from './sessionEfficiency';
+
+const CATEGORY_LEGEND = [
+	{ id: 'shipped',     label: 'shipped',     desc: 'Created at least one PR' },
+	{ id: 'committed',   label: 'committed',   desc: 'Committed but no PR opened' },
+	{ id: 'issue',       label: 'issue',       desc: 'Created or opened an issue' },
+	{ id: 'edited',      label: 'edited',      desc: 'Edited files but no commit' },
+	{ id: 'exploratory', label: 'exploratory', desc: 'Few tool calls, no edits — research/Q&A' },
+	{ id: 'no-pr',       label: 'no-pr',       desc: 'Heavy session (≥50 tool calls), no PR opened — work may have been pasted elsewhere or used in another session' },
+];
+
+export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): string {
+	// Pre-compress: drop verbose ref objects we don't render.
+	const slim = sessions.map(s => ({
+		id: s.id,
+		repo: s.repository || '',
+		branch: s.branch || '',
+		summary: s.summary || '',
+		firstUserMsg: s.firstUserMsg || '',
+		category: s.category,
+		userTurns: s.userTurns,
+		toolCalls: s.toolCalls,
+		commitCount: s.commitCount,
+		filesEdited: s.filesEdited,
+		prsCreated: s.prsCreated,
+		issuesCreated: s.issuesCreated,
+		output: s.output,
+		efficiency: s.efficiency,
+		model: s.model || '',
+		updatedAt: s.updatedAt,
+		topPrs: s.prRefs
+			.filter(r => r.confidence >= 2)
+			.slice(0, 5)
+			.map(r => ({ repo: r.repo, number: r.number })),
+	}));
+
+	const dataJson = JSON.stringify(slim).replace(/</g, '\\u003c');
+
+	return `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy"
+  content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+<title>Session Efficiency</title>
+<style>
+  body { font: 13px/1.45 var(--vscode-font-family, system-ui, sans-serif);
+         color: var(--vscode-foreground); background: var(--vscode-editor-background);
+         margin: 0; padding: 14px; }
+  h1 { margin: 0 0 6px 0; font-size: 20px; }
+  .muted { color: var(--vscode-descriptionForeground); font-size: 12px; }
+  .panel { background: var(--vscode-editorWidget-background, rgba(127,127,127,0.06));
+           border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25));
+           border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; }
+  .row { display: flex; gap: 12px; flex-wrap: wrap; }
+  .row > .panel { flex: 1 1 320px; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border-bottom: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.2));
+           padding: 5px 7px; text-align: left; vertical-align: top; }
+  th { background: var(--vscode-editorWidget-background, rgba(127,127,127,0.08));
+       cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 1; font-weight: 600; }
+  tr:hover td { background: var(--vscode-list-hoverBackground); }
+  .num { text-align: right; font-variant-numeric: tabular-nums; }
+  .cat { display: inline-block; padding: 1px 7px; border-radius: 10px;
+         font-size: 11px; font-weight: 600; white-space: nowrap; }
+  .cat-shipped     { background: rgba( 16,128, 64,0.20); color: #2faa64; }
+  .cat-committed   { background: rgba( 28, 71,179,0.20); color: #6c8df0; }
+  .cat-issue       { background: rgba(204,138,  0,0.22); color: #e2b249; }
+  .cat-edited      { background: rgba(127,127,127,0.22); color: var(--vscode-foreground); }
+  .cat-exploratory { background: rgba(122, 63,184,0.22); color: #b889e6; }
+  .cat-no-pr       { background: rgba(201,122, 20,0.22); color: #ff9d4a; }
+  input, select { padding: 4px 6px; font: inherit; margin-right: 6px;
+                  background: var(--vscode-input-background); color: var(--vscode-input-foreground);
+                  border: 1px solid var(--vscode-input-border, transparent); border-radius: 2px; }
+  .legend span { margin-right: 8px; cursor: help; }
+  svg { background: var(--vscode-editor-background); display: block;
+        border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25)); border-radius: 4px; }
+  .gridline { stroke: var(--vscode-panel-border, rgba(127,127,127,0.18)); }
+  .axis text { fill: var(--vscode-descriptionForeground); font-size: 10px; }
+  .axis-label { fill: var(--vscode-descriptionForeground); font-size: 11px; }
+  circle { cursor: pointer; opacity: 0.7; }
+  circle:hover { opacity: 1; stroke: var(--vscode-foreground); stroke-width: 1.4; }
+  #tooltip { position: fixed; pointer-events: none;
+             background: var(--vscode-editorHoverWidget-background, #222);
+             color: var(--vscode-editorHoverWidget-foreground, #fff);
+             border: 1px solid var(--vscode-editorHoverWidget-border, transparent);
+             padding: 6px 8px; border-radius: 3px; font-size: 12px;
+             max-width: 360px; display: none; z-index: 10; }
+  a { color: var(--vscode-textLink-foreground); }
+  code { font-size: 12px; background: rgba(127,127,127,0.15); padding: 0 4px; border-radius: 2px; }
+  .empty { padding: 36px; text-align: center; color: var(--vscode-descriptionForeground); }
+</style>
+</head><body>
+<h1>Session Efficiency</h1>
+<p class="muted" id="meta"></p>
+
+<div id="empty" class="empty" style="display:none">
+  <strong>No Copilot CLI sessions found.</strong><br>
+  Looked in <code>~/.copilot/session-state/</code>. This view reads
+  <code>events.jsonl</code> from each session directory.
+</div>
+
+<div id="root">
+  <div class="panel">
+    <strong>Output score</strong> = <code>10·PRs + 4·commits + 3·issues + filesEdited</code>.
+    <strong>Cost</strong> = total tool calls (proxy for tokens).
+    <strong>Efficiency</strong> = output ÷ cost.
+    <div class="legend" style="margin-top:6px" id="legend"></div>
+  </div>
+
+  <div class="row">
+    <div class="panel" style="flex: 2 1 600px">
+      <strong>Cost vs Output</strong>
+      <span class="muted">— top-left = efficient · bottom-right = heavy with no on-disk output</span>
+      <div id="scatter"></div>
+    </div>
+    <div class="panel" style="flex: 1 1 260px">
+      <strong>Sessions by category</strong>
+      <table id="cattable"><tbody></tbody></table>
+    </div>
+  </div>
+
+  <div class="panel">
+    <input id="q" placeholder="Filter (repo, branch, summary…)" size="36">
+    <select id="cat"><option value="">All categories</option></select>
+    <select id="repo"><option value="">All repos</option></select>
+    <label style="font-size:12px"><input type="checkbox" id="onlyOutput"> Only sessions with output</label>
+    <span class="muted" id="rowcount" style="margin-left:8px"></span>
+  </div>
+
+  <div class="panel" style="padding:0">
+    <table id="tbl">
+      <thead><tr>
+        <th data-k="category">Cat</th>
+        <th data-k="repo">Repo</th>
+        <th>Branch / summary</th>
+        <th data-k="prsCreated" class="num">PRs</th>
+        <th data-k="commitCount" class="num">Commits</th>
+        <th data-k="filesEdited" class="num">Files</th>
+        <th data-k="userTurns" class="num">Turns</th>
+        <th data-k="toolCalls" class="num">Tool calls</th>
+        <th data-k="output" class="num">Output</th>
+        <th data-k="efficiency" class="num" title="Output ÷ tool calls × 100">Eff×100</th>
+      </tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<div id="tooltip"></div>
+
+<script>
+const DATA = ${dataJson};
+const LEGEND = ${JSON.stringify(CATEGORY_LEGEND)};
+let SORT = { k: 'efficiency', dir: -1 };
+
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[<&>"']/g, c => ({ '<':'&lt;','&':'&amp;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function init() {
+  document.getElementById('meta').textContent =
+    \`\${DATA.length} session(s) scanned from ~/.copilot/session-state/\`;
+
+  if (DATA.length === 0) {
+    document.getElementById('root').style.display = 'none';
+    document.getElementById('empty').style.display = 'block';
+    return;
+  }
+
+  // Legend chips + category filter options
+  const legendEl = document.getElementById('legend');
+  const catSel = document.getElementById('cat');
+  for (const c of LEGEND) {
+    const span = document.createElement('span');
+    span.className = 'cat cat-' + c.id;
+    span.textContent = c.label;
+    span.title = c.desc;
+    legendEl.appendChild(span);
+    catSel.appendChild(new Option(c.label, c.id));
+  }
+
+  // Repo filter options
+  const repos = [...new Set(DATA.map(s => s.repo).filter(Boolean))].sort();
+  const repoSel = document.getElementById('repo');
+  for (const r of repos) repoSel.appendChild(new Option(r, r));
+
+  renderCatTable();
+  renderScatter();
+  renderTable();
+
+  ['q','cat','repo','onlyOutput'].forEach(id =>
+    document.getElementById(id).addEventListener('input', renderTable));
+  document.querySelectorAll('th[data-k]').forEach(th =>
+    th.addEventListener('click', () => {
+      const k = th.dataset.k;
+      if (SORT.k === k) SORT.dir = -SORT.dir;
+      else { SORT.k = k; SORT.dir = (k === 'repo' || k === 'category') ? 1 : -1; }
+      renderTable();
+    }));
+}
+
+function filtered() {
+  const q = document.getElementById('q').value.toLowerCase();
+  const cat = document.getElementById('cat').value;
+  const rp = document.getElementById('repo').value;
+  const only = document.getElementById('onlyOutput').checked;
+  return DATA.filter(s => {
+    if (cat && s.category !== cat) return false;
+    if (rp && s.repo !== rp) return false;
+    if (only && s.output === 0) return false;
+    if (q) {
+      const blob = (s.repo + ' ' + s.branch + ' ' + s.summary + ' ' + s.firstUserMsg + ' ' + s.id).toLowerCase();
+      if (!blob.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+function renderTable() {
+  const r = filtered().slice();
+  r.sort((a, b) => {
+    const k = SORT.k;
+    const av = a[k], bv = b[k];
+    if (typeof av === 'string') return SORT.dir * av.localeCompare(bv);
+    return SORT.dir * (((av || 0) - (bv || 0)) || 0);
+  });
+  document.getElementById('rowcount').textContent = \`\${r.length} match(es)\`;
+  const top = r.slice(0, 500);
+  const html = top.map(s => {
+    const prCells = s.topPrs.length
+      ? s.topPrs.map(p => \`<a href="https://github.com/\${p.repo}/pull/\${p.number}">#\${p.number}</a>\`).join(' ')
+      : (s.prsCreated || '');
+    return \`<tr>
+      <td><span class="cat cat-\${s.category}">\${s.category}</span></td>
+      <td>\${esc(s.repo)}</td>
+      <td><code>\${esc(s.id).slice(0,8)}</code> · <code>\${esc(s.branch)}</code><br>
+          <span class="muted">\${esc(s.summary || s.firstUserMsg).slice(0, 140)}</span></td>
+      <td class="num">\${prCells}</td>
+      <td class="num">\${s.commitCount || ''}</td>
+      <td class="num">\${s.filesEdited || ''}</td>
+      <td class="num">\${s.userTurns}</td>
+      <td class="num">\${s.toolCalls}</td>
+      <td class="num">\${s.output}</td>
+      <td class="num">\${(s.efficiency * 100).toFixed(1)}</td>
+    </tr>\`;
+  }).join('');
+  document.querySelector('#tbl tbody').innerHTML = html;
+}
+
+function renderCatTable() {
+  const counts = {};
+  for (const s of DATA) counts[s.category] = (counts[s.category] || 0) + 1;
+  const order = LEGEND.map(c => c.id);
+  const total = DATA.length;
+  document.querySelector('#cattable tbody').innerHTML = order
+    .filter(c => counts[c])
+    .map(c => \`<tr>
+      <td><span class="cat cat-\${c}" title="\${esc((LEGEND.find(x=>x.id===c)||{}).desc)}">\${c}</span></td>
+      <td class="num">\${counts[c]}</td>
+      <td class="num muted">\${Math.round(counts[c]*100/total)}%</td>
+    </tr>\`).join('');
+}
+
+function renderScatter() {
+  const W = 720, H = 380, M = { l: 50, r: 16, t: 10, b: 36 };
+  const data = DATA.filter(s => s.toolCalls > 0);
+  if (data.length === 0) { document.getElementById('scatter').innerHTML = '<p class="muted">No data.</p>'; return; }
+  const maxCost = Math.max(50,  ...data.map(s => s.toolCalls));
+  const maxOut  = Math.max(5,   ...data.map(s => s.output));
+  const x = v => M.l + (Math.log10(v + 1) / Math.log10(maxCost + 1)) * (W - M.l - M.r);
+  const y = v => H - M.b - (Math.log10(v + 1) / Math.log10(maxOut + 1)) * (H - M.t - M.b);
+  const colors = {
+    shipped:'#2faa64', committed:'#6c8df0', issue:'#e2b249',
+    edited:'#888', exploratory:'#b889e6', 'no-pr':'#ff9d4a',
+  };
+  const xticks = [1, 10, 100, 1000, 10000].filter(v => v <= maxCost * 1.5);
+  const yticks = [0, 1, 5, 10, 50, 100, 500].filter(v => v <= maxOut * 1.5);
+
+  const dots = data.map(s => {
+    const r = 3 + Math.min(7, Math.sqrt(s.userTurns || 1));
+    return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r.toFixed(1)}"
+              fill="\${colors[s.category] || '#888'}" data-i="\${esc(JSON.stringify(s))}"/>\`;
+  }).join('');
+  const gridX = xticks.map(v =>
+    \`<line class="gridline" x1="\${x(v)}" y1="\${M.t}" x2="\${x(v)}" y2="\${H-M.b}"/>
+     <text x="\${x(v)}" y="\${H-M.b+13}" text-anchor="middle">\${v}</text>\`).join('');
+  const gridY = yticks.map(v =>
+    \`<line class="gridline" x1="\${M.l}" y1="\${y(v)}" x2="\${W-M.r}" y2="\${y(v)}"/>
+     <text x="\${M.l-6}" y="\${y(v)+4}" text-anchor="end">\${v}</text>\`).join('');
+
+  const svg = \`<svg viewBox="0 0 \${W} \${H}" width="100%" height="\${H}" class="axis" preserveAspectRatio="xMidYMid meet">
+    \${gridX}\${gridY}
+    <text class="axis-label" x="\${W/2}" y="\${H-4}" text-anchor="middle">Tool calls (log) →</text>
+    <text class="axis-label" x="14" y="\${H/2}" text-anchor="middle" transform="rotate(-90 14 \${H/2})">Output score (log) →</text>
+    \${dots}
+  </svg>\`;
+  const wrap = document.getElementById('scatter');
+  wrap.innerHTML = svg;
+  const tip = document.getElementById('tooltip');
+  wrap.querySelectorAll('circle').forEach(c => {
+    c.addEventListener('mouseenter', () => {
+      const s = JSON.parse(c.dataset.i);
+      const prsHtml = s.topPrs.length
+        ? s.topPrs.map(p => '#' + p.number).join(' ')
+        : '—';
+      tip.innerHTML = \`<strong>\${esc(s.repo)}</strong> · <code>\${esc(s.branch)}</code><br>
+        <span class="cat cat-\${s.category}">\${s.category}</span>
+        · \${s.toolCalls} tool calls · \${s.userTurns} user turns<br>
+        PRs: \${prsHtml} · \${s.commitCount} commit(s) · \${s.filesEdited} file(s) edited<br>
+        eff×100 = \${(s.efficiency*100).toFixed(2)}<br>
+        <em>\${esc(s.summary || s.firstUserMsg).slice(0, 200)}</em>\`;
+      tip.style.display = 'block';
+    });
+    c.addEventListener('mousemove', e => {
+      tip.style.left = (e.clientX + 14) + 'px';
+      tip.style.top  = (e.clientY + 14) + 'px';
+    });
+    c.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
+  });
+}
+
+init();
+</script>
+</body></html>`;
+}

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -18,8 +18,84 @@ const CATEGORY_LEGEND = [
 	{ id: 'no-pr',       label: 'no-pr',       desc: 'Heavy session (≥50 tool calls), no PR opened — work may have been pasted elsewhere or used in another session' },
 ];
 
+const SHARED_HEAD_CSS = `
+  body { font: 13px/1.45 var(--vscode-font-family, system-ui, sans-serif);
+         color: var(--vscode-foreground); background: var(--vscode-editor-background);
+         margin: 0; padding: 14px; }
+  .header { display: flex; justify-content: space-between; align-items: flex-start;
+             flex-wrap: wrap; gap: 12px; margin-bottom: 14px; padding-bottom: 4px; }
+  .header-left { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .header-icon { font-size: 20px; }
+  .header-title { font-size: 16px; font-weight: 700;
+                  color: var(--vscode-editor-foreground); letter-spacing: 0.2px; }
+  .header-meta { font-size: 12px; color: var(--vscode-descriptionForeground);
+                 margin-left: 4px; font-weight: 400; }
+  .button-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .nav-btn { padding: 4px 11px; cursor: pointer; font: inherit; font-size: 13px;
+             background: var(--vscode-button-background, #0078d4);
+             color: var(--vscode-button-foreground, #ffffff);
+             border: none; border-radius: 2px; white-space: nowrap; }
+  .nav-btn:hover { background: var(--vscode-button-hoverBackground, #026ec1); }
+`;
+
+const SHARED_HEADER_HTML = `
+<div class="header">
+  <div class="header-left">
+    <span class="header-icon">📈</span>
+    <span class="header-title">Session Efficiency</span>
+    <span class="header-meta" id="header-meta"></span>
+  </div>
+  <div class="button-row">
+    <button class="nav-btn" id="nav-refresh">🔄 Refresh</button>
+    <button class="nav-btn" id="nav-details">🤖 Details</button>
+    <button class="nav-btn" id="nav-chart">📈 Chart</button>
+    <button class="nav-btn" id="nav-usage">📊 Usage Analysis</button>
+    <button class="nav-btn" id="nav-environmental">🌿 Environmental Impact</button>
+    <button class="nav-btn" id="nav-diagnostics">🔍 Diagnostics</button>
+    <button class="nav-btn" id="nav-maturity">🎯 Fluency Score</button>
+  </div>
+</div>`;
+
+/**
+ * Returns a lightweight loading screen shown immediately while sessions are scanned.
+ * The extension replaces this with the full view once the scan completes.
+ */
+export function renderSessionEfficiencyLoadingHtml(): string {
+	return `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+<title>Session Efficiency</title>
+<style>
+${SHARED_HEAD_CSS}
+  .spinner-wrap { display: flex; flex-direction: column; align-items: center;
+                  justify-content: center; height: 60vh; gap: 18px;
+                  color: var(--vscode-descriptionForeground); }
+  .spinner { width: 36px; height: 36px; border: 3px solid var(--vscode-panel-border, rgba(127,127,127,0.3));
+             border-top-color: var(--vscode-button-background, #0078d4);
+             border-radius: 50%; animation: spin 0.8s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head><body>
+${SHARED_HEADER_HTML}
+<div class="spinner-wrap">
+  <div class="spinner"></div>
+  <span>Scanning sessions…</span>
+</div>
+<script>
+const vscode = acquireVsCodeApi();
+document.getElementById('nav-refresh')?.addEventListener('click', () => vscode.postMessage({ command: 'refresh' }));
+document.getElementById('nav-details')?.addEventListener('click', () => vscode.postMessage({ command: 'showDetails' }));
+document.getElementById('nav-chart')?.addEventListener('click', () => vscode.postMessage({ command: 'showChart' }));
+document.getElementById('nav-usage')?.addEventListener('click', () => vscode.postMessage({ command: 'showUsageAnalysis' }));
+document.getElementById('nav-environmental')?.addEventListener('click', () => vscode.postMessage({ command: 'showEnvironmental' }));
+document.getElementById('nav-diagnostics')?.addEventListener('click', () => vscode.postMessage({ command: 'showDiagnostics' }));
+document.getElementById('nav-maturity')?.addEventListener('click', () => vscode.postMessage({ command: 'showMaturity' }));
+</script>
+</body></html>`;
+}
+
 export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): string {
-	// Pre-compress: drop verbose ref objects we don't render.
 	const slim = sessions.map(s => ({
 		id: s.id,
 		repo: s.repository || '',
@@ -53,6 +129,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
 	}));
 
 	const dataJson = JSON.stringify(slim).replace(/</g, '\\u003c');
+	const sessionCount = sessions.length;
 
 	return `<!DOCTYPE html>
 <html lang="en"><head>
@@ -61,10 +138,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
 <title>Session Efficiency</title>
 <style>
-  body { font: 13px/1.45 var(--vscode-font-family, system-ui, sans-serif);
-         color: var(--vscode-foreground); background: var(--vscode-editor-background);
-         margin: 0; padding: 14px; }
-  h1 { margin: 0 0 6px 0; font-size: 20px; }
+${SHARED_HEAD_CSS}
   .muted { color: var(--vscode-descriptionForeground); font-size: 12px; }
   .panel { background: var(--vscode-editorWidget-background, rgba(127,127,127,0.06));
            border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25));
@@ -92,7 +166,6 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   input, select { padding: 4px 6px; font: inherit; margin-right: 6px;
                   background: var(--vscode-input-background); color: var(--vscode-input-foreground);
                   border: 1px solid var(--vscode-input-border, transparent); border-radius: 2px; }
-  .legend span { margin-right: 8px; cursor: help; }
   svg { background: var(--vscode-editor-background); display: block;
         border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25)); border-radius: 4px;
         shape-rendering: geometricPrecision; }
@@ -110,18 +183,6 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   a { color: var(--vscode-textLink-foreground); }
   code { font-size: 12px; background: rgba(127,127,127,0.15); padding: 0 4px; border-radius: 2px; }
   .empty { padding: 36px; text-align: center; color: var(--vscode-descriptionForeground); }
-  .header { display: flex; justify-content: space-between; align-items: flex-start;
-             flex-wrap: wrap; gap: 12px; margin-bottom: 14px; padding-bottom: 4px; }
-  .header-left { display: flex; align-items: center; gap: 8px; }
-  .header-icon { font-size: 20px; }
-  .header-title { font-size: 16px; font-weight: 700;
-                  color: var(--vscode-editor-foreground); letter-spacing: 0.2px; }
-  .button-row { display: flex; flex-wrap: wrap; gap: 8px; }
-  .nav-btn { padding: 4px 11px; cursor: pointer; font: inherit; font-size: 13px;
-             background: var(--vscode-button-background, #0078d4);
-             color: var(--vscode-button-foreground, #ffffff);
-             border: none; border-radius: 2px; white-space: nowrap; }
-  .nav-btn:hover { background: var(--vscode-button-hoverBackground, #026ec1); }
   .mode-toggle { display: flex; border: 1px solid var(--vscode-button-border, rgba(127,127,127,0.3)); border-radius: 3px; overflow: hidden; }
   .mode-btn { padding: 3px 10px; cursor: pointer; font: inherit; font-size: 12px; border: none; border-radius: 0;
               background: transparent; color: var(--vscode-descriptionForeground); }
@@ -129,22 +190,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   .mode-btn:hover:not(.active) { background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.15)); }
 </style>
 </head><body>
-<div class="header">
-  <div class="header-left">
-    <span class="header-icon">📈</span>
-    <span class="header-title">Session Efficiency</span>
-  </div>
-  <div class="button-row">
-    <button class="nav-btn" id="nav-refresh">🔄 Refresh</button>
-    <button class="nav-btn" id="nav-details">🤖 Details</button>
-    <button class="nav-btn" id="nav-chart">📈 Chart</button>
-    <button class="nav-btn" id="nav-usage">📊 Usage Analysis</button>
-    <button class="nav-btn" id="nav-environmental">🌿 Environmental Impact</button>
-    <button class="nav-btn" id="nav-diagnostics">🔍 Diagnostics</button>
-    <button class="nav-btn" id="nav-maturity">🎯 Fluency Score</button>
-  </div>
-</div>
-<p class="muted" id="meta"></p>
+${SHARED_HEADER_HTML}
 
 <div id="empty" class="empty" style="display:none">
   <strong>No Copilot CLI sessions found.</strong><br>
@@ -171,7 +217,6 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
       or producing work that was continued, copy-pasted, or applied outside this editor.
       Use this view as a signal to spot patterns, not as a verdict on individual sessions.
     </p>
-    <div class="legend" style="margin-top:6px" id="legend"></div>
   </div>
 
   <div class="row">
@@ -231,8 +276,7 @@ function fmtTok(k) {
 }
 
 function init() {
-  document.getElementById('meta').textContent =
-    \`\${DATA.length} session(s) scanned from ~/.copilot/session-state/\`;
+  document.getElementById('header-meta').textContent = \`— \${DATA.length} session(s)\`;
 
   if (DATA.length === 0) {
     document.getElementById('root').style.display = 'none';
@@ -240,15 +284,9 @@ function init() {
     return;
   }
 
-  // Legend chips + category filter options
-  const legendEl = document.getElementById('legend');
+  // Category filter options (legend chips removed — see "Sessions by category" panel)
   const catSel = document.getElementById('cat');
   for (const c of LEGEND) {
-    const span = document.createElement('span');
-    span.className = 'cat cat-' + c.id;
-    span.textContent = c.label;
-    span.title = c.desc;
-    legendEl.appendChild(span);
     catSel.appendChild(new Option(c.label, c.id));
   }
 

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -87,8 +87,8 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   .gridline { stroke: var(--vscode-panel-border, rgba(127,127,127,0.18)); }
   .axis text { fill: var(--vscode-descriptionForeground); font-size: 10px; }
   .axis-label { fill: var(--vscode-descriptionForeground); font-size: 11px; }
-  circle { cursor: pointer; opacity: 0.65; }
-  circle:hover { opacity: 1; stroke-width: 1.5; }
+  circle { cursor: pointer; opacity: 0.85; }
+  circle:hover { opacity: 1; stroke: rgba(255,255,255,0.9) !important; stroke-width: 1.5; }
   #tooltip { position: fixed; pointer-events: none;
              background: var(--vscode-editorHoverWidget-background, #222);
              color: var(--vscode-editorHoverWidget-foreground, #fff);
@@ -304,7 +304,7 @@ function renderScatter() {
     const r = 4.5;
     const col = colors[s.category] || '#888';
     return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r}"
-              fill="\${col}" stroke="\${col}" stroke-width="0.5" stroke-opacity="0.4" data-i="\${esc(JSON.stringify(s))}"/>\`;
+              fill="\${col}" stroke="rgba(0,0,0,0.55)" stroke-width="1" data-i="\${esc(JSON.stringify(s))}"/>\`;
   }).join('');
   const gridX = xticks.map(v =>
     \`<line class="gridline" x1="\${x(v)}" y1="\${M.t}" x2="\${x(v)}" y2="\${H-M.b}"/>

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -110,12 +110,18 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   a { color: var(--vscode-textLink-foreground); }
   code { font-size: 12px; background: rgba(127,127,127,0.15); padding: 0 4px; border-radius: 2px; }
   .empty { padding: 36px; text-align: center; color: var(--vscode-descriptionForeground); }
-  .nav-buttons { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
-  .nav-btn { padding: 3px 10px; cursor: pointer; font: inherit; font-size: 12px;
-             background: var(--vscode-button-secondaryBackground, rgba(127,127,127,0.15));
-             color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
-             border: 1px solid var(--vscode-button-border, transparent); border-radius: 2px; }
-  .nav-btn:hover { background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.25)); }
+  .header { display: flex; justify-content: space-between; align-items: flex-start;
+             flex-wrap: wrap; gap: 12px; margin-bottom: 14px; padding-bottom: 4px; }
+  .header-left { display: flex; align-items: center; gap: 8px; }
+  .header-icon { font-size: 20px; }
+  .header-title { font-size: 16px; font-weight: 700;
+                  color: var(--vscode-editor-foreground); letter-spacing: 0.2px; }
+  .button-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .nav-btn { padding: 4px 11px; cursor: pointer; font: inherit; font-size: 13px;
+             background: var(--vscode-button-background, #0078d4);
+             color: var(--vscode-button-foreground, #ffffff);
+             border: none; border-radius: 2px; white-space: nowrap; }
+  .nav-btn:hover { background: var(--vscode-button-hoverBackground, #026ec1); }
   .mode-toggle { display: flex; border: 1px solid var(--vscode-button-border, rgba(127,127,127,0.3)); border-radius: 3px; overflow: hidden; }
   .mode-btn { padding: 3px 10px; cursor: pointer; font: inherit; font-size: 12px; border: none; border-radius: 0;
               background: transparent; color: var(--vscode-descriptionForeground); }
@@ -123,14 +129,20 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   .mode-btn:hover:not(.active) { background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.15)); }
 </style>
 </head><body>
-<h1>Session Efficiency</h1>
-<div class="nav-buttons">
-  <button class="nav-btn" id="nav-details">🤖 Details</button>
-  <button class="nav-btn" id="nav-chart">📈 Chart</button>
-  <button class="nav-btn" id="nav-usage">📊 Usage Analysis</button>
-  <button class="nav-btn" id="nav-environmental">🌿 Environmental Impact</button>
-  <button class="nav-btn" id="nav-diagnostics">🔍 Diagnostics</button>
-  <button class="nav-btn" id="nav-maturity">🎯 Fluency Score</button>
+<div class="header">
+  <div class="header-left">
+    <span class="header-icon">📈</span>
+    <span class="header-title">Session Efficiency</span>
+  </div>
+  <div class="button-row">
+    <button class="nav-btn" id="nav-refresh">🔄 Refresh</button>
+    <button class="nav-btn" id="nav-details">🤖 Details</button>
+    <button class="nav-btn" id="nav-chart">📈 Chart</button>
+    <button class="nav-btn" id="nav-usage">📊 Usage Analysis</button>
+    <button class="nav-btn" id="nav-environmental">🌿 Environmental Impact</button>
+    <button class="nav-btn" id="nav-diagnostics">🔍 Diagnostics</button>
+    <button class="nav-btn" id="nav-maturity">🎯 Fluency Score</button>
+  </div>
 </div>
 <p class="muted" id="meta"></p>
 
@@ -458,6 +470,7 @@ function renderScatter() {
 init();
 
 const vscode = acquireVsCodeApi();
+document.getElementById('nav-refresh')?.addEventListener('click', () => vscode.postMessage({ command: 'refresh' }));
 document.getElementById('nav-details')?.addEventListener('click', () => vscode.postMessage({ command: 'showDetails' }));
 document.getElementById('nav-chart')?.addEventListener('click', () => vscode.postMessage({ command: 'showChart' }));
 document.getElementById('nav-usage')?.addEventListener('click', () => vscode.postMessage({ command: 'showUsageAnalysis' }));

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -35,7 +35,14 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
 		issuesCreated: s.issuesCreated,
 		output: s.output,
 		efficiency: s.efficiency,
-		aiCredits: s.aiCredits,
+		estimatedCostUsd: s.estimatedCostUsd,
+		modelSummary: s.modelMetrics.map(m => ({
+			model: m.model,
+			inK: Math.round(m.inputTokens / 1000),
+			outK: Math.round(m.outputTokens / 1000),
+			cacheK: Math.round(m.cacheReadTokens / 1000),
+			costUsd: m.costUsd,
+		})),
 		model: s.model || '',
 		updatedAt: s.updatedAt,
 		topPrs: s.prRefs
@@ -141,7 +148,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
       <span class="muted" style="font-size:12px">Cost basis:</span>
       <div class="mode-toggle">
         <button class="mode-btn active" id="mode-effort" title="Use tool-call count as the cost metric">⚙ Effort (tool calls)</button>
-        <button class="mode-btn" id="mode-money" title="Use AI credits consumed as the cost metric (available for ~80% of sessions)">💳 Cost (AI credits)</button>
+        <button class="mode-btn" id="mode-money" title="Use token-based dollar cost (from session.shutdown metrics, ~80% of sessions)">💲 Cost ($)</button>
       </div>
     </div>
     <p class="muted" style="margin:8px 0 4px; font-size:12px; line-height:1.5; max-width:860px">
@@ -186,8 +193,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
         <th data-k="userTurns" class="num">Turns</th>
         <th data-k="toolCalls" class="num" data-label="Tool calls">Tool calls</th>
         <th data-k="output" class="num">Output</th>
-        <th data-k="efficiency" class="num" data-label="Eff×100" title="Output ÷ tool calls × 100">Eff×100</th>
-      </tr></thead>
+        <th data-k="efficiency" class="num" data-label="Eff×100" title="Output ÷ tool calls × 100">Eff×100</th>      </tr></thead>
       <tbody></tbody>
     </table>
   </div>
@@ -257,15 +263,15 @@ function setCostMode(mode) {
   // Update table header labels
   const thCost = document.querySelector('th[data-k="toolCalls"]');
   const thEff  = document.querySelector('th[data-k="efficiency"]');
-  if (thCost) { thCost.dataset.label = mode === 'effort' ? 'Tool calls' : 'AI credits'; }
-  if (thEff)  { thEff.dataset.label = mode === 'effort' ? 'Eff×100' : 'Eff/cr'; thEff.title = mode === 'effort' ? 'Output ÷ tool calls × 100' : 'Output ÷ AI credits × 100'; }
+  if (thCost) { thCost.dataset.label = mode === 'effort' ? 'Tool calls' : 'Cost ($)'; }
+  if (thEff)  { thEff.dataset.label = mode === 'effort' ? 'Eff×100' : 'Eff/$'; thEff.title = mode === 'effort' ? 'Output ÷ tool calls × 100' : 'Output ÷ cost in dollars × 100'; }
   renderScatter();
   renderTable();
 }
 
 // Returns the "cost" value to use for a session in the current COST_MODE.
-// Money mode falls back to tool calls when aiCredits = 0.
-function costVal(s) { return COST_MODE === 'money' && s.aiCredits > 0 ? s.aiCredits : s.toolCalls; }
+// Money mode falls back to tool calls when estimatedCostUsd = 0.
+function costVal(s) { return COST_MODE === 'money' && s.estimatedCostUsd > 0 ? s.estimatedCostUsd : s.toolCalls; }
 function effVal(s)  { const c = costVal(s); return c > 0 ? s.output / c : 0; }
 
 function filtered() {
@@ -316,7 +322,7 @@ function renderTable() {
       ? s.topPrs.map(p => \`<a href="https://github.com/\${p.repo}/pull/\${p.number}">#\${p.number}</a>\`).join(' ')
       : (s.prsCreated || '');
     const costCell = COST_MODE === 'money'
-      ? (s.aiCredits > 0 ? s.aiCredits : \`<span class="muted" title="No shutdown data">\${s.toolCalls}*</span>\`)
+      ? (s.estimatedCostUsd > 0 ? '$' + s.estimatedCostUsd.toFixed(2) : \`<span class="muted" title="No shutdown data">\${s.toolCalls}*</span>\`)
       : s.toolCalls;
     const effCell = (effVal(s) * 100).toFixed(1);
     return \`<tr>
@@ -364,7 +370,7 @@ function renderScatter() {
   };
   const xticks = [1, 10, 100, 1000, 10000].filter(v => v <= maxCost * 1.5);
   const yticks = [0, 1, 5, 10, 50, 100, 500].filter(v => v <= maxOut * 1.5);
-  const xLabel = COST_MODE === 'money' ? 'AI credits (log) →' : 'Tool calls (log) →';
+  const xLabel = COST_MODE === 'money' ? 'Cost in $ (log) →' : 'Tool calls (log) →';
 
   const dots = data.map(s => {
     const r = 3 + Math.min(7, Math.sqrt(s.userTurns || 1));
@@ -395,14 +401,19 @@ function renderScatter() {
         ? s.topPrs.map(p => '#' + p.number).join(' ')
         : '—';
       const costLine = COST_MODE === 'money'
-        ? \`\${s.aiCredits > 0 ? s.aiCredits + ' AI credits' : s.toolCalls + ' tool calls (no credit data)'}\`
+        ? (s.estimatedCostUsd > 0 ? '$' + s.estimatedCostUsd.toFixed(2) : s.toolCalls + ' tool calls (no cost data)')
         : \`\${s.toolCalls} tool calls\`;
+      const modelsHtml = s.modelSummary && s.modelSummary.length
+        ? s.modelSummary.map(m =>
+            \`<code>\${esc(m.model)}</code>: \${m.inK}k in / \${m.outK}k out / \${m.cacheK}k cached — \$\${m.costUsd.toFixed(2)}\`
+          ).join('<br>')
+        : '';
       tip.innerHTML = \`<strong>\${esc(s.repo)}</strong> · <code>\${esc(s.branch)}</code><br>
         <span class="cat cat-\${s.category}">\${s.category}</span>
         · \${costLine} · \${s.userTurns} user turns<br>
         PRs: \${prsHtml} · \${s.commitCount} commit(s) · \${s.filesEdited} file(s) edited<br>
         eff×100 = \${(effVal(s)*100).toFixed(2)}<br>
-        <em>\${esc(s.summary || s.firstUserMsg).slice(0, 200)}</em>\`;
+        \${modelsHtml ? modelsHtml + '<br>' : ''}<em>\${esc(s.summary || s.firstUserMsg).slice(0, 200)}</em>\`;
       tip.style.display = 'block';
     });
     c.addEventListener('mousemove', e => {

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -66,9 +66,10 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   th, td { border-bottom: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.2));
            padding: 5px 7px; text-align: left; vertical-align: top; }
   th { background: var(--vscode-editorWidget-background, rgba(127,127,127,0.08));
-       cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 1; font-weight: 600; }
-  th .sort-icon { margin-left: 4px; opacity: 0.5; font-size: 10px; }
-  th.sorted .sort-icon { opacity: 1; }
+       cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 1; font-weight: 600;
+       white-space: nowrap; }
+  th .sort-icon { margin-left: 3px; opacity: 0.35; font-size: 9px; vertical-align: middle; }
+  th.sorted .sort-icon { opacity: 1; color: var(--vscode-textLink-foreground); }
   tr:hover td { background: var(--vscode-list-hoverBackground); }
   .num { text-align: right; font-variant-numeric: tabular-nums; }
   .cat { display: inline-block; padding: 1px 7px; border-radius: 10px;
@@ -256,7 +257,7 @@ function renderTable() {
     th.classList.toggle('sorted', isSorted);
     let icon = th.querySelector('.sort-icon');
     if (!icon) { icon = document.createElement('span'); icon.className = 'sort-icon'; th.appendChild(icon); }
-    icon.textContent = isSorted ? (SORT.dir === 1 ? ' ▲' : ' ▼') : ' ⬍';
+    icon.textContent = isSorted ? (SORT.dir === 1 ? '▲' : '▼') : '⇅';
   });
   document.getElementById('rowcount').textContent = \`\${r.length} match(es)\`;
   const top = r.slice(0, 500);

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -47,6 +47,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
 		updatedAt: s.updatedAt,
 		topPrs: s.prRefs
 			.filter(r => r.confidence >= 2)
+			.filter((r, i, arr) => arr.findIndex(x => x.number === r.number) === i)
 			.slice(0, 5)
 			.map(r => ({ repo: r.repo, number: r.number })),
 	}));
@@ -167,7 +168,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
       <span class="muted">— top-left = efficient · bottom-right = heavy with no on-disk output</span>
       <div id="scatter"></div>
     </div>
-    <div class="panel" style="flex: 1 1 260px">
+    <div class="panel" style="flex: 1 1 182px">
       <strong>Sessions by category</strong>
       <table id="cattable"><tbody></tbody></table>
     </div>
@@ -211,6 +212,12 @@ function esc(s) {
   return String(s == null ? '' : s).replace(/[<&>"']/g, c => ({ '<':'&lt;','&':'&amp;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 }
 
+// Format a token count already in thousands (k). Shows "1.2M" above 1000k.
+function fmtTok(k) {
+  if (k >= 1000) return (k / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 }) + 'M';
+  return k + 'k';
+}
+
 function init() {
   document.getElementById('meta').textContent =
     \`\${DATA.length} session(s) scanned from ~/.copilot/session-state/\`;
@@ -243,7 +250,7 @@ function init() {
   renderTable();
 
   ['q','cat','repo','onlyOutput'].forEach(id =>
-    document.getElementById(id).addEventListener('input', renderTable));
+    document.getElementById(id).addEventListener('input', () => { renderTable(); if (id === 'cat') renderCatTable(); }));
   document.querySelectorAll('th[data-k]').forEach(th =>
     th.addEventListener('click', () => {
       const k = th.dataset.k;
@@ -347,13 +354,28 @@ function renderCatTable() {
   for (const s of DATA) counts[s.category] = (counts[s.category] || 0) + 1;
   const order = LEGEND.map(c => c.id);
   const total = DATA.length;
+  const activeCat = document.getElementById('cat').value;
   document.querySelector('#cattable tbody').innerHTML = order
     .filter(c => counts[c])
-    .map(c => \`<tr>
-      <td><span class="cat cat-\${c}" title="\${esc((LEGEND.find(x=>x.id===c)||{}).desc)}">\${c}</span></td>
-      <td class="num">\${counts[c]}</td>
-      <td class="num muted">\${Math.round(counts[c]*100/total)}%</td>
-    </tr>\`).join('');
+    .map(c => {
+      const isActive = activeCat === c;
+      return \`<tr style="cursor:pointer\${isActive ? ';background:var(--vscode-list-activeSelectionBackground);color:var(--vscode-list-activeSelectionForeground)' : ''}" data-cat="\${esc(c)}">
+        <td><span class="cat cat-\${c}" title="\${esc((LEGEND.find(x=>x.id===c)||{}).desc)}">\${c}</span></td>
+        <td class="num">\${counts[c]}</td>
+        <td class="num muted">\${Math.round(counts[c]*100/total)}%</td>
+      </tr>\`;
+    }).join('');
+
+  document.querySelectorAll('#cattable tr').forEach(row => {
+    row.addEventListener('click', () => {
+      const sel = document.getElementById('cat');
+      const clickedCat = row.dataset.cat;
+      document.getElementById('q').value = '';
+      sel.value = sel.value === clickedCat ? '' : clickedCat;
+      renderTable();
+      renderCatTable();
+    });
+  });
 }
 
 function renderScatter() {
@@ -405,7 +427,7 @@ function renderScatter() {
         : \`\${s.toolCalls} tool calls\`;
       const modelsHtml = s.modelSummary && s.modelSummary.length
         ? s.modelSummary.map(m =>
-            \`<code>\${esc(m.model)}</code>: \${m.inK}k in / \${m.outK}k out / \${m.cacheK}k cached — \$\${m.costUsd.toFixed(2)}\`
+            \`<code>\${esc(m.model)}</code>: \${fmtTok(m.inK)} in / \${fmtTok(m.outK)} out / \${fmtTok(m.cacheK)} cached — \$\${m.costUsd.toFixed(2)}\`
           ).join('<br>')
         : '';
       tip.innerHTML = \`<strong>\${esc(s.repo)}</strong> · <code>\${esc(s.branch)}</code><br>
@@ -421,6 +443,15 @@ function renderScatter() {
       tip.style.top  = (e.clientY + 14) + 'px';
     });
     c.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
+    c.addEventListener('click', () => {
+      const s = JSON.parse(c.dataset.i);
+      tip.style.display = 'none';
+      document.getElementById('cat').value = '';
+      document.getElementById('q').value = s.id;
+      renderTable();
+      renderCatTable();
+      document.getElementById('tbl').scrollIntoView({ behavior: 'smooth' });
+    });
   });
 }
 

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -203,13 +203,6 @@ ${SHARED_HEADER_HTML}
     <strong>Output score</strong> = <code>10·PRs + 4·commits + 3·issues + filesEdited</code>.
     <strong>Cost</strong> = total tool calls (proxy for effort) <em>or</em> AI credits used.
     <strong>Efficiency</strong> = output ÷ cost.
-    <div style="margin-top:6px; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
-      <span class="muted" style="font-size:12px">Cost basis:</span>
-      <div class="mode-toggle">
-        <button class="mode-btn active" id="mode-effort" title="Use tool-call count as the cost metric">⚙ Effort (tool calls)</button>
-        <button class="mode-btn" id="mode-money" title="Use token-based dollar cost (from session.shutdown metrics, ~80% of sessions)">💲 Cost ($)</button>
-      </div>
-    </div>
     <p class="muted" style="margin:8px 0 4px; font-size:12px; line-height:1.5; max-width:860px">
       <strong>Note:</strong> The output score only reflects what is visible in the session log.
       A session can create real value in ways that don't appear here — for example:
@@ -228,6 +221,13 @@ ${SHARED_HEADER_HTML}
     <div class="panel" style="flex: 1 1 182px">
       <strong>Sessions by category</strong>
       <table id="cattable"><tbody></tbody></table>
+      <div style="margin-top:12px; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+        <span class="muted" style="font-size:12px">Cost basis:</span>
+        <div class="mode-toggle">
+          <button class="mode-btn active" id="mode-effort" title="Use tool-call count as the cost metric">⚙ Effort (tool calls)</button>
+          <button class="mode-btn" id="mode-money" title="Use token-based dollar cost (from session.shutdown metrics, ~80% of sessions)">💲 Cost ($)</button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -214,7 +214,7 @@ ${SHARED_HEADER_HTML}
 
   <div class="row">
     <div class="panel" style="flex: 2 1 600px">
-      <strong>Cost vs Output</strong>
+      <strong><span id="chart-cost-label">Tool calls</span> vs Output</strong>
       <span class="muted">— top-left = efficient · bottom-right = heavy with no on-disk output</span>
       <div id="scatter"></div>
     </div>
@@ -320,6 +320,8 @@ function setCostMode(mode) {
   // Update table header labels
   const thCost = document.querySelector('th[data-k="toolCalls"]');
   const thEff  = document.querySelector('th[data-k="efficiency"]');
+  const chartLabel = document.getElementById('chart-cost-label');
+  if (chartLabel) chartLabel.textContent = mode === 'effort' ? 'Tool calls' : 'Cost ($)';
   if (thCost) { thCost.dataset.label = mode === 'effort' ? 'Tool calls' : 'Cost ($)'; }
   if (thEff)  { thEff.dataset.label = mode === 'effort' ? 'Eff×100' : 'Eff/$'; thEff.title = mode === 'effort' ? 'Output ÷ tool calls × 100' : 'Output ÷ cost in dollars × 100'; }
   renderScatter();
@@ -429,7 +431,7 @@ function renderCatTable() {
 }
 
 function renderScatter() {
-  const W = 720, H = 380, M = { l: 50, r: 16, t: 10, b: 36 };
+  const W = 720, H = 380, M = { l: 50, r: 20, t: 16, b: 36 };
   const data = DATA.filter(s => costVal(s) > 0);
   if (data.length === 0) { document.getElementById('scatter').innerHTML = '<p class="muted">No data.</p>'; return; }
   const maxCost = Math.max(50,  ...data.map(s => costVal(s)));

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -97,9 +97,23 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
   a { color: var(--vscode-textLink-foreground); }
   code { font-size: 12px; background: rgba(127,127,127,0.15); padding: 0 4px; border-radius: 2px; }
   .empty { padding: 36px; text-align: center; color: var(--vscode-descriptionForeground); }
+  .nav-buttons { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+  .nav-btn { padding: 3px 10px; cursor: pointer; font: inherit; font-size: 12px;
+             background: var(--vscode-button-secondaryBackground, rgba(127,127,127,0.15));
+             color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+             border: 1px solid var(--vscode-button-border, transparent); border-radius: 2px; }
+  .nav-btn:hover { background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.25)); }
 </style>
 </head><body>
 <h1>Session Efficiency</h1>
+<div class="nav-buttons">
+  <button class="nav-btn" id="nav-details">🤖 Details</button>
+  <button class="nav-btn" id="nav-chart">📈 Chart</button>
+  <button class="nav-btn" id="nav-usage">📊 Usage Analysis</button>
+  <button class="nav-btn" id="nav-environmental">🌿 Environmental Impact</button>
+  <button class="nav-btn" id="nav-diagnostics">🔍 Diagnostics</button>
+  <button class="nav-btn" id="nav-maturity">🎯 Fluency Score</button>
+</div>
 <p class="muted" id="meta"></p>
 
 <div id="empty" class="empty" style="display:none">
@@ -329,6 +343,14 @@ function renderScatter() {
 }
 
 init();
+
+const vscode = acquireVsCodeApi();
+document.getElementById('nav-details')?.addEventListener('click', () => vscode.postMessage({ command: 'showDetails' }));
+document.getElementById('nav-chart')?.addEventListener('click', () => vscode.postMessage({ command: 'showChart' }));
+document.getElementById('nav-usage')?.addEventListener('click', () => vscode.postMessage({ command: 'showUsageAnalysis' }));
+document.getElementById('nav-environmental')?.addEventListener('click', () => vscode.postMessage({ command: 'showEnvironmental' }));
+document.getElementById('nav-diagnostics')?.addEventListener('click', () => vscode.postMessage({ command: 'showDiagnostics' }));
+document.getElementById('nav-maturity')?.addEventListener('click', () => vscode.postMessage({ command: 'showMaturity' }));
 </script>
 </body></html>`;
 }

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -301,9 +301,9 @@ function renderScatter() {
   const yticks = [0, 1, 5, 10, 50, 100, 500].filter(v => v <= maxOut * 1.5);
 
   const dots = data.map(s => {
-    const r = 4.5;
+    const r = 3 + Math.min(7, Math.sqrt(s.userTurns || 1));
     const col = colors[s.category] || '#888';
-    return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r}"
+    return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r.toFixed(1)}"
               fill="\${col}" stroke="rgba(0,0,0,0.55)" stroke-width="1" data-i="\${esc(JSON.stringify(s))}"/>\`;
   }).join('');
   const gridX = xticks.map(v =>

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -67,6 +67,8 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
            padding: 5px 7px; text-align: left; vertical-align: top; }
   th { background: var(--vscode-editorWidget-background, rgba(127,127,127,0.08));
        cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 1; font-weight: 600; }
+  th .sort-icon { margin-left: 4px; opacity: 0.5; font-size: 10px; }
+  th.sorted .sort-icon { opacity: 1; }
   tr:hover td { background: var(--vscode-list-hoverBackground); }
   .num { text-align: right; font-variant-numeric: tabular-nums; }
   .cat { display: inline-block; padding: 1px 7px; border-radius: 10px;
@@ -247,6 +249,14 @@ function renderTable() {
     const av = a[k], bv = b[k];
     if (typeof av === 'string') return SORT.dir * av.localeCompare(bv);
     return SORT.dir * (((av || 0) - (bv || 0)) || 0);
+  });
+  // Update sort indicators on column headers
+  document.querySelectorAll('th[data-k]').forEach(th => {
+    const isSorted = th.dataset.k === SORT.k;
+    th.classList.toggle('sorted', isSorted);
+    let icon = th.querySelector('.sort-icon');
+    if (!icon) { icon = document.createElement('span'); icon.className = 'sort-icon'; th.appendChild(icon); }
+    icon.textContent = isSorted ? (SORT.dir === 1 ? ' ▲' : ' ▼') : ' ⬍';
   });
   document.getElementById('rowcount').textContent = \`\${r.length} match(es)\`;
   const top = r.slice(0, 500);

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -82,12 +82,13 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
                   border: 1px solid var(--vscode-input-border, transparent); border-radius: 2px; }
   .legend span { margin-right: 8px; cursor: help; }
   svg { background: var(--vscode-editor-background); display: block;
-        border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25)); border-radius: 4px; }
+        border: 1px solid var(--vscode-panel-border, rgba(127,127,127,0.25)); border-radius: 4px;
+        shape-rendering: geometricPrecision; }
   .gridline { stroke: var(--vscode-panel-border, rgba(127,127,127,0.18)); }
   .axis text { fill: var(--vscode-descriptionForeground); font-size: 10px; }
   .axis-label { fill: var(--vscode-descriptionForeground); font-size: 11px; }
-  circle { cursor: pointer; opacity: 0.7; }
-  circle:hover { opacity: 1; stroke: var(--vscode-foreground); stroke-width: 1.4; }
+  circle { cursor: pointer; opacity: 0.65; }
+  circle:hover { opacity: 1; stroke-width: 1.5; }
   #tooltip { position: fixed; pointer-events: none;
              background: var(--vscode-editorHoverWidget-background, #222);
              color: var(--vscode-editorHoverWidget-foreground, #fff);
@@ -300,9 +301,10 @@ function renderScatter() {
   const yticks = [0, 1, 5, 10, 50, 100, 500].filter(v => v <= maxOut * 1.5);
 
   const dots = data.map(s => {
-    const r = 3 + Math.min(7, Math.sqrt(s.userTurns || 1));
-    return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r.toFixed(1)}"
-              fill="\${colors[s.category] || '#888'}" data-i="\${esc(JSON.stringify(s))}"/>\`;
+    const r = 4.5;
+    const col = colors[s.category] || '#888';
+    return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r}"
+              fill="\${col}" stroke="\${col}" stroke-width="0.5" stroke-opacity="0.4" data-i="\${esc(JSON.stringify(s))}"/>\`;
   }).join('');
   const gridX = xticks.map(v =>
     \`<line class="gridline" x1="\${x(v)}" y1="\${M.t}" x2="\${x(v)}" y2="\${H-M.b}"/>

--- a/vscode-extension/src/sessionEfficiencyWebview.ts
+++ b/vscode-extension/src/sessionEfficiencyWebview.ts
@@ -35,6 +35,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
 		issuesCreated: s.issuesCreated,
 		output: s.output,
 		efficiency: s.efficiency,
+		aiCredits: s.aiCredits,
 		model: s.model || '',
 		updatedAt: s.updatedAt,
 		topPrs: s.prRefs
@@ -107,6 +108,11 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
              color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
              border: 1px solid var(--vscode-button-border, transparent); border-radius: 2px; }
   .nav-btn:hover { background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.25)); }
+  .mode-toggle { display: flex; border: 1px solid var(--vscode-button-border, rgba(127,127,127,0.3)); border-radius: 3px; overflow: hidden; }
+  .mode-btn { padding: 3px 10px; cursor: pointer; font: inherit; font-size: 12px; border: none; border-radius: 0;
+              background: transparent; color: var(--vscode-descriptionForeground); }
+  .mode-btn.active { background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); }
+  .mode-btn:hover:not(.active) { background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.15)); }
 </style>
 </head><body>
 <h1>Session Efficiency</h1>
@@ -129,8 +135,22 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
 <div id="root">
   <div class="panel">
     <strong>Output score</strong> = <code>10·PRs + 4·commits + 3·issues + filesEdited</code>.
-    <strong>Cost</strong> = total tool calls (proxy for tokens).
+    <strong>Cost</strong> = total tool calls (proxy for effort) <em>or</em> AI credits used.
     <strong>Efficiency</strong> = output ÷ cost.
+    <div style="margin-top:6px; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+      <span class="muted" style="font-size:12px">Cost basis:</span>
+      <div class="mode-toggle">
+        <button class="mode-btn active" id="mode-effort" title="Use tool-call count as the cost metric">⚙ Effort (tool calls)</button>
+        <button class="mode-btn" id="mode-money" title="Use AI credits consumed as the cost metric (available for ~80% of sessions)">💳 Cost (AI credits)</button>
+      </div>
+    </div>
+    <p class="muted" style="margin:8px 0 4px; font-size:12px; line-height:1.5; max-width:860px">
+      <strong>Note:</strong> The output score only reflects what is visible in the session log.
+      A session can create real value in ways that don't appear here — for example:
+      researching a topic before acting on it elsewhere, testing multiple hypotheses to settle on the right approach,
+      or producing work that was continued, copy-pasted, or applied outside this editor.
+      Use this view as a signal to spot patterns, not as a verdict on individual sessions.
+    </p>
     <div class="legend" style="margin-top:6px" id="legend"></div>
   </div>
 
@@ -164,9 +184,9 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
         <th data-k="commitCount" class="num">Commits</th>
         <th data-k="filesEdited" class="num">Files</th>
         <th data-k="userTurns" class="num">Turns</th>
-        <th data-k="toolCalls" class="num">Tool calls</th>
+        <th data-k="toolCalls" class="num" data-label="Tool calls">Tool calls</th>
         <th data-k="output" class="num">Output</th>
-        <th data-k="efficiency" class="num" title="Output ÷ tool calls × 100">Eff×100</th>
+        <th data-k="efficiency" class="num" data-label="Eff×100" title="Output ÷ tool calls × 100">Eff×100</th>
       </tr></thead>
       <tbody></tbody>
     </table>
@@ -179,6 +199,7 @@ export function renderSessionEfficiencyHtml(sessions: SessionEfficiency[]): stri
 const DATA = ${dataJson};
 const LEGEND = ${JSON.stringify(CATEGORY_LEGEND)};
 let SORT = { k: 'efficiency', dir: -1 };
+let COST_MODE = 'effort'; // 'effort' | 'money'
 
 function esc(s) {
   return String(s == null ? '' : s).replace(/[<&>"']/g, c => ({ '<':'&lt;','&':'&amp;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -224,7 +245,28 @@ function init() {
       else { SORT.k = k; SORT.dir = (k === 'repo' || k === 'category') ? 1 : -1; }
       renderTable();
     }));
+
+  document.getElementById('mode-effort').addEventListener('click', () => setCostMode('effort'));
+  document.getElementById('mode-money').addEventListener('click', () => setCostMode('money'));
 }
+
+function setCostMode(mode) {
+  COST_MODE = mode;
+  document.getElementById('mode-effort').classList.toggle('active', mode === 'effort');
+  document.getElementById('mode-money').classList.toggle('active', mode === 'money');
+  // Update table header labels
+  const thCost = document.querySelector('th[data-k="toolCalls"]');
+  const thEff  = document.querySelector('th[data-k="efficiency"]');
+  if (thCost) { thCost.dataset.label = mode === 'effort' ? 'Tool calls' : 'AI credits'; }
+  if (thEff)  { thEff.dataset.label = mode === 'effort' ? 'Eff×100' : 'Eff/cr'; thEff.title = mode === 'effort' ? 'Output ÷ tool calls × 100' : 'Output ÷ AI credits × 100'; }
+  renderScatter();
+  renderTable();
+}
+
+// Returns the "cost" value to use for a session in the current COST_MODE.
+// Money mode falls back to tool calls when aiCredits = 0.
+function costVal(s) { return COST_MODE === 'money' && s.aiCredits > 0 ? s.aiCredits : s.toolCalls; }
+function effVal(s)  { const c = costVal(s); return c > 0 ? s.output / c : 0; }
 
 function filtered() {
   const q = document.getElementById('q').value.toLowerCase();
@@ -247,9 +289,11 @@ function renderTable() {
   const r = filtered().slice();
   r.sort((a, b) => {
     const k = SORT.k;
-    const av = a[k], bv = b[k];
-    if (typeof av === 'string') return SORT.dir * av.localeCompare(bv);
-    return SORT.dir * (((av || 0) - (bv || 0)) || 0);
+    // For sort keys that depend on mode, use computed values
+    const va = k === 'toolCalls' ? costVal(a) : k === 'efficiency' ? effVal(a) : a[k];
+    const vb = k === 'toolCalls' ? costVal(b) : k === 'efficiency' ? effVal(b) : b[k];
+    if (typeof va === 'string') return SORT.dir * va.localeCompare(vb);
+    return SORT.dir * (((va || 0) - (vb || 0)) || 0);
   });
   // Update sort indicators on column headers
   document.querySelectorAll('th[data-k]').forEach(th => {
@@ -257,6 +301,12 @@ function renderTable() {
     th.classList.toggle('sorted', isSorted);
     let icon = th.querySelector('.sort-icon');
     if (!icon) { icon = document.createElement('span'); icon.className = 'sort-icon'; th.appendChild(icon); }
+    // Update label text (may have changed with mode toggle) keeping icon separate
+    const label = th.dataset.label;
+    if (label) {
+      const textNode = [...th.childNodes].find(n => n.nodeType === 3); // TEXT_NODE
+      if (textNode) textNode.textContent = label + ' ';
+    }
     icon.textContent = isSorted ? (SORT.dir === 1 ? '▲' : '▼') : '⇅';
   });
   document.getElementById('rowcount').textContent = \`\${r.length} match(es)\`;
@@ -265,6 +315,10 @@ function renderTable() {
     const prCells = s.topPrs.length
       ? s.topPrs.map(p => \`<a href="https://github.com/\${p.repo}/pull/\${p.number}">#\${p.number}</a>\`).join(' ')
       : (s.prsCreated || '');
+    const costCell = COST_MODE === 'money'
+      ? (s.aiCredits > 0 ? s.aiCredits : \`<span class="muted" title="No shutdown data">\${s.toolCalls}*</span>\`)
+      : s.toolCalls;
+    const effCell = (effVal(s) * 100).toFixed(1);
     return \`<tr>
       <td><span class="cat cat-\${s.category}">\${s.category}</span></td>
       <td>\${esc(s.repo)}</td>
@@ -274,9 +328,9 @@ function renderTable() {
       <td class="num">\${s.commitCount || ''}</td>
       <td class="num">\${s.filesEdited || ''}</td>
       <td class="num">\${s.userTurns}</td>
-      <td class="num">\${s.toolCalls}</td>
+      <td class="num">\${costCell}</td>
       <td class="num">\${s.output}</td>
-      <td class="num">\${(s.efficiency * 100).toFixed(1)}</td>
+      <td class="num">\${effCell}</td>
     </tr>\`;
   }).join('');
   document.querySelector('#tbl tbody').innerHTML = html;
@@ -298,9 +352,9 @@ function renderCatTable() {
 
 function renderScatter() {
   const W = 720, H = 380, M = { l: 50, r: 16, t: 10, b: 36 };
-  const data = DATA.filter(s => s.toolCalls > 0);
+  const data = DATA.filter(s => costVal(s) > 0);
   if (data.length === 0) { document.getElementById('scatter').innerHTML = '<p class="muted">No data.</p>'; return; }
-  const maxCost = Math.max(50,  ...data.map(s => s.toolCalls));
+  const maxCost = Math.max(50,  ...data.map(s => costVal(s)));
   const maxOut  = Math.max(5,   ...data.map(s => s.output));
   const x = v => M.l + (Math.log10(v + 1) / Math.log10(maxCost + 1)) * (W - M.l - M.r);
   const y = v => H - M.b - (Math.log10(v + 1) / Math.log10(maxOut + 1)) * (H - M.t - M.b);
@@ -310,11 +364,12 @@ function renderScatter() {
   };
   const xticks = [1, 10, 100, 1000, 10000].filter(v => v <= maxCost * 1.5);
   const yticks = [0, 1, 5, 10, 50, 100, 500].filter(v => v <= maxOut * 1.5);
+  const xLabel = COST_MODE === 'money' ? 'AI credits (log) →' : 'Tool calls (log) →';
 
   const dots = data.map(s => {
     const r = 3 + Math.min(7, Math.sqrt(s.userTurns || 1));
     const col = colors[s.category] || '#888';
-    return \`<circle cx="\${x(s.toolCalls).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r.toFixed(1)}"
+    return \`<circle cx="\${x(costVal(s)).toFixed(1)}" cy="\${y(s.output).toFixed(1)}" r="\${r.toFixed(1)}"
               fill="\${col}" stroke="rgba(0,0,0,0.55)" stroke-width="1" data-i="\${esc(JSON.stringify(s))}"/>\`;
   }).join('');
   const gridX = xticks.map(v =>
@@ -326,7 +381,7 @@ function renderScatter() {
 
   const svg = \`<svg viewBox="0 0 \${W} \${H}" width="100%" height="\${H}" class="axis" preserveAspectRatio="xMidYMid meet">
     \${gridX}\${gridY}
-    <text class="axis-label" x="\${W/2}" y="\${H-4}" text-anchor="middle">Tool calls (log) →</text>
+    <text class="axis-label" x="\${W/2}" y="\${H-4}" text-anchor="middle">\${xLabel}</text>
     <text class="axis-label" x="14" y="\${H/2}" text-anchor="middle" transform="rotate(-90 14 \${H/2})">Output score (log) →</text>
     \${dots}
   </svg>\`;
@@ -339,11 +394,14 @@ function renderScatter() {
       const prsHtml = s.topPrs.length
         ? s.topPrs.map(p => '#' + p.number).join(' ')
         : '—';
+      const costLine = COST_MODE === 'money'
+        ? \`\${s.aiCredits > 0 ? s.aiCredits + ' AI credits' : s.toolCalls + ' tool calls (no credit data)'}\`
+        : \`\${s.toolCalls} tool calls\`;
       tip.innerHTML = \`<strong>\${esc(s.repo)}</strong> · <code>\${esc(s.branch)}</code><br>
         <span class="cat cat-\${s.category}">\${s.category}</span>
-        · \${s.toolCalls} tool calls · \${s.userTurns} user turns<br>
+        · \${costLine} · \${s.userTurns} user turns<br>
         PRs: \${prsHtml} · \${s.commitCount} commit(s) · \${s.filesEdited} file(s) edited<br>
-        eff×100 = \${(s.efficiency*100).toFixed(2)}<br>
+        eff×100 = \${(effVal(s)*100).toFixed(2)}<br>
         <em>\${esc(s.summary || s.firstUserMsg).slice(0, 200)}</em>\`;
       tip.style.display = 'block';
     });

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -147,7 +147,8 @@ function renderLayout(data: InitialChartData): void {
 		createButton(BUTTONS['btn-usage']),
 		createButton(BUTTONS['btn-environmental']),
 		createButton(BUTTONS['btn-diagnostics']),
-		createButton(BUTTONS['btn-maturity'])
+		createButton(BUTTONS['btn-maturity']),
+		createButton(BUTTONS['btn-session-efficiency'])
 	);
 	if (data.backendConfigured) {
 		buttons.append(createButton(BUTTONS['btn-dashboard']));
@@ -321,6 +322,9 @@ function wireInteractions(data: InitialChartData): void {
 
 	const environmental = document.getElementById('btn-environmental');
 	environmental?.addEventListener('click', () => vscode.postMessage({ command: 'showEnvironmental' }));
+
+	const sessionEfficiency = document.getElementById('btn-session-efficiency');
+	sessionEfficiency?.addEventListener('click', () => vscode.postMessage({ command: 'showSessionEfficiency' }));
 
 	// Period toggle buttons
 	const periodButtons: Array<{ id: string; period: ChartPeriod }> = [

--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -174,6 +174,7 @@ function renderShell(root: HTMLElement, stats: DashboardStats): void {
     createButton(BUTTONS["btn-environmental"]),
     createButton(BUTTONS["btn-diagnostics"]),
     createButton(BUTTONS["btn-maturity"]),
+    createButton(BUTTONS["btn-session-efficiency"]),
   );
 
   header.append(titleGroup, buttonRow);
@@ -609,6 +610,9 @@ function wireButtons(): void {
   });
   document.getElementById("btn-environmental")?.addEventListener("click", () => {
     vscode.postMessage({ command: "showEnvironmental" });
+  });
+  document.getElementById("btn-session-efficiency")?.addEventListener("click", () => {
+    vscode.postMessage({ command: "showSessionEfficiency" });
   });
 
   // Note: No dashboard button handler - users are already on the dashboard

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -150,7 +150,8 @@ function renderShell(
 		createButton(BUTTONS['btn-usage']),
 		createButton(BUTTONS['btn-environmental']),
 		createButton(BUTTONS['btn-diagnostics']),
-		createButton(BUTTONS['btn-maturity'])
+		createButton(BUTTONS['btn-maturity']),
+		createButton(BUTTONS['btn-session-efficiency'])
 	);
 	if (stats.backendConfigured) {
 		buttonRow.append(createButton(BUTTONS['btn-dashboard']));
@@ -839,6 +840,9 @@ function wireButtons(): void {
 
 	const environmental = document.getElementById('btn-environmental');
 	environmental?.addEventListener('click', () => vscode.postMessage({ command: 'showEnvironmental' }));
+
+	const sessionEfficiency = document.getElementById('btn-session-efficiency');
+	sessionEfficiency?.addEventListener('click', () => vscode.postMessage({ command: 'showSessionEfficiency' }));
 }
 
 async function bootstrap(): Promise<void> {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1361,6 +1361,7 @@ function renderLayout(data: DiagnosticsData): void {
 					${buttonHtml("btn-usage")}
 					${buttonHtml("btn-environmental")}
 					${buttonHtml("btn-maturity")}
+					${buttonHtml("btn-session-efficiency")}
 					${data?.backendConfigured ? buttonHtml("btn-dashboard") : ""}
 				</div>
 			</div>
@@ -2330,6 +2331,11 @@ function renderLayout(data: DiagnosticsData): void {
     .getElementById("btn-environmental")
     ?.addEventListener("click", () =>
       vscode.postMessage({ command: "showEnvironmental" }),
+    );
+  document
+    .getElementById("btn-session-efficiency")
+    ?.addEventListener("click", () =>
+      vscode.postMessage({ command: "showSessionEfficiency" }),
     );
 
   setupSortHandlers();

--- a/vscode-extension/src/webview/environmental/main.ts
+++ b/vscode-extension/src/webview/environmental/main.ts
@@ -151,7 +151,8 @@ function render(stats: EnvironmentalStats): void {
 		createButton(BUTTONS['btn-chart']),
 		createButton(BUTTONS['btn-usage']),
 		createButton(BUTTONS['btn-diagnostics']),
-		createButton(BUTTONS['btn-maturity'])
+		createButton(BUTTONS['btn-maturity']),
+		createButton(BUTTONS['btn-session-efficiency'])
 	);
 	if (stats.backendConfigured) {
 		buttonRow.append(createButton(BUTTONS['btn-dashboard']));
@@ -298,6 +299,7 @@ function wireButtons(): void {
 	document.getElementById('btn-diagnostics')?.addEventListener('click', () => vscode.postMessage({ command: 'showDiagnostics' }));
 	document.getElementById('btn-maturity')?.addEventListener('click', () => vscode.postMessage({ command: 'showMaturity' }));
 	document.getElementById('btn-dashboard')?.addEventListener('click', () => vscode.postMessage({ command: 'showDashboard' }));
+	document.getElementById('btn-session-efficiency')?.addEventListener('click', () => vscode.postMessage({ command: 'showSessionEfficiency' }));
 }
 
 window.addEventListener('message', (event: MessageEvent) => {

--- a/vscode-extension/src/webview/fluency-level-viewer/main.ts
+++ b/vscode-extension/src/webview/fluency-level-viewer/main.ts
@@ -154,6 +154,7 @@ function renderLayout(data: FluencyLevelData): void {
 					${buttonHtml('btn-chart')}
 					${buttonHtml('btn-usage')}
 					${buttonHtml('btn-diagnostics')}
+					${buttonHtml('btn-session-efficiency')}
 					${data.backendConfigured ? buttonHtml('btn-dashboard') : ''}
 				</div>
 			</div>
@@ -202,6 +203,9 @@ function renderLayout(data: FluencyLevelData): void {
 	});
 	document.getElementById('btn-dashboard')?.addEventListener('click', () => {
 		vscode.postMessage({ command: 'showDashboard' });
+	});
+	document.getElementById('btn-session-efficiency')?.addEventListener('click', () => {
+		vscode.postMessage({ command: 'showSessionEfficiency' });
 	});
 
 	// Wire up category selection buttons

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -404,6 +404,7 @@ function renderLayout(data: MaturityData): void {
 					${buttonHtml('btn-usage')}
 					${buttonHtml('btn-environmental')}
 					${buttonHtml('btn-diagnostics')}
+					${buttonHtml('btn-session-efficiency')}
 					${data.backendConfigured ? buttonHtml('btn-dashboard') : ''}
 				</div>
 			</div>
@@ -565,6 +566,9 @@ function renderLayout(data: MaturityData): void {
 	});
 	document.getElementById('btn-environmental')?.addEventListener('click', () => {
 		vscode.postMessage({ command: 'showEnvironmental' });
+	});
+	document.getElementById('btn-session-efficiency')?.addEventListener('click', () => {
+		vscode.postMessage({ command: 'showSessionEfficiency' });
 	});
 
 	// Wire up share to issue button

--- a/vscode-extension/src/webview/shared/buttonConfig.ts
+++ b/vscode-extension/src/webview/shared/buttonConfig.ts
@@ -3,7 +3,7 @@
  * This ensures consistent button IDs, labels, and icons across all webviews.
  */
 
-export type ButtonId = 'btn-refresh' | 'btn-details' | 'btn-chart' | 'btn-usage' | 'btn-diagnostics' | 'btn-maturity' | 'btn-dashboard' | 'btn-level-viewer' | 'btn-environmental';
+export type ButtonId = 'btn-refresh' | 'btn-details' | 'btn-chart' | 'btn-usage' | 'btn-diagnostics' | 'btn-maturity' | 'btn-dashboard' | 'btn-level-viewer' | 'btn-environmental' | 'btn-session-efficiency';
 
 export interface ButtonConfig {
 	id: ButtonId;
@@ -51,6 +51,10 @@ export const BUTTONS: Record<ButtonId, ButtonConfig> = {
 	'btn-environmental': {
 		id: 'btn-environmental',
 		label: '🌿 Environmental Impact'
+	},
+	'btn-session-efficiency': {
+		id: 'btn-session-efficiency',
+		label: '📈 Session Efficiency'
 	}
 };
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1099,6 +1099,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 				${buttonHtml('btn-environmental')}
 				${buttonHtml('btn-diagnostics')}
 				${buttonHtml('btn-maturity')}
+				${buttonHtml('btn-session-efficiency')}
 				${stats.backendConfigured ? buttonHtml('btn-dashboard') : ''}
 				</div>
 			</div>
@@ -1426,6 +1427,9 @@ function renderLayout(stats: UsageAnalysisStats): void {
 	});
 	document.getElementById('btn-environmental')?.addEventListener('click', () => {
 		vscode.postMessage({ command: 'showEnvironmental' });
+	});
+	document.getElementById('btn-session-efficiency')?.addEventListener('click', () => {
+		vscode.postMessage({ command: 'showSessionEfficiency' });
 	});
 	
 	// Repository analysis buttons


### PR DESCRIPTION
## Why

Understanding how productive a Copilot session was is hard without a unified view. This adds a "Session Efficiency" panel to the VS Code extension that scans all local session logs and surfaces the relationship between effort (tool calls or dollar cost) and output (PRs, commits, issues, files edited) - helping spot patterns across hundreds of sessions at a glance.

## What changed

### New: Session Efficiency scanner (`sessionEfficiency.ts`)
Scans `~/.copilot/session-state/` for all session event logs and extracts:
- PR/issue/commit references from event text
- Tool call counts and model token metrics per session
- Dollar cost estimate per session using `modelPricing.json` copilot rates (with fallback to tool-call count)
- Session category: `shipped`, `committed`, `issue`, `edited`, `exploratory`, `no-pr`

### New: Session Efficiency webview (`sessionEfficiencyWebview.ts`)
Self-contained HTML panel with:
- **Scatter chart** (log scale): X = effort/cost, Y = output score. Bubble size = user turns. Top-left = efficient, bottom-right = heavy with no output.
- **Sessions by category** panel (right side) with click-to-filter rows and a cost basis toggle (Effort / Cost $) at the bottom.
- **Session table** with sortable columns, search/filter by repo, category, branch, and a "only sessions with output" checkbox.
- **Bubble click** filters the table to that session; **category click** filters to that category.
- Tooltip shows model breakdown with token counts (formatted as `1.2M`) and dollar cost per model.
- Chart title updates dynamically ("Tool calls vs Output" / "Cost ($) vs Output") to match the active cost basis.
- **Async loading**: spinner shown immediately, scan runs via `setImmediate` so the panel appears in ~0ms.

### Extension wiring (`extension.ts`)
- New `showSessionEfficiency()` command with async load pattern.
- `refreshSessionEfficiencyPanel()` shared helper for both open and refresh.
- Nav button added to all existing webviews so users can reach the view from anywhere.
- Command palette entry removed (nav button is sufficient).

## Non-obvious details

- The webview uses inlined JSON + plain `<button>` elements styled with VS Code CSS variables rather than the `@vscode/webview-ui-toolkit` components, because the efficiency view is generated as a plain HTML string without a bundled toolkit dependency.
- Dollar cost uses the `copilotPricing` block from `modelPricing.json`; sessions without shutdown events fall back to tool-call count and are flagged with `*` in the cost column.
- Multiple `session.shutdown` events per session (from checkpoints/resumes) are aggregated via a `Map` keyed by model name to avoid duplicate model rows in the tooltip.
- Top PRs and models in tooltips are deduplicated by PR number / model name before display.