### PR TITLE
fix: always show friendly model names in all display locations

### DIFF
--- a/vscode-extension/src/modelPricing.json
+++ b/vscode-extension/src/modelPricing.json
@@ -74,7 +74,10 @@
       "outputCostPerMillion": 10.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "GPT-5 Codex (Preview)"
+      ]
     },
     "gpt-5-mini": {
       "inputCostPerMillion": 0.25,
@@ -82,6 +85,9 @@
       "category": "GPT-5 models",
       "tier": "standard",
       "multiplier": 0,
+      "displayNames": [
+        "GPT-5 Mini"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 0.25,
         "cachedInputCostPerMillion": 0.025,
@@ -95,28 +101,40 @@
       "outputCostPerMillion": 10.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "GPT-5.1"
+      ]
     },
     "gpt-5.1-codex": {
       "inputCostPerMillion": 1.25,
       "outputCostPerMillion": 10.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "GPT-5.1 Codex"
+      ]
     },
     "gpt-5.1-codex-max": {
       "inputCostPerMillion": 1.75,
       "outputCostPerMillion": 14.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "GPT-5.1 Codex Max"
+      ]
     },
     "gpt-5.1-codex-mini": {
       "inputCostPerMillion": 0.25,
       "outputCostPerMillion": 2.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 0.33
+      "multiplier": 0.33,
+      "displayNames": [
+        "GPT-5.1 Codex Mini (Preview)"
+      ]
     },
     "gpt-5.2": {
       "inputCostPerMillion": 1.75,
@@ -124,6 +142,9 @@
       "category": "GPT-5 models",
       "tier": "premium",
       "multiplier": 1,
+      "displayNames": [
+        "GPT-5.2"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 1.75,
         "cachedInputCostPerMillion": 0.175,
@@ -138,6 +159,9 @@
       "category": "GPT-5 models",
       "tier": "premium",
       "multiplier": 1,
+      "displayNames": [
+        "GPT-5.2 Codex"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 1.75,
         "cachedInputCostPerMillion": 0.175,
@@ -151,7 +175,10 @@
       "outputCostPerMillion": 168.0,
       "category": "GPT-5 models",
       "tier": "premium",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "GPT-5.2 Pro"
+      ]
     },
     "gpt-5.3-codex": {
       "inputCostPerMillion": 1.75,
@@ -159,6 +186,9 @@
       "category": "GPT-5 models",
       "tier": "premium",
       "multiplier": 1,
+      "displayNames": [
+        "GPT-5.3 Codex"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 1.75,
         "cachedInputCostPerMillion": 0.175,
@@ -255,7 +285,10 @@
       "outputCostPerMillion": 1.6,
       "category": "GPT-4 models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "displayNames": [
+        "GPT-4.1 Mini"
+      ]
     },
     "gpt-4.1-nano": {
       "inputCostPerMillion": 0.1,
@@ -263,7 +296,10 @@
       "outputCostPerMillion": 0.4,
       "category": "GPT-4 models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "displayNames": [
+        "GPT-4.1 Nano"
+      ]
     },
     "gpt-4o": {
       "inputCostPerMillion": 2.5,
@@ -350,6 +386,9 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 1,
+      "displayNames": [
+        "Claude Sonnet 4.5"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 3.0,
         "cachedInputCostPerMillion": 0.3,
@@ -386,7 +425,10 @@
       "cacheCreationCostPerMillion": 0.3125,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "displayNames": [
+        "Claude Haiku"
+      ]
     },
     "claude-haiku-4.5": {
       "inputCostPerMillion": 1.0,
@@ -396,6 +438,9 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 0.33,
+      "displayNames": [
+        "Claude Haiku 4.5"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 1.0,
         "cachedInputCostPerMillion": 0.1,
@@ -412,7 +457,10 @@
       "cacheCreationCostPerMillion": 18.75,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
-      "multiplier": 10
+      "multiplier": 10,
+      "displayNames": [
+        "Claude Opus 4.1"
+      ]
     },
     "claude-opus-4.5": {
       "inputCostPerMillion": 5.0,
@@ -422,6 +470,9 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 3,
+      "displayNames": [
+        "Claude Opus 4.5"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 5.0,
         "cachedInputCostPerMillion": 0.5,
@@ -439,6 +490,9 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 3,
+      "displayNames": [
+        "Claude Opus 4.6"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 5.0,
         "cachedInputCostPerMillion": 0.5,
@@ -476,6 +530,9 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 30,
+      "displayNames": [
+        "Claude Opus 4.6 (Fast Mode Preview)"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 30.0,
         "cachedInputCostPerMillion": 3.0,
@@ -493,6 +550,9 @@
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 30,
+      "displayNames": [
+        "Claude Opus 4.6 (Fast)"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 30.0,
         "cachedInputCostPerMillion": 3.0,
@@ -575,28 +635,40 @@
       "outputCostPerMillion": 2.5,
       "category": "Google Gemini models",
       "tier": "unknown",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "Gemini 2.5 Flash"
+      ]
     },
     "gemini-2.5-flash-lite": {
       "inputCostPerMillion": 0.1,
       "outputCostPerMillion": 0.4,
       "category": "Google Gemini models",
       "tier": "unknown",
-      "multiplier": 1
+      "multiplier": 1,
+      "displayNames": [
+        "Gemini 2.5 Flash Lite"
+      ]
     },
     "gemini-2.0-flash": {
       "inputCostPerMillion": 0.1,
       "outputCostPerMillion": 0.4,
       "category": "Google Gemini models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "displayNames": [
+        "Gemini 2.0 Flash"
+      ]
     },
     "gemini-2.0-flash-lite": {
       "inputCostPerMillion": 0.075,
       "outputCostPerMillion": 0.3,
       "category": "Google Gemini models",
       "tier": "standard",
-      "multiplier": 0
+      "multiplier": 0,
+      "displayNames": [
+        "Gemini 2.0 Flash Lite"
+      ]
     },
     "gemini-3-flash": {
       "inputCostPerMillion": 0.5,
@@ -604,6 +676,9 @@
       "category": "Google Gemini models",
       "tier": "premium",
       "multiplier": 0.33,
+      "displayNames": [
+        "Gemini 3 Flash"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 0.5,
         "cachedInputCostPerMillion": 0.05,
@@ -666,6 +741,9 @@
       "category": "xAI Grok models",
       "tier": "premium",
       "multiplier": 0.25,
+      "displayNames": [
+        "Grok Code Fast 1"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 0.2,
         "cachedInputCostPerMillion": 0.02,
@@ -680,6 +758,9 @@
       "category": "GitHub Copilot fine-tuned models",
       "tier": "standard",
       "multiplier": 0,
+      "displayNames": [
+        "Raptor Mini"
+      ],
       "copilotPricing": {
         "inputCostPerMillion": 0.25,
         "cachedInputCostPerMillion": 0.025,

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,6 +1,7 @@
 ﻿// Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
+import { getModelDisplayName } from '../shared/modelUtils';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -298,7 +299,7 @@ function renderTurnModelBadge(model: string): string {
 		const family = escapeHtml(model);
 		return `<span class="turn-model" title="JetBrains session logs only record the model family (inferred from the tool call ID prefix). Specific version isn't persisted.">🎯 ${family}</span>`;
 	}
-	return `<span class="turn-model">🎯 ${escapeHtml(model)}</span>`;
+	return `<span class="turn-model">🎯 ${escapeHtml(getModelDisplayName(model))}</span>`;
 }
 
 function renderTurnCard(turn: ChatTurn, isJetBrains = false): string {
@@ -490,7 +491,7 @@ function renderTurnCard(turn: ChatTurn, isJetBrains = false): string {
 								<tr class="tool-row${tc.isSubAgent ? ' sub-agent-row' : ''}" data-tool-name="${tc.isSubAgent ? '__subagent__' : escapeHtml(lookupToolName(tc.toolName))}">
 									<td class="tool-name-cell">
 										<span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(tc.isSubAgent ? ({'task':'🤖 Sub-Agent','read_agent':'🤖 Sub-Agent (read)','write_agent':'🤖 Sub-Agent (write)','list_agents':'🤖 Sub-Agent (list)'}[tc.toolName] || `🤖 ${tc.toolName}`) : lookupToolName(tc.toolName))}</span>
-										${tc.isSubAgent && tc.subAgentModel ? `<span class="sub-agent-model-badge">${escapeHtml(tc.subAgentModel)}</span>` : ''}
+										${tc.isSubAgent && tc.subAgentModel ? `<span class="sub-agent-model-badge">${escapeHtml(getModelDisplayName(tc.subAgentModel))}</span>` : ''}
 										${tc.isSubAgent && tc.subAgentTokens ? `<span class="sub-agent-tokens">↑${tc.subAgentTokens.input.toLocaleString()} ↓${tc.subAgentTokens.output.toLocaleString()} tokens</span>` : ''}
 										${tc.arguments && !tc.isSubAgent ? `<details class="tool-details"><summary>Arguments</summary><pre>${escapeHtml(tc.arguments)}</pre></details>` : ''}
 										${tc.result && !tc.isSubAgent ? `<details class="tool-details"><summary>Result</summary><pre>${escapeHtml(truncateText(tc.result, 500))}</pre></details>` : ''}

--- a/vscode-extension/src/webview/shared/modelUtils.ts
+++ b/vscode-extension/src/webview/shared/modelUtils.ts
@@ -1,40 +1,20 @@
+// @ts-ignore — resolved by esbuild at bundle time
+import modelPricingJson from '../../modelPricing.json';
+
+type PricingEntry = { displayNames?: string[] };
+
+// Build display name map from pricing JSON (first displayName = canonical friendly name).
+// This is the single source of truth so it stays in sync with the nightly JSON refresh.
+const _modelNames: Record<string, string> = {};
+for (const [modelId, pricing] of Object.entries(modelPricingJson.pricing as Record<string, PricingEntry>)) {
+    if (pricing.displayNames && pricing.displayNames.length > 0) {
+        _modelNames[modelId] = pricing.displayNames[0];
+    }
+}
+
 /**
  * Returns a human-friendly display name for a given model identifier.
  */
 export function getModelDisplayName(model: string): string {
-    const names: Record<string, string> = {
-        'gpt-4': 'GPT-4',
-        'gpt-4.1': 'GPT-4.1',
-        'gpt-4o': 'GPT-4o',
-        'gpt-4o-mini': 'GPT-4o Mini',
-        'gpt-3.5-turbo': 'GPT-3.5 Turbo',
-        'gpt-5': 'GPT-5',
-        'gpt-5-codex': 'GPT-5 Codex (Preview)',
-        'gpt-5-mini': 'GPT-5 Mini',
-        'gpt-5.1': 'GPT-5.1',
-        'gpt-5.1-codex': 'GPT-5.1 Codex',
-        'gpt-5.1-codex-max': 'GPT-5.1 Codex Max',
-        'gpt-5.1-codex-mini': 'GPT-5.1 Codex Mini (Preview)',
-        'gpt-5.2': 'GPT-5.2',
-        'gpt-5.2-codex': 'GPT-5.2 Codex',
-        'claude-sonnet-3.5': 'Claude Sonnet 3.5',
-        'claude-sonnet-3.7': 'Claude Sonnet 3.7',
-        'claude-sonnet-4': 'Claude Sonnet 4',
-        'claude-sonnet-4.5': 'Claude Sonnet 4.5',
-        'claude-sonnet-4.6': 'Claude Sonnet 4.6',
-        'claude-haiku': 'Claude Haiku',
-        'claude-haiku-4.5': 'Claude Haiku 4.5',
-        'claude-opus-4.1': 'Claude Opus 4.1',
-        'claude-opus-4.5': 'Claude Opus 4.5',
-        'claude-opus-4.6': 'Claude Opus 4.6',
-        'gemini-2.5-pro': 'Gemini 2.5 Pro',
-        'gemini-3-flash': 'Gemini 3 Flash',
-        'gemini-3-pro': 'Gemini 3 Pro',
-        'gemini-3-pro-preview': 'Gemini 3 Pro (Preview)',
-        'grok-code-fast-1': 'Grok Code Fast 1',
-        'raptor-mini': 'Raptor Mini',
-        'o3-mini': 'o3-mini',
-        'o4-mini': 'o4-mini (Preview)'
-    };
-    return names[model] || model;
+    return _modelNames[model] || model;
 }


### PR DESCRIPTION
## Problem

Several new models were appearing in lowercase (raw model IDs) instead of friendly names:
- \claude-opus-4.7\ instead of 'Claude Opus 4.7' (details panel, chart)
- \gpt-5.4\ instead of 'GPT-5.4' (details panel, chart)
- \claude-sonnet-4.6\ instead of 'Claude Sonnet 4.6' (file viewer turn badge)
- Sub-agent model badges also showed raw IDs

## Root cause

Two separate issues:

1. **\modelUtils.ts\ had a hardcoded table** that didn't include newer models. Every time a new model was added to \modelPricing.json\ via the nightly refresh, it had to be manually added here too — and it wasn't.

2. **The logviewer's turn model badge** (\enderTurnModelBadge\) and sub-agent model badge weren't calling \getModelDisplayName()\ at all.

## Fix

### \modelUtils.ts\ — derived from \modelPricing.json\ (root cause fix)
Replaced the hardcoded table with dynamic derivation from \modelPricing.json\. The first \displayNames\ entry for each model is used as the canonical friendly name. This means the nightly JSON refresh automatically keeps display names in sync.

### \modelPricing.json\ — added missing \displayNames\
Added \displayNames\ to every model that was missing them (claude-opus series, haiku, gpt-5.x series, gemini flash variants, grok, raptor-mini, etc.)

### \logviewer/main.ts\ — use friendly names
- \enderTurnModelBadge()\ now calls \getModelDisplayName()\
- Sub-agent model badge now calls \getModelDisplayName()\

## Testing
- All 47 unit tests pass
- Build succeeds