### PR TITLE
fix(ci): use OIDC provenance for npm publish

### DIFF
--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -2,6 +2,42 @@
 applyTo: ".github/workflows/**"
 ---
 
+# npm Publishing via OIDC (Trusted Publishing)
+
+This repository publishes the CLI package to npm using GitHub Actions OIDC trusted publishing — no `NPM_TOKEN` secret is required.
+
+## Required setup
+
+1. **Job permission:** `id-token: write` must be set on the publish job.
+2. **setup-node:** Use `registry-url: 'https://registry.npmjs.org'` so npm is configured for the registry.
+3. **Publish command:** Always include `--provenance` so npm exchanges the OIDC token automatically:
+
+```yaml
+- name: Publish to npm
+  run: npm publish --provenance --access public
+```
+
+## Common mistake to avoid
+
+Do **not** set `NODE_AUTH_TOKEN` to an empty string:
+
+```yaml
+# ❌ WRONG — explicitly clears the token and causes ENEEDAUTH
+run: NODE_AUTH_TOKEN="" npm publish
+
+# ❌ ALSO WRONG — requires a secret that isn't needed
+run: npm publish
+env:
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+# ✅ CORRECT — OIDC token is exchanged automatically via --provenance
+run: npm publish --provenance --access public
+```
+
+Setting `NODE_AUTH_TOKEN=""` overrides the auth that `setup-node` configures and causes `ENEEDAUTH` failures even though `id-token: write` is set.
+
+---
+
 # Workflow Security: Validating Untrusted User Input
 
 ## Overview

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -125,15 +125,11 @@ jobs:
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' }}
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Dry run publish
         if: ${{ inputs.dry_run }}
-        run: npm publish --access public --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public --dry-run
 
       - name: Commit version bump and create PR
         if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' && steps.trigger_type.outputs.is_tag != 'true' }}

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -125,11 +125,15 @@ jobs:
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' }}
-        run: NODE_AUTH_TOKEN="" npm publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run publish
         if: ${{ inputs.dry_run }}
-        run: NODE_AUTH_TOKEN="" npm publish public --dry-run
+        run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit version bump and create PR
         if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' && steps.trigger_type.outputs.is_tag != 'true' }}


### PR DESCRIPTION
## Problem

The `Publish to npm` step was setting `NODE_AUTH_TOKEN=""`, which explicitly cleared the auth token that `actions/setup-node` configures when `registry-url` is provided. This caused `ENEEDAUTH` failures even though the job already had `id-token: write` for OIDC publishing.

## Fix

Removed the `NODE_AUTH_TOKEN` override and added `--provenance --access public` to both the publish and dry-run steps. With `--provenance`, npm automatically exchanges the GitHub Actions OIDC token for a short-lived registry token - no secret needed.