### PR TITLE
fix: propagate cache tokens in chart daily stats cost calculation

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+﻿import * as vscode from 'vscode';
 import type { AiFluencyExtensionApi, ExtensionPointButton } from './extensionPoints';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -2164,6 +2164,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 								if (!dailyEntry.modelUsage[model]) { dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
 								dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
 								dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
+								if (usage.cachedReadTokens !== undefined) {
+									dailyEntry.modelUsage[model].cachedReadTokens = (dailyEntry.modelUsage[model].cachedReadTokens ?? 0) + usage.cachedReadTokens;
+								}
+								if (usage.cacheCreationTokens !== undefined) {
+									dailyEntry.modelUsage[model].cacheCreationTokens = (dailyEntry.modelUsage[model].cacheCreationTokens ?? 0) + usage.cacheCreationTokens;
+								}
 							}
 						}
 					} else {
@@ -2197,6 +2203,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 							if (!dailyEntry.modelUsage[model]) { dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
 							dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
 							dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
+							if (usage.cachedReadTokens !== undefined) {
+								dailyEntry.modelUsage[model].cachedReadTokens = (dailyEntry.modelUsage[model].cachedReadTokens ?? 0) + usage.cachedReadTokens;
+							}
+							if (usage.cacheCreationTokens !== undefined) {
+								dailyEntry.modelUsage[model].cacheCreationTokens = (dailyEntry.modelUsage[model].cacheCreationTokens ?? 0) + usage.cacheCreationTokens;
+							}
 						}
 					}
 				} catch (fileError) {


### PR DESCRIPTION
## Problem

The "Est. Cost" chart showed ~$2811 for April 2026 while the detail page correctly showed ~$921. The detail page was previously fixed, but the chart used a separate code path that was missed.

## Root Cause

`calculateDailyStats()` builds per-day `modelUsage` rollups for the chart, but only copied `inputTokens` and `outputTokens` — it **dropped `cachedReadTokens` and `cacheCreationTokens`**. Without cache token data, `calculateEstimatedCost()` treats all input tokens as uncached (full rate), massively inflating the cost.

With ~92% cache hit rate for Claude Sonnet 4.6 in April, this caused a ~3x overestimate.

## Fix

In both code paths of `calculateDailyStats()`:
- **Per-UTC-day rollup path** (`dayRollup.modelUsage`)
- **Fallback session-level path** (`sessionData.modelUsage`)

Now propagate `cachedReadTokens` and `cacheCreationTokens` exactly like the `mergeInto()` helper already does in `buildChartData()`.

## Testing

- TypeScript compiles cleanly (`tsc --noEmit`)
- Chart monthly cost for April should now match the detail page value (~$921)