### PR TITLE
feat: surface Copilot CLI chat-only sessions from session-store.db

### DIFF
--- a/vscode-extension/src/adapters/copilotCliAdapter.ts
+++ b/vscode-extension/src/adapters/copilotCliAdapter.ts
@@ -1,26 +1,29 @@
 /**
- * CopilotCliAdapter — discovers GitHub Copilot CLI agent-mode session files
- * stored under `~/.copilot/session-state/`. Two layouts are supported:
- *   1. Flat .json / .jsonl files at the top level (legacy).
- *   2. UUID subdirectories containing an `events.jsonl` file (newer format).
+ * CopilotCliAdapter — discovers GitHub Copilot CLI agent-mode session files.
  *
- * Like CopilotChatAdapter, this adapter currently participates only in
- * discovery via IDiscoverableEcosystem. `handles()` returns `false` so the
- * existing fallback parsing in extension.ts continues to own CLI session
- * parsing semantics unchanged. The other IEcosystemAdapter methods are
- * implemented as safe defaults so a future PR can flip `handles()` to a
- * real path predicate without re-plumbing call sites.
+ * Two session storage formats are discovered:
+ *   1. ~/.copilot/session-state/<uuid>/events.jsonl — worktree/project sessions
+ *      with rich data (tool calls, model metrics, token counts).
+ *   2. ~/.copilot/session-store.db — all sessions including chat-only sessions
+ *      (repository IS NULL) that never produce an events.jsonl file.
+ *
+ * For events.jsonl files the adapter participates only in discovery (handles()
+ * returns false for those paths) so the existing fallback JSONL parser in
+ * extension.ts continues to own parsing. For session-store.db virtual paths
+ * handles() returns true and the adapter provides metadata from the DB.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import type { ModelUsage } from '../types';
+import type { ModelUsage, ChatTurn } from '../types';
 import type {
 	IEcosystemAdapter,
 	IDiscoverableEcosystem,
 	DiscoveryResult,
 	CandidatePath,
 } from '../ecosystemAdapter';
+import { CopilotCliStoreAccess } from '../copilotCliStore';
+import { createEmptyContextRefs } from '../tokenEstimation';
 
 /** Returns the canonical Copilot CLI session-state directory (~/.copilot/session-state). */
 export function getCopilotCliSessionStateDir(): string {
@@ -41,28 +44,40 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 	readonly id = 'copilotcli';
 	readonly displayName = 'GitHub Copilot CLI';
 
+	private readonly store = new CopilotCliStoreAccess();
+
 	/**
-	 * Currently a no-op match. The adapter participates in discovery via
-	 * IDiscoverableEcosystem but lets the existing fallback parsing code in
-	 * extension.ts continue to own per-session parsing for Copilot CLI files.
+	 * Returns true only for session-store.db virtual paths.
+	 * For events.jsonl files the adapter participates in discovery only; the
+	 * existing fallback JSONL parser in extension.ts continues to own those.
 	 */
-	handles(_sessionFile: string): boolean {
-		return false;
+	handles(sessionFile: string): boolean {
+		return this.store.isCliStoreSession(sessionFile);
 	}
 
 	getBackingPath(sessionFile: string): string {
+		if (this.store.isCliStoreSession(sessionFile)) {
+			return this.store.getDbPathFromVirtual(sessionFile);
+		}
 		return sessionFile;
 	}
 
 	async stat(sessionFile: string): Promise<fs.Stats> {
+		if (this.store.isCliStoreSession(sessionFile)) {
+			return this.store.stat(sessionFile);
+		}
 		return fs.promises.stat(sessionFile);
 	}
 
 	async getTokens(_sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+		// session-store.db does not store token counts
 		return { tokens: 0, thinkingTokens: 0, actualTokens: 0 };
 	}
 
-	async countInteractions(_sessionFile: string): Promise<number> {
+	async countInteractions(sessionFile: string): Promise<number> {
+		if (this.store.isCliStoreSession(sessionFile)) {
+			return this.store.countTurns(sessionFile);
+		}
 		return 0;
 	}
 
@@ -70,68 +85,136 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		return {};
 	}
 
-	async getMeta(_sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+		if (this.store.isCliStoreSession(sessionFile)) {
+			const session = await this.store.readSession(sessionFile);
+			if (!session) { return { title: undefined, firstInteraction: null, lastInteraction: null }; }
+			return {
+				title: session.summary ?? undefined,
+				firstInteraction: session.created_at,
+				lastInteraction: session.updated_at,
+				// workspacePath is intentionally absent for NULL-repository sessions
+				// so callers can detect the no-workspace case via its absence.
+			};
+		}
 		return { title: undefined, firstInteraction: null, lastInteraction: null };
 	}
 
-	getEditorRoot(_sessionFile: string): string {
+	getEditorRoot(sessionFile: string): string {
+		if (this.store.isCliStoreSession(sessionFile)) {
+			return path.join(os.homedir(), '.copilot');
+		}
 		return getCopilotCliSessionStateDir();
 	}
 
+	async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[] }> {
+		if (!this.store.isCliStoreSession(sessionFile)) {
+			return { turns: [] };
+		}
+		const dbTurns = await this.store.getTurns(sessionFile);
+		const turns: ChatTurn[] = dbTurns.map(t => ({
+			turnNumber: t.turn_index + 1,
+			timestamp: t.timestamp,
+			mode: 'cli' as const,
+			userMessage: t.user_message ?? '',
+			assistantResponse: t.assistant_response ?? '',
+			model: null,
+			toolCalls: [],
+			contextReferences: createEmptyContextRefs(),
+			mcpTools: [],
+			inputTokensEstimate: 0,
+			outputTokensEstimate: 0,
+			thinkingTokensEstimate: 0,
+		}));
+		return { turns };
+	}
+
+	async getDailyFractions(sessionFile: string): Promise<Record<string, number>> {
+		if (this.store.isCliStoreSession(sessionFile)) {
+			return this.store.getDailyFractions(sessionFile);
+		}
+		return {};
+	}
+
 	getCandidatePaths(): CandidatePath[] {
-		return [{ path: getCopilotCliSessionStateDir(), source: 'Copilot CLI' }];
+		const paths: CandidatePath[] = [
+			{ path: getCopilotCliSessionStateDir(), source: 'Copilot CLI' },
+		];
+		const dbPath = this.store.getDbPath();
+		paths.push({ path: dbPath, source: 'Copilot CLI (session-store.db)' });
+		return paths;
 	}
 
 	/**
-	 * Walk ~/.copilot/session-state collecting:
-	 *   - top-level .json / .jsonl files
-	 *   - UUID subdirectories' events.jsonl (when non-empty)
+	 * Discover session files from two sources:
+	 *   1. ~/.copilot/session-state/ — events.jsonl files (worktree sessions)
+	 *   2. ~/.copilot/session-store.db — DB-only sessions (chat sessions without
+	 *      a workspace, or sessions whose events.jsonl was not yet written)
+	 *
+	 * Sessions already represented by an events.jsonl are excluded from the DB
+	 * results to prevent double-counting.
 	 */
 	async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
 		const candidatePaths = this.getCandidatePaths();
 		const sessionFiles: string[] = [];
 		const root = getCopilotCliSessionStateDir();
 
+		// Collect UUID subdirectory names from session-state/ to exclude them
+		// from the DB discovery (they are already covered by events.jsonl).
+		const knownUuids = new Set<string>();
+
 		try {
-			if (!(await pathExists(root))) {
-				return { sessionFiles, candidatePaths };
-			}
-			let entries: fs.Dirent[];
-			try {
-				entries = await fs.promises.readdir(root, { withFileTypes: true });
-			} catch (e) {
-				log(`Could not read Copilot CLI session path in ${root}: ${e}`);
-				return { sessionFiles, candidatePaths };
-			}
+			if (await pathExists(root)) {
+				let entries: fs.Dirent[];
+				try {
+					entries = await fs.promises.readdir(root, { withFileTypes: true });
+				} catch (e) {
+					log(`Could not read Copilot CLI session path in ${root}: ${e}`);
+					entries = [];
+				}
 
-			// Top-level .json / .jsonl files
-			const flat = entries
-				.filter(e => !e.isDirectory() && (e.name.endsWith('.json') || e.name.endsWith('.jsonl')))
-				.map(e => path.join(root, e.name));
-			if (flat.length > 0) {
-				log(`📄 Found ${flat.length} session files in Copilot CLI directory`);
-				sessionFiles.push(...flat);
-			}
+				// Top-level .json / .jsonl files
+				const flat = entries
+					.filter(e => !e.isDirectory() && (e.name.endsWith('.json') || e.name.endsWith('.jsonl')))
+					.map(e => path.join(root, e.name));
+				if (flat.length > 0) {
+					log(`📄 Found ${flat.length} session files in Copilot CLI directory`);
+					sessionFiles.push(...flat);
+				}
 
-			// UUID subdirectories' events.jsonl
-			const subDirs = entries.filter(e => e.isDirectory());
-			const subDirFiles = (await Promise.all(
-				subDirs.map(async (subDir) => {
-					const eventsFile = path.join(root, subDir.name, 'events.jsonl');
-					try {
-						const stats = await fs.promises.stat(eventsFile);
-						return stats.size > 0 ? eventsFile : null;
-					} catch {
+				// UUID subdirectories' events.jsonl
+				const subDirs = entries.filter(e => e.isDirectory());
+				const subDirFiles = (await Promise.all(
+					subDirs.map(async (subDir) => {
+						const eventsFile = path.join(root, subDir.name, 'events.jsonl');
+						try {
+							const stats = await fs.promises.stat(eventsFile);
+							if (stats.size > 0) {
+								knownUuids.add(subDir.name);
+								return eventsFile;
+							}
+						} catch { /* no events.jsonl in this subdir */ }
 						return null;
-					}
-				}),
-			)).filter((f): f is string => f !== null);
-			if (subDirFiles.length > 0) {
-				log(`📄 Found ${subDirFiles.length} session files in Copilot CLI subdirectories`);
-				sessionFiles.push(...subDirFiles);
+					}),
+				)).filter((f): f is string => f !== null);
+				if (subDirFiles.length > 0) {
+					log(`📄 Found ${subDirFiles.length} session files in Copilot CLI subdirectories`);
+					sessionFiles.push(...subDirFiles);
+				}
 			}
 		} catch (e) {
 			log(`Could not check Copilot CLI session path ${root}: ${e}`);
+		}
+
+		// Also discover DB-only sessions (no matching events.jsonl)
+		try {
+			const dbOnlyIds = await this.store.discoverNewSessions(knownUuids);
+			if (dbOnlyIds.length > 0) {
+				log(`📄 Found ${dbOnlyIds.length} chat-only session(s) in Copilot CLI session-store.db`);
+				sessionFiles.push(...dbOnlyIds.map(id => this.store.virtualPath(id)));
+			}
+		} catch (e) {
+			log(`Could not read Copilot CLI session-store.db: ${e}`);
 		}
 
 		return { sessionFiles, candidatePaths };

--- a/vscode-extension/src/copilotCliStore.ts
+++ b/vscode-extension/src/copilotCliStore.ts
@@ -1,0 +1,227 @@
+/**
+ * CopilotCliStoreAccess — reads session metadata from ~/.copilot/session-store.db.
+ *
+ * The Copilot CLI persists all sessions (both worktree-backed and chat-only) in a
+ * central SQLite database at ~/.copilot/session-store.db. Worktree sessions also
+ * produce an events.jsonl file under ~/.copilot/session-state/<uuid>/; chat-only
+ * sessions (started without any project open, repository IS NULL) exist only in
+ * the database.
+ *
+ * Virtual path scheme: <absolute-path-to-db>#<session-uuid>
+ * Example (Windows): C:\Users\alice\.copilot\session-store.db#3ee22c56-...
+ * Example (Unix):    /home/alice/.copilot/session-store.db#3ee22c56-...
+ *
+ * The '#' character acts as a separator identical to the pattern used by Crush
+ * (crush.db#<uuid>) and OpenCode (opencode.db#ses_<id>).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import initSqlJs from 'sql.js';
+
+export interface CliStoreSession {
+	id: string;
+	repository: string | null;
+	branch: string | null;
+	summary: string | null;
+	created_at: string | null;
+	updated_at: string | null;
+}
+
+export interface CliStoreTurn {
+	session_id: string;
+	turn_index: number;
+	user_message: string | null;
+	assistant_response: string | null;
+	timestamp: string | null;
+}
+
+export class CopilotCliStoreAccess {
+	private _sqlJsModule: any = null;
+
+	/** Absolute path to ~/.copilot/session-store.db. */
+	getDbPath(): string {
+		return path.join(os.homedir(), '.copilot', 'session-store.db');
+	}
+
+	/** Build a virtual session path for the given session UUID. */
+	virtualPath(sessionId: string): string {
+		return `${this.getDbPath()}#${sessionId}`;
+	}
+
+	/** Returns true if the path is a session-store virtual path. */
+	isCliStoreSession(filePath: string): boolean {
+		return filePath.includes('session-store.db#');
+	}
+
+	/** Extract the real DB file path from a virtual session path. */
+	getDbPathFromVirtual(virtualPath: string): string {
+		const idx = virtualPath.indexOf('session-store.db#');
+		if (idx === -1) { return virtualPath; }
+		return virtualPath.substring(0, idx + 'session-store.db'.length);
+	}
+
+	/** Extract the session UUID from a virtual session path. */
+	getSessionId(virtualPath: string): string | null {
+		const idx = virtualPath.indexOf('session-store.db#');
+		if (idx === -1) { return null; }
+		const id = virtualPath.substring(idx + 'session-store.db#'.length);
+		return id || null;
+	}
+
+	/** Stat the underlying session-store.db file. */
+	async stat(virtualPath: string): Promise<fs.Stats> {
+		return fs.promises.stat(this.getDbPathFromVirtual(virtualPath));
+	}
+
+	/** Lazily initialise and cache the sql.js WASM module. */
+	async initSqlJs(): Promise<any> {
+		if (this._sqlJsModule) { return this._sqlJsModule; }
+		const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+		let wasmBinary: Uint8Array | undefined;
+		if (fs.existsSync(wasmPath)) {
+			wasmBinary = fs.readFileSync(wasmPath);
+		}
+		this._sqlJsModule = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
+		return this._sqlJsModule;
+	}
+
+	/**
+	 * Discover all session IDs in the DB whose UUIDs are NOT in `knownUuids`.
+	 * These are sessions that exist only in the DB (no events.jsonl on disk).
+	 * Returned in descending updated_at order (most recent first).
+	 */
+	async discoverNewSessions(knownUuids: Set<string>): Promise<string[]> {
+		const dbPath = this.getDbPath();
+		if (!fs.existsSync(dbPath)) { return []; }
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			const db = new SQL.Database(buffer);
+			try {
+				const result = db.exec('SELECT id FROM sessions ORDER BY updated_at DESC');
+				if (result.length === 0) { return []; }
+				return (result[0].values as unknown[][])
+					.map(row => row[0] as string)
+					.filter(id => !knownUuids.has(id));
+			} finally {
+				db.close();
+			}
+		} catch {
+			return [];
+		}
+	}
+
+	/** Read session metadata for a virtual session path. */
+	async readSession(virtualPath: string): Promise<CliStoreSession | null> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId || !fs.existsSync(dbPath)) { return null; }
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			const db = new SQL.Database(buffer);
+			try {
+				const result = db.exec(
+					'SELECT id, repository, branch, summary, created_at, updated_at FROM sessions WHERE id = ?',
+					[sessionId],
+				);
+				if (result.length === 0 || result[0].values.length === 0) { return null; }
+				const cols = result[0].columns;
+				const row = result[0].values[0];
+				const obj: Record<string, unknown> = {};
+				cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+				return obj as unknown as CliStoreSession;
+			} finally {
+				db.close();
+			}
+		} catch {
+			return null;
+		}
+	}
+
+	/** Read all turns for a session, ordered by turn_index. */
+	async getTurns(virtualPath: string): Promise<CliStoreTurn[]> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId || !fs.existsSync(dbPath)) { return []; }
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			const db = new SQL.Database(buffer);
+			try {
+				const result = db.exec(
+					'SELECT session_id, turn_index, user_message, assistant_response, timestamp FROM turns WHERE session_id = ? ORDER BY turn_index ASC',
+					[sessionId],
+				);
+				if (result.length === 0) { return []; }
+				const cols = result[0].columns;
+				return (result[0].values as unknown[][]).map(row => {
+					const obj: Record<string, unknown> = {};
+					cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+					return obj as unknown as CliStoreTurn;
+				});
+			} finally {
+				db.close();
+			}
+		} catch {
+			return [];
+		}
+	}
+
+	/** Count turns (user interactions) for a session. */
+	async countTurns(virtualPath: string): Promise<number> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId || !fs.existsSync(dbPath)) { return 0; }
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			const db = new SQL.Database(buffer);
+			try {
+				const result = db.exec(
+					'SELECT COUNT(*) FROM turns WHERE session_id = ?',
+					[sessionId],
+				);
+				if (result.length === 0 || result[0].values.length === 0) { return 0; }
+				return (result[0].values[0][0] as number) || 0;
+			} finally {
+				db.close();
+			}
+		} catch {
+			return 0;
+		}
+	}
+
+	/**
+	 * Returns per-UTC-day fractions for accurate session attribution.
+	 * Uses turn timestamps when available; falls back to a single entry at
+	 * the session's updated_at date.
+	 */
+	async getDailyFractions(virtualPath: string): Promise<Record<string, number>> {
+		const turns = await this.getTurns(virtualPath);
+		const counts: Record<string, number> = {};
+		let total = 0;
+		for (const turn of turns) {
+			if (!turn.timestamp) { continue; }
+			try {
+				const dateKey = new Date(turn.timestamp).toISOString().slice(0, 10);
+				counts[dateKey] = (counts[dateKey] || 0) + 1;
+				total++;
+			} catch { /* skip malformed timestamp */ }
+		}
+		if (total === 0) {
+			// Fallback: use session updated_at
+			const session = await this.readSession(virtualPath);
+			const fallbackDate = session?.updated_at
+				? new Date(session.updated_at).toISOString().slice(0, 10)
+				: new Date().toISOString().slice(0, 10);
+			return { [fallbackDate]: 1.0 };
+		}
+		const fractions: Record<string, number> = {};
+		for (const [day, count] of Object.entries(counts)) {
+			fractions[day] = count / total;
+		}
+		return fractions;
+	}
+}

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -712,7 +712,7 @@ function renderSessionTable(
 							<td class="session-title" title="${sf.title ? escapeHtml(sf.title) : "Empty session"}">
 								${sf.title ? `<a href="#" class="session-file-link" data-file="${encodeURIComponent(sf.file)}" title="${escapeHtml(sf.title)}">${escapeHtml(sf.title.length > 40 ? sf.title.substring(0, 40) + "..." : sf.title)}</a>` : `<a href="#" class="session-file-link empty-session-link" data-file="${encodeURIComponent(sf.file)}" title="Empty session">(Empty session)</a>`}
 							</td>
-							<td class="repository-cell" title="${sf.repository ? escapeHtml(sf.repository) : "No repository detected"}">${sf.repository ? escapeHtml(getRepoDisplayName(sf.repository)) : '<span style="color: #666;">—</span>'}</td>
+							<td class="repository-cell" title="${sf.repository ? escapeHtml(sf.repository) : (sf.file.includes('session-store.db') ? 'Chat session — no workspace connected' : 'No repository detected')}">${sf.repository ? escapeHtml(getRepoDisplayName(sf.repository)) : (sf.file.includes('session-store.db') ? '<span style="color: #888; font-style: italic;">No workspace</span>' : '<span style="color: #666;">—</span>')}</td>
 							<td>${formatFileSize(sf.size)}</td>
 							<td title="${Number(sf.tokens || 0).toLocaleString()} tokens">${formatTokenCount(sf.tokens)}</td>
 							<td>${sanitizeNumber(sf.interactions)}</td>

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -711,6 +711,9 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
 	if (normalizedPath.includes('/.copilot/jb/')) {
 		return 'JetBrains';
 	}
+	if (normalizedPath.includes('/.copilot/session-store.db#')) {
+		return 'Copilot CLI';
+	}
 	if (normalizedPath.includes('/.copilot/session-state/')) {
 		return 'Copilot CLI';
 	}

--- a/vscode-extension/test/unit/copilotCliAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotCliAdapter.test.ts
@@ -63,11 +63,15 @@ test('CopilotCliAdapter.getEditorRoot: returns ~/.copilot/session-state', () => 
     assert.equal(adapter.getEditorRoot('/anything'), getCopilotCliSessionStateDir());
 });
 
