### PR TITLE
feat: remove cost estimate row and rename TBB to UBB

### DIFF
--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -106,11 +106,8 @@ function printPeriodStats(
 	}
 	console.log(`  Avg tokens/session:    ${chalk.bold(formatTokens(stats.avgTokensPerSession))}`);
 
-	if (options.cost && stats.estimatedCost > 0) {
-		console.log(`  Estimated cost (est.): ${chalk.green('$' + stats.estimatedCost.toFixed(4))}  ${chalk.dim('(provider API rates)')}`);
-		if ((stats.estimatedCostCopilot ?? 0) > 0) {
-			console.log(`  Estimated cost (TBB):  ${chalk.green('$' + (stats.estimatedCostCopilot ?? 0).toFixed(4))}  ${chalk.dim('(Copilot AI Credits)')}`);
-		}
+	if (options.cost && (stats.estimatedCostCopilot ?? 0) > 0) {
+		console.log(`  Estimated cost (UBB):  ${chalk.green('$' + (stats.estimatedCostCopilot ?? 0).toFixed(4))}  ${chalk.dim('(Copilot AI Credits)')}`);
 	}
 
 	// Model breakdown

--- a/visualstudio-extension/src/CopilotTokenTracker/webview/details.js
+++ b/visualstudio-extension/src/CopilotTokenTracker/webview/details.js
@@ -20357,7 +20357,7 @@
     const projectedSessions = Math.round(calculateProjection(stats.last30Days.sessions));
     const projectedCo2 = calculateProjection(stats.last30Days.co2);
     const projectedWater = calculateProjection(stats.last30Days.waterUsage);
-    const projectedCost = calculateProjection(stats.last30Days.estimatedCost);
+    const projectedCost = calculateProjection(stats.last30Days.estimatedCostCopilot ?? 0);
     const projectedTrees = calculateProjection(stats.last30Days.treesEquivalent);
     renderShell(root, stats, {
       projectedTokens,
@@ -20438,7 +20438,7 @@
       { label: "Tokens (user estimated)", icon: "\u{1F4DD}", color: "#b39ddb", today: formatNumber(stats.today.estimatedTokens), last30Days: formatNumber(stats.last30Days.estimatedTokens), lastMonth: formatNumber(stats.lastMonth.estimatedTokens), projected: "\u2014" },
       { label: "Service overhead %", icon: "\u2601\uFE0F", color: "#90a4ae", today: (stats.today.actualTokens || 0) > 0 ? formatPercent((stats.today.tokens - stats.today.estimatedTokens) / stats.today.tokens * 100) : "\u2014", last30Days: (stats.last30Days.actualTokens || 0) > 0 ? formatPercent((stats.last30Days.tokens - stats.last30Days.estimatedTokens) / stats.last30Days.tokens * 100) : "\u2014", lastMonth: (stats.lastMonth.actualTokens || 0) > 0 ? formatPercent((stats.lastMonth.tokens - stats.lastMonth.estimatedTokens) / stats.lastMonth.tokens * 100) : "\u2014", projected: "\u2014" },
       { label: "Thinking tokens", icon: "\u{1F9E0}", color: "#a78bfa", today: formatNumber(stats.today.thinkingTokens || 0), last30Days: formatNumber(stats.last30Days.thinkingTokens || 0), lastMonth: formatNumber(stats.lastMonth.thinkingTokens || 0), projected: "\u2014" },
-      { label: "Estimated cost", icon: "\u{1FA99}", color: "#ffd166", today: formatCost(stats.today.estimatedCost), last30Days: formatCost(stats.last30Days.estimatedCost), lastMonth: formatCost(stats.lastMonth.estimatedCost), projected: formatCost(projections.projectedCost) },
+      { label: "Cost (UBB)", icon: "\u{1F7E2}", color: "#7ce38b", today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCost) },
       { label: "Sessions", icon: "\u{1F4C5}", color: "#66aaff", today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
       { label: "Average interactions/session", icon: "\u{1F4AC}", color: "#8ce0ff", today: formatNumber(stats.today.avgInteractionsPerSession), last30Days: formatNumber(stats.last30Days.avgInteractionsPerSession), lastMonth: formatNumber(stats.lastMonth.avgInteractionsPerSession), projected: "\u2014" },
       { label: "Average tokens/session", icon: "\u{1F522}", color: "#7ce38b", today: formatNumber(stats.today.avgTokensPerSession), last30Days: formatNumber(stats.last30Days.avgTokensPerSession), lastMonth: formatNumber(stats.lastMonth.avgTokensPerSession), projected: "\u2014" }

--- a/visualstudio-extension/src/CopilotTokenTracker/webview/environmental.js
+++ b/visualstudio-extension/src/CopilotTokenTracker/webview/environmental.js
@@ -20450,7 +20450,7 @@
     const notes = document.createElement("ul");
     notes.className = "notes";
     const items = [
-      "Cost estimate uses public API pricing with input/output token counts; GitHub Copilot billing may differ from direct API usage.",
+      "Cost (UBB) uses GitHub Copilot AI Credit rates (1 credit = $0.01) under Usage Based Billing.",
       "Estimated CO\u2082 is based on ~0.2 g CO\u2082e per 1,000 tokens (average data center energy mix and PUE).",
       "Estimated water usage is based on ~0.3 L per 1,000 tokens (data center cooling estimates).",
       "Tree equivalent represents the fraction of a single mature tree's annual CO\u2082 absorption (~21 kg/year).",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1574,8 +1574,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📅 Today  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.today.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.today.estimatedCost.toFixed(2)} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (UBB) :       | $ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.today.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.today.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.today.sessions} |\n`);
@@ -1588,8 +1587,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`📊 Last 30 Days  \n`);
 			tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
 			tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.last30Days.tokens.toLocaleString()} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (est.) :      | $ ${detailedStats.last30Days.estimatedCost.toFixed(2)} |\n`);
-			tooltip.appendMarkdown(`| Estimated cost (TBB) :       | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
+			tooltip.appendMarkdown(`| Estimated cost (UBB) :       | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
 			tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.last30Days.co2.toFixed(2)} grams |\n`);
 			tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.last30Days.waterUsage.toFixed(3)} liters |\n`);
 			tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.last30Days.sessions} |\n`);
@@ -1597,9 +1595,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`| Average tokens/session :            | ${detailedStats.last30Days.avgTokensPerSession.toLocaleString()} |\n`);
 			// Footer
 			tooltip.appendMarkdown('\n---\n');
-			tooltip.appendMarkdown('*Cost estimates based on actual input/output token ratios.*  \n');
-			tooltip.appendMarkdown('*(est.) = provider API market rates, for reference only.*  \n');
-			tooltip.appendMarkdown('*(TBB) = Copilot AI Credit rates — what Copilot will bill you.*  \n');
+			tooltip.appendMarkdown('*(UBB) = Copilot AI Credit rates — what Copilot will bill you under Usage Based Billing.*  \n');
 			tooltip.appendMarkdown('*Updates automatically every 5 minutes.*');
 
 			this.statusBarItem.tooltip = tooltip;

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -610,7 +610,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 				labels: period.labels,
 				datasets: [
 					{
-						label: isRolling ? `${rollingLabel} (TBB)` : 'Est. Cost (TBB)',
+						label: isRolling ? `${rollingLabel} (UBB)` : 'Est. Cost (UBB)',
 						data: costData,
 						backgroundColor: isRolling ? 'rgba(34, 197, 94, 0.15)' : 'rgba(34, 197, 94, 0.6)',
 						borderColor: 'rgba(34, 197, 94, 1)',
@@ -641,7 +641,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 						position: 'left' as const,
 						grid: { color: gridColor },
 						ticks: { color: textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` },
