### PR TITLE
Add missing friendly names for tools (fixes #858)

### DIFF
--- a/vscode-extension/src/automaticTools.json
+++ b/vscode-extension/src/automaticTools.json
@@ -129,5 +129,9 @@
   "stop_agent",
 
   "mcp_reload",
-  "mcp_validate"
+  "mcp_validate",
+
+  "add_loaded_assembly",
+  "analyze_symbol",
+  "search_decompiled_symbols"
 ]

--- a/vscode-extension/src/toolNames.json
+++ b/vscode-extension/src/toolNames.json
@@ -68,6 +68,8 @@
   ,"mcp_gitkraken_git_checkout": "GitKraken MCP: Git Checkout"
   ,"mcp_gitkraken_git_log_or_diff": "GitKraken MCP: Git Log or Diff"
   ,"mcp_gitkraken_gitkraken_workspace_list": "GitKraken MCP: List Workspaces"
+  ,"mcp_gitkraken_git_push": "GitKraken MCP: Git Push"
+  ,"mcp_gitkraken_gitlens_commit_composer": "GitKraken MCP: GitLens Commit Composer"
   ,"mcp_git_git_log": "Git MCP: Git Log"
   ,"mcp_git_git_show": "Git MCP: Git Show"
   ,"mcp_pencil_batch_design": "Pencil MCP: Batch Design"
@@ -534,4 +536,7 @@
   ,"mcp_ado-remote-mc_wit_work_item_link_write": "Azure DevOps MCP: Work Item Link Write"
   ,"mcp_ado-remote-mc_wit_work_item_write": "Azure DevOps MCP: Work Item Write"
   ,"mssql_list_servers": "MSSQL: List Servers"
+  ,"add_loaded_assembly": "Add Loaded Assembly"
+  ,"analyze_symbol": "Analyze Symbol"
+  ,"search_decompiled_symbols": "Search Decompiled Symbols"
 }


### PR DESCRIPTION
## Summary

Adds friendly display names for 5 missing tools detected in session logs, resolving #858.

### Tools Added to `toolNames.json`

| Tool ID | Friendly Name | Type |
|---|---|---|
| `mcp_gitkraken_git_push` | GitKraken MCP: Git Push | MCP |
| `mcp_gitkraken_gitlens_commit_composer` | GitKraken MCP: GitLens Commit Composer | MCP |
| `add_loaded_assembly` | Add Loaded Assembly | .NET analysis |
| `analyze_symbol` | Analyze Symbol | .NET analysis |
| `search_decompiled_symbols` | Search Decompiled Symbols | .NET analysis |

The three .NET analysis tools were also added to `automaticTools.json` since they are background context-gathering tools used by the agent.

### Validation
- ✅ JSON valid
- ✅ `npm run compile` passes
- ✅ All 51 test suites pass

Fixes: #858