### PR TITLE
chore: bump VS Code extension version to 0.9.0

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,20 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-14
+
+### Features
+- Add oh-my-posh segment command and Copilot CLI statusline support (#876)
+- Post-process SLM output to fix acronym capitalization (MCP, GitHub, etc.) (#880)
+- Add SLM-powered job to generate friendly tool names from issues (#875)
+
+### Bug Fixes
+- Populate cache tokens from CLI session.shutdown events (#869)
+- Pin Ollama install to versioned GitHub release with SHA256 verification (#881)
+
+### Improvements
+- Add friendly display names for 50+ tools (#862, #864, #865, #866, #867, #868, #872, #873, #874, #879)
+
 ## [0.8.0] - 2026-05-12
 
 ### Features

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
Version 0.8.0 is already published on the VS Code Marketplace. This bumps to 0.9.0 and documents the changes since that release.

### Changes since 0.8.0
- Add oh-my-posh segment command and Copilot CLI statusline support (#876)
- Post-process SLM output to fix acronym capitalization (#880)
- Add SLM-powered job to generate friendly tool names from issues (#875)
- Fix: populate cache tokens from CLI session.shutdown events (#869)
- Fix: pin Ollama install to versioned GitHub release with SHA256 verification (#881)
- Add friendly display names for 50+ tools (#862–#879)