### PR TITLE
chore: remove legacy deprecation popup and clean up publish script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,7 +450,7 @@ Or trigger the **Sync Release Notes** workflow from the Actions tab.
 If you need to re-publish manually (e.g., after a marketplace upload failure):
 
 ```powershell
-.\publish.ps1 -VsixPath ".\copilot-token-tracker-0.0.19.vsix"
+.\publish.ps1 -VsixPath ".\ai-engineering-fluency-0.0.19.vsix"
 ```
 
 ## Submitting Changes

--- a/vscode-extension/publish.ps1
+++ b/vscode-extension/publish.ps1
@@ -7,18 +7,15 @@
 # Use this script only when you need to manually publish a pre-built VSIX
 # (e.g., re-publishing after a marketplace upload failure).
 #
-# The extension is published under two IDs (dual-publish):
-#   - RobBos.ai-engineering-fluency  (new/primary ID)
-#   - RobBos.copilot-token-tracker   (legacy ID – kept for existing users)
+# The extension is published under a single ID:
+#   - RobBos.ai-engineering-fluency  (primary ID)
 #
 # Usage:
 #   .\publish.ps1 -VsixPath ".\ai-engineering-fluency-0.3.0.vsix"
-#   .\publish.ps1 -LegacyVsixPath ".\copilot-token-tracker-0.3.0.vsix"
-#   .\publish.ps1  # auto-detect both VSIXs in the current directory
+#   .\publish.ps1  # auto-detect VSIX in the current directory
 
 param(
-    [string]$VsixPath,        # Path to the primary (ai-engineering-fluency) .vsix
-    [string]$LegacyVsixPath   # Path to the legacy (copilot-token-tracker) .vsix
+    [string]$VsixPath        # Path to the primary (ai-engineering-fluency) .vsix
 )
 
 $ErrorActionPreference = "Stop"
@@ -39,17 +36,6 @@ if ([string]::IsNullOrWhiteSpace($VsixPath)) {
         Write-Host "Found primary VSIX: $VsixPath" -ForegroundColor Green
     } else {
         $VsixPath = Read-Host "Enter path to the primary (ai-engineering-fluency) .vsix"
-    }
-}
-
-# ── Resolve legacy VSIX path (optional) ──────────────────────────────────────
-if ([string]::IsNullOrWhiteSpace($LegacyVsixPath)) {
-    $defaultLegacy = ".\copilot-token-tracker-$version.vsix"
-    if (Test-Path $defaultLegacy) {
-        $LegacyVsixPath = $defaultLegacy
-        Write-Host "Found legacy VSIX:  $LegacyVsixPath" -ForegroundColor Green
-    } else {
-        Write-Host "⚠️  Legacy VSIX not found at $defaultLegacy — will only publish primary ID." -ForegroundColor Yellow
     }
 }
 
