### PR TITLE
chore: bump VS Code extension to v0.5.1

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,18 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-08
+
+### Features
+- Show cached input tokens in log viewer summary bar — a "Cached Input" card now appears for Copilot CLI sessions that have `cacheReadTokens` data (#807)
+
+### Improvements
+- Added friendly display names for additional tools: ADO MCP, MSSQL, Copilot search/memory tools, `mcp_git_git_log`, `mcp_git_git_show`, and Claude in Chrome MCP tools
+- Cleaned up publish script and removed legacy deprecation popup (#809)
+
+### Bug Fixes
+- Hidden Session Efficiency navigation buttons from all webview panels until the feature is stable (#815)
+
 ## [0.5.0] - 2026-05-06
 
 ### Features

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## VS Code Extension v0.5.1

Bumps the version to `0.5.1` and updates the changelog with all changes since `v0.5.0`.

### What's new

**Features**
- Show cached input tokens in log viewer summary bar (#807)

**Improvements**
- Added friendly display names for ADO MCP, MSSQL, Copilot search/memory tools, `mcp_git_git_log`, `mcp_git_git_show`, and Claude in Chrome MCP tools
- Cleaned up publish script and removed legacy deprecation popup (#809)

**Bug Fixes**
- Hidden Session Efficiency navigation buttons from all webview panels until the feature is stable (#815)

---

After merging, trigger the [Extensions - Release workflow](https://github.com/rajbos/ai-engineering-fluency/actions/workflows/release.yml) manually on `main` with default inputs to create the tag, GitHub Release, and publish to the VS Code Marketplace.