### PR TITLE
fix: pin Ollama install to versioned GitHub release with SHA256 verification

### DIFF
--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -176,6 +176,13 @@ jobs:
       issues: write
       contents: write
       pull-requests: write
+    services:
+      ollama:
+        image: ollama/ollama:0.23.4
+        ports:
+          - 11434:11434
+        volumes:
+          - /home/runner/.ollama:/root/.ollama
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -254,23 +261,10 @@ jobs:
           key: ollama-${{ runner.os }}-qwen2.5-1.5b-v1
           restore-keys: ollama-${{ runner.os }}-qwen2.5-1.5b-
 
-      - name: Install Ollama
-        if: steps.extract.outputs.has_missing == 'true'
-        env:
-          OLLAMA_VERSION: "v0.23.4"
-          OLLAMA_SHA256: "c0822ce85413647f8502862c7179740311f271fcff8f21d61c6d352729f4c28d"
-        run: |
-          curl -fsSL "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64.tar.zst" -o ollama-linux-amd64.tar.zst
-          echo "${OLLAMA_SHA256}  ollama-linux-amd64.tar.zst" | sha256sum -c
-          sudo tar -I zstd -xf ollama-linux-amd64.tar.zst -C /usr
-          rm ollama-linux-amd64.tar.zst
-
-      - name: Start Ollama and ensure model is available
+      - name: Ensure Ollama model is available
         if: steps.extract.outputs.has_missing == 'true'
         run: |
-          export OLLAMA_MODELS="$HOME/.ollama/models"
-          ollama serve &
-          echo "Waiting for Ollama to be ready..."
+          echo "Waiting for Ollama service to be ready..."
           for i in {1..30}; do
             if curl -fsS http://localhost:11434/api/tags >/dev/null 2>&1; then
               echo "Ollama is ready (attempt $i)"
@@ -279,11 +273,16 @@ jobs:
             sleep 2
           done
           curl -fsS http://localhost:11434/api/tags >/dev/null
-          if ! ollama list 2>/dev/null | grep -q "qwen2.5:1.5b"; then
-            echo "Pulling qwen2.5:1.5b model..."
-            ollama pull qwen2.5:1.5b
-          else
+          if curl -fsS http://localhost:11434/api/tags | \
+              python3 -c "import json,sys; d=json.load(sys.stdin); exit(0 if any('qwen2.5:1.5b' in m['name'] for m in d.get('models',[])) else 1)" \
+              2>/dev/null; then
             echo "Model qwen2.5:1.5b already available in cache"
+          else
+            echo "Pulling qwen2.5:1.5b model..."
+            curl -X POST http://localhost:11434/api/pull \
+              -H "Content-Type: application/json" \
+              -d '{"name":"qwen2.5:1.5b","stream":false}' \
+              --max-time 600
           fi
 
       - name: Generate friendly names with SLM

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -256,7 +256,14 @@ jobs:
 
       - name: Install Ollama
         if: steps.extract.outputs.has_missing == 'true'
-        run: curl -fsSL https://ollama.com/install.sh | sh
+        env:
+          OLLAMA_VERSION: "v0.23.4"
+          OLLAMA_SHA256: "c0822ce85413647f8502862c7179740311f271fcff8f21d61c6d352729f4c28d"
+        run: |
+          curl -fsSL "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64.tar.zst" -o ollama-linux-amd64.tar.zst
+          echo "${OLLAMA_SHA256}  ollama-linux-amd64.tar.zst" | sha256sum -c
+          sudo tar -I zstd -xf ollama-linux-amd64.tar.zst -C /usr
+          rm ollama-linux-amd64.tar.zst
 
       - name: Start Ollama and ensure model is available
         if: steps.extract.outputs.has_missing == 'true'


### PR DESCRIPTION
## Summary

Fixes security code-scanning alert [#62](https://github.com/rajbos/ai-engineering-fluency/security/code-scanning/62): `downloadThenRun not pinned by hash`.

Also makes the Ollama version **Dependabot-trackable** so it stays up to date automatically.

## Problem

The `check-toolnames.yml` workflow installed Ollama using:
```yaml
run: curl -fsSL https://ollama.com/install.sh | sh
```
This is a `downloadThenRun` pattern — a remote script executed without integrity verification. Even after pinning with SHA256, the version string lived in an `env:` variable that Dependabot cannot track.

## Fix

Replaced with a **Docker service container** (`ollama/ollama:0.23.4`):

```yaml
services:
  ollama:
    image: ollama/ollama:0.23.4
    ports:
      - 11434:11434
    volumes:
      - /home/runner/.ollama:/root/.ollama
```

- The manual install + start steps are removed — Ollama runs as a service before any steps execute
- **Dependabot's `github-actions` ecosystem will automatically update the `ollama/ollama` image version** (it tracks Docker images in `services:` blocks)
- Model caching is preserved via the bind mount: `actions/cache` restores blobs to `/home/runner/.ollama/models` on the host; the live bind mount makes them immediately visible inside the container as `/root/.ollama/models`, so `pull` is a no-op on cache hits
- The "Start Ollama" step is simplified to just wait for service readiness and pull via REST API (no `ollama` CLI needed on the host)
