### PR TITLE
feat: post-process SLM output to fix acronym capitalization (MCP, GitHub, etc.)

### DIFF
--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -379,6 +379,20 @@ jobs:
                       friendly = s.title()
                   validated[tool] = friendly
 
+              # Post-process: deterministically fix acronyms the 1.5B model often
+              # title-cases (e.g. "Mcp" -> "MCP", "Github" -> "GitHub").
+              # This is more reliable than asking the model to remember the list.
+              ACRONYMS = {
+                  "mcp": "MCP", "github": "GitHub", "api": "API",
+                  "url": "URL", "http": "HTTP", "https": "HTTPS",
+                  "cli": "CLI", "ui": "UI", "io": "IO", "id": "ID",
+                  "vscode": "VSCode", "json": "JSON", "html": "HTML",
+                  "css": "CSS", "sql": "SQL", "git": "Git",
+              }
+              def fix_acronyms(name):
+                  return re.sub(r'\b\w+\b', lambda m: ACRONYMS.get(m.group(0).lower(), m.group(0)), name)
+              validated = {k: fix_acronyms(v) for k, v in validated.items()}
+
               print("=== Validated names ===", file=sys.stderr)
               for k, v in validated.items():
                   print(f"  {k!r} -> {v!r}", file=sys.stderr)

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -341,35 +341,35 @@ jobs:
               "OUTPUT: JSON object only, no explanation.",
           ])
 
-          payload = {{
+          payload = {
               "model": "qwen2.5:1.5b",
               "prompt": prompt,
               "format": "json",
               "stream": False,
-              "options": {{"temperature": 0, "seed": 42}}
-          }}
+              "options": {"temperature": 0, "seed": 42}
+          }
 
           print("=== Calling Ollama API ===", file=sys.stderr)
           req = urllib.request.Request(
               "http://localhost:11434/api/generate",
               data=json.dumps(payload).encode(),
-              headers={{"Content-Type": "application/json"}}
+              headers={"Content-Type": "application/json"}
           )
 
           try:
               with urllib.request.urlopen(req, timeout=180) as resp:
                   data = json.loads(resp.read())
-              raw_response = data.get("response", "{{}}")
-              print(f"=== SLM response ===\n{{raw_response}}", file=sys.stderr)
+              raw_response = data.get("response", "{}")
+              print(f"=== SLM response ===\n{raw_response}", file=sys.stderr)
 
               try:
                   generated = json.loads(raw_response)
               except json.JSONDecodeError:
-                  m = re.search(r'\{{[^{{}}]*\}}', raw_response, re.DOTALL)
-                  generated = json.loads(m.group(0)) if m else {{}}
+                  m = re.search(r'\{[^{}]*\}', raw_response, re.DOTALL)
+                  generated = json.loads(m.group(0)) if m else {}
 
               # Only keep entries for the tool IDs we asked about; sanitize values.
-              validated = {{}}
+              validated = {}
               for tool in missing_tools:
                   friendly = str(generated.get(tool, "")).strip()
                   if not friendly or len(friendly) > 200:
@@ -381,14 +381,14 @@ jobs:
 
               print("=== Validated names ===", file=sys.stderr)
               for k, v in validated.items():
-                  print(f"  {{k!r}} -> {{v!r}}", file=sys.stderr)
+                  print(f"  {k!r} -> {v!r}", file=sys.stderr)
 
               with open("/tmp/slm-names.json", "w") as f:
                   json.dump(validated, f, indent=2)
               print("✅ SLM generation complete", file=sys.stderr)
 
           except Exception as e:
-              print(f"❌ SLM error: {{e}}", file=sys.stderr)
+              print(f"❌ SLM error: {e}", file=sys.stderr)
               import traceback; traceback.print_exc(file=sys.stderr)
               sys.exit(1)
           PYEOF


### PR DESCRIPTION
## Problem

The Qwen2.5-1.5B model reliably title-cases known acronyms even when the prompt instructs it not to — e.g.:

| Generated | Correct |
|---|---|
| `Mcp Github List Branches` | `MCP GitHub List Branches` |
| `Github Mcp Server List Pull Requests` | `GitHub MCP Server List Pull Requests` |
| `Mcp Microsoft Pla Browser Console Messages` | `MCP Microsoft Pla Browser Console Messages` |

## Fix

Add a deterministic Python post-processing step after SLM generation that uses word-boundary regex substitution to enforce correct casing for known acronyms and brand names:

| Word (any case) | Correct form |
|---|---|
| mcp | **MCP** |
| github | **GitHub** |
| api | **API** |
| url | **URL** |
| http / https | **HTTP / HTTPS** |
| cli | **CLI** |
| ui | **UI** |
| io | **IO** |
| id | **ID** |
| vscode | **VSCode** |
| json | **JSON** |
| html / css / sql | **HTML / CSS / SQL** |
| git | **Git** |

This is more reliable than asking a 1.5B model to remember a rules list. The post-processing runs after the model's output is validated, so the fallback path also benefits from it.