### PR TITLE
feat: add oh-my-posh segment command and Copilot CLI statusline support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -17,6 +17,18 @@ npm run cli:environmental   # Run environmental command
 npm run cli:fluency         # Run fluency command
 npm run cli:diagnostics     # Run diagnostics command
 npm run cli -- --help       # Run any CLI command
+npm run cli -- segment      # Output compact token string for oh-my-posh
+```
+
+### oh-my-posh segment
+
+The `segment` command outputs a compact token usage string designed for use in shell prompts.
+See [`../omp-segment/README.md`](../omp-segment/README.md) for full setup instructions.
+
+```bash
+node dist/cli.js segment            # Use 15-minute cache (default)
+node dist/cli.js segment --refresh  # Force refresh, bypass cache
+node dist/cli.js segment --hide-zero  # Output nothing when both counts are zero
 ```
 
 ## Requirements

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -13,6 +13,7 @@ import { diagnosticsCommand } from './commands/diagnostics';
 import { chartCommand } from './commands/chart';
 import { usageAnalysisCommand } from './commands/usage-analysis';
 import { allCommand } from './commands/all';
+import { segmentCommand } from './commands/segment';
 import { loadCache, saveCache, disableCache } from './helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -46,5 +47,6 @@ program.addCommand(diagnosticsCommand);
 program.addCommand(chartCommand);
 program.addCommand(usageAnalysisCommand);
 program.addCommand(allCommand);
+program.addCommand(segmentCommand);
 
 program.parse();

--- a/cli/src/commands/segment.ts
+++ b/cli/src/commands/segment.ts
@@ -1,0 +1,118 @@
+/**
+ * `segment` command - Output a compact token usage string for oh-my-posh.
+ *
+ * Maintains its own short-lived file cache (~/.copilot-token-tracker/omp-segment-cache.json)
+ * so that repeated prompt renders return immediately without re-parsing session files.
+ * The session file cache (cli-cache.json) is loaded automatically via the preAction hook
+ * in cli.ts, so a cache miss here still benefits from the parsed-session cache.
+ */
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { discoverSessionFiles, calculateDetailedStats, formatTokens } from '../helpers';
+
+const SEGMENT_CACHE_DIR = path.join(os.homedir(), '.copilot-token-tracker');
+const SEGMENT_CACHE_PATH = path.join(SEGMENT_CACHE_DIR, 'omp-segment-cache.json');
+const DEFAULT_TTL_MINUTES = 15;
+
+interface SegmentCacheFile {
+	updatedAt: string;
+	formatted: string;
+	todayTokens: number;
+	last30DaysTokens: number;
+}
+
+/** Read the segment output cache. Returns null on miss, expiry, or corrupt data. */
+function readSegmentCache(ttlMinutes: number): SegmentCacheFile | null {
+	try {
+		if (!fs.existsSync(SEGMENT_CACHE_PATH)) { return null; }
+		const data: SegmentCacheFile = JSON.parse(fs.readFileSync(SEGMENT_CACHE_PATH, 'utf-8'));
+
+		// Validate shape before trusting any values
+		if (
+			typeof data.formatted !== 'string' ||
+			typeof data.updatedAt !== 'string' ||
+			typeof data.todayTokens !== 'number' ||
+			typeof data.last30DaysTokens !== 'number'
+		) {
+			return null;
+		}
+
+		const updatedMs = Date.parse(data.updatedAt);
+		if (!Number.isFinite(updatedMs)) { return null; }
+
+		const ageMs = Date.now() - updatedMs;
+		// Reject negative ages (clock skew) and expired entries
+		if (ageMs < 0 || ageMs > ttlMinutes * 60_000) { return null; }
+
+		return data;
+	} catch {
+		return null;
+	}
+}
+
+/** Persist the segment output to the cache file. Best-effort — never throws. */
+function writeSegmentCache(entry: SegmentCacheFile): void {
+	try {
+		fs.mkdirSync(SEGMENT_CACHE_DIR, { recursive: true });
+		fs.writeFileSync(SEGMENT_CACHE_PATH, JSON.stringify(entry), 'utf-8');
+	} catch {
+		// Best-effort: cache write failures must not crash the prompt
+	}
+}
+
+export const segmentCommand = new Command('segment')
+	.description('Output a compact token usage string for use in oh-my-posh prompt segments')
+	.option('--ttl <minutes>', `Segment cache TTL in minutes (default: ${DEFAULT_TTL_MINUTES})`, `${DEFAULT_TTL_MINUTES}`)
+	.option('--refresh', 'Force refresh — bypass the segment output cache')
+	.option('--hide-zero', 'Output nothing when both today and 30-day token counts are zero')
+	.action(async (options) => {
+		const parsedTtl = Number(options.ttl);
+		const ttl = Number.isFinite(parsedTtl) && parsedTtl >= 0 ? parsedTtl : DEFAULT_TTL_MINUTES;
+
+		// Fast path: serve from the segment output cache when still fresh
+		if (!options.refresh) {
+			const cached = readSegmentCache(ttl);
+			if (cached) {
+				if (options.hideZero && cached.todayTokens === 0 && cached.last30DaysTokens === 0) {
+					return;
+				}
+				process.stdout.write(cached.formatted);
+				return;
+			}
+		}
+
+		// Cache miss — discover files and compute stats
+		// (The preAction hook in cli.ts has already loaded the session file cache)
+		const files = await discoverSessionFiles();
+		let todayTokens = 0;
+		let last30DaysTokens = 0;
+
+		if (files.length > 0) {
+			const stats = await calculateDetailedStats(files);
+			todayTokens = stats.today.tokens;
+			last30DaysTokens = stats.last30Days.tokens;
+		}
+
+		if (options.hideZero && todayTokens === 0 && last30DaysTokens === 0) {
+			writeSegmentCache({
+				updatedAt: new Date().toISOString(),
+				formatted: '',
+				todayTokens,
+				last30DaysTokens,
+			});
+			return;
+		}
+
+		const formatted = `${formatTokens(todayTokens)} today · ${formatTokens(last30DaysTokens)} 30d`;
+
+		writeSegmentCache({
+			updatedAt: new Date().toISOString(),
+			formatted,
+			todayTokens,
+			last30DaysTokens,
+		});
+
+		process.stdout.write(formatted);
+	});

--- a/omp-segment/README.md
+++ b/omp-segment/README.md
@@ -272,6 +272,131 @@ If you'd like to contribute this as a **native Go segment** to the oh-my-posh pr
 
 ---
 
+## GitHub Copilot CLI Statusline (Experimental)
+
+GitHub Copilot CLI has an experimental `STATUS_LINE` feature that calls a local command and renders its output at the bottom of the Copilot terminal UI. This folder includes ready-to-use scripts that combine the standard Copilot session data (context tokens, session duration, line changes) with your total daily / 30-day token usage from `ai-engineering-fluency`.
+
+> **Credit:** Setup pattern from [Scott Hanselman's gist](https://gist.github.com/shanselman/9623ac74888a07ba82f63f5310fda11b).
+
+Example statusline:
+
+```
+main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 1443.5M 30d
+```
+
+### Files
+
+| File | Purpose |
+|---|---|
+| [`statusline.cmd`](./statusline.cmd) | Windows wrapper — points `statusLine.command` at the PowerShell script |
+| [`statusline.ps1`](./statusline.ps1) | Reads Copilot's JSON stdin, sets env vars, calls `ai-engineering-fluency segment`, renders via oh-my-posh |
+| [`statusline.omp.json`](./statusline.omp.json) | Compact oh-my-posh theme — git, context gauge, duration, changes, token totals |
+
+### Requirements
+
+In addition to the [prerequisites above](#prerequisites):
+
+- **GitHub Copilot CLI** with the experimental `STATUS_LINE` feature flag
+- **oh-my-posh** available on `PATH` (`oh-my-posh version` should return output)
+
+### Setup
+
+#### Step 1 — Copy the files to your Copilot folder
+
+```powershell
+$dest = "$env:USERPROFILE\.copilot"
+New-Item -ItemType Directory -Force $dest | Out-Null
+
+# Adjust the source path to match where you cloned this repo
+$src = "path\to\ai-engineering-fluency\omp-segment"
+Copy-Item "$src\statusline.cmd"      $dest
+Copy-Item "$src\statusline.ps1"      $dest
+Copy-Item "$src\statusline.omp.json" $dest
+```
+
+#### Step 2 — Edit `%USERPROFILE%\.copilot\settings.json`
+
+Create or update the file (replace `YOURUSER` with your Windows username):
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "C:\\Users\\YOURUSER\\.copilot\\statusline.cmd",
+    "padding": 1
+  },
+  "feature_flags": {
+    "enabled": ["STATUS_LINE"]
+  },
+  "experimental": true
+}
+```
+
+If you already have a `feature_flags.enabled` array, **add** `"STATUS_LINE"` to it instead of replacing the array.
+
+#### Step 3 — Restart Copilot CLI
+
+```
+/restart
+```
+
+### Test Without Copilot
+
+Pipe a sample JSON payload directly to the command to verify output before wiring it into Copilot:
+
+```powershell
+@'
+{
+  "cwd": "C:\\src\\my-repo",
+  "context_window": {
+    "current_context_tokens": 123456,
+    "displayed_context_limit": 200000,
+    "current_context_used_percentage": 61.7
+  },
+  "cost": {
+    "total_duration_ms": 754000,
+    "total_lines_added": 42,
+    "total_lines_removed": 8
+  }
+}
+'@ | & "$env:USERPROFILE\.copilot\statusline.cmd"
+```
+
+Expected output (appearance depends on your Nerd Font):
+
+```
+main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 1443.5M 30d
+```
+
+### Customising the Theme
+
+Open `%USERPROFILE%\.copilot\statusline.omp.json` to adjust colours, icons, or segments.
+
+To use Nerd Font glyphs instead of plain ASCII separators, replace the diamond and powerline values:
+
+```json
+"leading_diamond": "\ue0b6",
+"trailing_diamond": "\ue0b0",
+"powerline_symbol": "\ue0b0"
+```
+
+> **Keep the theme small.** The statusline must render quickly — remove any segment that makes network calls or scans large directories.
+
+### How the Token Cache Works Here
+
+In the standard shell prompt setup, oh-my-posh's segment-level `cache` block prevents calling the CLI on every keystroke. That OMP cache **does not apply** in the Copilot CLI statusline context — each Copilot status refresh calls the script fresh.
+
+What does help is the CLI's own segment cache (`~/.copilot-token-tracker/omp-segment-cache.json`, default 15-minute TTL). After the first call, subsequent statusline renders return the cached value in ~150 ms instead of the full ~7 s cold parse.
+
+Tune the TTL with the `--ttl` flag inside `statusline.ps1` if you want more or less freshness:
+
+```powershell
+# Inside statusline.ps1 — change the ai-engineering-fluency segment call:
+$tokenOutput = & ai-engineering-fluency segment --ttl 5 2>$null   # refresh every 5 min
+```
+
+---
+
 ## Related
 
 - [AI Engineering Fluency CLI docs](../docs/cli/README.md)

