### PR TITLE
fix: add billion (B) tier to posh-hook Format-Tokens

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -931,6 +931,9 @@ export function fmt(n: number): string {
 
 /** Format token counts for display */
 export function formatTokens(tokens: number): string {
+	if (tokens >= 1_000_000_000) {
+		return `${(tokens / 1_000_000_000).toFixed(1)}B`;
+	}
 	if (tokens >= 1_000_000) {
 		return `${(tokens / 1_000_000).toFixed(1)}M`;
 	}

--- a/omp-segment/posh-hook.ps1
+++ b/omp-segment/posh-hook.ps1
@@ -32,9 +32,10 @@ function Set-PoshContext {
         $today  = [int]$data.today.tokens
         $days30 = [int]$data.last30Days.tokens
 
-        function Format-Tokens([int]$n) {
-            if ($n -ge 1000000) { return "{0:N1}M" -f ($n / 1000000) }
-            if ($n -ge 1000)    { return "{0:N1}K" -f ($n / 1000) }
+        function Format-Tokens([long]$n) {
+            if ($n -ge 1000000000) { return "{0:N1}B" -f ($n / 1000000000) }
+            if ($n -ge 1000000)    { return "{0:N1}M" -f ($n / 1000000) }
+            if ($n -ge 1000)       { return "{0:N1}K" -f ($n / 1000) }
             return "$n"
         }
 

--- a/omp-segment/statusline.ps1
+++ b/omp-segment/statusline.ps1
@@ -4,6 +4,7 @@ $ErrorActionPreference = 'Stop'
 function Format-TokenCount {
     param([Nullable[double]]$Value)
     if ($null -eq $Value) { return '?' }
+    if ($Value -ge 1000000000) { return ('{0:0.0}b' -f ($Value / 1000000000)) }
     if ($Value -ge 1000000) { return ('{0:0.0}m' -f ($Value / 1000000)) }
     if ($Value -ge 1000) { return ('{0:0.0}k' -f ($Value / 1000)) }
     return ([int]$Value).ToString()

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -246,6 +246,7 @@ function safeJson(data: unknown): string {
 }
 
 function fmt(n: number): string {
+	if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
 	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
 	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
 	return String(n);
@@ -1007,6 +1008,7 @@ var CHART_DATA = ${safeJson(chartData)};
 // Re-compute "Today" stats using browser's local timezone (server pre-renders in UTC)
 (function() {
   function fmtLocal(n) {
+    if (n >= 1000000000) return (n / 1000000000).toFixed(1) + 'B';
     if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
     if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
     return String(n);

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -217,6 +217,7 @@ function sanitizeNumber(value: number | undefined | null): string {
 function formatTokenCount(value: number | undefined | null): string {
   const n = Number(value ?? 0);
   if (!Number.isFinite(n) || n === 0) { return "0"; }
+  if (n >= 1_000_000_000) { return `${(n / 1_000_000_000).toFixed(1)}B`; }
   if (n >= 1_000_000) { return `${(n / 1_000_000).toFixed(1)}M`; }
   if (n >= 1_000) { return `${(n / 1_000).toFixed(1)}K`; }
   return Math.floor(n).toString();


### PR DESCRIPTION
The \Set-PoshContext\ hook in \posh-hook.ps1\ had its own inline \Format-Tokens\ function that was missed in the previous billion-tier fix (PR #899). It also uses \{0:N1}\ locale formatting, which is why the Dutch locale was showing \1.600,7M\ with period-separated thousands instead of the CLI's plain output.\n\nChanges:\n- Add \>= 1000000000 → B\ tier\n- Promote \[int]\ param to \[long]\ to avoid overflow for very large token counts