### PR TITLE
perf: eliminate redundant JSON.parse calls in session analysis

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1867,6 +1867,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			let cacheHits = 0;
 			let cacheMisses = 0;
 			let skippedFiles = 0;
+			const analysisStartMs = Date.now();
 
 			let sessionDataResults: ({ sessionFile: string; sessionData: SessionFileCache; details: SessionFileDetails; mtime: number; wasCached: boolean } | null | undefined)[];
 
@@ -1940,7 +1941,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			dailyStatsMap = aggregated.dailyStatsMap;
 			skippedFiles += aggregated.skippedCount;
 
-			this.log(`✅ Analysis complete: Today ${todayStats.sessions} sessions, Month ${monthStats.sessions} sessions, Last 30 Days ${last30DaysStats.sessions} sessions, Previous Month ${lastMonthStats.sessions} sessions`);
+			const analysisElapsedMs = Date.now() - analysisStartMs;
+			const analysisElapsedSec = (analysisElapsedMs / 1000).toFixed(1);
+			this.log(`✅ Analysis complete in ${analysisElapsedSec}s: Today ${todayStats.sessions} sessions, Month ${monthStats.sessions} sessions, Last 30 Days ${last30DaysStats.sessions} sessions, Previous Month ${lastMonthStats.sessions} sessions`);
 			if (skippedFiles > 0) {
 				this.log(`⏭️ Skipped ${skippedFiles} session file(s) (empty or no activity in recent months)`);
 			}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2758,7 +2758,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return _mergeUsageAnalysis(period, analysis);
 	}
 
