### PR TITLE
feat: team dashboard supports both Azure Storage and Team Server backends

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6040,10 +6040,8 @@ ${hashtag}`;
     }
 
     const { azureConfigured } = this.getDashboardBackendConfig();
-
     if (!azureConfigured) {
-      // Team server only — signal the webview to reload its iframe
-      this.dashboardPanel.webview.postMessage({ command: "dashboardTeamServerReload" });
+      // Team server only -- nothing to refresh (the panel is a launch card)
       return;
     }
 
@@ -6684,10 +6682,6 @@ ${hashtag}`;
     );
 
     const backendConfig = this.getDashboardBackendConfig();
-    // Allow iframe embedding of the team server URL (scoped to its origin)
-    const frameSrc = backendConfig.teamServerUrl
-      ? (() => { try { return new URL(backendConfig.teamServerUrl).origin; } catch { return null; } })()
-      : null;
 
     const csp = [
       `default-src 'none'`,
@@ -6695,7 +6689,6 @@ ${hashtag}`;
       `style-src 'unsafe-inline' ${webview.cspSource}`,
       `font-src ${webview.cspSource} https: data:`,
       `script-src 'nonce-${nonce}'`,
-      ...(frameSrc ? [`frame-src ${frameSrc}`] : []),
     ].join("; ");
 
     const dataWithBackend = data

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5938,16 +5938,8 @@ ${hashtag}`;
   public async showDashboard(): Promise<void> {
     this.log("📊 Opening Team Dashboard");
 
-    // Check if backend is configured
-    if (!this.backend) {
-      vscode.window.showWarningMessage(
-        "Team Dashboard requires backend sync to be configured. Please configure backend settings first.",
-      );
-      return;
-    }
-
-    const settings = this.backend.getSettings();
-    if (!this.backend.isConfigured(settings)) {
+    // Check if either backend is configured
+    if (!this.isBackendConfigured()) {
       vscode.window.showWarningMessage(
         "Team Dashboard requires backend sync to be configured. Please configure backend settings first.",
       );
@@ -5960,6 +5952,8 @@ ${hashtag}`;
       this.log("📊 Team Dashboard revealed (already exists)");
       return;
     }
+
+    const backendConfig = this.getDashboardBackendConfig();
 
     // Show panel immediately with loading state
     this.dashboardPanel = vscode.window.createWebviewPanel(
@@ -5992,6 +5986,11 @@ ${hashtag}`;
         case "backfillHistoricalData":
           await this.dispatch('backfillHistoricalData', () => this.handleBackfillHistoricalData());
           break;
+        case "openExternal":
+          if (typeof message.url === 'string') {
+            await vscode.env.openExternal(vscode.Uri.parse(message.url));
+          }
+          break;
       }
     });
 
@@ -6000,38 +5999,51 @@ ${hashtag}`;
       this.dashboardPanel = undefined;
     });
 
-    // If we have cached data, show it immediately so the panel renders fast
-    if (this.lastDashboardData) {
-      this.log("📊 Sending cached dashboard data immediately");
-      this.dashboardPanel.webview.postMessage({
-        command: "dashboardData",
-        data: this.lastDashboardData,
-      });
-    }
-
-    // Load (or refresh) data asynchronously and send to webview
-    try {
-      const dashboardData = await this.getDashboardData();
-      this.lastDashboardData = dashboardData;
-      this.dashboardPanel?.webview.postMessage({
-        command: "dashboardData",
-        data: dashboardData,
-      });
-    } catch (error) {
-      this.error("Failed to load dashboard data:", error);
-      // Only show error state when there's no cached data to fall back on
-      if (!this.lastDashboardData) {
-        this.dashboardPanel?.webview.postMessage({
-          command: "dashboardError",
-          message:
-            "Failed to load dashboard data. Please check backend configuration and try again.",
+    // Only load Azure data when Azure Storage is configured
+    if (backendConfig.azureConfigured) {
+      // If we have cached data, show it immediately so the panel renders fast
+      if (this.lastDashboardData) {
+        this.log("📊 Sending cached dashboard data immediately");
+        this.dashboardPanel.webview.postMessage({
+          command: "dashboardData",
+          data: this.lastDashboardData,
         });
       }
+
+      // Load (or refresh) data asynchronously and send to webview
+      try {
+        const dashboardData = await this.getDashboardData();
+        this.lastDashboardData = dashboardData;
+        this.dashboardPanel?.webview.postMessage({
+          command: "dashboardData",
+          data: dashboardData,
+        });
+      } catch (error) {
+        this.error("Failed to load dashboard data:", error);
+        // Only show error state when there's no cached data to fall back on
+        if (!this.lastDashboardData) {
+          this.dashboardPanel?.webview.postMessage({
+            command: "dashboardError",
+            message:
+              "Failed to load dashboard data. Please check backend configuration and try again.",
+          });
+        }
+      }
     }
+    // When only team server is configured, the webview renders the iframe
+    // immediately via __DASHBOARD_CONFIG__ injected in getDashboardHtml().
   }
 
   private async refreshDashboardPanel(): Promise<void> {
     if (!this.dashboardPanel) {
+      return;
+    }
+
+    const { azureConfigured } = this.getDashboardBackendConfig();
+
+    if (!azureConfigured) {
+      // Team server only — signal the webview to reload its iframe
+      this.dashboardPanel.webview.postMessage({ command: "dashboardTeamServerReload" });
       return;
     }
 
@@ -6671,12 +6683,19 @@ ${hashtag}`;
       vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "dashboard.js"),
     );
 
