### PR TITLE
perf(crush): fix N+1 DB read inefficiency with mtime-based caching

### DIFF
--- a/vscode-extension/src/crush.ts
+++ b/vscode-extension/src/crush.ts
@@ -16,6 +16,8 @@ import * as vscode from 'vscode';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 
+type CrushDbCacheEntry = { db: any; mtimeMs: number; size: number };
+
 export interface CrushProject {
 	path: string;
 	data_dir: string;
@@ -24,10 +26,107 @@ export interface CrushProject {
 
 export class CrushDataAccess {
 	private _sqlJsModule: any = null;
+	private _dbCache: Map<string, CrushDbCacheEntry> = new Map();
+	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
 	private readonly extensionUri: vscode.Uri;
 
 	constructor(extensionUri: vscode.Uri) {
 		this.extensionUri = extensionUri;
+	}
+
+	dispose(): void {
+		for (const entry of this._dbCache.values()) {
+			try { entry.db.close(); } catch { /* ignore */ }
+		}
+		this._dbCache.clear();
+		this._dbCacheInflight.clear();
+	}
+
+	private closeDb(db: any): void {
+		try { db.close(); } catch { /* ignore */ }
+	}
+
+	private isMissingFileError(error: unknown): boolean {
+		const code = (error as NodeJS.ErrnoException)?.code;
+		return code === 'ENOENT' || code === 'ENOTDIR';
+	}
+
+	private statCrushDb(dbPath: string): fs.Stats | null {
+		try {
+			return fs.statSync(dbPath);
+		} catch (error) {
+			if (this.isMissingFileError(error) && this._dbCache.has(dbPath)) {
+				this.closeDb(this._dbCache.get(dbPath)!.db);
+				this._dbCache.delete(dbPath);
+			}
+			return null;
+		}
+	}
+
+	private isCachedDbCurrent(dbPath: string, stats: fs.Stats): boolean {
+		const entry = this._dbCache.get(dbPath);
+		return !!entry && entry.mtimeMs === stats.mtimeMs && entry.size === stats.size;
+	}
+
+	private getDbCacheKey(dbPath: string, stats: fs.Stats): string {
+		return `${dbPath}:${stats.mtimeMs}:${stats.size}`;
+	}
+
+	private sameDbStats(left: fs.Stats, right: fs.Stats): boolean {
+		return left.mtimeMs === right.mtimeMs && left.size === right.size;
+	}
+
+	private async refreshCrushDb(dbPath: string, stats: fs.Stats): Promise<any | null> {
+		let db: any;
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			db = new SQL.Database(buffer);
+		} catch {
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+
+		const currentStats = this.statCrushDb(dbPath);
+		if (!currentStats || !this.sameDbStats(stats, currentStats)) {
+			this.closeDb(db);
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+
+		const existing = this._dbCache.get(dbPath);
+		if (existing) { this.closeDb(existing.db); }
+		this._dbCache.set(dbPath, { db, mtimeMs: stats.mtimeMs, size: stats.size });
+		return db;
+	}
+
+	/**
+	 * Returns a cached SQL.Database instance for the given crush.db path, re-opening
+	 * only when the file's mtime or size changes. This avoids reading and parsing the
+	 * entire DB file on every query (the primary cause of ~700ms-per-call latency).
+	 *
+	 * Uses single-flight deduplication to prevent concurrent callers from each
+	 * re-reading the DB file and leaving instances unclosed.
+	 */
+	private async getCrushDb(dbPath: string): Promise<any | null> {
+		const stats = this.statCrushDb(dbPath);
+		if (!stats) { return this._dbCache.get(dbPath)?.db ?? null; }
+
+		if (this.isCachedDbCurrent(dbPath, stats)) {
+			return this._dbCache.get(dbPath)!.db;
+		}
+
+		const cacheKey = this.getDbCacheKey(dbPath, stats);
+		const inflight = this._dbCacheInflight.get(cacheKey);
+		if (inflight) { return inflight; }
+
+		const createDbPromise = this.refreshCrushDb(dbPath, stats);
+		this._dbCacheInflight.set(cacheKey, createDbPromise);
+		try {
+			return await createDbPromise;
+		} finally {
+			if (this._dbCacheInflight.get(cacheKey) === createDbPromise) {
+				this._dbCacheInflight.delete(cacheKey);
+			}
+		}
 	}
 
 	/**
@@ -115,18 +214,12 @@ export class CrushDataAccess {
 	 * Discover all session IDs in a specific `crush.db` file.
 	 */
 	async discoverSessionsInDb(dbPath: string): Promise<string[]> {
-		if (!fs.existsSync(dbPath)) { return []; }
+		const db = await this.getCrushDb(dbPath);
+		if (!db) { return []; }
 		try {
-			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
-			const db = new SQL.Database(buffer);
-			try {
-				const result = db.exec('SELECT id FROM sessions');
-				if (result.length === 0) { return []; }
-				return result[0].values.map((row: unknown[]) => row[0] as string);
-			} finally {
-				db.close();
-			}
+			const result = db.exec('SELECT id FROM sessions');
+			if (result.length === 0) { return []; }
+			return result[0].values.map((row: unknown[]) => row[0] as string);
 		} catch {
 			return [];
 		}
@@ -138,25 +231,20 @@ export class CrushDataAccess {
 	async readCrushSession(virtualPath: string): Promise<any | null> {
 		const dbPath = this.getCrushDbPath(virtualPath);
 		const sessionId = this.getCrushSessionId(virtualPath);
-		if (!sessionId || !fs.existsSync(dbPath)) { return null; }
+		if (!sessionId) { return null; }
+		const db = await this.getCrushDb(dbPath);
+		if (!db) { return null; }
 		try {
-			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
-			const db = new SQL.Database(buffer);
-			try {
-				const result = db.exec(
-					'SELECT id, title, message_count, prompt_tokens, completion_tokens, created_at, updated_at FROM sessions WHERE id = ?',
-					[sessionId]
-				);
-				if (result.length === 0 || result[0].values.length === 0) { return null; }
-				const cols = result[0].columns;
-				const row = result[0].values[0];
-				const obj: any = {};
-				cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
-				return obj;
-			} finally {
-				db.close();
-			}
+			const result = db.exec(
+				'SELECT id, title, message_count, prompt_tokens, completion_tokens, created_at, updated_at FROM sessions WHERE id = ?',
+				[sessionId]
+			);
+			if (result.length === 0 || result[0].values.length === 0) { return null; }
+			const cols = result[0].columns;
+			const row = result[0].values[0];
+			const obj: any = {};
+			cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+			return obj;
 		} catch {
 			return null;
 		}
@@ -169,29 +257,24 @@ export class CrushDataAccess {
 	async getCrushMessages(virtualPath: string): Promise<any[]> {
 		const dbPath = this.getCrushDbPath(virtualPath);
 		const sessionId = this.getCrushSessionId(virtualPath);
-		if (!sessionId || !fs.existsSync(dbPath)) { return []; }
+		if (!sessionId) { return []; }
+		const db = await this.getCrushDb(dbPath);
+		if (!db) { return []; }
 		try {
-			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
-			const db = new SQL.Database(buffer);
-			try {
-				const result = db.exec(
-					'SELECT id, session_id, role, parts, model, provider, created_at, updated_at, finished_at FROM messages WHERE session_id = ? AND is_summary_message = 0 ORDER BY created_at ASC',
-					[sessionId]
-				);
-				if (result.length === 0) { return []; }
-				const cols = result[0].columns;
-				return result[0].values.map((row: unknown[]) => {
-					const obj: any = {};
-					cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
-					if (typeof obj.parts === 'string') {
-						try { obj.parts = JSON.parse(obj.parts); } catch { obj.parts = []; }
-					}
-					return obj;
-				});
-			} finally {
-				db.close();
-			}
+			const result = db.exec(
+				'SELECT id, session_id, role, parts, model, provider, created_at, updated_at, finished_at FROM messages WHERE session_id = ? AND is_summary_message = 0 ORDER BY created_at ASC',
+				[sessionId]
+			);
+			if (result.length === 0) { return []; }
+			const cols = result[0].columns;
+			return result[0].values.map((row: unknown[]) => {
+				const obj: any = {};
+				cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+				if (typeof obj.parts === 'string') {
+					try { obj.parts = JSON.parse(obj.parts); } catch { obj.parts = []; }
+				}
+				return obj;
+			});
 		} catch {
 			return [];
 		}

--- a/vscode-extension/test/unit/crush-cache.test.ts
+++ b/vscode-extension/test/unit/crush-cache.test.ts
@@ -1,0 +1,264 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CrushDataAccess } from '../../src/crush';
+
+const SESSION_ID = 'ses-001';
+
+type HarnessOptions = {
+	delayInit?: boolean;
+	failOpenAttempts?: Set<number>;
+	mutateOnOpen?: { attempt: number; content: string };
+};
+
+function createHarness(options: HarnessOptions = {}) {
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crush-cache-'));
+	const crushDir = path.join(tmpDir, '.crush');
+	fs.mkdirSync(crushDir, { recursive: true });
+	const dbPath = path.join(crushDir, 'crush.db');
+	const virtualPath = `${dbPath}#${SESSION_ID}`;
+
+	const opened: Array<{ content: string; closed: boolean }> = [];
+	let openAttempts = 0;
+	let initCalls = 0;
+	let touchCounter = 0;
+
+	const setDbContent = (content: string) => {
+		fs.writeFileSync(dbPath, content);
+		const touchedAt = new Date(Date.UTC(2026, 0, 1, 0, 0, touchCounter++));
+		fs.utimesSync(dbPath, touchedAt, touchedAt);
+	};
+	setDbContent('v1');
+
+	class FakeDatabase {
+		readonly content: string;
+		closed = false;
+
+		constructor(buffer: Uint8Array) {
+			openAttempts++;
+			if (options.failOpenAttempts?.has(openAttempts)) {
+				throw new Error('open failed');
+			}
+			this.content = Buffer.from(buffer).toString('utf8');
+			opened.push(this);
+			if (options.mutateOnOpen?.attempt === openAttempts) {
+				setDbContent(options.mutateOnOpen.content);
+			}
+		}
+
+		exec(_query: string, _params?: unknown[]): Array<{ columns: string[]; values: unknown[][] }> {
+			if (_query.includes('FROM messages')) {
+				return [{
+					columns: ['id', 'session_id', 'role', 'parts', 'model', 'provider', 'created_at', 'updated_at', 'finished_at'],
+					values: [[
+						`msg-${this.content}`,
+						SESSION_ID,
+						'assistant',
+						JSON.stringify([{ type: 'text', text: this.content }]),
+						'gpt-4',
+						'openai',
+						100,
+						200,
+						300,
+					]],
+				}];
+			}
+			if (_query.includes('FROM sessions') && _query.includes('WHERE id')) {
+				return [{
+					columns: ['id', 'title', 'message_count', 'prompt_tokens', 'completion_tokens', 'created_at', 'updated_at'],
+					values: [[SESSION_ID, `title-${this.content}`, 1, 50, 50, 100, 200]],
+				}];
+			}
+			if (_query.includes('FROM sessions')) {
+				return [{
+					columns: ['id'],
+					values: [[SESSION_ID]],
+				}];
+			}
+			return [];
+		}
+
+		close(): void {
+			this.closed = true;
+		}
+	}
+
+	const access = new CrushDataAccess(null as any);
+	(access as any).initSqlJs = async () => {
+		initCalls++;
+		if (options.delayInit) {
+			await new Promise(resolve => setTimeout(resolve, 10));
+		}
+		return { Database: FakeDatabase };
+	};
+
+	return {
+		access,
+		dbPath,
+		virtualPath,
+		opened,
+		setDbContent,
+		get openAttempts() { return openAttempts; },
+		get initCalls() { return initCalls; },
+		cleanup: () => {
+			access.dispose();
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		},
+	};
+}
+
+test('Crush DB cache reuses the same Database for unchanged files', async () => {
+	const harness = createHarness();
+	try {
+		const first = await harness.access.getCrushMessages(harness.virtualPath);
+		const second = await harness.access.getCrushMessages(harness.virtualPath);
+
+		assert.equal(first[0].parts[0].text, 'v1');
+		assert.equal(second[0].parts[0].text, 'v1');
+		assert.equal(harness.openAttempts, 1);
+		assert.equal(harness.initCalls, 1);
+		assert.equal(harness.opened[0].closed, false);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('Crush DB cache single-flights concurrent opens for the same file version', async () => {
+	const harness = createHarness({ delayInit: true });
+	try {
+		const results = await Promise.all([
+			harness.access.getCrushMessages(harness.virtualPath),
+			harness.access.getCrushMessages(harness.virtualPath),
+			harness.access.getCrushMessages(harness.virtualPath),
+		]);
+
+		assert.deepEqual(results.map(r => r[0].parts[0].text), ['v1', 'v1', 'v1']);
+		assert.equal(harness.openAttempts, 1);
+		assert.equal(harness.initCalls, 1);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('Crush DB cache falls back to stale cached DB when refresh open fails', async () => {
+	const harness = createHarness({ failOpenAttempts: new Set([2]) });
+	try {
+		const first = await harness.access.getCrushMessages(harness.virtualPath);
+		harness.setDbContent('v2');
+		const afterFailedRefresh = await harness.access.getCrushMessages(harness.virtualPath);
+
+		assert.equal(first[0].parts[0].text, 'v1');
+		assert.equal(afterFailedRefresh[0].parts[0].text, 'v1');
+		assert.equal(harness.openAttempts, 2);
+		assert.equal(harness.opened.length, 1);
+		assert.equal(harness.opened[0].closed, false);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('Crush DB cache closes cached DB when the backing file disappears', async () => {
+	const harness = createHarness();
+	try {
+		await harness.access.getCrushMessages(harness.virtualPath);
+		fs.unlinkSync(harness.dbPath);
+		const afterDelete = await harness.access.getCrushMessages(harness.virtualPath);
+
+		assert.deepEqual(afterDelete, []);
+		assert.equal(harness.opened[0].closed, true);
+		assert.equal((harness.access as any)._dbCache.size, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('Crush DB cache closes cached DB on dispose', async () => {
+	const harness = createHarness();
+	try {
+		await harness.access.getCrushMessages(harness.virtualPath);
+		harness.access.dispose();
+
+		assert.equal(harness.opened[0].closed, true);
+		assert.equal((harness.access as any)._dbCache.size, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('Crush DB cache does not install a DB if the file changes during refresh', async () => {
+	const harness = createHarness({ mutateOnOpen: { attempt: 2, content: 'v3' } });
+	try {
+		await harness.access.getCrushMessages(harness.virtualPath);
+		harness.setDbContent('v2');
+
+		const duringChangingRefresh = await harness.access.getCrushMessages(harness.virtualPath);
+		const afterSettledRefresh = await harness.access.getCrushMessages(harness.virtualPath);
+
+		assert.equal(duringChangingRefresh[0].parts[0].text, 'v1');
+		assert.equal(afterSettledRefresh[0].parts[0].text, 'v3');
+		assert.equal(harness.opened[1].content, 'v2');
+		assert.equal(harness.opened[1].closed, true);
+		assert.equal(harness.opened[0].closed, true);
+		assert.equal(harness.opened[2].closed, false);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('Crush DB cache maintains independent caches for different DB paths', async () => {
+	const harness = createHarness();
+	// Create a second project DB
+	const tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'crush-cache2-'));
+	try {
+		const crushDir2 = path.join(tmpDir2, '.crush');
+		fs.mkdirSync(crushDir2, { recursive: true });
+		const dbPath2 = path.join(crushDir2, 'crush.db');
+		const virtualPath2 = `${dbPath2}#ses-002`;
+		fs.writeFileSync(dbPath2, 'proj2');
+		const t2 = new Date(Date.UTC(2026, 0, 1, 1, 0, 0));
+		fs.utimesSync(dbPath2, t2, t2);
+
+		(harness.access as any).initSqlJs = async () => {
+			return {
+				Database: class {
+					content: string;
+					closed = false;
+					constructor(buf: Uint8Array) { this.content = Buffer.from(buf).toString('utf8'); }
+					exec(_q: string, _p?: unknown[]) {
+						if (_q.includes('FROM messages')) {
+							return [{ columns: ['id','session_id','role','parts','model','provider','created_at','updated_at','finished_at'], values: [[`msg-${this.content}`, 'ses-001', 'assistant', JSON.stringify([{type:'text',text:this.content}]), 'gpt-4', 'openai', 1, 2, 3]] }];
+						}
+						return [];
+					}
+					close() { this.closed = true; }
+				}
+			};
+		};
+
+		const r1 = await harness.access.getCrushMessages(harness.virtualPath);
+		const r2 = await harness.access.getCrushMessages(virtualPath2);
+
+		assert.equal(r1[0].parts[0].text, 'v1');
+		assert.equal(r2[0].parts[0].text, 'proj2');
+		assert.equal((harness.access as any)._dbCache.size, 2);
+	} finally {
+		harness.cleanup();
+		fs.rmSync(tmpDir2, { recursive: true, force: true });
+	}
+});
+
+test('Crush DB cache discoverSessionsInDb uses cache', async () => {
+	const harness = createHarness();
+	try {
+		const sessions1 = await harness.access.discoverSessionsInDb(harness.dbPath);
+		const sessions2 = await harness.access.discoverSessionsInDb(harness.dbPath);
+
+		assert.deepEqual(sessions1, [SESSION_ID]);
+		assert.deepEqual(sessions2, [SESSION_ID]);
+		assert.equal(harness.openAttempts, 1);
+	} finally {
+		harness.cleanup();
+	}
+});


### PR DESCRIPTION
## Summary

Fixes #923 — applies the same mtime-based SQLite caching strategy from #922 (OpenCode) to the Crush data access layer.

## Problem

Every call to \discoverSessionsInDb\, \eadCrushSession\, or \getCrushMessages\ was re-reading and re-parsing the entire \crush.db\ file through the sql.js WASM layer (~700ms per call). With N sessions this caused significant startup latency.

## Solution

- **Map-based cache** (\_dbCache: Map<string, CrushDbCacheEntry>\) — one entry per DB path, since Crush uses one \crush.db\ per project (unlike OpenCode's single global DB)
- **Single-flight deduplication** (\_dbCacheInflight\) — prevents concurrent callers from each re-loading the same DB file
- **mtime + size invalidation** — cache is only refreshed when the file actually changes on disk
- **Graceful fallback** — stale cache is returned on refresh failure; cache entry is evicted when the file is deleted
- **\dispose()\** — closes all cached DB instances on extension shutdown

## Tests

8 new tests in \crush-cache.test.ts\ (mirrors \opencode-cache.test.ts\):
- Cache reuse for unchanged files
- Concurrent single-flight open
- Stale-cache fallback on refresh failure
- Cache eviction on file deletion
- Dispose closes all instances
- No install when file mutates during refresh
- Independent caches for different DB paths
- \discoverSessionsInDb\ cache reuse