### PR TITLE
chore: bump VS Code extension to v0.8.0

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,16 +6,24 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## [0.7.1] - 2026-05-11
+## [0.8.0] - 2026-05-12
 
 ### Features
-- Add diagnostic logging to Details panel creation to aid blank-panel diagnosis (#)
+- Team dashboard now supports both Azure and Team Server backends (#854)
+- Surface cached tokens from all providers in Details view (#851)
+- Extract cached tokens from Copilot Chat debug logs (#851)
+- Remove cost estimate row and rename TBB to UBB (#847)
+- Add diagnostic logging to Details panel creation to aid blank-panel diagnosis (#845)
 
 ### Bug Fixes
-- Fix PID-based liveness check to break stale cache lock after force-kill
+- Replace team server iframe with launch card (#854)
+- Use PID-based liveness check to break stale cache lock after force-kill (#844)
 
 ### Improvements
-- Exclude `stryker.config.mjs` and `vs-session-sample.json` from VSIX package
+- Move action buttons to top and reduce report height in diagnostics view (#853)
+- Sync latest model data (#852)
+- Address npm audit warning
+- Exclude `stryker.config.mjs` and `vs-session-sample.json` from VSIX package (#843)
 
 ## [0.7.0] - 2026-05-28
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep: VS Code extension v0.8.0

Minor version bump consolidating all changes since `vscode/v0.7.0`.

### Changes included

#### Features
- Team dashboard now supports both Azure and Team Server backends (#854)
- Surface cached tokens from all providers in Details view (#851)
- Extract cached tokens from Copilot Chat debug logs (#851)
- Remove cost estimate row and rename TBB to UBB (#847)
- Add diagnostic logging to Details panel creation (#845)

#### Bug Fixes
- Replace team server iframe with launch card (#854)
- Use PID-based liveness check to break stale cache lock after force-kill (#844)

#### Improvements
- Move action buttons to top and reduce report height in diagnostics view (#853)
- Sync latest model data (#852)
- Address npm audit warning
- Exclude `stryker.config.mjs` and `vs-session-sample.json` from VSIX package (#843)

### Post-merge
After merging, tag the release with `vscode/v0.8.0` to trigger the publish workflow.