### PR TITLE
Hide session efficiency navigation buttons

### DIFF
--- a/vscode-extension/src/webview/shared/buttonConfig.ts
+++ b/vscode-extension/src/webview/shared/buttonConfig.ts
@@ -9,6 +9,8 @@ export interface ButtonConfig {
 	id: ButtonId;
 	label: string;
 	appearance?: 'primary' | 'secondary';
+	/** When true, the button is not rendered in the UI (code is preserved for re-enabling later). */
+	hidden?: boolean;
 }
 
 /**
@@ -54,7 +56,8 @@ export const BUTTONS: Record<ButtonId, ButtonConfig> = {
 	},
 	'btn-session-efficiency': {
 		id: 'btn-session-efficiency',
-		label: '📈 Session Efficiency'
+		label: '📈 Session Efficiency',
+		hidden: true
 	}
 };
 
@@ -71,6 +74,7 @@ export function getButton(id: ButtonId): ButtonConfig {
  */
 export function buttonHtml(id: ButtonId): string {
 	const config = BUTTONS[id];
+	if (config.hidden) { return ''; }
 	const appearance = config.appearance ? ` appearance="${config.appearance}"` : '';
 	return `<vscode-button id="${config.id}"${appearance}>${config.label}</vscode-button>`;
 }

--- a/vscode-extension/src/webview/shared/domUtils.ts
+++ b/vscode-extension/src/webview/shared/domUtils.ts
@@ -30,6 +30,7 @@ export function createButton(configOrId: ButtonConfig | string, label?: string, 
 		button.id = config.id;
 		button.textContent = config.label;
 		if (config.appearance) { button.setAttribute('appearance', config.appearance); }
+		if (config.hidden) { button.hidden = true; }
 	}
 	
 	return button;


### PR DESCRIPTION
## Summary

Temporarily hides the **Session Efficiency** navigation button from all webview panels. All underlying code is preserved so it can be re-enabled easily later.

## Changes

- Added `hidden?: boolean` to the `ButtonConfig` interface in `buttonConfig.ts`
- Set `hidden: true` on `btn-session-efficiency`  
- `buttonHtml()` returns an empty string when `hidden` is set  
- `createButton()` sets `button.hidden = true` on the DOM element when `hidden` is set

## Re-enabling

To bring the view back, simply remove `hidden: true` from the `btn-session-efficiency` entry in `buttonConfig.ts`.