### PR TITLE
fix: add billion (B) tier to token display formatters

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -931,6 +931,9 @@ export function fmt(n: number): string {
 
 /** Format token counts for display */
 export function formatTokens(tokens: number): string {
+	if (tokens >= 1_000_000_000) {
+		return `${(tokens / 1_000_000_000).toFixed(1)}B`;
+	}
 	if (tokens >= 1_000_000) {
 		return `${(tokens / 1_000_000).toFixed(1)}M`;
 	}

--- a/omp-segment/statusline.ps1
+++ b/omp-segment/statusline.ps1
@@ -4,6 +4,7 @@ $ErrorActionPreference = 'Stop'
 function Format-TokenCount {
     param([Nullable[double]]$Value)
     if ($null -eq $Value) { return '?' }
+    if ($Value -ge 1000000000) { return ('{0:0.0}b' -f ($Value / 1000000000)) }
     if ($Value -ge 1000000) { return ('{0:0.0}m' -f ($Value / 1000000)) }
     if ($Value -ge 1000) { return ('{0:0.0}k' -f ($Value / 1000)) }
     return ([int]$Value).ToString()

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -246,6 +246,7 @@ function safeJson(data: unknown): string {
 }
 
 function fmt(n: number): string {
+	if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
 	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
 	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
 	return String(n);
@@ -1007,6 +1008,7 @@ var CHART_DATA = ${safeJson(chartData)};
 // Re-compute "Today" stats using browser's local timezone (server pre-renders in UTC)
 (function() {
   function fmtLocal(n) {
+    if (n >= 1000000000) return (n / 1000000000).toFixed(1) + 'B';
     if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
     if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
     return String(n);

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -217,6 +217,7 @@ function sanitizeNumber(value: number | undefined | null): string {
 function formatTokenCount(value: number | undefined | null): string {
   const n = Number(value ?? 0);
   if (!Number.isFinite(n) || n === 0) { return "0"; }
+  if (n >= 1_000_000_000) { return `${(n / 1_000_000_000).toFixed(1)}B`; }
   if (n >= 1_000_000) { return `${(n / 1_000_000).toFixed(1)}M`; }
   if (n >= 1_000) { return `${(n / 1_000).toFixed(1)}K`; }
   return Math.floor(n).toString();


### PR DESCRIPTION
## Problem

Token counts >= 1,000,000,000 were displayed in millions (e.g. `1,593.9M`) instead of being rounded to billions (e.g. `1.6B`). This was reported in the omp-segment output but affected all token formatters.

## Changes

Added a `>= 1_000_000_000 → B` tier to every token formatting function across the codebase:

| File | Function |
|---|---|
| `cli/src/helpers.ts` | `formatTokens()` |
| `sharing-server/src/routes/dashboard.ts` | `fmt()` and inline `fmtLocal()` |
| `vscode-extension/src/webview/diagnostics/main.ts` | `formatTokenCount()` |
| `omp-segment/statusline.ps1` | `Format-TokenCount()` |

> Note: `vscode-extension/src/webview/shared/formatUtils.ts` uses `Intl.NumberFormat` with `notation: 'compact'` which already handles billions natively — no change needed there.