### PR TITLE
fix: implement IAnalyzableEcosystem on CopilotCliAdapter to prevent ENOENT on virtual session paths

### DIFF
--- a/vscode-extension/src/adapters/copilotCliAdapter.ts
+++ b/vscode-extension/src/adapters/copilotCliAdapter.ts
@@ -19,11 +19,14 @@ import type { ModelUsage, ChatTurn } from '../types';
 import type {
 	IEcosystemAdapter,
 	IDiscoverableEcosystem,
+	IAnalyzableEcosystem,
 	DiscoveryResult,
 	CandidatePath,
+	UsageAnalysisAdapterContext,
 } from '../ecosystemAdapter';
 import { CopilotCliStoreAccess } from '../copilotCliStore';
 import { createEmptyContextRefs } from '../tokenEstimation';
+import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
 
 /** Returns the canonical Copilot CLI session-state directory (~/.copilot/session-state). */
 export function getCopilotCliSessionStateDir(): string {
@@ -40,7 +43,7 @@ async function pathExists(p: string): Promise<boolean> {
 	try { await fs.promises.access(p); return true; } catch { return false; }
 }
 
-export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosystem {
+export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'copilotcli';
 	readonly displayName = 'GitHub Copilot CLI';
 
@@ -127,6 +130,15 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 			thinkingTokensEstimate: 0,
 		}));
 		return { turns };
+	}
+
+	async analyzeUsage(sessionFile: string, _ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {
+		const analysis = createEmptySessionUsageAnalysis();
+		if (!this.store.isCliStoreSession(sessionFile)) { return analysis; }
+		const turns = await this.store.getTurns(sessionFile);
+		// Each user turn counts as one CLI interaction; no model/tool data available in the schema.
+		analysis.modeUsage.cli = turns.filter(t => t.user_message !== null).length;
+		return analysis;
 	}
 
 	async getDailyFractions(sessionFile: string): Promise<Record<string, number>> {


### PR DESCRIPTION
## Problem

After updating the extension, users see hundreds of warnings like:

\\\
WARNING: Error analyzing session usage from C:\Users\...\session-store.db#<uuid>: Error: ENOENT: no such file or directory
\\\

This causes slow boot and floods the output channel.

## Root Cause

\CopilotCliAdapter.handles()\ returns \	rue\ for \session-store.db#<uuid>\ virtual paths, but the class did not implement \IAnalyzableEcosystem\ (no \nalyzeUsage()\ method).

In \nalyzeSessionUsage()\, the guard \isAnalyzable(eco)\ returned \alse\, so the code fell through to:
\\\	s
const fileContent = await fs.promises.readFile(sessionFile, 'utf8');
\\\
…where \sessionFile\ is the virtual path string \session-store.db#<uuid>\ — not a real file — causing ENOENT on every single session in the database.

## Fix

Implement \IAnalyzableEcosystem\ on \CopilotCliAdapter\. The new \nalyzeUsage()\ method reads turns from the SQLite DB and counts each user turn as \modeUsage.cli\ (no model/tool data is available in the session-store.db schema).

## Testing

All 10 existing \copilotCliAdapter\ unit tests pass. TypeScript compiles cleanly with \	sc --noEmit\.