@@ -144,19 +130,6 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 Write-Host "✅ Primary extension published successfully!" -ForegroundColor Green
-
-# ── Step 5: Publish the legacy VSIX (copilot-token-tracker) ──────────────────
-if (-not [string]::IsNullOrWhiteSpace($LegacyVsixPath) -and (Test-Path $LegacyVsixPath)) {
-    Write-Host "`nPublishing $LegacyVsixPath to the VS Code Marketplace (legacy ID)..." -ForegroundColor Cyan
-    npx vsce publish --packagePath $LegacyVsixPath --pat $pat
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "✅ Legacy extension published successfully!" -ForegroundColor Green
-    } else {
-        Write-Host "⚠️  Legacy VSIX publish failed — primary was already published. Check errors above." -ForegroundColor Yellow
-    }
-} else {
-    Write-Host "⚠️  Skipping legacy VSIX publish (not found)." -ForegroundColor Yellow
-}
 
 Write-Host ""
 Write-Host "It may take a few minutes to appear in the marketplace." -ForegroundColor Gray

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8295,73 +8295,6 @@ const NEW_EXTENSION_ID = 'RobBos.ai-engineering-fluency';
 const LEGACY_EXTENSION_ID = 'RobBos.copilot-token-tracker';
 
 /**
- * When running as the legacy copilot-token-tracker extension, shows a migration notice
- * and — if the new extension is already installed and activates successfully — returns
- * true so the caller can skip full legacy activation (avoiding duplicate timers/scanners).
- */
-async function handleLegacyExtensionDeprecation(context: vscode.ExtensionContext): Promise<boolean> {
-  if (context.extension.id !== LEGACY_EXTENSION_ID) {
-    return false;
-  }
-
-  const newExt = vscode.extensions.getExtension(NEW_EXTENSION_ID);
-
-  if (newExt) {
-    // New extension is installed — try to hand off activation before bailing out.
-    let newExtActivated = false;
-    try {
-      await newExt.activate();
-      newExtActivated = true;
-    } catch {
-      // New extension failed to activate; fall through and run legacy normally.
-    }
-
-    if (newExtActivated) {
-      const key = 'deprecation.dualInstallPrompt.v1.dismissed';
-      if (!context.globalState.get<boolean>(key, false)) {
-        const choice = await vscode.window.showWarningMessage(
-          'You have both "AI Engineering Fluency" and the deprecated "AI Engineering Fluency (Deprecated)" extensions installed. Please uninstall the deprecated one.',
-          'Uninstall Deprecated',
-          'Dismiss'
-        );
-        if (choice === 'Uninstall Deprecated') {
-          try {
-            await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', LEGACY_EXTENSION_ID);
-          } catch {
-            vscode.window.showInformationMessage('Please manually uninstall "AI Engineering Fluency (Deprecated)" from the Extensions view.');
-          }
-        } else if (choice === 'Dismiss') {
-          // Only suppress on explicit Dismiss — closing with ✕ shows again next startup.
-          await context.globalState.update(key, true);
-        }
-      }
-      return true; // New extension is active — skip legacy activation entirely.
-    }
-    // New ext failed to activate; continue legacy activation with an install nudge.
-  }
-
-  // New extension is not installed (or failed to activate) — show a one-time nudge.
-  const key = 'deprecation.installPrompt.v1.dismissed';
-  if (!context.globalState.get<boolean>(key, false)) {
-    const choice = await vscode.window.showInformationMessage(
-      '"AI Engineering Fluency (Deprecated)" is deprecated. Install the new AI Engineering Fluency extension for the latest features.',
-      'Install New Extension',
-      'Dismiss'
-    );
-    if (choice === 'Install New Extension') {
-      await vscode.env.openExternal(
-        vscode.Uri.parse('https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency')
-      );
-    } else if (choice === 'Dismiss') {
-      // Only suppress on explicit Dismiss — closing with ✕ shows again next startup.
-      await context.globalState.update(key, true);
-    }
-  }
-
-  return false; // Continue legacy activation so the user keeps working functionality.
-}
-
-/**
  * When running as the new ai-engineering-fluency extension, checks whether the legacy
  * copilot-token-tracker extension is also installed and shows a one-time prompt to
  * uninstall it. The old extension already skips its own activation when the new one
@@ -8397,12 +8330,6 @@ async function checkForLegacyExtensionConflict(context: vscode.ExtensionContext)
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-  // For the legacy copilot-token-tracker VSIX: show migration notice and skip full
-  // activation if the new extension is already installed and running.
-  if (await handleLegacyExtensionDeprecation(context)) {
-    return;
-  }
-
   // Create the token tracker
   const tokenTracker = new CopilotTokenTracker(context.extensionUri, context);
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8308,20 +8308,24 @@ async function checkForLegacyExtensionConflict(context: vscode.ExtensionContext)
   if (!legacyExt) {
     return;
   }
-  const key = 'conflict.legacyExtensionPresent.v1.dismissed';
+  // v2: reworded to clarify which extension to keep vs. remove (v1 was ambiguous due to similar names)
+  const key = 'conflict.legacyExtensionPresent.v2.dismissed';
   if (context.globalState.get<boolean>(key, false)) {
     return;
   }
   const choice = await vscode.window.showWarningMessage(
-    'The deprecated "AI Engineering Fluency (Deprecated)" extension is also installed. It has been prevented from running, but you should uninstall it to keep things clean.',
-    'Uninstall Deprecated',
+    'Cleanup needed: the old "copilot-token-tracker" extension is still installed alongside this one. ' +
+    'Keep "AI Engineering Fluency" (this extension) and remove the old one — it has been disabled automatically.',
+    'Remove Old Extension',
     'Dismiss'
   );
-  if (choice === 'Uninstall Deprecated') {
+  if (choice === 'Remove Old Extension') {
     try {
       await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', LEGACY_EXTENSION_ID);
     } catch {
-      vscode.window.showInformationMessage('Please manually uninstall "AI Engineering Fluency (Deprecated)" from the Extensions view.');
+      vscode.window.showInformationMessage(
+        'To finish cleanup: open Extensions (Ctrl+Shift+X), search for "copilot-token-tracker", and uninstall it. Keep "AI Engineering Fluency".'
+      );
     }
   } else if (choice === 'Dismiss') {
     // Only suppress on explicit Dismiss — closing with ✕ shows again next startup.


### PR DESCRIPTION
## Summary

Migration from \copilot-token-tracker\ to \i-engineering-fluency\ is complete. This PR cleans up the remaining artefacts.

### Changes

- **\scode-extension/src/extension.ts\**: Removed \handleLegacyExtensionDeprecation()\ — dead code since the legacy VSIX is no longer published. \checkForLegacyExtensionConflict()\ is **kept** — still nudges users who have both installed to uninstall the old one.
- **\scode-extension/publish.ps1\**: Removed \\\ param, legacy VSIX auto-detection, and Step 5 (legacy publish). Header updated for single-ID publishing.
- **\CONTRIBUTING.md\**: Fixed manual-publish example to use \i-engineering-fluency-*.vsix\ filename.