### PR TITLE
Persist chart view/period/displayMode selection across navigation

### DIFF
--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -148,6 +148,81 @@ To maintain a consistent, VS Code-native look across all webview panels (Details
   - Run `npm run compile` and verify TypeScript and ESLint pass.
   - Visually compare the header with the Details and other panels to confirm parity.
 
+## Webview State Persistence
+
+Webview panels are created with `retainContextWhenHidden: false`. When the user switches to a different tab (e.g. navigates from Chart to Details), VS Code **destroys the webview's JavaScript context**. When they switch back, the JS module re-executes with all variables reset to their defaults.
+
+`vscode.setState()` / `vscode.getState()` survive this cycle (and VS Code restarts). They are the correct mechanism for preserving user UI selections.
+
+### Standard pattern — `createViewStateManager`
+
+Use the shared factory from `vscode-extension/src/webview/shared/viewState.ts`:
+
+```ts
+import { createViewStateManager } from '../shared/viewState';
+
+// 1. Declare the state shape and its defaults (module-level, after acquireVsCodeApi())
+type MyViewState = {
+  activeTab: string;
+  sortDir: 'asc' | 'desc';
+};
+
+const viewState = createViewStateManager<MyViewState>(vscode, {
+  activeTab: 'report',
+  sortDir: 'asc',
+});
+
+// 2. In bootstrap() — restore before rendering:
+const { activeTab, sortDir } = viewState.restore();
+
+// 3. When the user changes a single field (safe partial update):
+viewState.patch({ activeTab: newTab });
+
+// 4. When saving the full state at once:
+viewState.save({ activeTab: currentTab, sortDir: currentSort });
+```
+
+**`restore()`** merges saved state with defaults, so adding new fields to the state type never breaks older persisted values.
+
+**`patch()`** does a read-modify-write atomically — no need to spread `vscode.getState()` manually. Always prefer `patch()` over raw `vscode.setState()` calls.
+
+### Two-layer persistence (for critical preferences)
+
+Some preferences (e.g. chart period, chart view) are also stored in the extension backend so they survive panel close/reopen:
+
+1. **Webview → extension**: post a `setXxxPreference` message when the value changes.
+2. **Extension**: handle the message and store it in a `lastXxx` field (e.g. `lastChartPeriod`, `lastChartView`).
+3. **Extension → webview**: inject the saved value into `__INITIAL_DATA__` as `initialXxx` when the panel is created.
+4. **Webview `bootstrap()`**: use `viewState.restore()` first (for tab-switch navigation); fall back to `initialData.initialXxx` when no saved state exists (fresh panel).
+
+Only add the backend layer for preferences the user would expect to persist across sessions. Tab selections and sort orders within a panel usually only need the `vscode.setState()` layer.
+
+### What state to save
+
+| ✅ Save | ❌ Don't save |
+|--------|--------------|
+| Active tab / subtab selection | Loading flags (`isLoading`, `isFetching`) |
+| Selected view / period | Cached API responses |
+| Sort column & direction | DOM element references |
+| Filter values | `setTimeout` / interval IDs |
+| Toggle states (e.g. rolling avg, demo mode) | Transient error messages |
+
+### Webview status
+
+| Webview | State manager | Notes |
+|---------|--------------|-------|
+| `chart/main.ts` | ✅ `createViewStateManager` | period, view, displayMode; also backend-persisted |
+| `diagnostics/main.ts` | ✅ `createViewStateManager` | activeTab, activeSubtab |
+| `usage/main.ts` | ⬜ Not yet wired | activeTab, selectedRepo, sort prefs |
+| `details/main.ts` | ⬜ Not yet wired | sort column/dir, expansion state |
+| `maturity/main.ts` | ⬜ Not yet wired | demo mode, stage overrides |
+| `fluency-level-viewer/main.ts` | ⬜ Not yet wired | selectedCategoryIndex |
+| `environmental/main.ts` | N/A | Stateless — data-driven view |
+| `logviewer/main.ts` | N/A | Ephemeral session-specific view |
+| `dashboard/main.ts` | N/A | Always re-fetches live backend data |
+
+When adding state to an unwired view, use `createViewStateManager` — do not call `vscode.setState` directly.
+
 ## Adding a New Editor / Data Source
 
 When adding support for a new editor or data source, you must wire it into **both** this extension (`vscode-extension/src/`) **and** the CLI (`cli/src/`). See `.github/instructions/cli.instructions.md` for the CLI integration checklist.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -275,6 +275,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private lastFullDailyStats: DailyTokenStats[] | undefined;
 	/** Last period selected by the user in the chart view; restored on next open. */
 	private lastChartPeriod: 'day' | 'week' | 'month' = 'day';
+	/** Last view selected by the user in the chart view; restored on next open. */
+	private lastChartView: 'total' | 'model' | 'editor' | 'repository' | 'cost' = 'total';
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private lastDashboardData: any | undefined;
 	private tokenEstimators: { [key: string]: number } = tokenEstimatorsData.estimators;
@@ -4641,6 +4643,12 @@ usageAnalysis: undefined
 					this.lastChartPeriod = p;
 				}
 			}
