### PR TITLE
chore: bump VS Code extension version to 0.7.0

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-28
+
+### Features
+- Add rolling average toggle for Total Tokens and Est. Cost chart views (#836)
+- Add Copilot Cloud Agent sessions view (#835)
+
 ## [0.5.2] - 2026-05-09
 
 ### Security

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.5.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.5.2",
+      "version": "0.7.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — VS Code extension v0.7.0

This PR bumps the VS Code extension version for the minor release, including two new features added since \scode/v0.6.0\.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.6.0 | v0.7.0 |

### Changes included

- **feat(chart): add rolling average toggle for Total Tokens and Est. Cost views** (#836)
- **feat: add Copilot Cloud Agent sessions view** (#835)

---

### After merging, run this workflow:

- **Extensions - Release** (\elease.yml\) — Actions → _Extensions - Release_ → Run workflow (on \main\)
- This publishes VS Code extension **v0.7.0** to the VS Code Marketplace