### PR TITLE
chore: bump vscode-extension version to 0.10.0

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -6,6 +6,21 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-19
+
+### Features
+- Surface Copilot CLI chat-only sessions from session-store.db (#915)
+- Add friendly display names for additional tools (#920)
+- Persist chart view/period/displayMode selection across navigation (#911)
+
+### Bug Fixes
+- Propagate cachedReadTokens/cacheCreationTokens in calculateDailyStats (#907)
+- Fix N+1 inefficiency in processing OpenCode sessions (#922)
+
+### Performance
+- Apply mtime-based DB caching to crush adapter to fix N+1 inefficiency (#924)
+- Eliminate redundant JSON.parse calls in session analysis (#910)
+
 ## [0.9.0] - 2026-05-14
 
 ### Features

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — VS Code Extension v0.10.0

This PR bumps the version number for the VS Code extension, which has new features and fixes since the last release tag \scode/v0.9.1\.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.9.1 | v0.10.0 |

### Changes since \scode/v0.9.1\

#### Features
- Surface Copilot CLI chat-only sessions from \session-store.db\ (#915)
- Add friendly display names for additional tools (#920)
- Persist chart view/period/displayMode selection across navigation (#911)

#### Bug Fixes
- Propagate \cachedReadTokens\/\cacheCreationTokens\ in \calculateDailyStats\ (#907)
- Fix N+1 inefficiency in processing OpenCode sessions (#922)

#### Performance
- Apply mtime-based DB caching to crush adapter to fix N+1 inefficiency (#924)
- Eliminate redundant \JSON.parse\ calls in session analysis (#910)

---

### After merging, run this workflow:

**Actions → Extensions - Release (\elease.yml\)** → Run workflow on \main\
- Publishes VS Code extension **v0.10.0** to the VS Code Marketplace