-test('CopilotCliAdapter.getCandidatePaths: returns single Copilot CLI entry', () => {
+test('CopilotCliAdapter.getCandidatePaths: returns session-state dir and session-store.db entries', () => {
     const paths = adapter.getCandidatePaths();
-    assert.equal(paths.length, 1);
+    assert.equal(paths.length, 2);
+    // First entry: session-state directory
     assert.equal(paths[0].source, 'Copilot CLI');
     assert.ok(paths[0].path.replace(/\\/g, '/').endsWith('/.copilot/session-state'));
+    // Second entry: session-store.db for chat-only sessions
+    assert.equal(paths[1].source, 'Copilot CLI (session-store.db)');
+    assert.ok(paths[1].path.replace(/\\/g, '/').endsWith('/.copilot/session-store.db'));
 });
 
 // ---------------------------------------------------------------------------
@@ -133,10 +137,25 @@ test('CopilotCliAdapter.discover: finds flat .json/.jsonl AND uuid subdir events
     assert.equal(result.sessionFiles.filter(f => f.includes('b2c3d4e5')).length, 0);
 });
 
-test('CopilotCliAdapter.discover: returns empty result when session-state dir does not exist', async () => {
-    // The real adapter points at the user's homedir; if that dir doesn't
-    // exist (e.g. in CI), discover() must return cleanly with empty results.
-    const result = await adapter.discover(() => { /* noop */ });
+test('CopilotCliAdapter.discover: returns empty result when session-state dir does not exist', async (t) => {
+    // Redirect HOME to an empty tmpdir so neither session-state/ nor session-store.db
+    // exist. This avoids loading sql.js WASM (which causes a Windows UV handle assertion
+    // on forced process exit) while still verifying that discover() handles missing dirs.
+    const tmpHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cli-home-empty-'));
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    t.after(async () => {
+        if (originalHome === undefined) { delete process.env.HOME; } else { process.env.HOME = originalHome; }
+        if (originalUserProfile === undefined) { delete process.env.USERPROFILE; } else { process.env.USERPROFILE = originalUserProfile; }
+        await fs.promises.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    const fresh = new CopilotCliAdapter();
+    const result = await fresh.discover(() => { /* noop */ });
     assert.ok(Array.isArray(result.sessionFiles));
     assert.ok(Array.isArray(result.candidatePaths));
+    assert.equal(result.sessionFiles.length, 0);
 });


### PR DESCRIPTION
## Summary

32% of chat-only sessions in `~/.copilot/session-store.db` have `session_files` data (file edits). This PR surfaces those sessions in the extension alongside the events.jsonl-based worktree sessions.

## What changed

### New file: `vscode-extension/src/copilotCliStore.ts`
A new `CopilotCliStoreAccess` data access class that reads `session-store.db` via sql.js WASM. Uses the virtual path scheme `<db-path>#<uuid>` (same pattern as the Crush adapter). Key methods:
- `discoverNewSessions(knownUuids)` — returns session IDs not already covered by an events.jsonl file (prevents double-counting)
- `readSession()`, `getTurns()`, `countTurns()`, `getDailyFractions()` — standard session data accessors

### `copilotCliAdapter.ts`
- `handles()` now returns `true` for `session-store.db#` virtual paths
- `discover()` queries both `session-state/` (events.jsonl) AND `session-store.db` (chat sessions)
- DB sessions excluded from the DB query if already represented by an events.jsonl to prevent double-counting

### `workspaceHelpers.ts`
`getEditorTypeFromPath()` now recognizes `session-store.db#` paths → returns `'Copilot CLI'`

### `diagnostics/main.ts`
Shows italic gray **"No workspace"** for sessions with a `session-store.db` virtual path and no repository.

### Test update: `copilotCliAdapter.test.ts`
- Updated `getCandidatePaths` test: now expects 2 entries (session-state dir + session-store.db)
- Fixed Windows `UV_HANDLE_CLOSING` assertion: the "empty dir" test now redirects HOME to a tmpdir with no DB file, avoiding sql.js WASM load during force-exit cleanup

## Test results
All 53 test files pass (`npm run test:node`). TypeScript compilation clean (`tsc --noEmit`). CLI build succeeds.