### PR TITLE
refactor: consolidate modelUsage accumulation with addModelUsage helper

### DIFF
--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -106,6 +106,36 @@ Prefer VS Code's debugger with breakpoints rather than adding log statements:
 2. Set breakpoints in `vscode-extension/src/extension.ts`
 3. Use the Debug Console to inspect variables
 
+## Parallel Model Usage Aggregation Paths
+
+Multiple places in `extension.ts` accumulate per-model token counts into a `ModelUsage` map. Historically these were written as inline `for` loops, which caused bugs when new token fields were added (e.g. cache tokens) because not all copies were updated.
+
+**The shared helper** — `addModelUsage(target: ModelUsage, source: ModelUsage): void` — lives in `vscode-extension/src/statsHelpers.ts` and handles all four token fields:
+- `inputTokens`
+- `outputTokens`
+- `cachedReadTokens` (optional)
+- `cacheCreationTokens` (optional)
+
+All accumulation sites must call this helper. The current locations are:
+
+| Location | Call |
+|---|---|
+| `calculateDailyStats()` — per-UTC-day rollup path | `addModelUsage(dailyEntry.modelUsage, dayRollup.modelUsage)` |
+| `calculateDailyStats()` — session-level fallback path | `addModelUsage(dailyEntry.modelUsage, modelUsage)` |
+| `buildChartData()` — `mergeInto()` local helper | `addModelUsage(target.modelUsage, src.modelUsage)` |
+| Backend sharing-server aggregation | `addModelUsage(personalModelUsage, { [model]: { inputTokens, outputTokens } })` |
+
+`aggregatePeriodStats()` in `statsHelpers.ts` also uses `addModelUsage` internally.
+
+**Rule**: Any new token type added to the `ModelUsage` interface **must** be handled inside `addModelUsage`. This ensures all accumulation sites are covered automatically.
+
+To find all accumulation sites, grep for:
+```
+modelUsage\[model\]\.inputTokens \+=
+```
+
+If you find any match outside of `addModelUsage` itself, convert it to use the helper.
+
 ## Key Files & Conventions
 
 - **`vscode-extension/src/extension.ts`**: The single source file containing all logic.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2160,17 +2160,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 							if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
 							dailyEntry.repositoryUsage[repository].tokens += dayTokens;
 							dailyEntry.repositoryUsage[repository].sessions += 1;
