### PR TITLE
Add missing friendly names for tools (fixes #862)

### DIFF
--- a/vscode-extension/src/toolNames.json
+++ b/vscode-extension/src/toolNames.json
@@ -549,4 +549,8 @@
   ,"mcp_gitnexus_list_repos": "GitNexus MCP: List Repos"
   ,"mcp_gitnexus_query": "GitNexus MCP: Query"
   ,"slidev_getSlideContent": "Slidev: Get Slide Content"
+  ,"mcp__GitLab__get_mcp_server_version": "GitLab MCP: Get MCP Server Version"
+  ,"mcp__plugin_figma_figma__get_design_context": "Figma MCP: Get Design Context"
+  ,"mcp__plugin_figma_figma__get_metadata": "Figma MCP: Get Metadata"
+  ,"mcp__plugin_figma_figma__get_screenshot": "Figma MCP: Get Screenshot"
 }


### PR DESCRIPTION
## Summary

Adds friendly display names for 4 unknown tools detected in session logs, as requested in #862.

### Tools Added to `toolNames.json`

| Raw Tool ID | Friendly Name |
|---|---|
| `mcp__GitLab__get_mcp_server_version` | GitLab MCP: Get MCP Server Version |
| `mcp__plugin_figma_figma__get_design_context` | Figma MCP: Get Design Context |
| `mcp__plugin_figma_figma__get_metadata` | Figma MCP: Get Metadata |
| `mcp__plugin_figma_figma__get_screenshot` | Figma MCP: Get Screenshot |

### Notes
- Not added to `automaticTools.json` — all 4 are MCP tools requiring explicit user configuration
- Figma plugin tools follow existing patterns (similar to `mcp_figma_*` entries)
- GitLab tool is a new MCP server prefix (`mcp__GitLab__`)

### Validation
- ✅ JSON is valid
- ✅ TypeScript compilation passes
- ✅ All node tests pass

Fixes: #862