### PR TITLE
feat: add SSMS Copilot session discovery and detection

### DIFF
--- a/vscode-extension/src/adapters/visualStudioAdapter.ts
+++ b/vscode-extension/src/adapters/visualStudioAdapter.ts
@@ -20,6 +20,11 @@ export class VisualStudioAdapter implements IEcosystemAdapter, IDiscoverableEcos
 		return this.visualStudio.isVSSessionFile(sessionFile);
 	}
 
+	getDisplayName(sessionFile: string): string {
+		const n = sessionFile.replace(/\\/g, '/').toLowerCase();
+		return n.includes('/ssmsgithubcopilot/') ? 'SSMS' : 'Visual Studio';
+	}
+
 	getBackingPath(sessionFile: string): string {
 		return sessionFile;
 	}

--- a/vscode-extension/src/adapters/visualStudioAdapter.ts
+++ b/vscode-extension/src/adapters/visualStudioAdapter.ts
@@ -79,7 +79,10 @@ export class VisualStudioAdapter implements IEcosystemAdapter, IDiscoverableEcos
 	}
 
 	getCandidatePaths(): CandidatePath[] {
-		return [{ path: this.visualStudio.getLogDir(), source: 'Visual Studio (log dir)' }];
+		return [
+			{ path: this.visualStudio.getLogDir(), source: 'Visual Studio (log dir)' },
+			{ path: this.visualStudio.getSsmsSessionsDir(), source: 'SSMS (sessions dir)' },
+		];
 	}
 
 	getRawFileContent(sessionFile: string): string {

--- a/vscode-extension/src/ecosystemAdapter.ts
+++ b/vscode-extension/src/ecosystemAdapter.ts
@@ -18,6 +18,12 @@ export interface IEcosystemAdapter {
 	/** Human-readable display name, e.g. 'OpenCode', 'Crush', 'Continue'. */
 	readonly displayName: string;
 	/**
+	 * Returns the human-readable display name for a specific session file.
+	 * Defaults to `displayName` for adapters that handle only one editor.
+	 * Override when a single adapter covers multiple tools (e.g. Visual Studio + SSMS).
+	 */
+	getDisplayName?(sessionFile: string): string;
+	/**
 	 * When true, backend sync is skipped for sessions handled by this adapter
 	 * (e.g. Visual Studio binary MessagePack sessions cannot be synced).
 	 */
@@ -148,6 +154,15 @@ export interface IDiscoverableEcosystem {
 /** Type guard: check whether an adapter also implements IDiscoverableEcosystem. */
 export function isDiscoverable(adapter: IEcosystemAdapter): adapter is IEcosystemAdapter & IDiscoverableEcosystem {
 	return typeof (adapter as any).discover === 'function';
+}
+
+/**
+ * Returns the display name for a session file from its adapter.
+ * Uses `getDisplayName(sessionFile)` when the adapter provides it (e.g. Visual Studio
+ * vs SSMS distinction); falls back to the static `displayName` otherwise.
+ */
+export function getEcosystemDisplayName(adapter: IEcosystemAdapter, sessionFile: string): string {
+	return adapter.getDisplayName ? adapter.getDisplayName(sessionFile) : adapter.displayName;
 }
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -77,6 +77,7 @@ import { ClaudeDesktopCoworkDataAccess } from './claudedesktop';
 import { MistralVibeDataAccess } from './mistralvibe';
 import { GeminiCliDataAccess } from './geminicli';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
+import { getEcosystemDisplayName } from './ecosystemAdapter';
 import {
 	OpenCodeAdapter,
 	CrushAdapter,
@@ -3242,7 +3243,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const eco = this.findEcosystem(sessionFile);
 		if (eco) {
 			details.editorRoot = eco.getEditorRoot(sessionFile);
-			details.editorName = eco.displayName;
+			details.editorName = getEcosystemDisplayName(eco, sessionFile);
 			return;
 		}
 		try {
@@ -3438,7 +3439,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				details.lastInteraction = meta.lastInteraction;
 				details.interactions = interactionCount;
 				details.editorRoot = eco.getEditorRoot(sessionFile);
-				details.editorName = eco.displayName;
+				details.editorName = getEcosystemDisplayName(eco, sessionFile);
 				if (meta.workspacePath) {
 					details.repository = path.basename(meta.workspacePath);
 				}
@@ -3704,7 +3705,7 @@ return {
 file: details.file,
 title: details.title || null,
 editorSource: details.editorSource,
-editorName: details.editorName || eco.displayName,
+editorName: details.editorName || getEcosystemDisplayName(eco, sessionFile),
 size: details.size,
 modified: details.modified,
 interactions: details.interactions,
@@ -7675,7 +7676,7 @@ ${hashtag}`;
         if (eco) {
           const editorRoot = eco.getEditorRoot(file);
           dirCounts.set(editorRoot, (dirCounts.get(editorRoot) || 0) + 1);
-          dirEditorNames.set(editorRoot, eco.displayName);
+          dirEditorNames.set(editorRoot, getEcosystemDisplayName(eco, file));
           continue;
         }
         const parts = file.split(/[\\\/]/);

--- a/vscode-extension/src/visualstudio.ts
+++ b/vscode-extension/src/visualstudio.ts
@@ -63,11 +63,22 @@ return path.join(localAppData, 'Temp', 'VSGitHubCopilotLogs');
 }
 
 /**
+ * Returns the SSMS AppData base directory where Copilot session files are stored.
+ * Pattern: %LOCALAPPDATA%\Microsoft\SSMS\
+ */
+getSsmsSessionsDir(): string {
+const localAppData = process.env.LOCALAPPDATA
+|| path.join(os.homedir(), 'AppData', 'Local');
+return path.join(localAppData, 'Microsoft', 'SSMS');
+}
+
+/**
  * Discover VS Copilot session files.
  * Primary: parse VS temp chat log files (fast).
  * Supplemental: filesystem scan of common development roots, to catch sessions
  * not yet referenced in logs (e.g. VS running but session not yet persisted to log,
  * or log files cleaned up by system temp cleaner).
+ * SSMS: dedicated scan of %LOCALAPPDATA%\Microsoft\SSMS\ for SSMSGitHubCopilot sessions.
  */
 discoverSessions(): string[] {
 const seen = new Set<string>();
@@ -75,6 +86,7 @@ const sessionFiles: string[] = [];
 
 this._discoverFromLogs(seen, sessionFiles);
 this._discoverFromFilesystem(seen, sessionFiles);
+this._discoverFromSsmsAppData(seen, sessionFiles);
 
 return sessionFiles;
 }
@@ -199,6 +211,48 @@ solutionDirs = fs.readdirSync(vsDir, { withFileTypes: true });
 for (const sol of solutionDirs) {
 if (!sol.isDirectory()) { continue; }
 const copilotChatDir = path.join(vsDir, sol.name, 'copilot-chat');
+let hashDirs: fs.Dirent[];
+try {
+hashDirs = fs.readdirSync(copilotChatDir, { withFileTypes: true });
+} catch { continue; }
+
+for (const hashDir of hashDirs) {
+if (!hashDir.isDirectory()) { continue; }
+const sessionsDir = path.join(copilotChatDir, hashDir.name, 'sessions');
+let sessionFiles: fs.Dirent[];
+try {
+sessionFiles = fs.readdirSync(sessionsDir, { withFileTypes: true });
+} catch { continue; }
+
+for (const sf of sessionFiles) {
+if (!sf.isFile()) { continue; }
+const fullPath = path.join(sessionsDir, sf.name);
+if (seen.has(fullPath)) { continue; }
+seen.add(fullPath);
+results.push(fullPath);
+}
+}
+}
+}
+
+/**
+ * Scan %LOCALAPPDATA%\Microsoft\SSMS\ for SSMSGitHubCopilot Copilot Chat sessions.
+ * Pattern: SSMS\<version>\SSMSGitHubCopilot\copilot-chat\<hash>\sessions\<uuid>
+ * SSMS only runs on Windows — skip on other platforms.
+ */
+private _discoverFromSsmsAppData(seen: Set<string>, results: string[]): void {
+if (os.platform() !== 'win32') { return; }
+const ssmsDir = this.getSsmsSessionsDir();
+if (!fs.existsSync(ssmsDir)) { return; }
+
+let versionDirs: fs.Dirent[];
+try {
+versionDirs = fs.readdirSync(ssmsDir, { withFileTypes: true });
+} catch { return; }
+
+for (const versionDir of versionDirs) {
+if (!versionDir.isDirectory()) { continue; }
+const copilotChatDir = path.join(ssmsDir, versionDir.name, 'SSMSGitHubCopilot', 'copilot-chat');
 let hashDirs: fs.Dirent[];
 try {
 hashDirs = fs.readdirSync(copilotChatDir, { withFileTypes: true });

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -160,6 +160,21 @@ test('GeminiCliAdapter.handles: rejects unrelated paths', () => {
     assert.ok(!geminiCliAdapter.handles(path.join(os.homedir(), '.gemini', 'logs.json')));
 });
 
+test('VisualStudioAdapter.handles: recognises VS .vs session paths', () => {
+    const p = 'C:\\repos\\MyProject\\.vs\\MyProject\\copilot-chat\\ca1642fb\\sessions\\7bb52dc2-4109-42b8-a24e-c5fb65fcce62';
+    assert.ok(visualStudioAdapter.handles(p));
+});
+
+test('VisualStudioAdapter.handles: recognises SSMS SSMSGitHubCopilot session paths', () => {
+    const p = 'C:\\Users\\user\\AppData\\Local\\Microsoft\\SSMS\\22.0_82a729ff\\SSMSGitHubCopilot\\copilot-chat\\ca1642fb\\sessions\\7bb52dc2-4109-42b8-a24e-c5fb65fcce62';
+    assert.ok(visualStudioAdapter.handles(p));
+});
+
+test('VisualStudioAdapter.handles: rejects unrelated paths', () => {
+    assert.ok(!visualStudioAdapter.handles(path.join(os.homedir(), '.claude', 'projects', 'hash', 'abc.jsonl')));
+    assert.ok(!visualStudioAdapter.handles(path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User', 'workspaceStorage', 'abc', 'chatSessions', 'session.json')));
+});
+
 // ---------------------------------------------------------------------------
 // getCandidatePaths() — structure validation
 // ---------------------------------------------------------------------------
@@ -218,6 +233,14 @@ test('GeminiCliAdapter.getCandidatePaths: returns Gemini session and index paths
     assert.ok(paths.some(p => p.source === 'Gemini CLI (sessions)'));
     assert.ok(paths.some(p => p.source === 'Gemini CLI (projects.json)'));
     assert.ok(paths.some(p => p.source === 'Gemini CLI (logs.json)'));
+});
+
+test('VisualStudioAdapter.getCandidatePaths: returns VS log dir and SSMS sessions dir', () => {
+    const paths = visualStudioAdapter.getCandidatePaths();
+    assert.equal(paths.length, 2);
+    assert.ok(paths.some(p => p.source === 'Visual Studio (log dir)'), 'Should include VS log dir');
+    assert.ok(paths.some(p => p.source === 'SSMS (sessions dir)'), 'Should include SSMS sessions dir');
+    assert.ok(paths.every(p => p.path.length > 0), 'All paths should be non-empty');
 });
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -175,6 +175,16 @@ test('VisualStudioAdapter.handles: rejects unrelated paths', () => {
     assert.ok(!visualStudioAdapter.handles(path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User', 'workspaceStorage', 'abc', 'chatSessions', 'session.json')));
 });
 
+test('VisualStudioAdapter.getDisplayName: returns "Visual Studio" for VS .vs paths', () => {
+    const p = 'C:\\repos\\MyProject\\.vs\\MyProject\\copilot-chat\\ca1642fb\\sessions\\7bb52dc2-4109-42b8-a24e-c5fb65fcce62';
+    assert.equal(visualStudioAdapter.getDisplayName(p), 'Visual Studio');
+});
+
+test('VisualStudioAdapter.getDisplayName: returns "SSMS" for SSMSGitHubCopilot paths', () => {
+    const p = 'C:\\Users\\user\\AppData\\Local\\Microsoft\\SSMS\\22.0_82a729ff\\SSMSGitHubCopilot\\copilot-chat\\ca1642fb\\sessions\\7bb52dc2-4109-42b8-a24e-c5fb65fcce62';
+    assert.equal(visualStudioAdapter.getDisplayName(p), 'SSMS');
+});
+
 // ---------------------------------------------------------------------------
 // getCandidatePaths() — structure validation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

SSMS (SQL Server Management Studio) stores GitHub Copilot Chat sessions at:
```
%LOCALAPPDATA%\Microsoft\SSMS\<version>\SSMSGitHubCopilot\copilot-chat\<hash>\sessions\<uuid>
```

When these files were found via VS chat logs, the extension failed to recognise them as Visual Studio (MessagePack) sessions and fell back to `JSON.parse`, causing:
```
Error parsing session file C:\...\SSMSGitHubCopilot\...: SyntaxError: Unexpected token '...' is not valid JSON
Error counting interactions in ...: SyntaxError: ...
Error getting model usage from ...: SyntaxError: ...
Error analyzing session usage from ...: SyntaxError: ...
```

The SSMS session format **is identical** to Visual Studio — same MessagePack binary encoding, same structure (session header + alternating request/response objects), same model info fields.

## Fix

- **`isVSSessionFile`** already had an `isSsms` check for `/ssmsgithubcopilot/` paths (parse routing was correct once files were identified)
- **Added `getSsmsSessionsDir()`** — returns `%LOCALAPPDATA%\Microsoft\SSMS\` base dir
- **Added `_discoverFromSsmsAppData()`** — proactively scans the SSMS sessions tree so files are found even without VS log entries
- **Updated `getCandidatePaths()`** — includes the SSMS dir in the diagnostics panel
- **Added tests** for `VisualStudioAdapter.handles()` (both VS `.vs` and SSMS paths) and `getCandidatePaths()` shape

## Testing

All 40 unit tests pass (`npm run test:node`).

Fixes the errors reported by @roycornelissen. 🙏