### PR TITLE
chore: bump versions for release (VS Code extension v0.10.1)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+## [0.10.1] - 2026-05-19
+
+### Bug Fixes
+- Implement IAnalyzableEcosystem on CopilotCliAdapter to prevent ENOENT errors on virtual session paths (#931)
+
 ## [0.10.0] - 2026-05-19
 
 ### Features

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to the VS Code extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
-
 ## [0.10.1] - 2026-05-19
 
 ### Bug Fixes

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
 ## [0.10.1] - 2026-05-19
 
 ### Bug Fixes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bump

This PR bumps the VS Code extension version for a patch release covering the bug fix merged in PR #931.

| Component | Old version | New version | Change |
|-----------|-------------|-------------|--------|
| VS Code extension | v0.10.0 | v0.10.1 | patch |

### What's included

- **Bug fix (PR #931):** Implement \IAnalyzableEcosystem\ on \CopilotCliAdapter\ to prevent ENOENT errors on virtual session paths

### Files changed
- \scode-extension/package.json\ — version \