### PR TITLE
Copilot/fix vscode extension error

### DIFF
--- a/usage-data/agent-sessions.json
+++ b/usage-data/agent-sessions.json
@@ -1,0 +1,20 @@
+{
+  "repos": [
+    {
+      "owner": "rajbos",
+      "repo": "ai-engineering-fluency",
+      "totalTasks": 0,
+      "totalSessions": 0,
+      "totalCredits": 0,
+      "tasksScanned": 0,
+      "tasksTotal": 0,
+      "partial": false
+    }
+  ],
+  "totalTasks": 0,
+  "totalSessions": 0,
+  "totalCredits": 0,
+  "authenticated": true,
+  "since": "2026-04-11T07:14:27.189Z",
+  "fetchedAt": "2026-05-11T07:14:27.980Z"
+}

--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -139,6 +139,7 @@ export class CacheManager {
 			const fd = await fs.promises.open(lockPath, 'wx');
 			await fd.writeFile(JSON.stringify({
 				sessionId: vscode.env.sessionId,
+				pid: process.pid,
 				timestamp: Date.now()
 			}));
 			await fd.close();
@@ -150,20 +151,40 @@ export class CacheManager {
 				return false;
 			}
 
-			// Lock file exists — check if it's stale (owner crashed)
+			// Lock file exists — check if the owning process is still alive or if the lock is stale
 			try {
 				const content = await fs.promises.readFile(lockPath, 'utf-8');
 				const lock = JSON.parse(content);
 				const staleThreshold = 5 * 60 * 1000; // 5 minutes (matches update interval)
 
-				if (Date.now() - lock.timestamp > staleThreshold) {
-					// Stale lock — break it and retry once
-					this.deps.log('Breaking stale cache lock');
+				// PID-based liveness check: if the owning process is gone, break immediately
+				let ownerAlive = true;
+				if (typeof lock.pid === 'number') {
+					try {
+						process.kill(lock.pid, 0); // Signal 0 checks existence without signalling
+					} catch (killErr: any) {
+						if (killErr.code === 'ESRCH') {
+							ownerAlive = false; // Process no longer exists
+						}
+						// EPERM means process exists but is owned by another user — treat as alive
+					}
+				}
+
+				const isTimestampStale = Date.now() - lock.timestamp > staleThreshold;
+
+				if (!ownerAlive || isTimestampStale) {
+					// Lock owner is dead or lock is old — break it and retry once
+					this.deps.log(
+						ownerAlive
+							? 'Breaking stale cache lock'
+							: 'Breaking stale cache lock (owner process no longer running)'
+					);
 					await fs.promises.unlink(lockPath);
 					try {
 						const fd = await fs.promises.open(lockPath, 'wx');
 						await fd.writeFile(JSON.stringify({
 							sessionId: vscode.env.sessionId,
+							pid: process.pid,
 							timestamp: Date.now()
 						}));
 						await fd.close();

--- a/vscode-extension/test/unit/cacheManager-lock.test.ts
+++ b/vscode-extension/test/unit/cacheManager-lock.test.ts
@@ -1,0 +1,132 @@
+import './vscode-shim-register';
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { CacheManager } from '../../src/cacheManager';
+
+function makeManager(dir: string): CacheManager {
+	const context: any = {
+		extensionMode: 1, // Production
+		globalStorageUri: { fsPath: dir },
+		globalState: {
+			get: () => undefined,
+			update: async () => {}
+		}
+	};
+	const deps = { log: () => {}, warn: () => {}, error: () => {} };
+	return new CacheManager(context, deps, 1);
+}
+
+function makeDirAndManager(): { dir: string; manager: CacheManager; logs: string[] } {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctt-lock-test-'));
+	const logs: string[] = [];
+	const context: any = {
+		extensionMode: 1,
+		globalStorageUri: { fsPath: dir },
+		globalState: { get: () => undefined, update: async () => {} }
+	};
+	const deps = { log: (m: string) => logs.push(m), warn: () => {}, error: () => {} };
+	const manager = new CacheManager(context, deps, 1);
+	return { dir, manager, logs };
+}
+
+test('acquireCacheLock: succeeds when no lock file exists', async () => {
+	const { manager } = makeDirAndManager();
+	const acquired = await manager.acquireCacheLock();
+	assert.equal(acquired, true);
+	await manager.releaseCacheLock();
+});
+
+test('acquireCacheLock: lock file contains pid field', async () => {
+	const { dir, manager } = makeDirAndManager();
+	await manager.acquireCacheLock();
+	const lockPath = manager.getCacheLockPath();
+	const content = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+	assert.equal(typeof content.pid, 'number', 'Lock file should contain a numeric pid');
+	assert.equal(content.pid, process.pid, 'Lock file pid should match current process pid');
+	await manager.releaseCacheLock();
+});
+
+test('acquireCacheLock: returns false when active lock held by live process', async () => {
+	const { dir, manager } = makeDirAndManager();
+	// Write a lock file owned by the current (live) process with a fresh timestamp
+	const lockPath = manager.getCacheLockPath();
+	fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+	fs.writeFileSync(lockPath, JSON.stringify({
+		sessionId: 'other-session',
+		pid: process.pid, // still alive
+		timestamp: Date.now()
+	}));
+
+	const manager2 = makeManager(dir);
+	const acquired = await manager2.acquireCacheLock();
+	assert.equal(acquired, false, 'Should not acquire lock held by a live process');
+
+	// Clean up
+	fs.unlinkSync(lockPath);
+});
+
+test('acquireCacheLock: breaks lock whose owner PID is dead', async () => {
+	const { dir, manager, logs } = makeDirAndManager();
+	const lockPath = manager.getCacheLockPath();
+	fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+	// Use a PID that cannot exist on any OS (> 4 million is always invalid)
+	const deadPid = 4_000_001;
+	fs.writeFileSync(lockPath, JSON.stringify({
+		sessionId: 'dead-session',
+		pid: deadPid,
+		timestamp: Date.now() // fresh timestamp — would NOT be broken by time-based check alone
+	}));
+
+	const acquired = await manager.acquireCacheLock();
+	assert.equal(acquired, true, 'Should acquire lock when owner PID is dead');
+	assert.ok(
+		logs.some(l => l.includes('no longer running')),
+		'Should log that the owner process is no longer running'
+	);
+	await manager.releaseCacheLock();
+});
+
+test('acquireCacheLock: breaks stale lock even without pid field (backward compat)', async () => {
+	const { dir, manager, logs } = makeDirAndManager();
+	const lockPath = manager.getCacheLockPath();
+	fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+	// Old-format lock (no pid), with stale timestamp
+	fs.writeFileSync(lockPath, JSON.stringify({
+		sessionId: 'old-session',
+		timestamp: Date.now() - (10 * 60 * 1000) // 10 minutes ago
+	}));
+
+	const acquired = await manager.acquireCacheLock();
+	assert.equal(acquired, true, 'Should acquire a stale lock with no pid field');
+	assert.ok(
+		logs.some(l => l.includes('Breaking stale cache lock')),
+		'Should log stale lock break'
+	);
+	await manager.releaseCacheLock();
+});
+
+test('releaseCacheLock: only releases own lock', async () => {
+	const { dir, manager } = makeDirAndManager();
+	const lockPath = manager.getCacheLockPath();
+	fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+	// Write a lock belonging to a different session
+	fs.writeFileSync(lockPath, JSON.stringify({
+		sessionId: 'foreign-session',
+		pid: process.pid,
+		timestamp: Date.now()
+	}));
+
+	// The manager (with a different sessionId from the shim) should NOT delete the foreign lock
+	await manager.releaseCacheLock();
+	assert.ok(fs.existsSync(lockPath), 'Foreign lock should not be deleted');
+
+	// Clean up
+	fs.unlinkSync(lockPath);
+});

--- a/vscode-extension/test/unit/vscode-shim-register.ts
+++ b/vscode-extension/test/unit/vscode-shim-register.ts
@@ -113,6 +113,7 @@ function attachMock(target: any): void {
 	};
 
 	target.ConfigurationTarget = target.ConfigurationTarget ?? { Global: 1 };
+	target.ExtensionMode = target.ExtensionMode ?? { Production: 1, Development: 2, Test: 3 };
 	target.ProgressLocation = target.ProgressLocation ?? { Notification: 15 };
 	target.ViewColumn = target.ViewColumn ?? { Active: -1, Beside: -2, One: 1, Two: 2, Three: 3 };
 


### PR DESCRIPTION
This pull request enhances the cache locking mechanism in the VSCode extension to improve reliability and prevent stale lock issues. The main improvements include adding process ID tracking to lock files, implementing a process liveness check to break locks held by dead processes, and introducing comprehensive unit tests for these scenarios.

**Cache Locking Improvements:**

* Added a `pid` (process ID) field to the cache lock file in `CacheManager`, enabling identification of the process holding the lock.
* Enhanced lock acquisition logic to check if the process holding the lock is still alive using the `pid` field, and to break the lock if the process is no longer running or the lock is stale.

**Testing Enhancements:**

* Introduced a new test suite in `cacheManager-lock.test.ts` that covers scenarios including live and dead process locks, backward compatibility with old lock formats, and correct lock release behavior.
* Added `ExtensionMode` to the VSCode shim to support the new tests.

**Usage Data:**

* Added a new `agent-sessions.json` file to track repository session and task usage data.