### PR TITLE
chore: bump versions for release (vscode-extension v0.5.2, cli v0.1.1)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-09
+
+### ✨ Features & Improvements
+- Added `--json` output option to the `stats` command (#818)
+
+### 🔧 Maintenance
+- Bumped @types/node from 25.6.0 to 25.6.2
+
 ## [0.1.0] - 2026-05-04
 
 ### ✨ Features & Improvements

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-09
+
+### Security
+- Bumped `fast-uri` to ≥3.1.2 to fix GHSA-v39h-62p7-jpjc and GHSA-q3j6-qgpj-74h6
+
+### Improvements
+- Added friendly display names for `list_bash`, `read_bash`, and `stop_bash` tools (#822)
+- Bumped `fast-xml-builder` dependency (#819)
+- Cleaned up legacy code references (#821)
+
 ## [0.5.1] - 2026-05-08
 
 ### Features

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Last tag | Old version | New version | Bump type |
|-----------|----------|-------------|-------------|-----------|
| VS Code extension | `vscode/v0.5.1` | 0.5.1 | **0.5.2** | patch |
| CLI | `cli/v0.0.8` | 0.1.0 | **0.1.1** | patch |

### What changed

#### VS Code extension (0.5.1 → 0.5.2)
- 🔒 **Security:** bumped `fast-uri` to ≥3.1.2 (fixes GHSA-v39h-62p7-jpjc and GHSA-q3j6-qgpj-74h6)
- ✨ Added friendly display names for `list_bash`, `read_bash`, and `stop_bash` tools (#822)
- 🔧 Bumped `fast-xml-builder` dependency (#819)
- 🧹 Cleaned up legacy code references (#821)

#### CLI (0.1.0 → 0.1.1)
- ✨ Added `--json` output option to the `stats` command (#818)
- 🔧 Bumped `@types/node` from 25.6.0 to 25.6.2

---

### After merging, run these workflows:

#### 1. VS Code Extension
- **Actions → Extensions - Release → Run workflow** (on `main`)
- Publishes VS Code extension **v0.5.2** to the VS Code Marketplace

#### 2. CLI
- **Actions → CLI - Publish to npm and GitHub → Run workflow** (on `main`)
- Publishes **@rajbos/ai-engineering-fluency@0.1.1** to npm