-						title: { display: true, text: 'Estimated Cost (TBB)', color: textColor, font: { size: 12, weight: 'bold' as const } }
+						title: { display: true, text: 'Estimated Cost (UBB)', color: textColor, font: { size: 12, weight: 'bold' as const } }
 					}
 				}
 			}

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -232,14 +232,8 @@ function buildMetricsSection(
 		{ label: 'Service overhead %', icon: '☁️', color: '#90a4ae', today: (stats.today.actualTokens || 0) > 0 ? formatPercent(((stats.today.tokens - stats.today.estimatedTokens) / stats.today.tokens) * 100) : '—', last30Days: (stats.last30Days.actualTokens || 0) > 0 ? formatPercent(((stats.last30Days.tokens - stats.last30Days.estimatedTokens) / stats.last30Days.tokens) * 100) : '—', lastMonth: (stats.lastMonth.actualTokens || 0) > 0 ? formatPercent(((stats.lastMonth.tokens - stats.lastMonth.estimatedTokens) / stats.lastMonth.tokens) * 100) : '—', projected: '—' },
 		{ label: 'Thinking tokens', icon: '🧠', color: '#a78bfa', today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: '—' },
 		{
-			label: 'Estimated cost (est.)',
-			labelTooltip: 'Based on public provider API rates — for comparison only. This is not what you are billed.',
-			icon: '🪙', color: '#ffd166',
-			today: formatCost(stats.today.estimatedCost), last30Days: formatCost(stats.last30Days.estimatedCost), lastMonth: formatCost(stats.lastMonth.estimatedCost), projected: formatCost(projections.projectedCost)
-		},
-		{
-			label: 'Estimated cost (TBB)',
-			labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. TBB = To Be Billed.',
+			label: 'Estimated cost (UBB)',
+			labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. UBB = Usage Based Billing.',
 			icon: '🟢', color: '#7ce38b',
 			today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0)
 		},