+    const backendConfig = this.getDashboardBackendConfig();
+    // Allow iframe embedding of the team server URL (scoped to its origin)
+    const frameSrc = backendConfig.teamServerUrl
+      ? (() => { try { return new URL(backendConfig.teamServerUrl).origin; } catch { return null; } })()
+      : null;
+
     const csp = [
       `default-src 'none'`,
       `img-src ${webview.cspSource} https: data:`,
       `style-src 'unsafe-inline' ${webview.cspSource}`,
       `font-src ${webview.cspSource} https: data:`,
       `script-src 'nonce-${nonce}'`,
+      ...(frameSrc ? [`frame-src ${frameSrc}`] : []),
     ].join("; ");
 
     const dataWithBackend = data
@@ -6685,6 +6704,7 @@ ${hashtag}`;
     const initialDataScript = dataWithBackend
       ? `<script nonce="${nonce}">window.__INITIAL_DASHBOARD__ = ${JSON.stringify(dataWithBackend).replace(/</g, "\\u003c")};</script>`
       : "";
+    const configScript = `<script nonce="${nonce}">window.__DASHBOARD_CONFIG__ = ${JSON.stringify(backendConfig).replace(/</g, "\\u003c")};</script>`;
 
     return `<!DOCTYPE html>
 		<html lang="en">
