### PR TITLE
feat: show cached input tokens in log viewer summary bar

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2899,6 +2899,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			lastInteraction: sessionMeta.lastInteraction,
 			thinkingTokens: tokenResult.thinkingTokens,
 			actualTokens: tokenResult.actualTokens,
+			...(tokenResult.cacheReadTokens ? { cacheReadTokens: tokenResult.cacheReadTokens } : {}),
 			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
 		};
 
@@ -3060,6 +3061,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const resolvedActualTokens = tokenResult?.actualTokens ?? existingCache?.actualTokens;
 		const resolvedTokens = tokenResult?.tokens ?? existingCache?.tokens ?? 0;
 		const resolvedThinkingTokens = tokenResult?.thinkingTokens ?? existingCache?.thinkingTokens;
+		const resolvedCacheReadTokens = (tokenResult as any)?.cacheReadTokens ?? existingCache?.cacheReadTokens;
 		details.tokens = resolvedActualTokens || resolvedTokens || 0;
 
 		// Create or update cache entry
@@ -3071,6 +3073,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			size: stat.size,
 			actualTokens: resolvedActualTokens,
 			thinkingTokens: resolvedThinkingTokens,
+			...(resolvedCacheReadTokens ? { cacheReadTokens: resolvedCacheReadTokens } : {}),
 			// Preserve existing dailyRollups so this partial update does not discard
 			// the per-day breakdown computed by getSessionFileDataCached().
 			dailyRollups: existingCache?.dailyRollups,
@@ -3899,6 +3902,7 @@ usageAnalysis: undefined
 			turns,
 			usageAnalysis,
 			actualTokens: sessionCache?.actualTokens || 0,
+			...(sessionCache?.cacheReadTokens ? { cachedTokens: sessionCache.cacheReadTokens } : {}),
 			...(subAgentsStarted !== undefined ? { subAgentsStarted } : {})
 		};
 	}
@@ -3988,7 +3992,7 @@ usageAnalysis: undefined
 
 
 
-	private async estimateTokensFromSession(sessionFilePath: string, preloadedContent?: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+	private async estimateTokensFromSession(sessionFilePath: string, preloadedContent?: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens?: number }> {
 		try {
 			const eco = this.findEcosystem(sessionFilePath);
 			if (eco) { return eco.getTokens(sessionFilePath); }
@@ -4070,7 +4074,7 @@ usageAnalysis: undefined
 		}
 	}
 
-	private estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number } {
+	private estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number } {
 		return _estimateTokensFromJsonlSession(fileContent);
 	}
 

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -70,7 +70,7 @@ export function extractSubAgentData(item: unknown): { prompt: string; result: st
  * Estimate tokens from a JSONL session file (used by Copilot CLI/Agent mode and VS Code incremental format)
  * Each line is a separate JSON object representing an event in the session
  */
-export function estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; modelUsage: ModelUsage; dailyActualTokens: Record<string, number> } {
+export function estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number; modelUsage: ModelUsage; dailyActualTokens: Record<string, number> } {
 	let totalTokens = 0;
 	let totalThinkingTokens = 0;
 	const lines = fileContent.trim().split('\n');
@@ -83,6 +83,8 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 	let parseFailedLines = 0;
 	// For CLI (non-delta) format: accumulate actual token totals from session.shutdown
 	let cliActualTokens = 0;
+	// Total cache-read tokens from CLI session.shutdown events (across all models)
+	let cliCacheReadTokens = 0;
 	// Per-model breakdown from CLI session.shutdown events
 	let cliShutdownModelUsage: ModelUsage | null = null;
 	// Per-UTC-day actual token breakdown from shutdown event timestamps
@@ -109,7 +111,9 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 					if (usage) {
 						const input = typeof usage.inputTokens === 'number' ? usage.inputTokens : 0;
 						const output = typeof usage.outputTokens === 'number' ? usage.outputTokens : 0;
+						const cacheRead = typeof usage.cacheReadTokens === 'number' ? usage.cacheReadTokens : 0;
 						cliActualTokens += input + output;
+						cliCacheReadTokens += cacheRead;
 						shutdownTotal += input + output;
 						if (!cliShutdownModelUsage[modelName]) {
 							cliShutdownModelUsage[modelName] = { inputTokens: 0, outputTokens: 0 };
@@ -244,7 +248,7 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 		}
 	}
 
-	return { tokens: totalTokens + totalThinkingTokens, thinkingTokens: totalThinkingTokens, actualTokens: finalActualTokens, modelUsage: cliShutdownModelUsage ?? {}, dailyActualTokens };
+	return { tokens: totalTokens + totalThinkingTokens, thinkingTokens: totalThinkingTokens, actualTokens: finalActualTokens, cacheReadTokens: cliCacheReadTokens, modelUsage: cliShutdownModelUsage ?? {}, dailyActualTokens };
 }
 
 /**

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -173,6 +173,7 @@ export interface SessionFileCache {
   workspaceFolderPath?: string; // Full local path to the workspace folder (optional)
   thinkingTokens?: number; // Estimated thinking/reasoning tokens
   actualTokens?: number; // Actual token count from LLM API usage data (when available)
+  cacheReadTokens?: number; // Cache-read token count from session.shutdown modelMetrics (CLI sessions only)
   /** Per-UTC-day token/interaction breakdown (keyed by YYYY-MM-DD UTC). Used for consistent daily stats. */
   dailyRollups?: { [utcDayKey: string]: DailyRollupEntry };
 }
