### PR TITLE
fix: use real outputTokens from assistant.message to fix CLI token undercount

### DIFF
--- a/.github/skills/copilot-log-analysis/SKILL.md
+++ b/.github/skills/copilot-log-analysis/SKILL.md
@@ -179,14 +179,18 @@ See the **Executable Scripts** section for available utilities:
 ```jsonl
 {"type": "user.message", "data": {"content": "..."}, "model": "gpt-4o"}
 {"type": "assistant.message", "data": {"content": "..."}}
-{"type": "tool.result", "data": {"output": "..."}}
+{"type": "tool.execution_start", "data": {"toolCallId": "...", "toolName": "...", "arguments": {}}}
+{"type": "tool.execution_complete", "data": {"toolCallId": "...", "success": true, "result": {"content": "...", "detailedContent": "..."}}}
+{"type": "session.shutdown", "data": {"modelMetrics": {"claude-opus-4.6": {"usage": {"inputTokens": 0, "outputTokens": 0, "cacheReadTokens": 0, "cacheWriteTokens": 0}}}}}
 ```
 
 **Key fields:**
 - Event type: `type`
 - User input: `data.content` (when `type: 'user.message'`)
 - Assistant output: `data.content` (when `type: 'assistant.message'`)
-- Tool output: `data.output` (when `type: 'tool.result'`)
+- Tool output: `data.result.content` or `data.result.detailedContent` (when `type: 'tool.execution_complete'`)
+- Tool name for counting: `data.toolName` (when `type: 'tool.execution_start'`)
+- API-accurate token counts: `data.modelMetrics[model].usage` (when `type: 'session.shutdown'`) — always prefer these over estimates when available
 - Model: `model` (optional, defaults to `gpt-4o`)
 
 ## JSONL File Structure (JetBrains IDE)

--- a/.github/skills/copilot-log-analysis/session-file-discovery.js
+++ b/.github/skills/copilot-log-analysis/session-file-discovery.js
@@ -147,7 +147,7 @@ function getCopilotSessionFiles() {
     }
 
     // OpenCode session files (XDG data directory)
-    const xdgDataHome = (platform === 'win32')
+    const xdgDataHome = (os.platform() === 'win32')
         ? path.join(homedir, '.local', 'share')
         : (process.env.XDG_DATA_HOME || path.join(homedir, '.local', 'share'));
     const openCodeSessionDir = path.join(xdgDataHome, 'opencode', 'storage', 'session');

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -87,6 +87,9 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 	let cliCacheReadTokens = 0;
 	// Per-model breakdown from CLI session.shutdown events
 	let cliShutdownModelUsage: ModelUsage | null = null;
+	// Real outputTokens from assistant.message events (used when session.shutdown is absent)
+	let cliRealOutputByModel: { [model: string]: number } | null = null;
+	let totalEstToolCalls = 0;
 	// Per-UTC-day actual token breakdown from shutdown event timestamps
 	const dailyActualTokens: Record<string, number> = {};
 
@@ -150,8 +153,18 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 				// the rendered version subsumes the bare message, so any double-count is minor
 				// as user.message is typically short compared to the full rendered content.)
 				totalTokens += estimateTokensFromText(event.data.renderedMessage);
-			} else if (event.type === 'assistant.message' && event.data?.content) {
-				totalTokens += estimateTokensFromText(event.data.content);
+			} else if (event.type === 'assistant.message') {
+				const realOut = typeof event.data?.outputTokens === 'number' ? event.data.outputTokens : 0;
+				if (realOut > 0) {
+					// Real API-reported output tokens — accumulate for ratio-based total estimation
+					if (!cliRealOutputByModel) { cliRealOutputByModel = {}; }
+					const m = event.data?.model || 'unknown';
+					cliRealOutputByModel[m] = (cliRealOutputByModel[m] ?? 0) + realOut;
+				} else if (event.data?.content) {
+					totalTokens += estimateTokensFromText(event.data.content);
+				}
+			} else if (event.type === 'tool.execution_start') {
+				totalEstToolCalls++;
 			} else if (event.type === 'tool.execution_complete' && event.data?.result) {
 				const result = event.data.result;
 				// Prefer detailedContent (captures full subagent prompt for task launches)
@@ -205,6 +218,17 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 		} catch (e) {
 			// Track parse failures for regex fallback
 			parseFailedLines++;
+		}
+	}
+
+	// No session.shutdown: use real outputTokens from assistant.message + observed input:output ratios.
+	// Heavy agent sessions show ~130x ratio; cache reads ≈ input (50% of total from completed sessions).
+	if (!isDeltaBased && !cliActualTokens && cliRealOutputByModel) {
+		const inputOutputRatio = totalEstToolCalls > 20 ? 130 : totalEstToolCalls > 5 ? 50 : 10;
+		for (const realOutput of Object.values(cliRealOutputByModel)) {
+			const estimatedInput = Math.round(realOutput * inputOutputRatio);
+			cliActualTokens += estimatedInput + realOutput;  // input + output (cache is a subset of input)
+			cliCacheReadTokens += estimatedInput;            // cache ≈ input from empirical data
 		}
 	}
 

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1499,6 +1499,9 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 			let isDeltaBased = false;
 			// For CLI (non-delta) sessions: capture exact per-model usage from session.shutdown
 			let cliShutdownModelUsage: ModelUsage | null = null;
