### PR TITLE
chore: release VS Code extension v0.5.0

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,26 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-06
+
+### Features
+- Added Session Efficiency view — scatter chart of sessions by token usage and tool calls, with sortable table, model/PR filters, and async load with spinner
+- Added cost-mode toggle (AI credits vs. dollar cost) and explainer to Session Efficiency view
+- Added Session Efficiency nav button to all views; removed palette command
+- Cost basis toggle moved into Sessions by category panel; chart title updates to reflect active mode
+- Added sort indicator to active column header in session table
+
+### Improvements
+- Added Mistral AI model pricing and token estimators (#796)
+- Added missing friendly names for 17 additional tools (TaskCreate, TaskUpdate, dismiss_deployment_notifications, Claude in Chrome MCP, and 13 others)
+- Scatter chart: dark border on dots for readability, crisp rendering, variable circle size restored
+- Compact token format in Session Efficiency table; dedup models/PRs; clear filters on click
+- Session Efficiency header/buttons match styling of other views
+
+### Bug Fixes
+- Fixed duplicate loading sessions appearing in the status bar
+- Fixed sort indicator wrapping to new line in session table headers
+
 ## [0.4.4] - 2026-05-05
 
 ### Bug Fixes

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
Bumps the VS Code extension from v0.4.4 to v0.5.0 and updates the changelog. This release ships the new Session Efficiency view and a batch of improvements that have accumulated since the last release.

### Features

- **Session Efficiency view** -- scatter chart of sessions by token usage and tool calls, with sortable table, model/PR filters, and async load with spinner
- **Cost-mode toggle** (AI credits vs. dollar cost) with explainer in Session Efficiency view
- Session Efficiency nav button added to all views; palette command removed
- Cost basis toggle moved into Sessions by category panel; chart title reflects active mode
- Sort indicator on active column header in session table

### Improvements

- Added Mistral AI model pricing and token estimators (#796)
- Added missing friendly names for 17 additional tools (TaskCreate, TaskUpdate, dismiss_deployment_notifications, Claude in Chrome MCP, and others)
- Scatter chart: dark border on dots for readability, crisp rendering, variable circle size restored
- Compact token format in Session Efficiency table; dedup models/PRs; clear filters on click
- Session Efficiency header/buttons match styling of other views

### Bug Fixes

- Fixed duplicate loading sessions appearing in the status bar
- Fixed sort indicator wrapping to new line in session table headers

---

After merging, tag `main` with `vscode/v0.5.0` to trigger the release workflow.