### PR TITLE
fix(mutation-benchmark): gracefully handle invalid/expired GH_PAT

### DIFF
--- a/.github/workflows/mutation-benchmark.yml
+++ b/.github/workflows/mutation-benchmark.yml
@@ -167,6 +167,7 @@ jobs:
       run: |
         if [ -z "$GH_TOKEN" ]; then
           echo "⚠️ GH_PAT secret is not set; skipping Copilot CLI steps."
+          printf '> [!WARNING]\n> **GH_PAT secret is not set.** The Copilot CLI follow-up step was skipped.\n> Renew the PAT and add it as a repository secret named `GH_PAT` to re-enable issue creation.\n' >> "$GITHUB_STEP_SUMMARY"
           echo "auth_ok=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
@@ -174,6 +175,7 @@ jobs:
           echo "auth_ok=true" >> "$GITHUB_OUTPUT"
         else
           echo "⚠️ GH_PAT token is invalid or expired; skipping Copilot CLI steps."
+          printf '> [!WARNING]\n> **GH_PAT token is invalid or expired.** The Copilot CLI follow-up step was skipped.\n> Renew the PAT and update the repository secret named `GH_PAT` to re-enable issue creation.\n' >> "$GITHUB_STEP_SUMMARY"
           echo "auth_ok=false" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/mutation-benchmark.yml
+++ b/.github/workflows/mutation-benchmark.yml
@@ -160,25 +160,32 @@ jobs:
     # absent or scoped differently outside main.
 
     - name: Authenticate GitHub CLI
+      id: auth
       if: steps.gate.outputs.should_run == 'true' && steps.mutation.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       env:
         GH_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         if [ -z "$GH_TOKEN" ]; then
-          echo "❌ GH_PAT secret is not set; cannot run Copilot CLI step."
-          exit 1
+          echo "⚠️ GH_PAT secret is not set; skipping Copilot CLI steps."
+          echo "auth_ok=false" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
-        gh auth status
+        if gh auth status 2>&1; then
+          echo "auth_ok=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "⚠️ GH_PAT token is invalid or expired; skipping Copilot CLI steps."
+          echo "auth_ok=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Check Copilot CLI version
-      if: steps.gate.outputs.should_run == 'true' && steps.mutation.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      if: steps.gate.outputs.should_run == 'true' && steps.mutation.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.auth.outputs.auth_ok == 'true'
       env:
         GH_TOKEN: ${{ secrets.GH_PAT }}
         COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       run: npx @github/copilot --version
 
     - name: Run Copilot CLI to draft mutation improvement issue
-      if: steps.gate.outputs.should_run == 'true' && steps.mutation.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      if: steps.gate.outputs.should_run == 'true' && steps.mutation.outcome == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.auth.outputs.auth_ok == 'true'
       env:
         GH_TOKEN: ${{ secrets.GH_PAT }}
         COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/mutation-benchmark.yml
+++ b/.github/workflows/mutation-benchmark.yml
@@ -167,7 +167,7 @@ jobs:
       run: |
         if [ -z "$GH_TOKEN" ]; then
           echo "⚠️ GH_PAT secret is not set; skipping Copilot CLI steps."
-          printf '> [!WARNING]\n> **GH_PAT secret is not set.** The Copilot CLI follow-up step was skipped.\n> Renew the PAT and add it as a repository secret named `GH_PAT` to re-enable issue creation.\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '> [!WARNING]\n> **GH_PAT secret is not set.** The Copilot CLI follow-up step was skipped.\n> Renew the PAT and add it as a repository secret named **GH_PAT** to re-enable issue creation.\n' >> "$GITHUB_STEP_SUMMARY"
           echo "auth_ok=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
@@ -175,7 +175,7 @@ jobs:
           echo "auth_ok=true" >> "$GITHUB_OUTPUT"
         else
           echo "⚠️ GH_PAT token is invalid or expired; skipping Copilot CLI steps."
-          printf '> [!WARNING]\n> **GH_PAT token is invalid or expired.** The Copilot CLI follow-up step was skipped.\n> Renew the PAT and update the repository secret named `GH_PAT` to re-enable issue creation.\n' >> "$GITHUB_STEP_SUMMARY"
+          printf '> [!WARNING]\n> **GH_PAT token is invalid or expired.** The Copilot CLI follow-up step was skipped.\n> Renew the PAT and update the repository secret named **GH_PAT** to re-enable issue creation.\n' >> "$GITHUB_STEP_SUMMARY"
           echo "auth_ok=false" >> "$GITHUB_OUTPUT"
         fi
 


### PR DESCRIPTION
## Problem

The daily mutation test workflow was **failing every run** because the `GH_PAT` secret is invalid/expired. The `Authenticate GitHub CLI` step ran `gh auth status`, got a non-zero exit code, and caused the entire job to fail — even though the mutation tests themselves had already succeeded.

Screenshot showing the failure pattern:
- ✅ Compile tests
- ✅ Run mutation tests
- ✅ Publish mutation summary  
- ✅ Upload mutation report
- ❌ Authenticate GitHub CLI ← kills the job

## Fix

Make the auth step a **non-fatal gate** instead of a hard failure:

- Added `id: auth` so the step's output can be read by downstream steps
- When `GH_PAT` is absent or the token is rejected, the step now sets `auth_ok=false` and exits 0 (success) with a clear warning message
- When auth succeeds, sets `auth_ok=true`  
- `Check Copilot CLI version` and `Run Copilot CLI...` steps are now gated on `steps.auth.outputs.auth_ok == 'true'`, so they skip cleanly when the PAT is unavailable

The workflow now **always succeeds** and publishes mutation results; only the optional Copilot issue-creation follow-up is skipped when the PAT is expired.

## Root cause note

The underlying `GH_PAT` secret needs to be renewed separately — but with this fix the workflow is resilient to that situation rather than failing hard.