### PR TITLE
chore: release VS Code extension v0.7.1

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-11
+
+### Features
+- Add diagnostic logging to Details panel creation to aid blank-panel diagnosis (#)
+
+### Bug Fixes
+- Fix PID-based liveness check to break stale cache lock after force-kill
+
+### Improvements
+- Exclude `stryker.config.mjs` and `vs-session-sample.json` from VSIX package
+
 ## [0.7.0] - 2026-05-28
 
 ### Features

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## VS Code Extension v0.7.1

Bumps the VS Code extension from `0.7.0` → `0.7.1`.

### Changes since v0.7.0

#### Features
- Add diagnostic logging to Details panel creation to aid blank-panel diagnosis

#### Bug Fixes
- Fix PID-based liveness check to break stale cache lock after force-kill

#### Improvements
- Exclude `stryker.config.mjs` and `vs-session-sample.json` from VSIX package

---

After merging, tag the release with `vscode/v0.7.1` to trigger the publish workflow.