@@ -247,7 +241,7 @@ function buildMetricsSection(
 			const credits = stats.copilotPlan.monthlyAiCreditsUsd > 0 ? `$${stats.copilotPlan.monthlyAiCreditsUsd} credits/month` : 'no credits';
 			return [{
 				label: `${stats.copilotPlan.planName} (${credits})`,
-				labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${stats.copilotPlan.planId}). Included AI credits cover token-based billing (1 AI credit = $0.01).`,
+				labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${stats.copilotPlan.planId}). Included AI credits cover usage-based billing (1 AI credit = $0.01).`,
 				icon: '🏷️', color: '#60a5fa',
 				today: '—', last30Days: '—', lastMonth: '—', projected: '—'
 			}];
@@ -805,7 +799,7 @@ function buildEstimatesSection(): HTMLElement {
 	notes.className = 'notes';
 
 	const items = [
-		'Cost estimate uses public API pricing with input/output token counts; GitHub Copilot billing may differ from direct API usage.',
+		'Cost (UBB) uses GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what you are billed under Usage Based Billing.',
 		'Estimated CO₂ is based on ~0.2 g CO₂e per 1,000 tokens.',
 		'Estimated water usage is based on ~0.3 L per 1,000 tokens.',
 		'Tree equivalent represents the fraction of a single mature tree\'s annual CO₂ absorption (~21 kg/year).'

--- a/vscode-extension/src/webview/environmental/main.ts
+++ b/vscode-extension/src/webview/environmental/main.ts
@@ -272,7 +272,7 @@ function buildEstimatesSection(): HTMLElement {
 	notes.className = 'notes';
 
 	const items = [
-		'Cost estimate uses public API pricing with input/output token counts; GitHub Copilot billing may differ from direct API usage.',
+		'Cost (UBB) uses GitHub Copilot AI Credit rates (1 credit = $0.01) under Usage Based Billing.',
 		'Estimated CO₂ is based on ~0.2 g CO₂e per 1,000 tokens (average data center energy mix and PUE).',
 		'Estimated water usage is based on ~0.3 L per 1,000 tokens (data center cooling estimates).',
 		'Tree equivalent represents the fraction of a single mature tree\'s annual CO₂ absorption (~21 kg/year).',


### PR DESCRIPTION
## Summary

The cost estimate (provider API rate) now shows the same value as the TBB (Token Based Billing) figure, making the estimate row redundant.

### Changes
- **Remove** the `Estimated cost (est.)` row from all UI surfaces (details panel, status bar tooltip, CLI output)
- **Rename** `TBB` → `UBB` (Usage Based Billing) everywhere:
  - VS Code extension status bar tooltip
  - Details panel table row label and tooltip
  - Chart view axis/dataset labels
  - CLI `--cost` output
  - Environmental view notes
  - Visual Studio extension compiled webview artifacts

### Files changed
- `vscode-extension/src/extension.ts` — status bar tooltip
- `vscode-extension/src/webview/details/main.ts` — details table
- `vscode-extension/src/webview/chart/main.ts` — cost chart labels
- `vscode-extension/src/webview/environmental/main.ts` — notes
- `cli/src/commands/usage.ts` — CLI cost output
- `visualstudio-extension/src/.../details.js` — compiled artifact
- `visualstudio-extension/src/.../environmental.js` — compiled artifact