@@ -446,6 +447,8 @@ export interface SessionLogData {
   usageAnalysis?: SessionUsageAnalysis;
   /** Session-level actual token count from LLM API (e.g. session.shutdown in CLI format). 0 when unavailable. */
   actualTokens?: number;
+  /** Cache-read token count from session.shutdown modelMetrics (CLI sessions only). Absent when unavailable. */
+  cachedTokens?: number;
   /** Number of distinct subagent sessions started (CLI format only, from subagent.started events). */
   subAgentsStarted?: number;
 }

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -62,6 +62,8 @@ type SessionLogData = {
 	usageAnalysis?: SessionUsageAnalysis;
 	/** Session-level actual token count from LLM API (e.g. CLI session.shutdown). 0 when unavailable. */
 	actualTokens?: number;
+	/** Cache-read token count from session.shutdown modelMetrics (CLI sessions only). Absent when unavailable. */
+	cachedTokens?: number;
 	/** Number of subagent sessions started (CLI format only). */
 	subAgentsStarted?: number;
 	compactNumbers?: boolean;
@@ -694,18 +696,25 @@ function renderLayout(data: SessionLogData): void {
 					<div class="summary-sub">${data.editorName === 'JetBrains' ? 'User + assistant text only (no API counts, no thinking)' : 'Input + Output estimated from text'}</div>
 				</div>
 				${hasAnyActualUsage ? `
-				<div class="summary-card actual-usage-card">
-					<div class="summary-label">✅ Actual Tokens</div>
-					<div class="summary-value">${formatCompact(actualTotal)}</div>
-					<div class="summary-sub">↑${formatCompact(actualPromptTotal)} prompt, ↓${formatCompact(actualCompletionTotal)} completion</div>
-				</div>
-				` : hasSessionActualOnly ? `
-				<div class="summary-card actual-usage-card">
-					<div class="summary-label">✅ Actual Tokens</div>
-					<div class="summary-value">${formatCompact(sessionActualTokens)}</div>
-							<div class="summary-sub">${data.editorName === 'Mistral Vibe' ? 'From session data' : 'Total from session shutdown event'}</div>
-				</div>
-				` : ''}
+			<div class="summary-card actual-usage-card">
+				<div class="summary-label">✅ Actual Tokens</div>
+				<div class="summary-value">${formatCompact(actualTotal)}</div>
+				<div class="summary-sub">↑${formatCompact(actualPromptTotal)} prompt, ↓${formatCompact(actualCompletionTotal)} completion</div>
+			</div>
+			` : hasSessionActualOnly ? `
+			<div class="summary-card actual-usage-card">
+				<div class="summary-label">✅ Actual Tokens</div>
+				<div class="summary-value">${formatCompact(sessionActualTokens)}</div>
+						<div class="summary-sub">${data.editorName === 'Mistral Vibe' ? 'From session data' : 'Total from session shutdown event'}</div>
+			</div>
+			` : ''}
+			${(data.cachedTokens ?? 0) > 0 ? `
+			<div class="summary-card actual-usage-card" title="Tokens served from the provider's prompt cache. Cached tokens are billed at a lower rate and reduce latency. Source: session.shutdown modelMetrics.">
+				<div class="summary-label">💾 Cached Input</div>
+				<div class="summary-value">${formatCompact(data.cachedTokens!)}</div>
+				<div class="summary-sub">Prompt tokens served from cache</div>
+			</div>
+			` : ''}
 				${totalThinkingTokens > 0 ? `<div class="summary-card">
 					<div class="summary-label">🧠 Thinking Tokens</div>
 					<div class="summary-value">${formatCompact(totalThinkingTokens)}</div>


### PR DESCRIPTION
## Summary

Surfaces cached input token counts in the session log viewer's top-level summary cards. Previously this data (from `session.shutdown` → `modelMetrics[model].usage.cacheReadTokens`) was only visible in the Session Efficiency tooltip.

## Changes

### `tokenEstimation.ts`
- Add `cacheReadTokens` to `estimateTokensFromJsonlSession` return type
- Populate it by summing `usage.cacheReadTokens` from all models in `session.shutdown` events

### `types.ts`
- Add `cacheReadTokens?: number` to `SessionFileCache`
- Add `cachedTokens?: number` to `SessionLogData`

### `extension.ts`
- Update `estimateTokensFromJsonlSession` (private wrapper) and `estimateTokensFromSession` return types to include `cacheReadTokens`
- Store `cacheReadTokens` in `getSessionFileDataCached` session data object
- Preserve `cacheReadTokens` in `updateCacheWithSessionDetails`
- Pass `cachedTokens` from session cache in `getSessionLogData` return value

### `webview/logviewer/main.ts`
- Add `cachedTokens?: number` to local `SessionLogData` type
- Add **💾 Cached Input** summary card (shown only when `cachedTokens > 0`) with tooltip explaining that cached tokens are billed at a lower rate

## Behaviour

- Card only appears for Copilot CLI sessions (`events.jsonl`) where `session.shutdown` reports non-zero `cacheReadTokens` 
- No `CACHE_VERSION` bump required — `cacheReadTokens` is a new optional field; absence in old cache entries is treated as 0 (card hidden)
- Existing sessions without cache data are unaffected