### PR TITLE
chore: remove empty Unreleased sections and Keep a Changelog references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 >
 > The entries below are historical (pre-split) VS Code extension releases.
 
-## [Unreleased]
 ## [0.0.18]
 
 ## [0.0.17]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to the CLI (`@rajbos/ai-engineering-fluency`) will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
 ## [0.1.1] - 2026-05-09
 
 ### ✨ Features & Improvements

--- a/visualstudio-extension/CHANGELOG.md
+++ b/visualstudio-extension/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to the Visual Studio extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
 ## [1.0.5] - 2026-04-11
 
 ### ✨ Features & Improvements

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
 ## [0.10.0] - 2026-05-19
 
 ### Features


### PR DESCRIPTION
The `## [Unreleased]` section has been empty across all changelogs, and the "Keep a Changelog" boilerplate link added no value for readers. Both were just noise at the top of each file.

- Removed the empty `## [Unreleased]` section from all 4 changelogs (`CHANGELOG.md`, `vscode-extension`, `cli`, `visualstudio-extension`)
- Removed the `Check [Keep a Changelog](...)` reference line from the 3 component changelogs