+			if (message.command === 'setViewPreference') {
+				const v = message.view;
+				if (v === 'total' || v === 'model' || v === 'editor' || v === 'repository' || v === 'cost') {
+					this.lastChartView = v;
+				}
+			}
 		});
 
 		// Render immediately; Week/Month buttons are shown as loading if full-year data isn't ready
@@ -8444,7 +8452,7 @@ ${hashtag}`;
       `script-src 'nonce-${nonce}'`,
     ].join("; ");
 
-    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod };
+    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView };
 
     const initialData = JSON.stringify(chartData).replace(/</g, "\\u003c");
 

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -4,6 +4,7 @@ import { BUTTONS } from '../shared/buttonConfig';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import { getCurrentPeriodFraction, computeProjectionExtra } from './projectionUtils';
+import { createViewStateManager } from '../shared/viewState';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -102,8 +103,14 @@ type ChartWebviewState = {
 	displayMode: DisplayMode;
 };
 
+const chartState = createViewStateManager<ChartWebviewState>(vscode, {
+	period: 'day',
+	view: 'total',
+	displayMode: 'actual',
+});
+
 function saveWebviewState(): void {
-	vscode.setState<ChartWebviewState>({ period: currentPeriod, view: currentView, displayMode: currentDisplayMode });
+	chartState.save({ period: currentPeriod, view: currentView, displayMode: currentDisplayMode });
 }
 const ROLLING_WINDOW: Record<ChartPeriod, number> = { day: 7, week: 4, month: 3 };
 
@@ -788,11 +795,13 @@ async function bootstrap(): Promise<void> {
 	}
 
 	// Restore view state — vscode.getState() survives context destruction (retainContextWhenHidden: false)
-	const saved = vscode.getState<ChartWebviewState>();
-	if (saved) {
-		if (saved.period) { currentPeriod = saved.period; }
-		if (saved.view) { currentView = saved.view; }
-		if (saved.displayMode) { currentDisplayMode = saved.displayMode; }
+	const saved = chartState.restore();
+	// chartState.restore() merges defaults, so only override if the saved value differs from default
+	const hasSaved = !!vscode.getState();
+	if (hasSaved) {
+		currentPeriod = saved.period;
+		currentView = saved.view;
+		currentDisplayMode = saved.displayMode;
 	} else {
 		// Fall back to server-supplied initial values (e.g., panel closed and reopened)
 		if (initialData.initialPeriod) { currentPeriod = initialData.initialPeriod; }

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -53,6 +53,7 @@ type InitialChartData = {
 	compactNumbers?: boolean;
 	periodsReady?: boolean;
 	initialPeriod?: ChartPeriod;
+	initialView?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
 	periods?: {
 		day: ChartPeriodData;
 		week: ChartPeriodData;
@@ -94,6 +95,16 @@ let pendingPeriod: ChartPeriod | null = null;
 
 type DisplayMode = 'actual' | 'rolling';
 let currentDisplayMode: DisplayMode = 'actual';
+
+type ChartWebviewState = {
+	period: ChartPeriod;
+	view: 'total' | 'model' | 'editor' | 'repository' | 'cost';
+	displayMode: DisplayMode;
+};
+
+function saveWebviewState(): void {
+	vscode.setState<ChartWebviewState>({ period: currentPeriod, view: currentView, displayMode: currentDisplayMode });
+}
 const ROLLING_WINDOW: Record<ChartPeriod, number> = { day: 7, week: 4, month: 3 };
 
 function computeRollingAverage(data: number[], window: number): number[] {
@@ -414,6 +425,7 @@ async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promis
 	}
 	currentPeriod = period;
 	vscode.postMessage({ command: 'setPeriodPreference', period });
+	saveWebviewState();
 	setActivePeriod(period);
 	updateSummaryCards(data);
 	if (!chart) {
@@ -444,6 +456,8 @@ async function switchView(view: 'total' | 'model' | 'editor' | 'repository' | 'c
 		currentDisplayMode = 'actual';
 	}
 	currentView = view;
+	vscode.postMessage({ command: 'setViewPreference', view });
+	saveWebviewState();
 	setActiveView(view);
 	const rollingBtnEl = document.getElementById('view-rolling');
 	if (rollingBtnEl) {
@@ -497,6 +511,7 @@ function setActiveDisplayMode(mode: DisplayMode): void {
 async function switchDisplayMode(data: InitialChartData): Promise<void> {
 	currentDisplayMode = currentDisplayMode === 'actual' ? 'rolling' : 'actual';
 	setActiveDisplayMode(currentDisplayMode);
+	saveWebviewState();
 	updateSummaryCards(data);
 	if (!chart) { return; }
 	const canvas = chart.canvas as HTMLCanvasElement | null;
@@ -771,9 +786,19 @@ async function bootstrap(): Promise<void> {
 		}
 		return;
 	}
-	if (initialData.initialPeriod) {
-		currentPeriod = initialData.initialPeriod;
+
+	// Restore view state — vscode.getState() survives context destruction (retainContextWhenHidden: false)
+	const saved = vscode.getState<ChartWebviewState>();
+	if (saved) {
+		if (saved.period) { currentPeriod = saved.period; }
+		if (saved.view) { currentView = saved.view; }
+		if (saved.displayMode) { currentDisplayMode = saved.displayMode; }
+	} else {
+		// Fall back to server-supplied initial values (e.g., panel closed and reopened)
+		if (initialData.initialPeriod) { currentPeriod = initialData.initialPeriod; }
+		if (initialData.initialView) { currentView = initialData.initialView; }
 	}
+
 	renderLayout(initialData);
 }
 

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1,6 +1,7 @@
 ﻿// Diagnostics Report webview with tabbed interface
 import { buttonHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
+import { createViewStateManager } from "../shared/viewState";
 // CSS imported as text via esbuild
 import themeStyles from "../shared/theme.css";
 import styles from "./styles.css";
@@ -126,6 +127,11 @@ declare global {
 
 const vscode = acquireVsCodeApi<DiagnosticsViewState>();
 const initialData = window.__INITIAL_DIAGNOSTICS__;
+
+const diagState = createViewStateManager<DiagnosticsViewState>(vscode, {
+  activeTab: undefined,
+  activeSubtab: undefined,
+});
 
 // Sorting and filtering state
 let currentSortColumn: "lastInteraction" | "size" | "tokens" | "interactions" | "contextRefs" = "lastInteraction";
@@ -1532,7 +1538,7 @@ function renderLayout(data: DiagnosticsData): void {
           // Capture active subtab before re-rendering so we can restore it
           const activeSubtabEl = backendTabContent.querySelector(".subtab.active") as HTMLElement | null;
           const previousSubtab = activeSubtabEl?.getAttribute("data-subtab")
-            ?? vscode.getState()?.activeSubtab;
+            ?? diagState.restore().activeSubtab;
 
           backendTabContent.innerHTML = renderBackendStoragePanel(
             currentBackendInfo,
@@ -1545,8 +1551,7 @@ function renderLayout(data: DiagnosticsData): void {
           // Restore previously-active subtab (or default to first)
           if (previousSubtab) {
             activateSubtab(previousSubtab);
-            const currentState = vscode.getState() ?? {};
-            vscode.setState({ ...currentState, activeSubtab: previousSubtab });
+            diagState.patch({ activeSubtab: previousSubtab });
           }
         }
       } else {
@@ -1942,7 +1947,7 @@ function renderLayout(data: DiagnosticsData): void {
 
       if (tabId && activateTab(tabId)) {
         // Save the active tab state
-        vscode.setState({ activeTab: tabId });
+        diagState.patch({ activeTab: tabId });
       }
     });
   });
@@ -2029,8 +2034,7 @@ function renderLayout(data: DiagnosticsData): void {
       ?.addEventListener("click", () => {
         // Pre-save the teamserver subtab so the diagnostics panel restores to it
         // after the settings change triggers a panel refresh
-        const currentState = vscode.getState() ?? {};
-        vscode.setState({ ...currentState, activeTab: "backend", activeSubtab: "backend-teamserver" });
+        diagState.patch({ activeTab: "backend", activeSubtab: "backend-teamserver" });
         vscode.postMessage({ command: "configureTeamServer" });
       });
 
@@ -2069,8 +2073,7 @@ function renderLayout(data: DiagnosticsData): void {
         subtab.classList.add("active");
         document.getElementById(`subtab-${subtabId}`)?.classList.add("active");
         // Persist active subtab so it can be restored after a data refresh
-        const currentState = vscode.getState() ?? {};
-        vscode.setState({ ...currentState, activeSubtab: subtabId });
+        diagState.patch({ activeSubtab: subtabId });
       });
     });
   }
@@ -2347,7 +2350,7 @@ function renderLayout(data: DiagnosticsData): void {
   setupFolderAnalyzerHandlers();
 
   // Restore active tab from saved state, with fallback to default
-  const savedState = vscode.getState();
+  const savedState = diagState.restore();
   if (savedState?.activeTab && !activateTab(savedState.activeTab)) {
     // If saved tab doesn't exist (e.g., structure changed), activate default "report" tab
     activateTab("report");

--- a/vscode-extension/src/webview/shared/viewState.ts
+++ b/vscode-extension/src/webview/shared/viewState.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared webview state persistence utility.
+ *
+ * VS Code webview panels created with `retainContextWhenHidden: false` (the default)
+ * destroy their JavaScript context when the tab is hidden and recreate it when shown
+ * again. `vscode.setState()` / `vscode.getState()` survive this cycle and also persist
+ * across VS Code restarts, making them the correct mechanism for preserving user UI
+ * selections (active tab, sort order, selected view, etc.).
+ *
+ * Use `createViewStateManager` in every webview that has user-selectable state.
+ * See `.github/instructions/vscode-extension.instructions.md` for the full pattern.
+ */
+
+/** Minimal subset of the VS Code webview API needed for state persistence. */
+export interface WebviewStateApi<T> {
+	setState: (newState: T) => void;
+	getState: () => T | undefined;
+}
+
+/**
+ * Creates a typed state manager for a VS Code webview panel.
+ *
+ * @param vscode - The result of `acquireVsCodeApi()` (or any compatible object).
+ * @param defaults - Default state values used when nothing has been saved yet,
+ *                   and to fill in any keys missing from an older saved state.
+ *
+ * @example
+ * ```ts
+ * const state = createViewStateManager(vscode, { tab: 'report' as string, sort: 'asc' as 'asc' | 'desc' });
+ *
+ * // In bootstrap / init — always safe, even on first run:
+ * const { tab, sort } = state.restore();
+ *
+ * // When the user changes a tab:
+ * state.patch({ tab: newTab });
+ *
+ * // When saving the whole state at once:
+ * state.save({ tab: currentTab, sort: currentSort });
+ * ```
+ */
+export function createViewStateManager<T extends Record<string, unknown>>(
+	vscode: WebviewStateApi<T>,
+	defaults: T
+): {
+	/**
+	 * Returns saved state merged with defaults. Safe to call even when nothing
+	 * has been persisted yet, or when the saved state predates newly added fields.
+	 */
+	restore(): T;
+	/** Replaces the entire persisted state object. */
+	save(state: T): void;
+	/**
+	 * Merges a partial update into the current saved state and persists the result.
+	 * Returns the new full state. Use this for incremental field updates so that
+	 * unrelated saved fields are not lost.
+	 */
+	patch(partial: Partial<T>): T;
+} {
+	return {
+		restore(): T {
+			const saved = vscode.getState();
+			// Merge with defaults so that any newly added fields get their default value
+			// even when an older saved state doesn't include them yet.
+			return { ...defaults, ...(saved ?? {}) };
+		},
+		save(state: T): void {
+			vscode.setState(state);
+		},
+		patch(partial: Partial<T>): T {
+			const current = vscode.getState() ?? { ...defaults };
+			const next = { ...defaults, ...current, ...partial } as T;
+			vscode.setState(next);
+			return next;
+		},
+	};
+}


### PR DESCRIPTION
## Problem

When the user selects a period (e.g. "Month") and a view (e.g. "Est. Cost") in the chart, navigates to the Details page, and then navigates back, the chart reset to the default "Day" period and "Total Tokens" view.

**Root cause:** The chart panel is created with `retainContextWhenHidden: false`. When the chart tab becomes hidden, VS Code destroys the webview JS context. On reveal, module-level variables reset to their defaults.

## Fix

### Commit 1: Chart state persistence
- Added `vscode.setState()` / `vscode.getState()` calls to persist `period`, `view`, and `displayMode` in `chart/main.ts`
- Added `lastChartView` / `initialView` to the extension backend (mirrors the existing `lastChartPeriod` / `initialPeriod` pattern) for when the panel is fully closed and reopened

### Commit 2: Shared `createViewStateManager` utility + instructions

Rather than letting each webview invent its own approach, introduced a typed shared factory and documented it as the standard pattern.

**`vscode-extension/src/webview/shared/viewState.ts`** — new shared factory:
```ts
const myState = createViewStateManager<MyViewState>(vscode, { tab: 'report', sort: 'asc' });
const { tab, sort } = myState.restore(); // safe merge with defaults
myState.patch({ tab: newTab });           // incremental update, no spread needed
myState.save({ tab, sort });             // full replacement
```
- `restore()` merges saved state with defaults → adding new fields never breaks old persisted state
- `patch()` does read-modify-write atomically → replaces the `{ ...vscode.getState(), key: val }` anti-pattern

**`chart/main.ts`**: migrated from ad-hoc `saveWebviewState()` + direct `vscode.setState` to `createViewStateManager`

**`diagnostics/main.ts`**: migrated from scattered `{ ...currentState, activeSubtab }` spreads to `diagState.patch({ activeSubtab })`

**`.github/instructions/vscode-extension.instructions.md`**: added a full "Webview State Persistence" section documenting:
- Why the pattern is needed
- How to use `createViewStateManager`
- When to add the backend two-layer persistence
- What state to save vs skip
- Status table of all webviews (which are wired, which still need it)