### PR TITLE
feat: add SLM-powered job to generate friendly tool names from issues

### DIFF
--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -315,29 +315,31 @@ jobs:
           )
           tool_ids_json = json.dumps(missing_tools, indent=2)
 
-          prompt = f"""Convert each tool ID in the INPUT array to a friendly display name.
-
-RULES:
-- Replace _, -, . with spaces; split camelCase (readFile -> read File)
-- Title Case all words
-- Keep ALL CAPS: MCP, GITHUB, API, URL, JSON, HTTP, HTTPS, CLI, UI, IO, ID, VSCODE
-- MCP prefix mappings (strip prefix, format action, combine):
-  mcp_io_github_git_ -> "GitHub MCP (Local): <action>"
-  mcp_github_github_ -> "GitHub MCP (Remote): <action>"
-  mcp_microsoft_pla_ -> "Playwright MCP: <action>"
-  mcp_oraios_serena_ -> "Serena: <action>"
-  mcp_gitkraken_ -> "GitKraken MCP: <action>"
-  mcp_io_github_ups_ -> "Context7 MCP: <action>"
-  mcp_microsoftdocs_microsoft_ -> "Microsoft Docs MCP: <action>"
-  other mcp_* -> derive server name from identifier
-
-EXISTING MAPPINGS (follow these patterns):
-{sample_lines}
-
-INPUT:
-{tool_ids_json}
-
-OUTPUT: JSON object only, no explanation."""
+          prompt = "\n".join([
+              "Convert each tool ID in the INPUT array to a friendly display name.",
+              "",
+              "RULES:",
+              "- Replace _, -, . with spaces; split camelCase (readFile -> read File)",
+              "- Title Case all words",
+              "- Keep ALL CAPS: MCP, GITHUB, API, URL, JSON, HTTP, HTTPS, CLI, UI, IO, ID, VSCODE",
+              "- MCP prefix mappings (strip prefix, format action, combine):",
+              '  mcp_io_github_git_ -> "GitHub MCP (Local): <action>"',
+              '  mcp_github_github_ -> "GitHub MCP (Remote): <action>"',
+              '  mcp_microsoft_pla_ -> "Playwright MCP: <action>"',
+              '  mcp_oraios_serena_ -> "Serena: <action>"',
+              '  mcp_gitkraken_ -> "GitKraken MCP: <action>"',
+              '  mcp_io_github_ups_ -> "Context7 MCP: <action>"',
+              '  mcp_microsoftdocs_microsoft_ -> "Microsoft Docs MCP: <action>"',
+              "  other mcp_ prefix -> derive server name from identifier",
+              "",
+              "EXISTING MAPPINGS (follow these patterns):",
+              sample_lines,
+              "",
+              "INPUT:",
+              tool_ids_json,
+              "",
+              "OUTPUT: JSON object only, no explanation.",
+          ])
 
           payload = {{
               "model": "qwen2.5:1.5b",

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   # Checks each tool name in the issue body against src/toolNames.json on main
   # and posts a comment with the status of each one.
+  # Trigger: label "Toolnames checkup"
   check-toolnames:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'Toolnames checkup'
@@ -163,3 +164,402 @@ jobs:
               --body-file /tmp/toolnames-comment.md
           
           echo "✅ Comment posted successfully"
+
+  # Uses a local SLM (Qwen2.5-1.5B via Ollama) to generate friendly names for
+  # tool IDs that are missing from toolNames.json, then opens a PR with the
+  # new entries. The model is cached between runs to avoid re-downloading.
+  # Trigger: label "add-toolnames"
+  add-toolnames-with-slm:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'add-toolnames'
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout main branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate issue body for hidden content
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TEXT: ${{ github.event.issue.body }}
+          ITEM_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          CONTEXT_TYPE: issue
+          FINDINGS_FILE: /tmp/validation-findings.txt
+        run: bash .github/workflows/validate-input.sh
+
+      - name: Extract missing tool names
+        id: extract
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          python3 - << 'PYEOF'
+          import json, os, re, sys
+
+          issue_body = os.environ.get("ISSUE_BODY", "")
+          MAX_BODY_LEN = 100_000
+          if len(issue_body) > MAX_BODY_LEN:
+              issue_body = issue_body[:MAX_BODY_LEN]
+              print("Warning: issue body truncated", file=sys.stderr)
+
+          # Extract backtick-wrapped strings; apply strict allowlist to prevent
+          # any user-controlled text from being forwarded raw to the model.
+          # Only accept characters valid in tool identifiers.
+          raw_matches = re.findall(r'`([^`\n]+)`', issue_body)
+          TOOL_ID_RE = re.compile(r'^[a-zA-Z0-9_.:\-]{1,128}$')
+          tools = sorted(set(
+              m for m in raw_matches
+              if TOOL_ID_RE.match(m)
+          ))
+          print(f"Candidate tools: {tools}", file=sys.stderr)
+
+          with open("vscode-extension/src/toolNames.json") as f:
+              known_tools = json.load(f)
+
+          missing = []
+          for tool in tools:
+              if tool not in known_tools:
+                  lower = tool.lower()
+                  case_match = next((k for k in known_tools if k.lower() == lower), None)
+                  if not case_match:
+                      missing.append(tool)
+
+          print(f"Missing tools: {missing}", file=sys.stderr)
+          with open("/tmp/missing-tools.json", "w") as f:
+              json.dump(missing, f)
+
+          has_missing = "true" if missing else "false"
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"has_missing={has_missing}\n")
+              f.write(f"missing_count={len(missing)}\n")
+          PYEOF
+
+      - name: Cache Ollama models
+        if: steps.extract.outputs.has_missing == 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.ollama/models
+          key: ollama-${{ runner.os }}-qwen2.5-1.5b-v1
+          restore-keys: ollama-${{ runner.os }}-qwen2.5-1.5b-
+
+      - name: Install Ollama
+        if: steps.extract.outputs.has_missing == 'true'
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start Ollama and ensure model is available
+        if: steps.extract.outputs.has_missing == 'true'
+        run: |
+          export OLLAMA_MODELS="$HOME/.ollama/models"
+          ollama serve &
+          echo "Waiting for Ollama to be ready..."
+          for i in {1..30}; do
+            if curl -fsS http://localhost:11434/api/tags >/dev/null 2>&1; then
+              echo "Ollama is ready (attempt $i)"
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://localhost:11434/api/tags >/dev/null
+          if ! ollama list 2>/dev/null | grep -q "qwen2.5:1.5b"; then
+            echo "Pulling qwen2.5:1.5b model..."
+            ollama pull qwen2.5:1.5b
+          else
+            echo "Model qwen2.5:1.5b already available in cache"
+          fi
+
+      - name: Generate friendly names with SLM
+        if: steps.extract.outputs.has_missing == 'true'
+        env:
+          TOOLNAMES_JSON: vscode-extension/src/toolNames.json
+        run: |
+          python3 - << 'PYEOF'
+          import json, re, sys, urllib.request, urllib.error, os
+
+          with open("/tmp/missing-tools.json") as f:
+              missing_tools = json.load(f)
+
+          with open(os.environ["TOOLNAMES_JSON"]) as f:
+              known_tools = json.load(f)
+
+          # Build a representative sample of existing mappings for context.
+          # Only use data from the known-good JSON file, never from the issue body.
+          sample_entries = {}
+          mcp_local, mcp_remote, plain = 0, 0, 0
+          for k, v in known_tools.items():
+              if k == "unknown":
+                  continue
+              if "mcp_io_github_git_" in k and mcp_local < 3:
+                  sample_entries[k] = v; mcp_local += 1
+              elif "mcp_github_github_" in k and mcp_remote < 2:
+                  sample_entries[k] = v; mcp_remote += 1
+              elif not k.startswith("mcp") and plain < 4:
+                  sample_entries[k] = v; plain += 1
+              if mcp_local >= 3 and mcp_remote >= 2 and plain >= 4:
+                  break
+
+          sample_lines = "\n".join(
+              f'{json.dumps(k)} -> {json.dumps(v)}'
+              for k, v in sample_entries.items()
+          )
+          tool_ids_json = json.dumps(missing_tools, indent=2)
+
+          prompt = f"""Convert each tool ID in the INPUT array to a friendly display name.
+
+RULES:
+- Replace _, -, . with spaces; split camelCase (readFile -> read File)
+- Title Case all words
+- Keep ALL CAPS: MCP, GITHUB, API, URL, JSON, HTTP, HTTPS, CLI, UI, IO, ID, VSCODE
+- MCP prefix mappings (strip prefix, format action, combine):
+  mcp_io_github_git_ -> "GitHub MCP (Local): <action>"
+  mcp_github_github_ -> "GitHub MCP (Remote): <action>"
+  mcp_microsoft_pla_ -> "Playwright MCP: <action>"
+  mcp_oraios_serena_ -> "Serena: <action>"
+  mcp_gitkraken_ -> "GitKraken MCP: <action>"
+  mcp_io_github_ups_ -> "Context7 MCP: <action>"
+  mcp_microsoftdocs_microsoft_ -> "Microsoft Docs MCP: <action>"
+  other mcp_* -> derive server name from identifier
+
+EXISTING MAPPINGS (follow these patterns):
+{sample_lines}
+
+INPUT:
+{tool_ids_json}
+
+OUTPUT: JSON object only, no explanation."""
+
+          payload = {{
+              "model": "qwen2.5:1.5b",
+              "prompt": prompt,
+              "format": "json",
+              "stream": False,
+              "options": {{"temperature": 0, "seed": 42}}
+          }}
+
+          print("=== Calling Ollama API ===", file=sys.stderr)
+          req = urllib.request.Request(
+              "http://localhost:11434/api/generate",
+              data=json.dumps(payload).encode(),
+              headers={{"Content-Type": "application/json"}}
+          )
+
+          try:
+              with urllib.request.urlopen(req, timeout=180) as resp:
+                  data = json.loads(resp.read())
+              raw_response = data.get("response", "{{}}")
+              print(f"=== SLM response ===\n{{raw_response}}", file=sys.stderr)
+
+              try:
+                  generated = json.loads(raw_response)
+              except json.JSONDecodeError:
+                  m = re.search(r'\{{[^{{}}]*\}}', raw_response, re.DOTALL)
+                  generated = json.loads(m.group(0)) if m else {{}}
+
+              # Only keep entries for the tool IDs we asked about; sanitize values.
+              validated = {{}}
+              for tool in missing_tools:
+                  friendly = str(generated.get(tool, "")).strip()
+                  if not friendly or len(friendly) > 200:
+                      # Local fallback transformation
+                      s = re.sub(r'[_\-.]', ' ', tool)
+                      s = re.sub(r'([a-z])([A-Z])', r'\1 \2', s)
+                      friendly = s.title()
+                  validated[tool] = friendly
+
+              print("=== Validated names ===", file=sys.stderr)
+              for k, v in validated.items():
+                  print(f"  {{k!r}} -> {{v!r}}", file=sys.stderr)
+
+              with open("/tmp/slm-names.json", "w") as f:
+                  json.dump(validated, f, indent=2)
+              print("✅ SLM generation complete", file=sys.stderr)
+
+          except Exception as e:
+              print(f"❌ SLM error: {{e}}", file=sys.stderr)
+              import traceback; traceback.print_exc(file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+
+      - name: Update toolNames.json with new entries
+        if: steps.extract.outputs.has_missing == 'true'
+        run: |
+          python3 - << 'PYEOF'
+          import json, re, sys
+
+          TOOLNAMES_FILE = "vscode-extension/src/toolNames.json"
+
+          with open("/tmp/slm-names.json") as f:
+              new_entries = json.load(f)
+
+          if not new_entries:
+              print("No new entries to add.", file=sys.stderr)
+              sys.exit(0)
+
+          with open(TOOLNAMES_FILE) as f:
+              content = f.read()
+          known_tools = json.loads(content)
+
+          # Deduplicate: skip anything already present (case-insensitive)
+          to_add = {}
+          for tool_id, friendly_name in new_entries.items():
+              if tool_id in known_tools:
+                  print(f"Skipping {tool_id!r} — already present", file=sys.stderr)
+                  continue
+              if any(k.lower() == tool_id.lower() for k in known_tools):
+                  print(f"Skipping {tool_id!r} — case variant present", file=sys.stderr)
+                  continue
+              to_add[tool_id] = friendly_name
+
+          if not to_add:
+              print("All entries already present after dedup. Nothing to write.", file=sys.stderr)
+              sys.exit(0)
+
+          lines = content.splitlines(keepends=True)
+
+          MCP_PREFIXES = [
+              "mcp_io_github_git_", "mcp_github_github_", "mcp_github-code",
+              "mcp_github_", "github-mcp-server-", "github-", "mcp_microsoft_pla_",
+              "mcp_oraios_serena_", "mcp_gitkraken_", "mcp_io_github_ups_",
+              "mcp_microsoftdocs_", "mcp_",
+          ]
+
+          def get_prefix(tool_id):
+              for p in MCP_PREFIXES:
+                  if tool_id.startswith(p):
+                      return p
+              return ""
+
+          def find_last_line_with_prefix(lines, prefix):
+              last_idx = -1
+              for i, line in enumerate(lines):
+                  m = re.search(r'"([^"]+)":', line)
+                  if m and m.group(1).startswith(prefix):
+                      last_idx = i
+              return last_idx
+
+          def find_closing_brace(lines):
+              for i in range(len(lines) - 1, -1, -1):
+                  if lines[i].strip() == "}":
+                      return i
+              return len(lines) - 1
+
+          for tool_id, friendly_name in to_add.items():
+              entry_line = f"  ,{json.dumps(tool_id)}: {json.dumps(friendly_name)}\n"
+              prefix = get_prefix(tool_id)
+              insert_after = find_last_line_with_prefix(lines, prefix) if prefix else -1
+              if insert_after == -1:
+                  insert_after = find_closing_brace(lines) - 1
+              lines.insert(insert_after + 1, entry_line)
+              print(f"Inserted {tool_id!r} -> {friendly_name!r} after line {insert_after + 1}", file=sys.stderr)
+
+          new_content = "".join(lines)
+          try:
+              json.loads(new_content)
+          except json.JSONDecodeError as e:
+              print(f"❌ JSON validation failed after insertion: {e}", file=sys.stderr)
+              sys.exit(1)
+
+          with open(TOOLNAMES_FILE, "w") as f:
+              f.write(new_content)
+          print(f"✅ Wrote {len(to_add)} new entries to toolNames.json", file=sys.stderr)
+          PYEOF
+
+      - name: Create Pull Request
+        if: steps.extract.outputs.has_missing == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          branch: add-toolnames/issue-${{ github.event.issue.number }}
+          add-paths: vscode-extension/src/toolNames.json
+          commit-message: |
+            feat: add friendly names from issue #${{ github.event.issue.number }}
+
+            Generated by Qwen2.5-1.5B SLM from tool names in issue #${{ github.event.issue.number }}.
+
+            Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+          title: "feat: add ${{ steps.extract.outputs.missing_count }} friendly tool name(s) from issue #${{ github.event.issue.number }}"
+          body: |
+            Adds friendly names for tool ID(s) identified in issue #${{ github.event.issue.number }}.
+
+            Generated using **Qwen2.5-1.5B** running locally on the GitHub Actions runner (no Copilot tokens used).
+
+            **Review checklist before merging:**
+            - [ ] Verify each generated friendly name looks correct
+            - [ ] Check if any new tools should also be added to `vscode-extension/src/automaticTools.json`
+
+            Closes #${{ github.event.issue.number }}
+          labels: autogenerated,toolnames
+
+      - name: Post result comment on issue
+        if: always() && steps.extract.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          HAS_MISSING: ${{ steps.extract.outputs.has_missing }}
+        run: |
+          python3 - << 'PYEOF'
+          import json, os
+
+          pr_url    = os.environ.get("PR_URL", "")
+          has_missing = os.environ.get("HAS_MISSING", "false")
+          run_id    = os.environ.get("RUN_ID", "")
+          server_url = os.environ.get("SERVER_URL", "https://github.com")
+          repo      = os.environ.get("REPO", "")
+
+          def esc(s):
+              return str(s).replace("|", "\\|").replace("`", "\\`")
+
+          if has_missing != "true":
+              comment = (
+                  "## 🤖 Add Toolnames (SLM)\n\n"
+                  "✅ All tool names in this issue are already mapped in `toolNames.json`. Nothing to add.\n"
+              )
+          else:
+              slm_path = "/tmp/slm-names.json"
+              names = json.load(open(slm_path)) if os.path.exists(slm_path) else {}
+
+              lines = [
+                  "## 🤖 Add Toolnames (SLM)",
+                  "",
+                  "Generated friendly names using **Qwen2.5-1.5B** running locally on the GitHub Actions runner:",
+                  "",
+                  "| Tool ID | Generated Friendly Name |",
+                  "| --- | --- |",
+              ]
+              for tool_id, friendly in names.items():
+                  lines.append(f"| `{esc(tool_id)}` | {esc(friendly)} |")
+              lines.append("")
+              if pr_url:
+                  lines.append(f"➡️ **[Review PR]({pr_url})** — verify the names look right before merging.")
+                  lines.append("")
+                  lines.append("> ⚠️ Also check whether any of these tools should be added to `automaticTools.json`.")
+              else:
+                  lines.append("> ℹ️ No PR was opened (either no changes were needed or generation failed).")
+              lines.append("")
+              lines.append(f"_Workflow run: {server_url}/{repo}/actions/runs/{run_id}_")
+              comment = "\n".join(lines)
+
+          with open("/tmp/slm-comment.md", "w") as f:
+              f.write(comment)
+          PYEOF
+
+          gh issue comment "$ISSUE_NUMBER" \
+              --repo "$REPO" \
+              --body-file /tmp/slm-comment.md
+
+          echo "✅ Issue comment posted"


### PR DESCRIPTION
## Summary

Adds a new `add-toolnames-with-slm` job to `.github/workflows/check-toolnames.yml`. When an issue is labeled **`add-toolnames`**, this job:

1. Extracts backtick-wrapped tool IDs from the issue body (strict allowlist: `^[a-zA-Z0-9_.:\-]{1,128}$`)
2. Finds which ones are **missing** from `toolNames.json`
3. Uses **Qwen2.5-1.5B via Ollama** to generate friendly display names — running entirely on the GitHub Actions runner, no Copilot tokens used
4. Inserts the new entries into `toolNames.json` (with prefix grouping + JSON validation)
5. Opens a PR with the updated file
6. Posts a result table as a comment on the original issue

## Model caching

The ~1 GB Qwen2.5-1.5B model is cached in `~/.ollama/models` between runs using `actions/cache@v4.2.3`, keyed to `ollama-${{ runner.os }}-qwen2.5-1.5b-v1`. After the first run, the model is served directly from cache — no re-download.

## Architecture

| Concern | Handled by |
|---|---|
| Parse issue body, find missing tools | Python script |
| Generate friendly names | SLM (Qwen2.5-1.5B) |
| Insert into JSON, validate, commit | Python script |
| Create PR + post comment | `peter-evans/create-pull-request` + `gh` CLI |

## Security

- All user-provided input validated by `validate-input.sh` before processing
- Tool IDs filtered through strict allowlist regex — raw issue body is never forwarded to the model
- Only tool IDs from the allowlist are included in the SLM prompt; prompt contains only static rules + data from the trusted `toolNames.json`

## Review checklist

- [ ] The existing `check-toolnames` job is untouched
- [ ] The `add-toolnames` label needs to be created in the repo
- [ ] New entries may also need to be added to `automaticTools.json` (noted in the generated PR body)