### PR TITLE
chore: bump versions for release (vscode-extension, visualstudio-extension, jetbrains-plugin)

### DIFF
--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.1.0
+pluginVersion = 0.1.1
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.12"
+              Version="1.0.13"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — 2026-05-16

Version bumps for all non-npm components (plus VS Code extension).

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | `0.9.0` | `0.9.1` |
| Visual Studio extension | `1.0.12` | `1.0.13` |
| JetBrains plugin | `0.1.0` | `0.1.1` |

### VS Code extension (0.9.0 → 0.9.1)
Changes since `vscode/v0.9.0`: SSMS session discovery, billion-tier fix, Today's Sessions tab, chart projection, cold-start freeze fix, 4 new tool names, and more.

### Visual Studio extension (1.0.12 → 1.0.13)
Patch release with recent fixes.

### JetBrains plugin (0.1.0 → 0.1.1)
First published release — patch bump for consistency.

---

### After merging, trigger these workflows on `main`:
1. **Extensions - Release** → publishes VS Code extension v0.9.1
2. **Visual Studio Extension - Build & Package** (set `publish_marketplace: true`) → publishes v1.0.13
3. **JetBrains build/publish workflow** → publishes v0.1.1 (first release)