--- a/omp-segment/README.md
+++ b/omp-segment/README.md
@@ -1,0 +1,280 @@
+# Oh-My-Posh Token Usage Segment
+
+Display your AI token usage (today and last 30 days) directly in your terminal prompt, powered by the [`@rajbos/ai-engineering-fluency`](https://www.npmjs.com/package/@rajbos/ai-engineering-fluency) CLI.
+
+Example output in your prompt:
+
+```
+ 󱊤 1.2K today · 45.3K 30d 
+```
+
+The segment reads **local session files** on your machine — no internet connection or API token required. It tracks tokens from VS Code Copilot Chat, Claude Code, Gemini CLI, OpenCode, and [all other supported editors](../cli/README.md).
+
+---
+
+## How It Works
+
+The CLI's `segment` command outputs a compact formatted string. Oh-my-posh calls it via the `{{ cmd }}` template helper and caches the result, so your prompt stays fast.
+
+Two caches work together:
+| Cache | Location | TTL | Purpose |
+|---|---|---|---|
+| **Oh-my-posh segment cache** | in-memory, per shell session | 5 min (configurable) | Prevents calling the CLI on every keystroke |
+| **CLI segment cache** | `~/.copilot-token-tracker/omp-segment-cache.json` | 15 min (configurable) | Prevents re-parsing session files when OMP cache expires |
+
+A session parsing run (cache miss) typically takes < 1 second.
+
+---
+
+## Prerequisites
+
+1. **Node.js 22+** — [nodejs.org](https://nodejs.org)
+2. **Oh-my-posh** — [ohmyposh.dev/docs/installation](https://ohmyposh.dev/docs/installation)
+3. **The CLI installed globally:**
+
+```powershell
+npm install -g @rajbos/ai-engineering-fluency
+```
+
+Verify it works:
+
+```powershell
+ai-engineering-fluency segment
+# e.g.: 1.2K today · 45.3K 30d
+```
+
+> **Note:** If you use `npx` instead of a global install, replace `"ai-engineering-fluency"` with `"npx"` and add `"-y"`, `"@rajbos/ai-engineering-fluency"` as additional arguments in the `cmd` call below. `npx` is significantly slower due to package resolution on first run.
+
+---
+
+## Method 1: Using `{{ cmd }}` — Recommended
+
+This is the cleanest approach. Add the segment config to your oh-my-posh theme file.
+
+### Step 1: Find your theme file
+
+```powershell
+# Show the currently active theme path
+$env:POSH_THEME
+
+# Or export your current config to edit it
+oh-my-posh config export --output "$env:USERPROFILE\.omp.json"
+```
+
+### Step 2: Add the segment
+
+Open your theme JSON (or YAML/TOML) and add the following to a `segments` array inside a `block`. The content of [`segment.omp.json`](./segment.omp.json) can be pasted directly:
+
+```json
+{
+  "type": "text",
+  "style": "diamond",
+  "leading_diamond": "\ue0b6",
+  "trailing_diamond": "\ue0b4",
+  "foreground": "#ffffff",
+  "background": "#005ca5",
+  "cache": {
+    "duration": "5m",
+    "strategy": "session"
+  },
+  "template": " \uec1e {{ cmd \"ai-engineering-fluency\" \"segment\" }} "
+}
+```
+
+> The `\uec1e` character is the Copilot icon from [Nerd Fonts](https://www.nerdfonts.com). Remove it (or replace with `🤖`) if you are not using a Nerd Font.
+
+### Step 3: Reload your shell
+
+```powershell
+# Reload your profile
+. $PROFILE
+
+# Or open a new terminal window
+```
+
+---
+
+## Method 2: PowerShell Pre-Prompt Hook
+
+Use this if you cannot use `{{ cmd }}` or want more control over the output.
+
+### Step 1: Add the hook to your PowerShell profile
+
+Copy the function from [`posh-hook.ps1`](./posh-hook.ps1) into your `$PROFILE`:
+
+```powershell
+# Open your profile to edit
+notepad $PROFILE
+```
+
+Paste the `Set-PoshContext` function at the end of the file and save.
+
+### Step 2: Add the environment-variable segment to your theme
+
+```json
+{
+  "type": "text",
+  "style": "diamond",
+  "leading_diamond": "\ue0b6",
+  "trailing_diamond": "\ue0b4",
+  "foreground": "#ffffff",
+  "background": "#005ca5",
+  "template": " \uec1e {{ .Env.COPILOT_TOKENS_TODAY }} today · {{ .Env.COPILOT_TOKENS_30D }} 30d "
+}
+```
+
+The hook updates `$env:COPILOT_TOKENS_TODAY` and `$env:COPILOT_TOKENS_30D` at most once every 15 minutes.
+
+---
+
+## Style Variants
+
+### Powerline style (arrow separators)
+
+```json
+{
+  "type": "text",
+  "style": "powerline",
+  "powerline_symbol": "\ue0b0",
+  "foreground": "#ffffff",
+  "background": "#005ca5",
+  "cache": { "duration": "5m", "strategy": "session" },
+  "template": " \uec1e {{ cmd \"ai-engineering-fluency\" \"segment\" }} "
+}
+```
+
+### Plain / no background
+
+```json
+{
+  "type": "text",
+  "style": "plain",
+  "foreground": "#005ca5",
+  "cache": { "duration": "5m", "strategy": "session" },
+  "template": "\uec1e {{ cmd \"ai-engineering-fluency\" \"segment\" }} "
+}
+```
+
+### Hide when no data
+
+```json
+{
+  "type": "text",
+  "style": "diamond",
+  "leading_diamond": "\ue0b6",
+  "trailing_diamond": "\ue0b4",
+  "foreground": "#ffffff",
+  "background": "#005ca5",
+  "cache": { "duration": "5m", "strategy": "session" },
+  "template": "{{ $out := cmd \"ai-engineering-fluency\" \"segment\" \"--hide-zero\" }}{{ if $out }} \uec1e {{ $out }} {{ end }}"
+}
+```
+
+---
+
+## Options Reference
+
+```
+ai-engineering-fluency segment [options]
+
+Options:
+  --ttl <minutes>   Segment cache TTL in minutes (default: 15)
+  --refresh         Force refresh — bypass the segment output cache
+  --hide-zero       Output nothing when both token counts are zero
+  --no-cache        Also bypass the underlying session file cache
+  -h, --help        Show help
+```
+
+### Force a refresh
+
+```powershell
+# Refresh the segment output cache immediately
+ai-engineering-fluency segment --refresh
+
+# Force a full re-parse of all session files
+ai-engineering-fluency --no-cache segment --refresh
+```
+
+---
+
+## Local Validation
+
+### Test the CLI output directly
+
+```powershell
+# Check basic output
+ai-engineering-fluency segment
+
+# Force refresh to see current numbers
+ai-engineering-fluency segment --refresh
+
+# Inspect the cache file
+Get-Content "$env:USERPROFILE\.copilot-token-tracker\omp-segment-cache.json" | ConvertFrom-Json
+```
+
+### Preview the segment in your theme
+
+```powershell
+# Export your current config (if you haven't already)
+oh-my-posh config export --output "$env:TEMP\test.omp.json"
+
+# Add the segment to test.omp.json (open in your editor)
+code "$env:TEMP\test.omp.json"
+
+# Preview the prompt without changing your active theme
+oh-my-posh prompt print primary --config "$env:TEMP\test.omp.json"
+
+# Full debug output showing all segment values
+oh-my-posh debug --config "$env:TEMP\test.omp.json"
+```
+
+### Measure render time
+
+```powershell
+# Time a single prompt render (OMP cache cold)
+oh-my-posh cache clear
+Measure-Command { oh-my-posh prompt print primary --config "$env:TEMP\test.omp.json" }
+
+# Time a render with OMP cache warm (should be near-instant)
+Measure-Command { oh-my-posh prompt print primary --config "$env:TEMP\test.omp.json" }
+```
+
+### Activate the test theme in your shell
+
+```powershell
+oh-my-posh init pwsh --config "$env:TEMP\test.omp.json" | Invoke-Expression
+# Open a new terminal to test, then restore your normal theme
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Command not found: `ai-engineering-fluency` | CLI not installed globally | `npm install -g @rajbos/ai-engineering-fluency` |
+| Segment shows `0 today · 0 30d` | No session files found | Run `ai-engineering-fluency diagnostics` to check paths |
+| Segment never updates | OMP cache too long | Set `cache.duration` to `"1m"` or use `--hide-zero` |
+| Stale numbers | CLI cache still valid | Run `ai-engineering-fluency segment --refresh` |
+| Icon shows as a box / `?` | Not using a Nerd Font | Replace `\uec1e` with `🤖` or remove the icon |
+| Prompt slows down | OMP cache not set | Add `"cache": {"duration": "5m", "strategy": "session"}` to the segment |
+
+---
+
+## Publishing / Sharing
+
+The oh-my-posh **theme marketplace is closed** to new submissions, but you can share your setup:
+
+- Post in [oh-my-posh Discussions → Themes](https://github.com/JanDeDobbeleer/oh-my-posh/discussions/categories/themes)
+- Share in the [oh-my-posh Discord](https://discord.com/channels/1023597603331526656/1055533233309233252) `#themes` channel
+
+If you'd like to contribute this as a **native Go segment** to the oh-my-posh project (so it appears in the official docs), the contribution guide is at [ohmyposh.dev/docs/contributing/segment](https://ohmyposh.dev/docs/contributing/segment). A native Go segment would call `exec.Command("ai-engineering-fluency", "segment")` and parse its output, making it available as a first-class `"type": "copilot-tokens"` (or similar) segment.
+
+---
+
+## Related
+
+- [AI Engineering Fluency CLI docs](../docs/cli/README.md)
+- [npm package: `@rajbos/ai-engineering-fluency`](https://www.npmjs.com/package/@rajbos/ai-engineering-fluency)
+- [oh-my-posh template functions](https://ohmyposh.dev/docs/configuration/templates)
+- [oh-my-posh segment configuration](https://ohmyposh.dev/docs/configuration/segment)

--- a/omp-segment/posh-hook.ps1
+++ b/omp-segment/posh-hook.ps1
@@ -1,0 +1,49 @@
+# oh-my-posh Pre-Prompt Hook (PowerShell)
+#
+# Alternative to the `cmd` approach: this hook runs the CLI before each prompt
+# and stores the results in environment variables that your oh-my-posh segment reads.
+#
+# Use this if you prefer not to use the `{{ cmd "..." }}` template function,
+# or if you want more control over formatting.
+#
+# HOW TO USE
+# ----------
+# 1. Add this function to your PowerShell profile ($PROFILE).
+#    Open it with: notepad $PROFILE
+#
+# 2. Add the function below to your profile.
+#
+# 3. Add the environment-variable segment to your oh-my-posh theme (see README.md).
+#
+# 4. Reload your profile: . $PROFILE
+
+function Set-PoshContext {
+    # Only refresh every 15 minutes to keep prompt fast.
+    $lastRun = if ($env:COPILOT_TOKEN_LAST_RUN) {
+        try { [DateTime]::Parse($env:COPILOT_TOKEN_LAST_RUN) } catch { [DateTime]::MinValue }
+    } else {
+        [DateTime]::MinValue
+    }
+
+    if (([DateTime]::UtcNow - $lastRun).TotalMinutes -lt 15) { return }
+
+    try {
+        $data   = ai-engineering-fluency usage --json | ConvertFrom-Json
+        $today  = [int]$data.today.tokens
+        $days30 = [int]$data.last30Days.tokens
+
+        function Format-Tokens([int]$n) {
+            if ($n -ge 1000000) { return "{0:N1}M" -f ($n / 1000000) }
+            if ($n -ge 1000)    { return "{0:N1}K" -f ($n / 1000) }
+            return "$n"
+        }
+
+        $env:COPILOT_TOKENS_TODAY   = Format-Tokens $today
+        $env:COPILOT_TOKENS_30D     = Format-Tokens $days30
+        $env:COPILOT_TOKEN_LAST_RUN = [DateTime]::UtcNow.ToString("o")
+    }
+    catch {
+        $env:COPILOT_TOKENS_TODAY = "?"
+        $env:COPILOT_TOKENS_30D   = "?"
+    }
+}

--- a/omp-segment/segment.omp.json
+++ b/omp-segment/segment.omp.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Paste this segment object into a 'segments' array inside a block in your oh-my-posh theme file.",
+  "_comment2": "Requires: ai-engineering-fluency CLI installed globally (npm install -g @rajbos/ai-engineering-fluency)",
+  "_comment3": "The Copilot icon (\\uec1e) requires a Nerd Font. Remove it if you do not use one.",
+  "type": "text",
+  "style": "diamond",
+  "leading_diamond": "\ue0b6",
+  "trailing_diamond": "\ue0b4",
+  "foreground": "#ffffff",
+  "background": "#005ca5",
+  "cache": {
+    "duration": "5m",
+    "strategy": "session"
+  },
+  "template": " \uec1e {{ cmd \"ai-engineering-fluency\" \"segment\" }} "
+}

--- a/omp-segment/statusline.cmd
+++ b/omp-segment/statusline.cmd
@@ -1,0 +1,2 @@
+@echo off
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0statusline.ps1"

--- a/omp-segment/statusline.omp.json
+++ b/omp-segment/statusline.omp.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "version": 3,
+  "final_space": false,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "git",
+          "style": "diamond",
+          "leading_diamond": "<",
+          "trailing_diamond": ">",
+          "foreground": "#193549",
+          "background": "#FFA500",
+          "template": " {{ .HEAD }}{{ if .Working.Changed }} +{{ .Working.String }}{{ end }} ",
+          "properties": {
+            "fetch_status": true,
+            "fetch_upstream_icon": true
+          }
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#193549",
+          "background": "#FFA500",
+          "template": " ctx {{ .Env.COPILOT_STATUS_CONTEXT }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#6CA35E",
+          "template": " {{ .Env.COPILOT_STATUS_GAUGE }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#0184bc",
+          "template": " {{ .Env.COPILOT_STATUS_DURATION }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#a1108c",
+          "template": "{{ if .Env.COPILOT_STATUS_CHANGES }} {{ .Env.COPILOT_STATUS_CHANGES }} {{ end }}"
+        },
+        {
+          "type": "text",
+          "style": "diamond",
+          "trailing_diamond": ">",
+          "foreground": "#ffffff",
+          "background": "#005ca5",
+          "template": "{{ if .Env.COPILOT_TOKEN_USAGE }}  {{ .Env.COPILOT_TOKEN_USAGE }} {{ end }}"
+        }
+      ]
+    }
+  ]
+}

--- a/omp-segment/statusline.ps1
+++ b/omp-segment/statusline.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+function Format-TokenCount {
+    param([Nullable[double]]$Value)
+    if ($null -eq $Value) { return '?' }
+    if ($Value -ge 1000000) { return ('{0:0.0}m' -f ($Value / 1000000)) }
+    if ($Value -ge 1000) { return ('{0:0.0}k' -f ($Value / 1000)) }
+    return ([int]$Value).ToString()
+}
+
+function Format-Duration {
+    param([Nullable[double]]$Milliseconds)
+    if ($null -eq $Milliseconds -or $Milliseconds -le 0) { return '00:00:00' }
+    $duration = [TimeSpan]::FromMilliseconds($Milliseconds)
+    return '{0:00}:{1:00}:{2:00}' -f [int]$duration.TotalHours, $duration.Minutes, $duration.Seconds
+}
+
+function New-Gauge {
+    param([Nullable[double]]$Percent)
+    if ($null -eq $Percent) { return '..........' }
+    $bounded = [Math]::Max(0, [Math]::Min(100, [Math]::Round($Percent)))
+    $filled = [int][Math]::Floor($bounded / 10)
+    return ('#' * $filled) + ('.' * (10 - $filled))
+}
+
+$payload = [Console]::In.ReadToEnd()
+
+try {
+    $json = $payload | ConvertFrom-Json
+} catch {
+    Write-Host -NoNewline 'Copilot status unavailable'
+    exit 0
+}
+
+$context = $json.context_window
+$cost    = $json.cost
+
+$currentTokens = if ($null -ne $context.current_context_tokens)       { [double]$context.current_context_tokens }       else { $null }
+$contextLimit  = if ($null -ne $context.displayed_context_limit)       { [double]$context.displayed_context_limit }       else { $null }
+$contextPercent = if ($null -ne $context.current_context_used_percentage) {
+    [double]$context.current_context_used_percentage
+} elseif ($null -ne $context.used_percentage) {
+    [double]$context.used_percentage
+} else {
+    $null
+}
+
+$linesAdded   = if ($null -ne $cost.total_lines_added)   { [int]$cost.total_lines_added }   else { 0 }
+$linesRemoved = if ($null -ne $cost.total_lines_removed) { [int]$cost.total_lines_removed } else { 0 }
+
+$env:COPILOT_STATUS_CONTEXT  = "$(Format-TokenCount $currentTokens)/$(Format-TokenCount $contextLimit)"
+$env:COPILOT_STATUS_GAUGE    = New-Gauge $contextPercent
+$env:COPILOT_STATUS_DURATION = Format-Duration $cost.total_duration_ms
+$env:COPILOT_STATUS_CHANGES  = if ($linesAdded -or $linesRemoved) { "+$linesAdded/-$linesRemoved" } else { '' }
+
+# Add total daily / 30-day token usage (cached via ai-engineering-fluency's own segment cache)
+try {
+    $tokenOutput = & ai-engineering-fluency segment 2>$null
+    $env:COPILOT_TOKEN_USAGE = if ($tokenOutput) { $tokenOutput.Trim() } else { '' }
+} catch {
+    $env:COPILOT_TOKEN_USAGE = ''
+}
+
+$theme = Join-Path $PSScriptRoot 'statusline.omp.json'
+$cwd   = if ($json.cwd) { [string]$json.cwd } else { (Get-Location).Path }
+
+try {
+    $output = & oh-my-posh print primary --config $theme --pwd $cwd --force --escape=false 2>$null
+    if ([string]::IsNullOrWhiteSpace($output)) { throw 'Oh My Posh returned no output.' }
+    Write-Host -NoNewline $output.TrimEnd()
+} catch {
+    # Plain-text fallback when oh-my-posh is unavailable
+    $changes = if ($env:COPILOT_STATUS_CHANGES) { " | $($env:COPILOT_STATUS_CHANGES)" } else { '' }
+    $tokens  = if ($env:COPILOT_TOKEN_USAGE)    { " | $($env:COPILOT_TOKEN_USAGE)" }    else { '' }
+    Write-Host -NoNewline "ctx $($env:COPILOT_STATUS_CONTEXT) $($env:COPILOT_STATUS_GAUGE) | $($env:COPILOT_STATUS_DURATION)$changes$tokens"
+}


### PR DESCRIPTION
## Summary

Adds a new `segment` CLI sub-command and a full `omp-segment/` directory for integrating token usage data into shell prompts and the GitHub Copilot CLI statusline.

### Part 1 — oh-my-posh shell prompt segment

The oh-my-posh native `copilot` segment shows GitHub API billing quota — **not** local session token counts. This fills that gap.

**New `cli segment` command:**
- Outputs `"12.9M today · 1443.5M 30d"` to stdout (no trailing newline)
- `--hide-zero` — output nothing when both counts are zero
- `--refresh` — bypass the local cache for a forced refresh
- `--ttl <minutes>` — cache TTL (default: 15 min)

**Two-layer cache:**
| Layer | TTL | Purpose |
|---|---|---|
| OMP segment cache | 5 min | Prevents Node.js on every prompt render |
| CLI segment cache | 15 min | Prevents session file re-parsing |

Performance: ~6.8s cold → ~150ms cached.

**`omp-segment/` files:**

| File | Purpose |
|---|---|
| `README.md` | End-user setup guide (2 methods, style variants, validation, troubleshooting) |
| `segment.omp.json` | Ready-to-paste OMP segment config |
| `posh-hook.ps1` | Alternative PowerShell `Set-PoshContext` hook |

---

### Part 2 — GitHub Copilot CLI statusline (experimental)

Copilot CLI's `STATUS_LINE` feature calls a local command with a JSON payload (context tokens, duration, line changes) and renders the output at the bottom of its terminal UI. Based on [Scott Hanselman's gist](https://gist.github.com/shanselman/9623ac74888a07ba82f63f5310fda11b).

The scripts here add **total daily / 30-day token usage** to that statusline:

```
main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 1443.5M 30d
```

**New files:**

| File | Purpose |
|---|---|
| `statusline.cmd` | Windows wrapper for `settings.json` command path |
| `statusline.ps1` | Reads Copilot JSON stdin, sets `COPILOT_STATUS_*` env vars, calls `ai-engineering-fluency segment`, renders via oh-my-posh |
| `statusline.omp.json` | Compact OMP theme (git, ctx gauge, duration, changes, token totals) |

**Setup:** copy 3 files to `%USERPROFILE%\.copilot\`, add `statusLine` + `STATUS_LINE` flag to `settings.json`, run `/restart`.

---

### Updated files
- `cli/src/commands/segment.ts` — new command implementation
- `cli/src/cli.ts` — registers `segmentCommand`
- `cli/README.md` — documents `segment` in dev section
- `omp-segment/README.md` — full end-user docs for both methods

### Validation

```powershell
cd cli && npm install && npm run build
node dist/cli.js segment --help
node dist/cli.js segment --refresh   # => "12.9M today · 1443.5M 30d"

# Test statusline
@'{ "cwd": "C:\\src", "context_window": { "current_context_tokens": 123456, "displayed_context_limit": 200000, "current_context_used_percentage": 61.7 }, "cost": { "total_duration_ms": 754000, "total_lines_added": 42, "total_lines_removed": 8 } }'@ | pwsh -NoProfile -File omp-segment\statusline.ps1
```
