### PR TITLE
fix(deps): bump fast-uri to >=3.1.2 (closes Dependabot alerts #81 and #82)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -6373,9 +6373,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -573,6 +573,7 @@
   },
   "overrides": {
     "diff": ">=8.0.3",
+    "fast-uri": ">=3.1.2",
     "serialize-javascript": ">=7.0.3",
     "uuid": "^14.0.0"
   }


### PR DESCRIPTION
## Summary

Fixes two open Dependabot security alerts in `vscode-extension/package-lock.json` by adding `fast-uri` to the `overrides` block in `vscode-extension/package.json`.

`fast-uri` is a **transitive** dev-only dependency (pulled in via `ajv`) — it cannot be updated directly. The `overrides` field forces npm to resolve it to a patched version.

## Alerts resolved

| # | CVE | Severity | Summary |
|---|-----|----------|---------|
| [#82](https://github.com/rajbos/ai-engineering-fluency/security/dependabot/82) | CVE-2026-6322 | High | Host confusion via percent-encoded authority delimiters |
| [#81](https://github.com/rajbos/ai-engineering-fluency/security/dependabot/81) | CVE-2026-6321 | High | Path traversal via percent-encoded dot segments |

Both require `fast-uri >= 3.1.2` — now enforced via the `overrides` entry.

## Changes

- `vscode-extension/package.json` — added `"fast-uri": ">=3.1.2"` to `overrides`
- `vscode-extension/package-lock.json` — bumped `fast-uri` from `3.1.0` → `3.1.2`

## Validation

- ✅ `npm run compile` — TypeScript + ESLint + esbuild all pass
- ✅ `npm run test:node` — all 30 unit tests pass