+			// Real outputTokens from assistant.message events (used when session.shutdown is absent)
+			let cliRealOutputByModel: { [model: string]: number } | null = null;
+			let totalCliToolCalls = 0;
 
 			for (const line of lines) {
 				if (!line.trim()) { continue; }
@@ -1579,11 +1582,20 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 							}
 						} else if (event.type === 'user.message' && event.data?.content) {
 							modelUsage[model].inputTokens += estimateTokensFromText(event.data.content, model, deps.tokenEstimators);
-						} else if (event.type === 'assistant.message' && event.data?.content) {
-							modelUsage[model].outputTokens += estimateTokensFromText(event.data.content, model, deps.tokenEstimators);
-						} else if (event.type === 'tool.result' && event.data?.output) {
-							// Tool outputs are typically input context
-							modelUsage[model].inputTokens += estimateTokensFromText(event.data.output, model, deps.tokenEstimators);
+						} else if (event.type === 'assistant.message') {
+							const realOutput = typeof event.data?.outputTokens === 'number' ? event.data.outputTokens : 0;
+							if (realOutput > 0) {
+								if (!cliRealOutputByModel) { cliRealOutputByModel = {}; }
+								cliRealOutputByModel[model] = (cliRealOutputByModel[model] ?? 0) + realOutput;
+							} else if (event.data?.content) {
+								modelUsage[model].outputTokens += estimateTokensFromText(event.data.content, model, deps.tokenEstimators);
+							}
+						} else if (event.type === 'tool.execution_start') {
+							totalCliToolCalls++;
+						} else if (event.type === 'tool.execution_complete' && (event.data?.result?.content || event.data?.result?.detailedContent)) {
+							// Tool outputs are fed back as input context in the next turn
+							const toolContent = event.data.result.content || event.data.result.detailedContent;
+							modelUsage[model].inputTokens += estimateTokensFromText(String(toolContent), model, deps.tokenEstimators);
 						}
 					}
 				} catch (e) {
@@ -1594,6 +1606,24 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 			// If CLI session.shutdown provided exact per-model data, use it instead of estimates
 			if (!isDeltaBased && cliShutdownModelUsage) {
 				return cliShutdownModelUsage;
+			}
+
+			// No session.shutdown: assistant.message events carry real per-response outputTokens from the API.
+			// Estimate input using observed ratio from completed agent sessions (~130x output for heavy
+			// agent sessions with >20 tool calls, ~50x for moderate, ~10x for light/chat-only).
+			// Cache reads empirically equal ~input tokens (prompt caching caches the full context).
+			if (!isDeltaBased && cliRealOutputByModel) {
+				const inputOutputRatio = totalCliToolCalls > 20 ? 130 : totalCliToolCalls > 5 ? 50 : 10;
+				const estimatedUsage: ModelUsage = {};
+				for (const [m, realOutput] of Object.entries(cliRealOutputByModel)) {
+					const estimatedInput = Math.round(realOutput * inputOutputRatio);
+					estimatedUsage[m] = {
+						inputTokens: estimatedInput,
+						outputTokens: realOutput,
+						cachedReadTokens: estimatedInput,
+					};
+				}
+				return estimatedUsage;
 			}
 
 			// For delta-based formats, extract actual usage from reconstructed state


### PR DESCRIPTION
## Problem

CLI sessions that end abnormally (no `session.shutdown` event) were severely undercounted because:
1. The old code used character-based text estimation for `assistant.message` output, which is tiny compared to actual API token usage
2. For sessions without shutdown, `actualTokens` was left at 0 and `cacheReadTokens` was also 0

A secondary bug caused an **impossible state**: "Cached tokens" was shown *higher* than "Tokens (total)". This happened because:
- `usageAnalysis.ts` (model breakdown) received the fix but `tokenEstimation.ts` (scalar totals) did not
- `extension.ts` picks up `cachedReadTokens` from model usage as a fallback when `tokenEstimation.ts` returns 0 for cache
- Result: small total (old estimate) + large cache (new estimate from model usage) → Cached > Total

## Root Cause

7 of 19 CLI sessions today had no `session.shutdown` event (abnormal exit). The fix needed to be applied to **two parallel parsers** that both process the same `events.jsonl`:
- `usageAnalysis.ts`: drives per-model `ModelUsage` breakdown
- `tokenEstimation.ts`: drives scalar `actualTokens`, `tokens`, `cacheReadTokens`

## Fix

Both parsers now:
1. Capture real `outputTokens` from `assistant.message` events (present in 538/552 sessions; only 14 ancient Feb 2026 sessions lack it)
2. Count `tool.execution_start` events for ratio selection
3. After the event loop: if no `session.shutdown` but real output tokens exist, derive total and cache estimates using empirically observed ratios:
   - `inputOutputRatio = 130x` (>20 tool calls — heavy agent session)
   - `inputOutputRatio = 50x` (>5 tool calls — moderate)
   - `inputOutputRatio = 10x` (≤5 tool calls — light/chat)
   - `cliCacheReadTokens ≈ estimatedInput` (cache ≈ 50% of total, empirically)

## Impact

- Today's token count: ~19M (old) → ~68M (estimated, 11 completed sessions + 7 ratio-estimated)
- "Cached tokens" now correctly shows less than "Tokens (total)"
- Sessions with `session.shutdown` are unaffected (ground-truth API data still used)
- The 14 ancient sessions without `outputTokens` gracefully fall through to character estimation

## Other Changes

- Fixed `tool.result` → `tool.execution_complete` event type in `usageAnalysis.ts` (wrong event type was being used for tool output estimation)
- Fixed `os.platform()` bug in `session-file-discovery.js` skill script
- Updated SKILL.md with correct CLI event schema