-							for (const [model, usage] of Object.entries(dayRollup.modelUsage)) {
-								if (!dailyEntry.modelUsage[model]) { dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
-								dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
-								dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
-								if (usage.cachedReadTokens !== undefined) {
-									dailyEntry.modelUsage[model].cachedReadTokens = (dailyEntry.modelUsage[model].cachedReadTokens ?? 0) + usage.cachedReadTokens;
-								}
-								if (usage.cacheCreationTokens !== undefined) {
-									dailyEntry.modelUsage[model].cacheCreationTokens = (dailyEntry.modelUsage[model].cacheCreationTokens ?? 0) + usage.cacheCreationTokens;
-								}
-							}
+							addModelUsage(dailyEntry.modelUsage, dayRollup.modelUsage);
 						}
 					} else {
 						// Fallback: session-level attribution
@@ -2199,17 +2189,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 						if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
 						dailyEntry.repositoryUsage[repository].tokens += tokens;
 						dailyEntry.repositoryUsage[repository].sessions += 1;
-						for (const [model, usage] of Object.entries(modelUsage)) {
-							if (!dailyEntry.modelUsage[model]) { dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
-							dailyEntry.modelUsage[model].inputTokens += usage.inputTokens;
-							dailyEntry.modelUsage[model].outputTokens += usage.outputTokens;
-							if (usage.cachedReadTokens !== undefined) {
-								dailyEntry.modelUsage[model].cachedReadTokens = (dailyEntry.modelUsage[model].cachedReadTokens ?? 0) + usage.cachedReadTokens;
-							}
-							if (usage.cacheCreationTokens !== undefined) {
-								dailyEntry.modelUsage[model].cacheCreationTokens = (dailyEntry.modelUsage[model].cacheCreationTokens ?? 0) + usage.cacheCreationTokens;
-							}
-						}
+						addModelUsage(dailyEntry.modelUsage, modelUsage);
 					}
 				} catch (fileError) {
 					this.warn(`Error processing session file ${sessionFile} for daily stats: ${fileError}`);
@@ -6516,11 +6496,7 @@ ${hashtag}`;
         personalDevices.add(machineId);
         personalWorkspaces.add(workspaceId);
 
-        if (!personalModelUsage[model]) {
-          personalModelUsage[model] = { inputTokens: 0, outputTokens: 0 };
-        }
-        personalModelUsage[model].inputTokens += inputTokens;
-        personalModelUsage[model].outputTokens += outputTokens;
+        addModelUsage(personalModelUsage, { [model]: { inputTokens, outputTokens } });
       }
 
       // Team data aggregation - use userId|datasetId as key to track users across datasets.
@@ -8223,17 +8199,7 @@ ${hashtag}`;
       target.tokens += src.tokens;
       target.sessions += src.sessions;
       target.interactions += src.interactions;
-      for (const [m, u] of Object.entries(src.modelUsage)) {
-        if (!target.modelUsage[m]) { target.modelUsage[m] = { inputTokens: 0, outputTokens: 0 }; }
-        target.modelUsage[m].inputTokens += u.inputTokens;
-        target.modelUsage[m].outputTokens += u.outputTokens;
-        if (u.cachedReadTokens !== undefined) {
-          target.modelUsage[m].cachedReadTokens = (target.modelUsage[m].cachedReadTokens ?? 0) + u.cachedReadTokens;
-        }
-        if (u.cacheCreationTokens !== undefined) {
-          target.modelUsage[m].cacheCreationTokens = (target.modelUsage[m].cacheCreationTokens ?? 0) + u.cacheCreationTokens;
-        }
-      }
+      addModelUsage(target.modelUsage, src.modelUsage);
       for (const [e, u] of Object.entries(src.editorUsage)) {
         if (!target.editorUsage[e]) { target.editorUsage[e] = { tokens: 0, sessions: 0 }; }
         target.editorUsage[e].tokens += u.tokens;


### PR DESCRIPTION
## Summary

Preventative refactor following PR #907 (fix for April cost inflation caused by `calculateDailyStats` not propagating cache tokens).

The root cause of that bug was that model usage token accumulation was duplicated in **4 separate inline loops** in `extension.ts`. Every time a new token field is added to `ModelUsage`, all four need to be updated — with no obvious trigger to remind us.

## Changes

### 1. Code consolidation — replace inline loops with `addModelUsage`

`addModelUsage(target, source)` already existed in `statsHelpers.ts` and already handled all four token fields. It just wasn't being used in these four locations:

| Location | Before | After |
|---|---|---|
| `calculateDailyStats()` rollup path | 10-line `for` loop | `addModelUsage(dailyEntry.modelUsage, dayRollup.modelUsage)` |
| `calculateDailyStats()` fallback path | 10-line `for` loop | `addModelUsage(dailyEntry.modelUsage, modelUsage)` |
| `buildChartData()` `mergeInto()` | 10-line `for` loop | `addModelUsage(target.modelUsage, src.modelUsage)` |
| Backend sharing-server aggregation | 5-line `if/assign/+=` | `addModelUsage(personalModelUsage, { [model]: { inputTokens, outputTokens } })` |

### 2. Instructions update

Added a **"Parallel Model Usage Aggregation Paths"** section to `.github/instructions/vscode-extension.instructions.md` that:
- Documents all accumulation sites and their `addModelUsage` calls
- Provides the grep pattern to find any new rogue inline loops
- States the rule: new token types must be added to `addModelUsage` only

## Verification

- ✅ All 53 unit tests pass (`npm run test:node`)
- ✅ TypeScript compiles clean (included in test run via `tsc -p tsconfig.tests.json`)
- ✅ Pure refactor — no behaviour changes