@@ -6696,6 +6716,7 @@ ${hashtag}`;
 		</head>
 		<body>
 			<div id="root"></div>
+			${configScript}
 			${initialDataScript}
 			${this.extensionPointButtonsScript(nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -6714,14 +6735,37 @@ ${hashtag}`;
   }
 
   /**
-   * Check if backend sync is configured for Team Dashboard access.
+   * Check if either Azure Storage or Team Server backend is configured for Team Dashboard access.
    */
   private isBackendConfigured(): boolean {
-    if (!this.backend) {
-      return false;
+    const { azureConfigured, teamServerConfigured } = this.getDashboardBackendConfig();
+    return azureConfigured || teamServerConfigured;
+  }
+
+  /**
+   * Returns which backends are configured and the validated team server URL.
+   * Azure is considered configured when all required Azure Storage fields are filled.
+   * Team Server is configured when enabled with a valid http/https URL.
+   */
+  private getDashboardBackendConfig(): { azureConfigured: boolean; teamServerConfigured: boolean; teamServerUrl: string } {
+    const settings = this.backend?.getSettings();
+    const azureConfigured = !!(
+      settings?.subscriptionId &&
+      settings?.resourceGroup &&
+      settings?.storageAccount &&
+      settings?.aggTable
+    );
+    const rawUrl = (settings?.sharingServerEnabled && settings?.sharingServerEndpointUrl) ? settings.sharingServerEndpointUrl : '';
+    let teamServerUrl = '';
+    if (rawUrl) {
+      try {
+        const parsed = new URL(rawUrl);
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          teamServerUrl = rawUrl;
+        }
+      } catch { /* invalid URL — leave empty */ }
     }
-    const settings = this.backend.getSettings();
-    return this.backend.isConfigured(settings);
+    return { azureConfigured, teamServerConfigured: !!teamServerUrl, teamServerUrl };
   }
 
   private getDetailsHtml(

--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -64,9 +64,16 @@ declare function acquireVsCodeApi<TState = unknown>(): {
 
 type VSCodeApi = ReturnType<typeof acquireVsCodeApi>;
 
+interface DashboardConfig {
+  azureConfigured: boolean;
+  teamServerConfigured: boolean;
+  teamServerUrl: string;
+}
+
 declare global {
   interface Window {
     __INITIAL_DASHBOARD__?: DashboardStats;
+    __DASHBOARD_CONFIG__?: DashboardConfig;
   }
 }
 
@@ -74,6 +81,9 @@ const vscode: VSCodeApi = acquireVsCodeApi();
 const initialData = window.__INITIAL_DASHBOARD__;
 console.log("[CopilotTokenTracker] dashboard webview loaded");
 console.log("[CopilotTokenTracker] initialData:", initialData);
+
+/** Active backend config, set once from __DASHBOARD_CONFIG__ during bootstrap. */
+let currentConfig: DashboardConfig | null = null;
 
 /** Reference to the loading text element so backfillProgress messages can update it in place. */
 let loadingTextEl: HTMLElement | null = null;
@@ -150,6 +160,7 @@ function render(stats: DashboardStats): void {
 
 function renderShell(root: HTMLElement, stats: DashboardStats): void {
   const lastUpdated = new Date(stats.lastUpdated);
+  const hasBothBackends = !!(currentConfig?.azureConfigured && currentConfig?.teamServerConfigured);
 
   root.replaceChildren();
 
@@ -189,7 +200,17 @@ function renderShell(root: HTMLElement, stats: DashboardStats): void {
   sections.append(buildPersonalSection(stats.personal, stats.lookbackDays ?? 30));
   sections.append(buildTeamSection(stats));
 
-  container.append(header, sections, footer);
+  if (hasBothBackends) {
+    const tabNav = buildTabNav();
+    const teamServerPanel = buildTeamServerPanel(currentConfig!.teamServerUrl);
+    teamServerPanel.style.display = "none";
+
+    container.append(header, tabNav, sections, footer, teamServerPanel);
+    wireTabNav(tabNav, sections, footer, teamServerPanel);
+  } else {
+    container.append(header, sections, footer);
+  }
+
   root.append(themeStyle, style, container);
 }
 
@@ -584,6 +605,90 @@ function renderTipHtml(tip: string): string {
 	return lines.map(line => markdownToHtml(line)).join('<br>');
 }
 
+/** Builds the tab navigation bar shown when both Azure and Team Server are configured. */
+function buildTabNav(): HTMLElement {
+  const nav = el("div", "tab-nav");
+
+  const azureTab = el("button", "tab-btn tab-btn-active", "☁️ Azure Dashboard") as HTMLButtonElement;
+  azureTab.dataset.tab = "azure";
+
+  const teamServerTab = el("button", "tab-btn", "🖥️ Team Server") as HTMLButtonElement;
+  teamServerTab.dataset.tab = "teamServer";
+
+  nav.append(azureTab, teamServerTab);
+  return nav;
+}
+
+/** Wires tab click handlers to show/hide the Azure and Team Server panels. */
+function wireTabNav(
+  tabNav: HTMLElement,
+  azureContent: HTMLElement,
+  footer: HTMLElement,
+  teamServerPanel: HTMLElement,
+): void {
+  const tabs = tabNav.querySelectorAll<HTMLButtonElement>(".tab-btn");
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      tabs.forEach((t) => t.classList.remove("tab-btn-active"));
+      tab.classList.add("tab-btn-active");
+      const isTeamServer = tab.dataset.tab === "teamServer";
+      azureContent.style.display = isTeamServer ? "none" : "";
+      footer.style.display = isTeamServer ? "none" : "";
+      teamServerPanel.style.display = isTeamServer ? "" : "none";
+    });
+  });
+}
+
+/** Builds the team server panel containing an info bar and embedded iframe. */
+function buildTeamServerPanel(url: string): HTMLElement {
+  const panel = el("div", "team-server-panel");
+
+  const infoBar = el("div", "team-server-info");
+  const urlLabel = el("span", "team-server-url-label", `🖥️ ${url}`);
+
+  const openBtn = el("button", "team-server-open-btn", "↗ Open in Browser") as HTMLButtonElement;
+  openBtn.addEventListener("click", () => {
+    vscode.postMessage({ command: "openExternal", url });
+  });
+
+  infoBar.append(urlLabel, openBtn);
+
+  const iframe = document.createElement("iframe");
+  iframe.src = url;
+  iframe.className = "team-server-iframe";
+  iframe.title = "Team Server Dashboard";
+
+  panel.append(infoBar, iframe);
+  return panel;
+}
+
+/** Shows the team-server-only full view (when Azure is not configured). */
+function showTeamServerView(url: string): void {
+  loadingTextEl = null;
+  const root = document.getElementById("root");
+  if (!root) { return; }
+
+  root.replaceChildren();
+
+  const themeStyle = document.createElement("style");
+  themeStyle.textContent = themeStyles;
+  const style = document.createElement("style");
+  style.textContent = styles;
+
+  const container = el("div", "container");
+  const header = el("div", "header");
+  const title = el("div", "title", "📊 Team Dashboard");
+  const buttonRow = el("div", "button-row");
+  buttonRow.append(createButton(BUTTONS["btn-refresh"]));
+  header.append(title, buttonRow);
+
+  const panel = buildTeamServerPanel(url);
+
+  container.append(header, panel);
+  root.append(themeStyle, style, container);
+  wireButtons();
+}
+
 function wireButtons(): void {
   document.getElementById("btn-refresh")?.addEventListener("click", () => {
     vscode.postMessage({ command: "refresh" });
@@ -633,6 +738,11 @@ window.addEventListener("message", (event) => {
     case "dashboardError":
       showError(message.message);
       break;
+    case "dashboardTeamServerReload": {
+      const iframe = document.querySelector<HTMLIFrameElement>(".team-server-iframe");
+      if (iframe) { iframe.src = iframe.src; }
+      break;
+    }
     case "backfillProgress": {
       const progressText = message.text ?? "Backfill in progress...";
       if (!loadingTextEl) {
@@ -653,8 +763,13 @@ async function bootstrap(): Promise<void> {
     await import("@vscode/webview-ui-toolkit");
   provideVSCodeDesignSystem().register(vsCodeButton());
 
+  currentConfig = window.__DASHBOARD_CONFIG__ ?? null;
+
   if (initialData) {
     render(initialData);
+  } else if (currentConfig?.teamServerConfigured && !currentConfig.azureConfigured) {
+    // Team server only — show iframe immediately, no Azure data needed
+    showTeamServerView(currentConfig.teamServerUrl);
   } else {
     showLoading();
   }

--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -639,26 +639,32 @@ function wireTabNav(
   });
 }
 
-/** Builds the team server panel containing an info bar and embedded iframe. */
+/** Builds the team server launch card (no iframe -- VS Code webviews don't share
+ *  browser cookie/session state, so OAuth-gated pages cannot be embedded). */
 function buildTeamServerPanel(url: string): HTMLElement {
   const panel = el("div", "team-server-panel");
 
-  const infoBar = el("div", "team-server-info");
-  const urlLabel = el("span", "team-server-url-label", `🖥️ ${url}`);
+  const card = el("div", "team-server-card");
 
-  const openBtn = el("button", "team-server-open-btn", "↗ Open in Browser") as HTMLButtonElement;
+  const icon = el("div", "team-server-card-icon", "🖥️");
+  const heading = el("div", "team-server-card-heading", "Team Server Dashboard");
+  const urlEl = el("div", "team-server-card-url", url);
+
+  const openBtn = el("button", "team-server-open-btn", "↗ Open Team Server in Browser") as HTMLButtonElement;
   openBtn.addEventListener("click", () => {
     vscode.postMessage({ command: "openExternal", url });
   });
 
-  infoBar.append(urlLabel, openBtn);
+  const note = el(
+    "p",
+    "team-server-card-note",
+    "The team server dashboard uses GitHub OAuth for authentication. " +
+    "VS Code webviews run in an isolated sandbox that cannot share browser sessions, " +
+    "so the dashboard opens in your default browser instead.",
+  );
 
-  const iframe = document.createElement("iframe");
-  iframe.src = url;
-  iframe.className = "team-server-iframe";
-  iframe.title = "Team Server Dashboard";
-
-  panel.append(infoBar, iframe);
+  card.append(icon, heading, urlEl, openBtn, note);
+  panel.append(card);
   return panel;
 }
 
@@ -679,7 +685,14 @@ function showTeamServerView(url: string): void {
   const header = el("div", "header");
   const title = el("div", "title", "📊 Team Dashboard");
   const buttonRow = el("div", "button-row");
-  buttonRow.append(createButton(BUTTONS["btn-refresh"]));
+  buttonRow.append(
+    createButton(BUTTONS["btn-details"]),
+    createButton(BUTTONS["btn-chart"]),
+    createButton(BUTTONS["btn-usage"]),
+    createButton(BUTTONS["btn-environmental"]),
+    createButton(BUTTONS["btn-diagnostics"]),
+    createButton(BUTTONS["btn-maturity"]),
+  );
   header.append(title, buttonRow);
 
   const panel = buildTeamServerPanel(url);
@@ -739,8 +752,7 @@ window.addEventListener("message", (event) => {
       showError(message.message);
       break;
     case "dashboardTeamServerReload": {
-      const iframe = document.querySelector<HTMLIFrameElement>(".team-server-iframe");
-      if (iframe) { iframe.src = iframe.src; }
+      // No-op: team server is now a launch card, not an iframe
       break;
     }
     case "backfillProgress": {

--- a/vscode-extension/src/webview/dashboard/styles.css
+++ b/vscode-extension/src/webview/dashboard/styles.css
@@ -461,3 +461,92 @@
 	padding-top: 8px;
 	border-top: 1px solid #2a2a30;
 }
+
+/* Tab navigation (shown when both Azure and Team Server are configured) */
+.tab-nav {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 20px;
+	border-bottom: 2px solid var(--vscode-panel-border);
+	padding-bottom: 0;
+}
+
+.tab-btn {
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -2px;
+	padding: 8px 16px;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	border-radius: 4px 4px 0 0;
+	transition: color 0.15s, background-color 0.15s;
+}
+
+.tab-btn:hover {
+	background-color: var(--vscode-list-hoverBackground);
+	color: var(--vscode-foreground);
+}
+
+.tab-btn-active {
+	color: var(--vscode-foreground);
+	border-bottom-color: var(--vscode-textLink-foreground);
+	font-weight: 600;
+}
+
+/* Team server panel */
+.team-server-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	flex: 1;
+}
+
+.team-server-info {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 8px 12px;
+	background-color: var(--vscode-editor-background);
+	border: 1px solid var(--vscode-panel-border);
+	border-bottom: none;
+	border-radius: 6px 6px 0 0;
+	font-size: 12px;
+}
+
+.team-server-url-label {
+	color: var(--vscode-descriptionForeground);
+	font-family: var(--vscode-editor-font-family);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.team-server-open-btn {
+	background: none;
+	border: 1px solid var(--vscode-button-border, transparent);
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	font-size: 12px;
+	padding: 3px 10px;
+	border-radius: 4px;
+	white-space: nowrap;
+	flex-shrink: 0;
+	transition: background-color 0.15s;
+}
+
+.team-server-open-btn:hover {
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+.team-server-iframe {
+	width: 100%;
+	height: calc(100vh - 160px);
+	min-height: 400px;
+	border: 1px solid var(--vscode-panel-border);
+	border-radius: 0 0 6px 6px;
+	background: var(--vscode-editor-background);
+}

--- a/vscode-extension/src/webview/dashboard/styles.css
+++ b/vscode-extension/src/webview/dashboard/styles.css
@@ -496,57 +496,72 @@
 	font-weight: 600;
 }
 
-/* Team server panel */
+/* Team server panel (launch card, no iframe -- OAuth sessions don't carry over) */
 .team-server-panel {
 	display: flex;
-	flex-direction: column;
-	gap: 0;
-	flex: 1;
+	justify-content: center;
+	align-items: flex-start;
+	padding: 40px 20px;
 }
 
-.team-server-info {
+.team-server-card {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
-	justify-content: space-between;
 	gap: 12px;
-	padding: 8px 12px;
+	padding: 40px 48px;
 	background-color: var(--vscode-editor-background);
 	border: 1px solid var(--vscode-panel-border);
-	border-bottom: none;
-	border-radius: 6px 6px 0 0;
-	font-size: 12px;
+	border-radius: 8px;
+	max-width: 480px;
+	width: 100%;
+	text-align: center;
 }
 
-.team-server-url-label {
-	color: var(--vscode-descriptionForeground);
+.team-server-card-icon {
+	font-size: 40px;
+	line-height: 1;
+}
+
+.team-server-card-heading {
+	font-size: 18px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.team-server-card-url {
+	font-size: 12px;
 	font-family: var(--vscode-editor-font-family);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	color: var(--vscode-textLink-foreground);
+	word-break: break-all;
+	padding: 4px 8px;
+	background: var(--vscode-list-hoverBackground);
+	border-radius: 4px;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .team-server-open-btn {
-	background: none;
-	border: 1px solid var(--vscode-button-border, transparent);
-	color: var(--vscode-textLink-foreground);
-	cursor: pointer;
-	font-size: 12px;
-	padding: 3px 10px;
+	margin-top: 4px;
+	padding: 8px 24px;
+	background-color: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	border: none;
 	border-radius: 4px;
-	white-space: nowrap;
-	flex-shrink: 0;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
 	transition: background-color 0.15s;
 }
 
 .team-server-open-btn:hover {
-	background-color: var(--vscode-list-hoverBackground);
+	background-color: var(--vscode-button-hoverBackground);
 }
 
-.team-server-iframe {
-	width: 100%;
-	height: calc(100vh - 160px);
-	min-height: 400px;
-	border: 1px solid var(--vscode-panel-border);
-	border-radius: 0 0 6px 6px;
-	background: var(--vscode-editor-background);
+.team-server-card-note {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.5;
+	margin: 4px 0 0;
+	opacity: 0.8;
 }


### PR DESCRIPTION
Previously the "Team Dashboard" button was only shown when Azure Storage was fully configured. Users with only the self-hosted Team Server set up had no way to reach the shared dashboard from within the extension.

## What changed

**Button visibility** -- `isBackendConfigured()` now checks both backends independently. The button appears in all navigation views as long as at least one of the following is true:
- Azure Storage fields (subscription, resource group, storage account, table) are all filled in
- Team Server is enabled with a valid `http`/`https` URL

**Single-backend behaviour (no breaking change)**
- Azure only: existing flow unchanged -- loads Azure aggregate data as before
- Team Server only: the dashboard panel opens and shows a launch card with the server URL and an "Open Team Server in Browser" button

**Dual-backend behaviour (new tabs)**
When both are configured, the panel shows a tab bar below the header:

| Tab | Content |
|---|---|
| ☁️ Azure Dashboard | existing Azure data view (default) |
| 🖥️ Team Server | launch card for the configured server URL |

**Why not an iframe?**
VS Code webviews run in an isolated sandbox that does not share cookies or session state with the system browser. GitHub OAuth redirects and the resulting session cookies cannot cross that boundary -- clicking "sign in" inside the embedded iframe does nothing, and completing auth in a real browser tab does not carry over. The launch card with an "Open in Browser" button is the correct UX here.

## Notable details

- **URL validation** -- `getDashboardBackendConfig()` only accepts `http`/`https` schemes; invalid URLs are silently treated as not configured.
- **Refresh** -- When only Team Server is configured, the Refresh button is a no-op (nothing to reload on a launch card). When Azure is also configured, Refresh fetches fresh Azure data regardless of the active tab.
- **CSP** -- No `frame-src` directive is needed now that the iframe is gone; the dashboard CSP is back to its original strict policy.
