### PR TITLE
fix: keep chart in sync with toolbar on background stat refreshes

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1455,6 +1455,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.setStatusBarText(`$(loading~spin) Analyzing Logs: ${percentage}%`);
 			});
 			this.lastDailyStats = dailyStats;
+			// Keep lastFullDailyStats fresh: replace the recent 30-day entries so the chart
+			// shows the same data as the toolbar/details panel on every background refresh.
+			if (this.lastFullDailyStats) {
+				const fullMap = new Map(this.lastFullDailyStats.map(d => [d.date, d]));
+				for (const day of dailyStats) {
+					fullMap.set(day.date, day);
+				}
+				this.lastFullDailyStats = Array.from(fullMap.values()).sort((a, b) => a.date.localeCompare(b.date));
+			}
 
 			if (detailedStats.today.sessions === 0 && detailedStats.last30Days.sessions === 0) {
 				this.setStatusBarText('$(symbol-numeric) No session data yet');


### PR DESCRIPTION
## Problem

The chart and toolbar were showing different "today" token counts. For example, the toolbar would show 17M tokens used today while the chart only showed ~4.3M for the same day. The details screen was also counting more sessions (20) than the chart (3).

## Root cause

`_runUpdateTokenStats()` runs every 5 minutes and correctly refreshes `lastDailyStats` (fresh 30-day window) to update the toolbar and details panel. When it also pushes an update to the open chart panel, it prefers `lastFullDailyStats` (the 365-day dataset computed **once** when the chart was first opened) -- but that full-year dataset is **never refreshed** by the background timer. So the chart always displayed the stale snapshot from when the chart was opened, while the toolbar reflected current data.

## Fix

After each `calculateDetailedStats()` run, merge the fresh 30-day `dailyStats` entries into `lastFullDailyStats` by upsert on the date key. Sessions older than 30 days are unaffected (their historical dates are stable), while the recent window stays accurate on every background refresh.

```ts
if (this.lastFullDailyStats) {
    const fullMap = new Map(this.lastFullDailyStats.map(d => [d.date, d]));
    for (const day of dailyStats) {
        fullMap.set(day.date, day);
    }
    this.lastFullDailyStats = Array.from(fullMap.values()).sort(...);
}
```

This is a surgical 9-line addition in `extension.ts` with no API or schema changes.