-	private async countInteractionsInSession(sessionFile: string, preloadedContent?: string): Promise<number> {
+	private async countInteractionsInSession(sessionFile: string, preloadedContent?: string, preloadedParsedJson?: any): Promise<number> {
 		try {
 			const eco = this.findEcosystem(sessionFile);
 			if (eco) { return eco.countInteractions(sessionFile); }
@@ -2799,7 +2799,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			}
 
 			// Handle regular .json files
-			const sessionContent = JSON.parse(fileContent);
+			const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 
 			// Count the number of requests as interactions
 			if (sessionContent.requests && Array.isArray(sessionContent.requests)) {
@@ -2900,7 +2900,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 
-	private async extractSessionMetadata(sessionFile: string, preloadedContent?: string): Promise<{
+	private async extractSessionMetadata(sessionFile: string, preloadedContent?: string, preloadedParsedJson?: any): Promise<{
 		title: string | undefined;
 		firstInteraction: string | null;
 		lastInteraction: string | null;
@@ -2988,7 +2988,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			} else {
 				// JSON format - try to parse
 				try {
-					const parsed = JSON.parse(fileContent);
+					const parsed = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 					if (parsed.customTitle) { title = parsed.customTitle; }
 					// creationDate is session creation, not a request — only add to timestamps
 					if (parsed.creationDate) { timestamps.push(parsed.creationDate); }
@@ -3040,21 +3040,34 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		this._cacheMisses++;
 
-		// Pre-read file content once for regular Copilot Chat files to avoid 5 redundant reads
+		// Pre-read file content once for regular Copilot Chat files to avoid redundant reads
 		let preloadedContent: string | undefined;
 		const isSpecialSession = this.findEcosystem(sessionFilePath) !== null;
 		if (!isSpecialSession) {
 			preloadedContent = await fs.promises.readFile(sessionFilePath, 'utf8');
 		}
 
-		// Cache miss - process the file (using pre-read content when available)
-		const tokenResult = await this.estimateTokensFromSession(sessionFilePath, preloadedContent);
-		const interactions = await this.countInteractionsInSession(sessionFilePath, preloadedContent);
-		const modelUsage = await _getModelUsageFromSession(this.usageAnalysisDeps, sessionFilePath, preloadedContent);
-		const usageAnalysis = await _analyzeSessionUsage(this.usageAnalysisDeps, sessionFilePath, preloadedContent);
+		// Pre-parse JSON content once for non-JSONL files to avoid multiple redundant JSON.parse calls.
+		// Each analysis function independently parses the same content; sharing the parsed object
+		// eliminates up to 7 redundant JSON.parse operations per cache miss for large session files.
+		let preloadedParsedJson: any | undefined;
+		if (preloadedContent
+			&& !sessionFilePath.endsWith('.jsonl')
+			&& !_isJsonlContent(preloadedContent)
+			&& !_isUuidPointerFile(preloadedContent)
+		) {
+			try { preloadedParsedJson = JSON.parse(preloadedContent); } catch { /* each function handles parse errors individually */ }
+		}
 
-		// Extract title and timestamps from the session file
-		const sessionMeta = await this.extractSessionMetadata(sessionFilePath, preloadedContent);
+		// Cache miss - process the file using pre-read content and pre-parsed JSON when available.
+		// Use Promise.all so ecosystem-session I/O (eco.getTokens etc.) can overlap across calls.
+		const [tokenResult, interactions, modelUsage, usageAnalysis, sessionMeta] = await Promise.all([
+			this.estimateTokensFromSession(sessionFilePath, preloadedContent, preloadedParsedJson),
+			this.countInteractionsInSession(sessionFilePath, preloadedContent, preloadedParsedJson),
+			_getModelUsageFromSession(this.usageAnalysisDeps, sessionFilePath, preloadedContent, preloadedParsedJson),
+			_analyzeSessionUsage(this.usageAnalysisDeps, sessionFilePath, preloadedContent, preloadedParsedJson),
+			this.extractSessionMetadata(sessionFilePath, preloadedContent, preloadedParsedJson),
+		]);
 
 		// Compute per-UTC-day rollups by distributing cached totals proportionally across days
 		// (same approach as syncService.processCachedSessionFile)
@@ -4282,7 +4295,7 @@ usageAnalysis: undefined
 
 
 
-	private async estimateTokensFromSession(sessionFilePath: string, preloadedContent?: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens?: number }> {
+	private async estimateTokensFromSession(sessionFilePath: string, preloadedContent?: string, preloadedParsedJson?: any): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens?: number }> {
 		try {
 			const eco = this.findEcosystem(sessionFilePath);
 			if (eco) { return eco.getTokens(sessionFilePath); }
@@ -4301,7 +4314,7 @@ usageAnalysis: undefined
 			}
 
 			// Handle regular .json files
-			const sessionContent = JSON.parse(fileContent);
+			const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 			let totalInputTokens = 0;
 			let totalOutputTokens = 0;
 			let totalThinkingTokens = 0;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1577,6 +1577,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return { sessionFiles, preloaded: [] };
 		}
 
+		const analyzeStartMs = Date.now();
 		const results = await this.runWithConcurrency(sessionFiles, async (sessionFile, i) => {
 			if (progressCallback) { progressCallback(i + 1, sessionFiles.length); }
 			const fileStats = await this.statSessionFile(sessionFile);
@@ -1592,7 +1593,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		});
 
 		const preloaded = results.filter((r): r is SessionFilePreload => r !== null && r !== undefined);
-		this.log(`📦 Preloaded ${preloaded.length}/${sessionFiles.length} session file(s) within date range`);
+		this.log(`📦 Preloaded ${preloaded.length}/${sessionFiles.length} session file(s) within date range in ${((Date.now() - analyzeStartMs) / 1000).toFixed(1)}s`);
 		return { sessionFiles, preloaded };
 	}
 

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -172,6 +172,7 @@ export class SessionDiscovery {
 
 		const sessionFiles: string[] = [];
 		try {
+			const discoveryStartMs = Date.now();
 			this.deps.log(`🔍 Searching for session files via ${this.deps.ecosystems.filter(isDiscoverable).length} discoverable ecosystem adapter(s)`);
 			for (const eco of this.deps.ecosystems) {
 				if (!isDiscoverable(eco)) { continue; }
@@ -201,7 +202,7 @@ export class SessionDiscovery {
 				this.deps.log(`🧹 Deduplicated ${dupCount} duplicate session path(s)`);
 			}
 
-			this.deps.log(`✨ Total: ${deduped.length} session file(s) discovered`);
+			this.deps.log(`✨ Total: ${deduped.length} session file(s) discovered in ${((Date.now() - discoveryStartMs) / 1000).toFixed(1)}s`);
 			if (deduped.length === 0) {
 				this.deps.warn('⚠️ No session files found - Have you used GitHub Copilot Chat yet?');
 			}

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -583,11 +583,11 @@ export function applyModelTierClassification(
  * Calculate model switching statistics for a session file.
  * This method updates the analysis.modelSwitching field in place.
  */
-export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'warn' | 'modelPricing' | 'tokenEstimators' | 'ecosystems'>, sessionFile: string, analysis: SessionUsageAnalysis, preloadedContent?: string): Promise<void> {
+export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'warn' | 'modelPricing' | 'tokenEstimators' | 'ecosystems'>, sessionFile: string, analysis: SessionUsageAnalysis, preloadedContent?: string, preloadedParsedJson?: any): Promise<void> {
 	try {
 		// Use non-cached method to avoid circular dependency
 		// (getSessionFileDataCached -> analyzeSessionUsage -> getModelUsageFromSessionCached -> getSessionFileDataCached)
-		const modelUsage = await getModelUsageFromSession(deps, sessionFile, preloadedContent);
+		const modelUsage = await getModelUsageFromSession(deps, sessionFile, preloadedContent, preloadedParsedJson);
 		const modelCount = modelUsage ? Object.keys(modelUsage).length : 0;
 
 		// Skip if modelUsage is undefined or empty (not a valid session file)
@@ -627,7 +627,7 @@ export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'war
 		}
 		const isJsonl = sessionFile.endsWith('.jsonl') || isJsonlContent(fileContent);
 		if (!isJsonl) {
-			const sessionContent = JSON.parse(fileContent);
+			const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 			if (sessionContent.requests && Array.isArray(sessionContent.requests)) {
 				let previousModel: string | null = null;
 				let switchCount = 0;
@@ -756,7 +756,7 @@ export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'war
  * - Conversation patterns (multi-turn sessions)
  * - Agent type usage
  */
-export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>, sessionFile: string, analysis: SessionUsageAnalysis, preloadedContent?: string): Promise<void> {
+export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>, sessionFile: string, analysis: SessionUsageAnalysis, preloadedContent?: string, preloadedParsedJson?: any): Promise<void> {
 	try {
 		const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 
@@ -865,7 +865,7 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 			}
 		} else {
 			// Handle regular JSON files
-			const sessionContent = JSON.parse(fileContent);
+			const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 			
 			// Extract timestamps
 			if (sessionContent.creationDate) { timestamps.push(sessionContent.creationDate); }
@@ -996,7 +996,7 @@ export function createEmptySessionUsageAnalysis(): SessionUsageAnalysis {
 /**
  * Analyze a session file for usage patterns (tool calls, modes, context references, MCP tools)
  */
-export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: string, preloadedContent?: string): Promise<SessionUsageAnalysis> {
+export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: string, preloadedContent?: string, preloadedParsedJson?: any): Promise<SessionUsageAnalysis> {
 	const analysis: SessionUsageAnalysis = createEmptySessionUsageAnalysis();
 
 	try {
@@ -1370,7 +1370,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 		}
 
 		// Handle regular .json files
-		const sessionContent = JSON.parse(fileContent);
+		const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 
 		// Detect session mode and count interactions per request
 		if (sessionContent.requests && Array.isArray(sessionContent.requests)) {
@@ -1455,10 +1455,10 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 		}
 
 		// Calculate model switching statistics from session (pass preloaded content to avoid re-reading)
-		await calculateModelSwitching(deps, sessionFile, analysis, fileContent);
+		await calculateModelSwitching(deps, sessionFile, analysis, fileContent, preloadedParsedJson);
 
 		// Track new metrics: edit scope, apply usage, session duration, conversation patterns, agent types
-		await trackEnhancedMetrics(deps, sessionFile, analysis, fileContent);
+		await trackEnhancedMetrics(deps, sessionFile, analysis, fileContent, preloadedParsedJson);
 	} catch (error) {
 		deps.warn(`Error analyzing session usage from ${sessionFile}: ${error}`);
 	}
@@ -1466,7 +1466,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 	return analysis;
 }
 
-export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'warn' | 'tokenEstimators' | 'modelPricing' | 'ecosystems'>, sessionFile: string, preloadedContent?: string): Promise<ModelUsage> {
+export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'warn' | 'tokenEstimators' | 'modelPricing' | 'ecosystems'>, sessionFile: string, preloadedContent?: string, preloadedParsedJson?: any): Promise<ModelUsage> {
 	const modelUsage: ModelUsage = {};
 
 	// Dispatch to ecosystem adapter when available
@@ -1706,7 +1706,7 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 		}
 
 		// Handle regular .json files
-		const sessionContent = JSON.parse(fileContent);
+		const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 
 		if (sessionContent.requests && Array.isArray(sessionContent.requests)) {
 			for (const request of sessionContent.requests) {


### PR DESCRIPTION
## Problem

Each cache miss in `getSessionFileDataCached` triggered up to **8 redundant `JSON.parse()` calls** on the same file content, across 5 analysis functions and their nested helpers:

1. `estimateTokensFromSession`
2. `countInteractionsInSession`
3. `getModelUsageFromSession` (direct call)
4. `analyzeSessionUsage`
5. `calculateModelSwitching` (called from `analyzeSessionUsage`) — also calls `getModelUsageFromSession` again
6. `trackEnhancedMetrics` (called from `analyzeSessionUsage`)
7. `extractSessionMetadata`

For large session files (~5MB), each `JSON.parse` costs ~100ms. So 8 parses ≈ 800ms per file. With 615 cache misses and concurrency=10, this explains the observed **49-second** analysis time.

## Fix

- **Pre-parse JSON once** in `getSessionFileDataCached` and thread the parsed object through all callers via a new optional `preloadedParsedJson?: any` parameter
- The pre-parse is guarded to only apply for non-JSONL, non-pointer regular JSON session files
- **Switch 5 sequential awaits to `Promise.all`** so ecosystem session I/O (`eco.getTokens` etc.) can overlap

## Expected improvement

~7× reduction in parsing work per cache miss → analysis time should drop from ~49s to ~7-8s for 615 misses.

## Changes

- `vscode-extension/src/usageAnalysis.ts`: Added `preloadedParsedJson?: any` to 4 functions; replaced `JSON.parse(fileContent)` with sentinel check
- `vscode-extension/src/extension.ts`: Added `preloadedParsedJson?: any` to 3 methods; pre-parse once in `getSessionFileDataCached`; switched to `Promise.all`

All 53 unit tests pass. ✅