### PR TITLE
Add friendly name for mcp_io_github_git_get_job_logs tool

### DIFF
--- a/vscode-extension/src/toolNames.json
+++ b/vscode-extension/src/toolNames.json
@@ -25,6 +25,7 @@
   ,"mcp_io_github_git_list_commits": "GitHub MCP (Local): List Commits"
   ,"mcp_io_github_git_list_code_scanning_alerts": "GitHub MCP (Local): List Code Scanning Alerts"
   ,"mcp_io_github_git_get_repository_tree": "GitHub MCP (Local): Get Repository Tree"
+  ,"mcp_io_github_git_get_job_logs": "GitHub MCP (Local): Get Job Logs"
   ,"mcp_io_github_git_list_tags": "GitHub MCP (Local): List Tags"
   ,"mcp_io_github_git_search_repositories": "GitHub MCP (Local): Search Repositories"
   ,"mcp_io_github_git_create_repository": "GitHub MCP (Local): Create Repository"


### PR DESCRIPTION
Closes #863

## Changes
- Added friendly display name `"GitHub MCP (Local): Get Job Logs"` for `mcp_io_github_git_get_job_logs` in `vscode-extension/src/toolNames.json`

## Validation
- ✅ JSON valid
- ✅ TypeScript compilation passes
- ✅ ESLint passes
- ✅ All 53 unit tests pass