### PR TITLE
diagnostics: move action buttons to top and reduce report height

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1,4 +1,4 @@
-// Diagnostics Report webview with tabbed interface
+﻿// Diagnostics Report webview with tabbed interface
 import { buttonHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
 // CSS imported as text via esbuild
@@ -1386,13 +1386,13 @@ function renderLayout(data: DiagnosticsData): void {
 						code or conversation content. You can safely share this report when reporting issues.
 					</div>
 				</div>
-				<div class="report-content">${escapedReport}</div>
-				${sessionFilesHtml}
-				<div class="button-group">
+				<div class="button-group" style="margin-bottom: 12px;">
 					<button class="button" id="btn-copy"><span>📋</span><span>Copy to Clipboard</span></button>
 					<button class="button secondary" id="btn-issue"><span>🐛</span><span>Open GitHub Issue</span></button>
 					<button class="button secondary" id="btn-clear-cache"><span>🗑️</span><span>Clear Cache</span></button>
 				</div>
+				<div class="report-content">${escapedReport}</div>
+				${sessionFilesHtml}
 			</div>
 
 			<div id="tab-sessions" class="tab-content">

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -428,7 +428,7 @@ background-position: center;
 	white-space: pre-wrap;
 	font-size: 13px;
 	overflow: auto;
-	max-height: 60vh;
+	max-height: 45vh;
 }
 
 .file-subpath {


### PR DESCRIPTION
- Move 'Copy to Clipboard', 'Open GitHub Issue', and 'Clear Cache' buttons above the report content so they are immediately visible
- Reduce report-content max-height from 60vh to 45vh to save screen real estate and expose session folder sections below