### PR TITLE
refactor: extract calculateMaturityScores into focused private helpers

### DIFF
--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -19,6 +19,384 @@ function fmt(n: number): string {
 	return n.toLocaleString('en-US');
 }
 
+type CategoryScore = { stage: number; evidence: string[]; tips: string[] };
+
+function _scorePromptEngineering(p: UsageAnalysisPeriod): CategoryScore {
+	const evidence: string[] = [];
+	const tips: string[] = [];
+	let stage = 1;
+
+	const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent + p.modeUsage.cli;
+	if (totalInteractions > 0) { evidence.push(`${fmt(totalInteractions)} total interactions`); }
+	if (p.modeUsage.ask > 0) { evidence.push(`${fmt(p.modeUsage.ask)} ask-mode conversations`); }
+	if (p.modeUsage.agent > 0) { evidence.push(`${fmt(p.modeUsage.agent)} agent-mode interactions`); }
+	if (p.modeUsage.cli > 0) { evidence.push(`${fmt(p.modeUsage.cli)} CLI interactions`); }
+
+	if (p.conversationPatterns) {
+		const multiTurnRate = p.sessions > 0
+			? Math.round((p.conversationPatterns.multiTurnSessions / p.sessions) * 100)
+			: 0;
+		if (p.conversationPatterns.multiTurnSessions > 0) {
+			evidence.push(`${fmt(p.conversationPatterns.multiTurnSessions)} multi-turn sessions (${multiTurnRate}%)`);
+		}
+		if (p.conversationPatterns.avgTurnsPerSession >= 3) {
+			evidence.push(`Avg ${p.conversationPatterns.avgTurnsPerSession.toFixed(1)} exchanges per session`);
+			stage = Math.max(stage, 2) as 1 | 2 | 3 | 4;
+		}
+		if (p.conversationPatterns.avgTurnsPerSession >= 5) {
+			stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+		}
+	}
+
+	if (totalInteractions >= 5) { stage = 2; }
+
+	const slashCommands = ['explain', 'fix', 'tests', 'doc', 'generate', 'optimize', 'new', 'newNotebook', 'search', 'fixTestFailure', 'setupTests'];
+	const claudeSlashCommands = ['review', 'bug', 'think', 'compact', 'pr_comments'];
+	const usedSlashCommands = [
+		...slashCommands.filter(cmd => (p.toolCalls.byTool[cmd] || 0) > 0),
+		...claudeSlashCommands.filter(cmd => (p.toolCalls.byTool[`__slash__${cmd}`] || 0) > 0),
+	];
+	if (usedSlashCommands.length > 0) { evidence.push(`Used slash commands: /${usedSlashCommands.join(', /')}`); }
+
+	const hasModelSwitching = p.modelSwitching.mixedTierSessions > 0 || p.modelSwitching.switchingFrequency > 0;
+	const hasAgentMode = p.modeUsage.agent > 0 || p.modeUsage.cli > 0;
+
+	if (totalInteractions >= 30 && (usedSlashCommands.length >= 2 || hasAgentMode)) { stage = 3; }
+	if (totalInteractions >= 100 && hasAgentMode && (hasModelSwitching || usedSlashCommands.length >= 3)) { stage = 4; }
+
+	if (hasModelSwitching) {
+		evidence.push(`Switched models in ${Math.round(p.modelSwitching.switchingFrequency)}% of sessions`);
+		if (stage < 4 && p.modelSwitching.mixedTierSessions > 0) {
+			stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+		}
+	}
+
+	if (stage < 2) { tips.push('Try asking Copilot a question using the Chat panel'); }
+	if (stage < 3) {
+		if (!hasAgentMode) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-file changes'); }
+		if (usedSlashCommands.length < 2) { tips.push('Use [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /fix, or /tests to give structured prompts'); }
+	}
+	if (stage < 4) {
+		if (!hasAgentMode) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for autonomous, multi-step coding tasks'); }
+		if (!hasModelSwitching) { tips.push('Experiment with [different models](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_choose-a-language-model) for different tasks - use fast models for simple queries and reasoning models for complex problems'); }
+		if (usedSlashCommands.length < 3 && hasAgentMode && hasModelSwitching) { tips.push('Explore more [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /tests, or /doc to diversify your prompting'); }
+	}
+
+	return { stage, evidence, tips };
+}
+
+function _scoreContextEngineering(p: UsageAnalysisPeriod): CategoryScore {
+	const evidence: string[] = [];
+	const tips: string[] = [];
+	let stage = 1;
+
+	const refs = p.contextReferences;
+	const totalContextRefs = refs.file + refs.selection + refs.symbol + refs.codebase + refs.workspace;
+	const usedRefTypeCount = [
+		refs.file, refs.selection, refs.symbol, refs.codebase, refs.workspace,
+		refs.terminal, refs.vscode, refs.clipboard, refs.changes,
+		refs.problemsPanel, refs.outputPanel, refs.terminalLastCommand, refs.terminalSelection,
+	].filter(Boolean).length;
+
+	if (refs.file > 0) { evidence.push(`${fmt(refs.file)} #file references`); }
+	if (refs.selection > 0) { evidence.push(`${fmt(refs.selection)} #selection references`); }
+	if (refs.codebase > 0) { evidence.push(`${fmt(refs.codebase)} #codebase references`); }
+	if (refs.workspace > 0) { evidence.push(`${fmt(refs.workspace)} @workspace references`); }
+	if (refs.terminal > 0) { evidence.push(`${fmt(refs.terminal)} @terminal references`); }
+	if (refs.vscode > 0) { evidence.push(`${fmt(refs.vscode)} @vscode references`); }
+	if (refs.clipboard > 0) { evidence.push(`${fmt(refs.clipboard)} #clipboard references`); }
+	if (refs.changes > 0) { evidence.push(`${fmt(refs.changes)} #changes references`); }
+	if (refs.problemsPanel > 0) { evidence.push(`${fmt(refs.problemsPanel)} #problemsPanel references`); }
+	if (refs.outputPanel > 0) { evidence.push(`${fmt(refs.outputPanel)} #outputPanel references`); }
+	if (refs.terminalLastCommand > 0) { evidence.push(`${fmt(refs.terminalLastCommand)} #terminalLastCommand references`); }
+	if (refs.terminalSelection > 0) { evidence.push(`${fmt(refs.terminalSelection)} #terminalSelection references`); }
+
+	if (totalContextRefs >= 1) { stage = 2; }
+	if (usedRefTypeCount >= 3 && totalContextRefs >= 10) { stage = 3; }
+	if (usedRefTypeCount >= 5 && totalContextRefs >= 30) { stage = 4; }
+
+	const imageRefs = refs.byKind['copilot.image'] || 0;
+	if (imageRefs > 0) {
+		evidence.push(`${fmt(imageRefs)} image references (vision)`);
+		stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+	}
+
+	if (stage < 2) { tips.push('Try adding [#file or #selection](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) references to give Copilot more context'); }
+	if (stage < 3) { tips.push('Explore [@workspace, #codebase, and @terminal](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) for broader context'); }
+	if (stage < 4) {
+		const typesStillNeeded = Math.max(0, 5 - usedRefTypeCount);
+		const refsStillNeeded = Math.max(0, 30 - totalContextRefs);
+		const specializedItems = [
+			{ name: 'image attachments', used: imageRefs > 0 },
+			{ name: '#changes', used: refs.changes > 0 },
+			{ name: '#problemsPanel', used: refs.problemsPanel > 0 },
+			{ name: '#outputPanel', used: refs.outputPanel > 0 },
+			{ name: '#terminalLastCommand', used: refs.terminalLastCommand > 0 },
+			{ name: '#terminalSelection', used: refs.terminalSelection > 0 },
+			{ name: '#clipboard', used: refs.clipboard > 0 },
+			{ name: '@vscode', used: refs.vscode > 0 },
+		];
+		const specializedUsedCount = specializedItems.filter(i => i.used).length;
+		if (specializedUsedCount >= 2) {
+			const allTypesNotUsed = [
+				{ name: '#symbol', used: refs.symbol > 0 },
+				{ name: '@workspace', used: refs.workspace > 0 },
+				{ name: '#codebase', used: refs.codebase > 0 },
+				{ name: '@terminal', used: refs.terminal > 0 },
+				...specializedItems,
+			].filter(i => !i.used).map(i => i.name);
+			const gapParts: string[] = [];
+			if (typesStillNeeded > 0) { gapParts.push(`${fmt(usedRefTypeCount)} of 5 different reference types used`); }
+			if (refsStillNeeded > 0) { gapParts.push(`${fmt(totalContextRefs)} of 30 total references`); }
+			if (gapParts.length > 0) {
+				const suggest = allTypesNotUsed.slice(0, 3);
+				const suggStr = suggest.length > 0 ? ` — try ${suggest.join(', ')}` : '';
+				tips.push(`Stage 4 needs ${gapParts.join(' and ')}${suggStr}`);
+			}
+		} else {
+			const specializedNotYetUsed = specializedItems.filter(i => !i.used).map(i => i.name);
+			if (specializedNotYetUsed.length > 0) {
+				const toMention = specializedNotYetUsed.slice(0, 3);
+				const extra = specializedNotYetUsed.length > 3 ? ` and ${specializedNotYetUsed.length - 3} more` : '';
+				tips.push(`Try ${toMention.join(', ')}${extra} — see [specialized context variables](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) to reach Stage 4`);
+			}
+		}
+	}
+
+	return { stage, evidence, tips };
+}
+
+function _scoreAgentic(p: UsageAnalysisPeriod): CategoryScore {
+	const evidence: string[] = [];
+	const tips: string[] = [];
+	let stage = 1;
+
+	if (p.modeUsage.agent > 0) { evidence.push(`${fmt(p.modeUsage.agent)} agent-mode interactions`); stage = 2; }
+	if (p.modeUsage.cli > 0) { evidence.push(`${fmt(p.modeUsage.cli)} CLI interactions`); stage = Math.max(stage, 2) as 1 | 2 | 3 | 4; }
+	if (p.toolCalls.total > 0) { evidence.push(`${fmt(p.toolCalls.total)} tool calls executed`); }
+	if (p.modeUsage.edit > 0) { evidence.push(`${fmt(p.modeUsage.edit)} edit-mode interactions`); }
+
+	if (p.editScope) {
+		const multiFileRate = p.editScope.totalEditedFiles > 0
+			? Math.round((p.editScope.multiFileEdits / (p.editScope.singleFileEdits + p.editScope.multiFileEdits)) * 100)
+			: 0;
+		if (p.editScope.multiFileEdits > 0) {
+			evidence.push(`${fmt(p.editScope.multiFileEdits)} multi-file edit sessions (${multiFileRate}%)`);
+			stage = Math.max(stage, 2) as 1 | 2 | 3 | 4;
+		}
+		if (p.editScope.avgFilesPerSession >= 3) {
+			evidence.push(`Avg ${p.editScope.avgFilesPerSession.toFixed(1)} files per edit session`);
+			stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+		}
+	}
+
+	if (p.agentTypes && p.agentTypes.editsAgent > 0) {
+		evidence.push(`${fmt(p.agentTypes.editsAgent)} edits agent sessions`);
+		stage = Math.max(stage, 2) as 1 | 2 | 3 | 4;
+	}
+
+	const nonAutoToolCount = Object.keys(p.toolCalls.byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase()) && !t.startsWith('__slash__')).length;
+	if ((p.modeUsage.agent + p.modeUsage.cli) >= 10 && nonAutoToolCount >= 3) { stage = 3; }
+	if ((p.modeUsage.agent + p.modeUsage.cli) >= 50 && nonAutoToolCount >= 5) { stage = 4; }
+	if (p.editScope && p.editScope.multiFileEdits >= 20 && p.editScope.avgFilesPerSession >= 3) {
+		stage = Math.max(stage, 4) as 1 | 2 | 3 | 4;
+	}
+
+	if (stage < 2) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) — it can run terminal commands, edit files, and explore your codebase autonomously'); }
+	if (stage < 3) { tips.push('Use [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-step tasks; let it chain tools like file search, terminal, and code edits'); }
+	if (stage < 4) { tips.push('Tackle complex refactoring or debugging tasks in [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for deeper autonomous workflows'); }
+
+	return { stage, evidence, tips };
+}
+
+function _scoreToolUsage(p: UsageAnalysisPeriod): CategoryScore {
+	const evidence: string[] = [];
+	const tips: string[] = [];
+	let stage = 1;
+
+	const toolCount = Object.keys(p.toolCalls.byTool).length;
+	const nonAutoToolCount = Object.keys(p.toolCalls.byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase()) && !t.startsWith('__slash__')).length;
+
+	if (nonAutoToolCount > 0) {
+		const autoCount = toolCount - nonAutoToolCount;
+		const autoNote = autoCount > 0 ? ` (+ ${fmt(autoCount)} automatic)` : '';
+		evidence.push(`${fmt(nonAutoToolCount)} intentional tools used${autoNote}`);
+		stage = 2;
+	} else if (toolCount > 0) {
+		evidence.push(`${fmt(toolCount)} tools used (all automatic — agent reads/searches)`);
+	}
+
+	if (p.agentTypes) {
+		if (p.agentTypes.workspaceAgent > 0) {
+			evidence.push(`${fmt(p.agentTypes.workspaceAgent)} @workspace agent sessions`);
+			stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+		}
+	}
+
+	const advancedToolFriendlyNames: Record<string, string> = {
+		github_pull_request: 'GitHub Pull Request',
+		github_repo: 'GitHub Repository',
+		run_in_terminal: 'Run In Terminal',
+		editFiles: 'Edit Files',
+		listFiles: 'List Files'
+	};
+	const usedAdvanced = Object.keys(advancedToolFriendlyNames).filter(t => (p.toolCalls.byTool[t] || 0) > 0);
+	if (usedAdvanced.length > 0) {
+		evidence.push(`Advanced tools: ${usedAdvanced.map(t => advancedToolFriendlyNames[t]).join(', ')}`);
+		if (usedAdvanced.length >= 2) { stage = Math.max(stage, 3) as 1 | 2 | 3 | 4; }
+	}
+
+	const mcpServers = Object.keys(p.mcpTools.byServer);
+	if (p.mcpTools.total > 0) {
+		evidence.push(`${fmt(p.mcpTools.total)} MCP tool calls across ${mcpServers.length} server(s)`);
+		stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+		if (mcpServers.length >= 2) { stage = 4; }
+	}
+
+	if (stage < 2) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) to let Copilot use built-in tools for file operations and terminal commands'); }
+	if (stage < 3) {
+		if (mcpServers.length === 0) {
+			tips.push('Set up [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) to connect Copilot to external tools (databases, APIs, cloud services)');
+		} else {
+			tips.push('Explore [GitHub integrations](https://code.visualstudio.com/docs/copilot/agents/agent-tools) and advanced tools like editFiles and run_in_terminal');
+		}
+	}
+	if (stage < 4) {
+		if (mcpServers.length === 1) {
+			tips.push('Add more [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) to expand Copilot\'s capabilities - check the VS Code MCP registry');
+		} else if (mcpServers.length === 0) {
+			tips.push('Explore the [VS Code MCP registry](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) for tools that integrate with your workflow');
+		} else {
+			tips.push('You\'re using multiple MCP servers - keep exploring advanced tool combinations');
+		}
+	}
+
+	return { stage, evidence, tips };
+}
+
+function _scoreCustomization(p: UsageAnalysisPeriod, lastCustomizationMatrix: WorkspaceCustomizationMatrix | undefined): CategoryScore {
+	const evidence: string[] = [];
+	const tips: string[] = [];
+	let stage = 1;
+
+	const matrix = lastCustomizationMatrix;
+	const totalRepos = matrix?.totalWorkspaces ?? 0;
+	const reposWithCustomization = totalRepos - (matrix?.workspacesWithIssues ?? 0);
+	const customizationRate = totalRepos > 0 ? (reposWithCustomization / totalRepos) : 0;
+
+	if (totalRepos > 0) { evidence.push(`Worked in ${totalRepos} repositor${totalRepos === 1 ? 'y' : 'ies'}`); }
+	if (reposWithCustomization > 0) { stage = 2; }
+	if (customizationRate >= 0.3 && reposWithCustomization >= 2) { stage = 3; }
+	if (customizationRate >= 0.7 && reposWithCustomization >= 3) { stage = 4; }
+
+	const uniqueModels = [...new Set([...p.modelSwitching.standardModels, ...p.modelSwitching.premiumModels])];
+	if (uniqueModels.length >= 3) {
+		const hasStage4Models = uniqueModels.length >= 5 && reposWithCustomization >= 3;
+		evidence.push(`Used ${uniqueModels.length} different models`);
+		if (hasStage4Models) {
+			stage = 4;
+		} else {
+			stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+		}
+	}
+
+	if (stage >= 4) {
+		evidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos customized (70%+ with 3+ repos → Stage 4)`);
+	} else if (stage >= 3) {
+		evidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos customized (30%+ with 2+ repos → Stage 3)`);
+	} else if (reposWithCustomization > 0) {
+		evidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos with custom instructions or agents.md`);
+	}
+
+	if (stage < 2) { tips.push('Create a [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) or [CLAUDE.md](https://docs.anthropic.com/en/docs/claude-code/memory) file with project-specific guidelines'); }
+	if (stage < 3) { tips.push('Add [custom instructions](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) to more repositories to standardize your Copilot experience'); }
+	if (stage < 4) {
+		const uncustomized = totalRepos - reposWithCustomization;
+		if (totalRepos > 0 && uncustomized > 0) {
+			tips.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos have customization — add [instructions and agents.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) to the remaining ${fmt(uncustomized)} repo${uncustomized === 1 ? '' : 's'} for Stage 4`);
+		} else {
+			tips.push('Aim for consistent customization across all projects with [instructions and agents.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)');
+		}
+	}
+	if (stage >= 4) {
+		const uncustomized = totalRepos - reposWithCustomization;
+		if (uncustomized > 0) {
+			const missingCustomizationRepos = (matrix?.workspaces || [])
+				.filter(row => Object.values(row.typeStatuses).every(status => status === '❌'));
+			const prioritizedMissingRepos = missingCustomizationRepos
+				.filter(row => !row.workspacePath.startsWith('<unresolved:'))
+				.sort((a, b) => {
+					if (b.interactionCount !== a.interactionCount) { return b.interactionCount - a.interactionCount; }
+					return b.sessionCount - a.sessionCount;
+				})
+				.slice(0, 3);
+			const summaryTip = `${fmt(uncustomized)} repo${uncustomized === 1 ? '' : 's'} still missing customization — add [instructions](https://code.visualstudio.com/docs/copilot/customization/custom-instructions), [agents.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions), or [MCP configs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) for full coverage.`;
+			if (prioritizedMissingRepos.length > 0) {
+				const repoLines = prioritizedMissingRepos.map(row =>
+					`${row.workspaceName} (${fmt(row.interactionCount)} interaction${row.interactionCount === 1 ? '' : 's'})`
+				).join('\n');
+				tips.push(`${summaryTip}\n\nTop repos to customize first:\n${repoLines}`);
+			} else {
+				tips.push(summaryTip);
+			}
+		} else {
+			tips.push('All repos customized! Keep instructions up to date and add [skill files](https://code.visualstudio.com/docs/copilot/customization/agent-skills) or [MCP server configs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) for deeper integration');
+		}
+	}
+
+	return { stage, evidence, tips };
+}
+
+function _scoreWorkflowIntegration(p: UsageAnalysisPeriod): CategoryScore {
+	const evidence: string[] = [];
+	const tips: string[] = [];
+	let stage = 1;
+
+	if (p.sessions >= 3) { evidence.push(`${fmt(p.sessions)} sessions in the last 30 days`); stage = 2; }
+
+	if (p.applyUsage && p.applyUsage.totalCodeBlocks > 0) {
+		const applyRatePercent = Math.round(p.applyUsage.applyRate);
+		evidence.push(`${applyRatePercent}% code block apply rate (${fmt(p.applyUsage.totalApplies)}/${fmt(p.applyUsage.totalCodeBlocks)})`);
+		if (applyRatePercent >= 50) { stage = Math.max(stage, 2) as 1 | 2 | 3 | 4; }
+	}
+
+	if (p.sessionDuration && p.sessionDuration.avgDurationMs > 0) {
+		const avgMinutes = Math.round(p.sessionDuration.avgDurationMs / 60000);
+		evidence.push(`Avg ${avgMinutes}min session duration`);
+	}
+
+	const totalContextRefs = p.contextReferences.file + p.contextReferences.selection +
+		p.contextReferences.symbol + p.contextReferences.codebase + p.contextReferences.workspace;
+	const modesUsed = [p.modeUsage.ask > 0, p.modeUsage.agent > 0, p.modeUsage.cli > 0].filter(Boolean).length;
+	if (modesUsed >= 2) {
+		evidence.push(`Uses ${modesUsed} modes (ask/agent/cli)`);
+		stage = Math.max(stage, 3) as 1 | 2 | 3 | 4;
+	}
+
+	const hasExplicitContext = totalContextRefs >= 10;
+	if (hasExplicitContext) {
+		evidence.push(`${fmt(totalContextRefs)} explicit context references`);
+		if (totalContextRefs >= 20) { stage = Math.max(stage, 3) as 1 | 2 | 3 | 4; }
+	}
+
+	if (p.sessions >= 15 && modesUsed >= 2 && totalContextRefs >= 20) {
+		stage = 4;
+		evidence.push('Deep integration: regular usage with multi-mode and explicit context');
+	}
+
+	if (stage < 2) { tips.push('Use AI more regularly - even for quick questions'); }
+	if (stage < 3) {
+		if (modesUsed < 2) { tips.push('Combine [ask mode with agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) in your daily workflow'); }
+		if (totalContextRefs < 10) { tips.push('Use explicit [context references](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like #file, @workspace, and #selection'); }
+	}
+	if (stage < 4) {
+		if (totalContextRefs < 20) { tips.push('Make explicit context a habit - use [#file, @workspace, and other references](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) consistently'); }
+		tips.push('Make AI part of every coding task: planning, coding, testing, and reviewing');
+	}
+
+	return { stage, evidence, tips };
+}
+
 
 export function getFluencyLevelData(isDebugMode: boolean): {
     categories: Array<{
@@ -661,469 +1039,14 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 		4: 'Stage 4: AI Strategist'
 	};
 
-	// ---------- 1. Prompt Engineering ----------
-	const peEvidence: string[] = [];
-	const peTips: string[] = [];
-	let peStage = 1;
+	const pe = _scorePromptEngineering(p);
+	const ce = _scoreContextEngineering(p);
+	const ag = _scoreAgentic(p);
+	const tu = _scoreToolUsage(p);
+	const cu = _scoreCustomization(p, lastCustomizationMatrix);
+	const wi = _scoreWorkflowIntegration(p);
 
-	const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent + p.modeUsage.cli;
-	if (totalInteractions > 0) {
-		peEvidence.push(`${fmt(totalInteractions)} total interactions`);
-	}
-	if (p.modeUsage.ask > 0) {
-		peEvidence.push(`${fmt(p.modeUsage.ask)} ask-mode conversations`);
-	}
-	if (p.modeUsage.agent > 0) {
-		peEvidence.push(`${fmt(p.modeUsage.agent)} agent-mode interactions`);
-	}
-	if (p.modeUsage.cli > 0) {
-		peEvidence.push(`${fmt(p.modeUsage.cli)} CLI interactions`);
-	}
-
-	// Conversation patterns (multi-turn shows iterative refinement)
-	if (p.conversationPatterns) {
-		const multiTurnRate = p.sessions > 0
-			? Math.round((p.conversationPatterns.multiTurnSessions / p.sessions) * 100)
-			: 0;
-		if (p.conversationPatterns.multiTurnSessions > 0) {
-			peEvidence.push(`${fmt(p.conversationPatterns.multiTurnSessions)} multi-turn sessions (${multiTurnRate}%)`);
-		}
-		if (p.conversationPatterns.avgTurnsPerSession >= 3) {
-			peEvidence.push(`Avg ${p.conversationPatterns.avgTurnsPerSession.toFixed(1)} exchanges per session`);
-			peStage = Math.max(peStage, 2) as 1 | 2 | 3 | 4;
-		}
-		if (p.conversationPatterns.avgTurnsPerSession >= 5) {
-			peStage = Math.max(peStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	if (totalInteractions >= 5) {
-		peStage = 2; // At least trying it out
-	}
-
-	// Check slash command / tool usage (indicates structured prompts)
-	// VS Code Copilot slash commands (stored as tool calls by the session parser)
-	const slashCommands = ['explain', 'fix', 'tests', 'doc', 'generate', 'optimize', 'new', 'newNotebook', 'search', 'fixTestFailure', 'setupTests'];
-	// Claude Code slash commands (stored with __slash__ prefix to avoid inflating tool counts)
-	const claudeSlashCommands = ['review', 'bug', 'think', 'compact', 'pr_comments'];
-	const usedSlashCommands = [
-		...slashCommands.filter(cmd => (p.toolCalls.byTool[cmd] || 0) > 0),
-		...claudeSlashCommands.filter(cmd => (p.toolCalls.byTool[`__slash__${cmd}`] || 0) > 0),
-	];
-	if (usedSlashCommands.length > 0) {
-		peEvidence.push(`Used slash commands: /${usedSlashCommands.join(', /')}`);
-	}
-
-	const hasModelSwitching = p.modelSwitching.mixedTierSessions > 0 || p.modelSwitching.switchingFrequency > 0;
-	const hasAgentMode = p.modeUsage.agent > 0 || p.modeUsage.cli > 0;
-
-	if (totalInteractions >= 30 && (usedSlashCommands.length >= 2 || hasAgentMode)) {
-		peStage = 3; // Regular, purposeful use
-	}
-
-	// Strategist: high volume + agent mode + (model switching or diverse slash commands)
-	if (totalInteractions >= 100 && hasAgentMode && (hasModelSwitching || usedSlashCommands.length >= 3)) {
-		peStage = 4;
-	}
-
-	// Model switching awareness
-	if (hasModelSwitching) {
-		peEvidence.push(`Switched models in ${Math.round(p.modelSwitching.switchingFrequency)}% of sessions`);
-		if (peStage < 4 && p.modelSwitching.mixedTierSessions > 0) {
-			peStage = Math.max(peStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// Context-aware tips
-	if (peStage < 2) { peTips.push('Try asking Copilot a question using the Chat panel'); }
-	if (peStage < 3) {
-		if (!hasAgentMode) { peTips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-file changes'); }
-		if (usedSlashCommands.length < 2) { peTips.push('Use [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /fix, or /tests to give structured prompts'); }
-	}
-	if (peStage < 4) {
-		if (!hasAgentMode) { peTips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for autonomous, multi-step coding tasks'); }
-		if (!hasModelSwitching) { peTips.push('Experiment with [different models](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_choose-a-language-model) for different tasks - use fast models for simple queries and reasoning models for complex problems'); }
-		if (usedSlashCommands.length < 3 && hasAgentMode && hasModelSwitching) { peTips.push('Explore more [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /tests, or /doc to diversify your prompting'); }
-	}
-
-	// ---------- 2. Context Engineering ----------
-	const ceEvidence: string[] = [];
-	const ceTips: string[] = [];
-	let ceStage = 1;
-
-	const totalContextRefs = p.contextReferences.file + p.contextReferences.selection +
-		p.contextReferences.symbol + p.contextReferences.codebase + p.contextReferences.workspace;
-	const refTypes = [
-		p.contextReferences.file > 0,
-		p.contextReferences.selection > 0,
-		p.contextReferences.symbol > 0,
-		p.contextReferences.codebase > 0,
-		p.contextReferences.workspace > 0,
-		p.contextReferences.terminal > 0,
-		p.contextReferences.vscode > 0,
-		p.contextReferences.clipboard > 0,
-		p.contextReferences.changes > 0,
-		p.contextReferences.problemsPanel > 0,
-		p.contextReferences.outputPanel > 0,
-		p.contextReferences.terminalLastCommand > 0,
-		p.contextReferences.terminalSelection > 0
-	];
-	const usedRefTypeCount = refTypes.filter(Boolean).length;
-
-	if (p.contextReferences.file > 0) { ceEvidence.push(`${fmt(p.contextReferences.file)} #file references`); }
-	if (p.contextReferences.selection > 0) { ceEvidence.push(`${fmt(p.contextReferences.selection)} #selection references`); }
-	if (p.contextReferences.codebase > 0) { ceEvidence.push(`${fmt(p.contextReferences.codebase)} #codebase references`); }
-	if (p.contextReferences.workspace > 0) { ceEvidence.push(`${fmt(p.contextReferences.workspace)} @workspace references`); }
-	if (p.contextReferences.terminal > 0) { ceEvidence.push(`${fmt(p.contextReferences.terminal)} @terminal references`); }
-	if (p.contextReferences.vscode > 0) { ceEvidence.push(`${fmt(p.contextReferences.vscode)} @vscode references`); }
-	if (p.contextReferences.clipboard > 0) { ceEvidence.push(`${fmt(p.contextReferences.clipboard)} #clipboard references`); }
-	if (p.contextReferences.changes > 0) { ceEvidence.push(`${fmt(p.contextReferences.changes)} #changes references`); }
-	if (p.contextReferences.problemsPanel > 0) { ceEvidence.push(`${fmt(p.contextReferences.problemsPanel)} #problemsPanel references`); }
-	if (p.contextReferences.outputPanel > 0) { ceEvidence.push(`${fmt(p.contextReferences.outputPanel)} #outputPanel references`); }
-	if (p.contextReferences.terminalLastCommand > 0) { ceEvidence.push(`${fmt(p.contextReferences.terminalLastCommand)} #terminalLastCommand references`); }
-	if (p.contextReferences.terminalSelection > 0) { ceEvidence.push(`${fmt(p.contextReferences.terminalSelection)} #terminalSelection references`); }
-
-	if (totalContextRefs >= 1) { ceStage = 2; }
-	if (usedRefTypeCount >= 3 && totalContextRefs >= 10) { ceStage = 3; }
-	if (usedRefTypeCount >= 5 && totalContextRefs >= 30) { ceStage = 4; }
-
-	// Image context (byKind: copilot.image)
-	const imageRefs = p.contextReferences.byKind['copilot.image'] || 0;
-	if (imageRefs > 0) {
-		ceEvidence.push(`${fmt(imageRefs)} image references (vision)`);
-		ceStage = Math.max(ceStage, 3) as 1 | 2 | 3 | 4;
-	}
-
-	if (ceStage < 2) { ceTips.push('Try adding [#file or #selection](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) references to give Copilot more context'); }
-	if (ceStage < 3) { ceTips.push('Explore [@workspace, #codebase, and @terminal](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) for broader context'); }
-	if (ceStage < 4) {
-		const typesStillNeeded = Math.max(0, 5 - usedRefTypeCount);
-		const refsStillNeeded = Math.max(0, 30 - totalContextRefs);
-		const specializedItems = [
-			{ name: 'image attachments', used: imageRefs > 0 },
-			{ name: '#changes', used: p.contextReferences.changes > 0 },
-			{ name: '#problemsPanel', used: p.contextReferences.problemsPanel > 0 },
-			{ name: '#outputPanel', used: p.contextReferences.outputPanel > 0 },
-			{ name: '#terminalLastCommand', used: p.contextReferences.terminalLastCommand > 0 },
-			{ name: '#terminalSelection', used: p.contextReferences.terminalSelection > 0 },
-			{ name: '#clipboard', used: p.contextReferences.clipboard > 0 },
-			{ name: '@vscode', used: p.contextReferences.vscode > 0 },
-		];
-		const specializedUsedCount = specializedItems.filter(i => i.used).length;
-		if (specializedUsedCount >= 2) {
-			// User already uses multiple specialized context techniques — show a concrete gap tip.
-			const allTypesNotUsed = [
-				{ name: '#symbol', used: p.contextReferences.symbol > 0 },
-				{ name: '@workspace', used: p.contextReferences.workspace > 0 },
-				{ name: '#codebase', used: p.contextReferences.codebase > 0 },
-				{ name: '@terminal', used: p.contextReferences.terminal > 0 },
-				...specializedItems,
-			].filter(i => !i.used).map(i => i.name);
-			const gapParts: string[] = [];
-			if (typesStillNeeded > 0) { gapParts.push(`${fmt(usedRefTypeCount)} of 5 different reference types used`); }
-			if (refsStillNeeded > 0) { gapParts.push(`${fmt(totalContextRefs)} of 30 total references`); }
-			if (gapParts.length > 0) {
-				const suggest = allTypesNotUsed.slice(0, 3);
-				const suggStr = suggest.length > 0 ? ` — try ${suggest.join(', ')}` : '';
-				ceTips.push(`Stage 4 needs ${gapParts.join(' and ')}${suggStr}`);
-			}
-		} else {
-			// User hasn't explored many specialized vars yet — suggest them.
-			const specializedNotYetUsed = specializedItems.filter(i => !i.used).map(i => i.name);
-			if (specializedNotYetUsed.length > 0) {
-				const toMention = specializedNotYetUsed.slice(0, 3);
-				const extra = specializedNotYetUsed.length > 3 ? ` and ${specializedNotYetUsed.length - 3} more` : '';
-				ceTips.push(`Try ${toMention.join(', ')}${extra} — see [specialized context variables](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) to reach Stage 4`);
-			}
-		}
-	}
-
-	// ---------- 3. Agentic ----------
-	const agEvidence: string[] = [];
-	const agTips: string[] = [];
-	let agStage = 1;
-
-	if (p.modeUsage.agent > 0) {
-		agEvidence.push(`${fmt(p.modeUsage.agent)} agent-mode interactions`);
-		agStage = 2;
-	}
-	if (p.modeUsage.cli > 0) {
-		agEvidence.push(`${fmt(p.modeUsage.cli)} CLI interactions`);
-		agStage = Math.max(agStage, 2) as 1 | 2 | 3 | 4;
-	}
-	if (p.toolCalls.total > 0) {
-		agEvidence.push(`${fmt(p.toolCalls.total)} tool calls executed`);
-	}
-	if (p.modeUsage.edit > 0) {
-		agEvidence.push(`${fmt(p.modeUsage.edit)} edit-mode interactions`);
-	}
-
-	// Edit scope tracking (multi-file edits show advanced agentic behavior)
-	if (p.editScope) {
-		const multiFileRate = p.editScope.totalEditedFiles > 0
-			? Math.round((p.editScope.multiFileEdits / (p.editScope.singleFileEdits + p.editScope.multiFileEdits)) * 100)
-			: 0;
-		if (p.editScope.multiFileEdits > 0) {
-			agEvidence.push(`${fmt(p.editScope.multiFileEdits)} multi-file edit sessions (${multiFileRate}%)`);
-			agStage = Math.max(agStage, 2) as 1 | 2 | 3 | 4;
-		}
-		if (p.editScope.avgFilesPerSession >= 3) {
-			agEvidence.push(`Avg ${p.editScope.avgFilesPerSession.toFixed(1)} files per edit session`);
-			agStage = Math.max(agStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// Agent type distribution
-	if (p.agentTypes && p.agentTypes.editsAgent > 0) {
-		agEvidence.push(`${fmt(p.agentTypes.editsAgent)} edits agent sessions`);
-		agStage = Math.max(agStage, 2) as 1 | 2 | 3 | 4;
-	}
-
-	// Diverse tool usage in agent mode
-	const toolCount = Object.keys(p.toolCalls.byTool).length;
-	// Exclude __slash__ pseudo-entries from real tool counts (they track Claude slash commands, not actual tool calls)
-	const nonAutoToolCount = Object.keys(p.toolCalls.byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase()) && !t.startsWith('__slash__')).length;
-	if ((p.modeUsage.agent + p.modeUsage.cli) >= 10 && nonAutoToolCount >= 3) {
-		agStage = 3;
-	}
-
-	// Heavy agentic use with many tool types or high multi-file edit rate
-	if ((p.modeUsage.agent + p.modeUsage.cli) >= 50 && nonAutoToolCount >= 5) {
-		agStage = 4;
-	}
-	if (p.editScope && p.editScope.multiFileEdits >= 20 && p.editScope.avgFilesPerSession >= 3) {
-		agStage = Math.max(agStage, 4) as 1 | 2 | 3 | 4;
-	}
-
-	if (agStage < 2) { agTips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) — it can run terminal commands, edit files, and explore your codebase autonomously'); }
-	if (agStage < 3) { agTips.push('Use [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-step tasks; let it chain tools like file search, terminal, and code edits'); }
-	if (agStage < 4) { agTips.push('Tackle complex refactoring or debugging tasks in [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for deeper autonomous workflows'); }
-
-	// ---------- 4. Tool Usage ----------
-	const tuEvidence: string[] = [];
-	const tuTips: string[] = [];
-	let tuStage = 1;
-
-	// Basic tool usage — only count tools the user intentionally enables/configures (not automatic agent tools)
-	if (nonAutoToolCount > 0) {
-		const autoCount = toolCount - nonAutoToolCount;
-		const autoNote = autoCount > 0 ? ` (+ ${fmt(autoCount)} automatic)` : '';
-		tuEvidence.push(`${fmt(nonAutoToolCount)} intentional tools used${autoNote}`);
-		tuStage = 2;
-	} else if (toolCount > 0) {
-		tuEvidence.push(`${fmt(toolCount)} tools used (all automatic — agent reads/searches)`);
-	}
-
-	// Agent type distribution (workspace agent shows advanced tool usage)
-	if (p.agentTypes) {
-		if (p.agentTypes.workspaceAgent > 0) {
-			tuEvidence.push(`${fmt(p.agentTypes.workspaceAgent)} @workspace agent sessions`);
-			tuStage = Math.max(tuStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// Specific advanced tool IDs (intentional tool integration)
-	const advancedToolFriendlyNames: Record<string, string> = {
-		github_pull_request: 'GitHub Pull Request',
-		github_repo: 'GitHub Repository',
-		run_in_terminal: 'Run In Terminal',
-		editFiles: 'Edit Files',
-		listFiles: 'List Files'
-	};
-	const usedAdvanced = Object.keys(advancedToolFriendlyNames).filter(t => (p.toolCalls.byTool[t] || 0) > 0);
-	if (usedAdvanced.length > 0) {
-		tuEvidence.push(`Advanced tools: ${usedAdvanced.map(t => advancedToolFriendlyNames[t]).join(', ')}`);
-		if (usedAdvanced.length >= 2) {
-			tuStage = Math.max(tuStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// MCP tools are a strong signal of strategic/advanced use
-	const mcpServers = Object.keys(p.mcpTools.byServer);
-	if (p.mcpTools.total > 0) {
-		tuEvidence.push(`${fmt(p.mcpTools.total)} MCP tool calls across ${mcpServers.length} server(s)`);
-		tuStage = Math.max(tuStage, 3) as 1 | 2 | 3 | 4; // Using any MCP server is stage 3
-		if (mcpServers.length >= 2) {
-			tuStage = 4; // Multiple MCP servers = strategist
-		}
-	}
-
-	// Tips based on current state
-	if (tuStage < 2) {
-		tuTips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) to let Copilot use built-in tools for file operations and terminal commands');
-	}
-	if (tuStage < 3) {
-		if (mcpServers.length === 0) {
-			tuTips.push('Set up [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) to connect Copilot to external tools (databases, APIs, cloud services)');
-		} else {
-			tuTips.push('Explore [GitHub integrations](https://code.visualstudio.com/docs/copilot/agents/agent-tools) and advanced tools like editFiles and run_in_terminal');
-		}
-	}
-	if (tuStage < 4) {
-		if (mcpServers.length === 1) {
-			tuTips.push('Add more [MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) to expand Copilot\'s capabilities - check the VS Code MCP registry');
-		} else if (mcpServers.length === 0) {
-			tuTips.push('Explore the [VS Code MCP registry](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) for tools that integrate with your workflow');
-		} else {
-			tuTips.push('You\'re using multiple MCP servers - keep exploring advanced tool combinations');
-		}
-	}
-
-	// ---------- 5. Customization ----------
-	const cuEvidence: string[] = [];
-	const cuTips: string[] = [];
-	let cuStage = 1;
-
-	// Derive repo-level customization from the customization matrix (which is actually populated)
-	const matrix = lastCustomizationMatrix;
-	const totalRepos = matrix?.totalWorkspaces ?? 0;
-	const reposWithCustomization = totalRepos - (matrix?.workspacesWithIssues ?? 0);
-	const customizationRate = totalRepos > 0 ? (reposWithCustomization / totalRepos) : 0;
-
-	if (totalRepos > 0) {
-		cuEvidence.push(`Worked in ${totalRepos} repositor${totalRepos === 1 ? 'y' : 'ies'}`);
-	}
-
-	if (reposWithCustomization > 0) {
-		cuStage = 2;
-	}
-
-	// Stage thresholds based on adoption rate
-	if (customizationRate >= 0.3 && reposWithCustomization >= 2) {
-		cuStage = 3;
-	}
-
-	if (customizationRate >= 0.7 && reposWithCustomization >= 3) {
-		cuStage = 4;
-	}
-
-	// Model selection awareness (choosing specific models)
-	const uniqueModels = [...new Set([
-		...p.modelSwitching.standardModels,
-		...p.modelSwitching.premiumModels
-	])];
-	if (uniqueModels.length >= 3) {
-		// Check for Stage 4 criteria first
-		const hasStage4Models = uniqueModels.length >= 5 && reposWithCustomization >= 3;
-		
-		cuEvidence.push(`Used ${uniqueModels.length} different models`);
-		if (hasStage4Models) {
-			cuStage = 4;
-		} else if (uniqueModels.length >= 5) {
-			cuStage = Math.max(cuStage, 3) as 1 | 2 | 3 | 4;
-		} else {
-			cuStage = Math.max(cuStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// Show repo customization evidence once, reflecting the final achieved stage
-	if (cuStage >= 4) {
-		cuEvidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos customized (70%+ with 3+ repos → Stage 4)`);
-	} else if (cuStage >= 3) {
-		cuEvidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos customized (30%+ with 2+ repos → Stage 3)`);
-	} else if (reposWithCustomization > 0) {
-		cuEvidence.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos with custom instructions or agents.md`);
-	}
-
-	if (cuStage < 2) { cuTips.push('Create a [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) or [CLAUDE.md](https://docs.anthropic.com/en/docs/claude-code/memory) file with project-specific guidelines'); }
-	if (cuStage < 3) { cuTips.push('Add [custom instructions](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) to more repositories to standardize your Copilot experience'); }
-	if (cuStage < 4) {
-		const uncustomized = totalRepos - reposWithCustomization;
-		if (totalRepos > 0 && uncustomized > 0) {
-			cuTips.push(`${fmt(reposWithCustomization)} of ${fmt(totalRepos)} repos have customization — add [instructions and agents.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) to the remaining ${fmt(uncustomized)} repo${uncustomized === 1 ? '' : 's'} for Stage 4`);
-		} else {
-			cuTips.push('Aim for consistent customization across all projects with [instructions and agents.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)');
-		}
-	}
-	if (cuStage >= 4) {
-		const uncustomized = totalRepos - reposWithCustomization;
-		if (uncustomized > 0) {
-			const missingCustomizationRepos = (matrix?.workspaces || [])
-				.filter(row => Object.values(row.typeStatuses).every(status => status === '❌'));
-			const prioritizedMissingRepos = missingCustomizationRepos
-				.filter(row => !row.workspacePath.startsWith('<unresolved:'))
-				.sort((a, b) => {
-					if (b.interactionCount !== a.interactionCount) {
-						return b.interactionCount - a.interactionCount;
-					}
-					return b.sessionCount - a.sessionCount;
-				})
-				.slice(0, 3);
-
-			const summaryTip = `${fmt(uncustomized)} repo${uncustomized === 1 ? '' : 's'} still missing customization — add [instructions](https://code.visualstudio.com/docs/copilot/customization/custom-instructions), [agents.md](https://code.visualstudio.com/docs/copilot/customization/custom-instructions), or [MCP configs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) for full coverage.`;
-			if (prioritizedMissingRepos.length > 0) {
-				const repoLines = prioritizedMissingRepos.map(row => 
-					`${row.workspaceName} (${fmt(row.interactionCount)} interaction${row.interactionCount === 1 ? '' : 's'})`
-				).join('\n');
-				cuTips.push(`${summaryTip}\n\nTop repos to customize first:\n${repoLines}`);
-			} else {
-				cuTips.push(summaryTip);
-			}
-		} else {
-			cuTips.push('All repos customized! Keep instructions up to date and add [skill files](https://code.visualstudio.com/docs/copilot/customization/agent-skills) or [MCP server configs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) for deeper integration');
-		}
-	}
-
-	// ---------- 6. Workflow Integration ----------
-	const wiEvidence: string[] = [];
-	const wiTips: string[] = [];
-	let wiStage = 1;
-
-	// Sessions count reflects regularity
-	if (p.sessions >= 3) {
-		wiEvidence.push(`${fmt(p.sessions)} sessions in the last 30 days`);
-		wiStage = 2;
-	}
-
-	// Apply button usage (high rate shows active adoption of suggestions)
-	if (p.applyUsage && p.applyUsage.totalCodeBlocks > 0) {
-		const applyRatePercent = Math.round(p.applyUsage.applyRate);
-		wiEvidence.push(`${applyRatePercent}% code block apply rate (${fmt(p.applyUsage.totalApplies)}/${fmt(p.applyUsage.totalCodeBlocks)})`);
-		if (applyRatePercent >= 50) {
-			wiStage = Math.max(wiStage, 2) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// Session duration (informational only - not used for staging)
-	if (p.sessionDuration && p.sessionDuration.avgDurationMs > 0) {
-		const avgMinutes = Math.round(p.sessionDuration.avgDurationMs / 60000);
-		wiEvidence.push(`Avg ${avgMinutes}min session duration`);
-	}
-
-	// Multi-mode usage (ask + agent + cli) - key indicator of integration
-	const modesUsed = [p.modeUsage.ask > 0, p.modeUsage.agent > 0, p.modeUsage.cli > 0].filter(Boolean).length;
-	if (modesUsed >= 2) {
-		wiEvidence.push(`Uses ${modesUsed} modes (ask/agent/cli)`);
-		wiStage = Math.max(wiStage, 3) as 1 | 2 | 3 | 4;
-	}
-
-	// Explicit context usage - strong signal of intentional integration
-	const hasExplicitContext = totalContextRefs >= 10;
-	if (hasExplicitContext) {
-		wiEvidence.push(`${fmt(totalContextRefs)} explicit context references`);
-		if (totalContextRefs >= 20) {
-			wiStage = Math.max(wiStage, 3) as 1 | 2 | 3 | 4;
-		}
-	}
-
-	// Stage 4: Multi-mode + explicit context + regular usage
-	if (p.sessions >= 15 && modesUsed >= 2 && totalContextRefs >= 20) {
-		wiStage = 4;
-		wiEvidence.push('Deep integration: regular usage with multi-mode and explicit context');
-	}
-
-	if (wiStage < 2) { wiTips.push('Use AI more regularly - even for quick questions'); }
-	if (wiStage < 3) { 
-		if (modesUsed < 2) { wiTips.push('Combine [ask mode with agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) in your daily workflow'); }
-		if (totalContextRefs < 10) { wiTips.push('Use explicit [context references](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like #file, @workspace, and #selection'); }
-	}
-	if (wiStage < 4) { 
-		if (totalContextRefs < 20) { wiTips.push('Make explicit context a habit - use [#file, @workspace, and other references](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) consistently'); }
-		wiTips.push('Make AI part of every coding task: planning, coding, testing, and reviewing'); 
-	}
-
-	// ---------- Overall score (median) ----------
-	const scores = [peStage, ceStage, agStage, tuStage, cuStage, wiStage].sort((a, b) => a - b);
+	const scores = [pe.stage, ce.stage, ag.stage, tu.stage, cu.stage, wi.stage].sort((a, b) => a - b);
 	const mid = Math.floor(scores.length / 2);
 	const overallStage = scores.length % 2 === 0
 		? Math.round((scores[mid - 1] + scores[mid]) / 2)
@@ -1133,12 +1056,12 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 		overallStage,
 		overallLabel: stageLabels[overallStage] || `Stage ${overallStage}`,
 		categories: [
-			{ category: 'Prompt Engineering', icon: '💬', stage: peStage, evidence: peEvidence, tips: peTips },
-			{ category: 'Context Engineering', icon: '📎', stage: ceStage, evidence: ceEvidence, tips: ceTips },
-			{ category: 'Agentic', icon: '🤖', stage: agStage, evidence: agEvidence, tips: agTips },
-			{ category: 'Tool Usage', icon: '🔧', stage: tuStage, evidence: tuEvidence, tips: tuTips },
-			{ category: 'Customization', icon: '⚙️', stage: cuStage, evidence: cuEvidence, tips: cuTips },
-			{ category: 'Workflow Integration', icon: '🔄', stage: wiStage, evidence: wiEvidence, tips: wiTips }
+			{ category: 'Prompt Engineering', icon: '💬', stage: pe.stage, evidence: pe.evidence, tips: pe.tips },
+			{ category: 'Context Engineering', icon: '📎', stage: ce.stage, evidence: ce.evidence, tips: ce.tips },
+			{ category: 'Agentic', icon: '🤖', stage: ag.stage, evidence: ag.evidence, tips: ag.tips },
+			{ category: 'Tool Usage', icon: '🔧', stage: tu.stage, evidence: tu.evidence, tips: tu.tips },
+			{ category: 'Customization', icon: '⚙️', stage: cu.stage, evidence: cu.evidence, tips: cu.tips },
+			{ category: 'Workflow Integration', icon: '🔄', stage: wi.stage, evidence: wi.evidence, tips: wi.tips }
 		],
 		period: p,
 		lastUpdated: stats.lastUpdated.toISOString()


### PR DESCRIPTION
## Motivation

`calculateMaturityScores` in `src/maturityScoring.ts` was ~500 lines long — a single monolithic function computing 6 scoring categories inline, hitting the `max-lines-per-function` ESLint rule.

## What changed

Each scoring category is now its own focused private helper, reducing the public function from ~500 lines to ~44:

| Method | Responsibility |
|---|---|
| `_scorePromptEngineering(p)` | Compute stage/evidence/tips for Prompt Engineering |
| `_scoreContextEngineering(p)` | Compute stage/evidence/tips for Context Engineering |
| `_scoreAgentic(p)` | Compute stage/evidence/tips for Agentic |
| `_scoreToolUsage(p)` | Compute stage/evidence/tips for Tool Usage |
| `_scoreCustomization(p, matrix)` | Compute stage/evidence/tips for Customization |
| `_scoreWorkflowIntegration(p)` | Compute stage/evidence/tips for Workflow Integration |

A shared `CategoryScore` type (`{ stage, evidence, tips }`) keeps the return type consistent across all helpers.

## Verification

- ✅ TypeScript (`tsc --noEmit`) — no errors
- ✅ ESLint — no **new** warnings on the refactored function; pre-existing warnings on `getFluencyLevelData` and `calculateFluencyScoreForTeamMember` are unchanged
- ✅ All unit tests (`npm run test:node`) — all 20 test files PASS
- ✅ Production esbuild bundle — built successfully
- The public API of `calculateMaturityScores` is unchanged