### PR TITLE
chore: remove Session Efficiency references from CHANGELOG

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -15,15 +15,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added friendly display names for additional tools: ADO MCP, MSSQL, Copilot search/memory tools, `mcp_git_git_log`, `mcp_git_git_show`, and Claude in Chrome MCP tools
 - Cleaned up publish script and removed legacy deprecation popup (#809)
 
-### Bug Fixes
-- Hidden Session Efficiency navigation buttons from all webview panels until the feature is stable (#815)
-
 ## [0.5.0] - 2026-05-06
 
 ### Features
-- Added Session Efficiency view — scatter chart of sessions by token usage and tool calls, with sortable table, model/PR filters, and async load with spinner
-- Added cost-mode toggle (AI credits vs. dollar cost) and explainer to Session Efficiency view
-- Added Session Efficiency nav button to all views; removed palette command
 - Cost basis toggle moved into Sessions by category panel; chart title updates to reflect active mode
 - Added sort indicator to active column header in session table
 
@@ -31,8 +25,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added Mistral AI model pricing and token estimators (#796)
 - Added missing friendly names for 17 additional tools (TaskCreate, TaskUpdate, dismiss_deployment_notifications, Claude in Chrome MCP, and 13 others)
 - Scatter chart: dark border on dots for readability, crisp rendering, variable circle size restored
-- Compact token format in Session Efficiency table; dedup models/PRs; clear filters on click
-- Session Efficiency header/buttons match styling of other views
 
 ### Bug Fixes
 - Fixed duplicate loading sessions appearing in the status bar


### PR DESCRIPTION
Removes all 6 changelog entries that mention Session Efficiency so that the feature's existence is not visible in the OSS repo history.

The feature now lives entirely in the private companion extension.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>