### PR TITLE
refactor: break down large functions and improve type safety in syncService.ts

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -13,7 +13,7 @@ import type { DailyRollupKey } from '../rollups';
 import { upsertDailyRollup } from '../rollups';
 import type { BackendSettings } from '../settings';
 import { BACKEND_SYNC_MIN_INTERVAL_MS } from '../constants';
-import type { DailyRollupValue, ChatRequest, SessionFileCache } from '../types';
+import type { DailyRollupValue, ChatRequest, SessionFileCache, ModelUsage } from '../types';
 import { resolveUserIdentityForSync, type BackendUserIdentityMode } from '../identity';
 import { computeBackendSharingPolicy, hashMachineIdForTeam, hashWorkspaceIdForTeam } from '../sharingProfile';
 import { createDailyAggEntity } from '../storageTables';
@@ -24,6 +24,10 @@ import { SharingServerUploadService, type SharingServerEntry } from './sharingSe
 import { isJsonlContent } from '../../tokenEstimation';
 import { getEditorTypeFromPath } from '../../workspaceHelpers';
 
+/** Ecosystem session per-model usage entry (input, output, optional interactions). */
+type ModelUsageEntry = { inputTokens: number; outputTokens: number; interactions?: number };
+
+
 /**
  * Interface for blob upload service to avoid circular dependency.
  */
@@ -31,7 +35,7 @@ interface BlobUploadServiceLike {
 	uploadSessionFiles(
 		storageAccount: string,
 		settings: { enabled: boolean; containerName: string; uploadFrequencyHours: number; compressFiles: boolean },
-		credential: any,
+		credential: unknown,
 		sessionFiles: string[],
 		machineId: string,
 		datasetId: string
@@ -86,10 +90,10 @@ export interface SyncServiceDeps {
 	statSessionFile: (sessionFile: string) => Promise<fs.Stats>;
 	// OpenCode session handling
 	isOpenCodeSession?: (sessionFile: string) => boolean;
-	getOpenCodeSessionData?: (sessionFile: string) => Promise<{ tokens: number; interactions: number; modelUsage: any; timestamp: number }>;
+	getOpenCodeSessionData?: (sessionFile: string) => Promise<{ tokens: number; interactions: number; modelUsage: Record<string, ModelUsageEntry>; timestamp: number }>;
 	// Crush session handling (per-project crush.db virtual paths)
 	isCrushSession?: (sessionFile: string) => boolean;
-	getCrushSessionData?: (sessionFile: string) => Promise<{ tokens: number; interactions: number; modelUsage: any; timestamp: number }>;
+	getCrushSessionData?: (sessionFile: string) => Promise<{ tokens: number; interactions: number; modelUsage: Record<string, ModelUsageEntry>; timestamp: number }>;
 	// Visual Studio session detection (binary MessagePack — cannot be parsed as JSON)
 	isVSSessionFile?: (sessionFile: string) => boolean;
 	/** Returns the current GitHub OAuth access token, or undefined if not authenticated. */
@@ -284,345 +288,459 @@ export class SyncService {
 		return this.syncQueue;
 	}
 
-	/**
-	 * Process a session file using cached data for token counts but extracting accurate timestamps.
-	 * Returns true if successful, false if cache miss (caller should parse file).
-	 * Validates all cached data at runtime to prevent injection/corruption.
-	 * 
-	 * CRITICAL: We parse the file to extract actual interaction timestamps and create per-day
-	 * rollups, but use cached token counts for performance. This ensures accurate day assignment
-	 * while still benefiting from cached calculations.
-	 */
-	private async processCachedSessionFile(
-		sessionFile: string,
-		fileMtimeMs: number,
-		fileSize: number,
-		workspaceId: string,
-		machineId: string,
-		userId: string | undefined,
-		rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>,
-		startMs: number,
-		now: Date,
-		editor?: string
-	): Promise<boolean> {
-		try {
-			const cachedData = await this.deps.getSessionFileDataCached!(sessionFile, fileMtimeMs, fileSize);
-			
-			// Validate cached data structure to prevent injection/corruption
-			if (!cachedData || typeof cachedData !== 'object') {
-				this.deps.warn(`Backend sync: invalid cached data structure for ${sessionFile}`);
-				return false;
-			}
-			if (typeof cachedData.modelUsage !== 'object' || cachedData.modelUsage === null) {
-				this.deps.warn(`Backend sync: invalid modelUsage in cached data for ${sessionFile}`);
-				return false;
-			}
-			if (!Number.isFinite(cachedData.interactions) || cachedData.interactions < 0) {
-				this.deps.warn(`Backend sync: invalid interactions count in cached data for ${sessionFile}`);
-				return false;
-			}
 
-			// Fast path: use pre-computed dailyRollups (same data as extension stats — avoids re-parsing the file).
-			// When present, token attribution is already distributed per-UTC-day and per-model, so results
-			// will exactly match what the extension shows locally.
-			if (cachedData.dailyRollups && Object.keys(cachedData.dailyRollups).length > 0) {
-				const totalSessionInteractions = cachedData.interactions || 1;
-				const dayKeys = Object.keys(cachedData.dailyRollups).sort();
+/** Arguments shared across per-session rollup helper methods. */
+private makeSessionRollupArgs(
+machineId: string,
+userId: string | undefined,
+editorForFile: string | undefined,
+workspaceNamesById: Record<string, string>,
+rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>,
+startMs: number
+): { machineId: string; userId: string | undefined; editorForFile: string | undefined; workspaceNamesById: Record<string, string>; rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>; startMs: number } {
+return { machineId, userId, editorForFile, workspaceNamesById, rollups, startMs };
+}
 
-				for (const dayKey of dayKeys) {
-					const dayEntry = cachedData.dailyRollups[dayKey];
-					const dayStartMs = new Date(dayKey + 'T00:00:00Z').getTime();
-					if (dayStartMs < startMs) { continue; }
+/**
+ * Build day→model interaction counts from Copilot CLI non-delta JSONL format.
+ * Each JSONL line is a single event; counts all events per day per model.
+ */
+private buildDayModelInteractionsFromCliJsonl(
+content: string,
+sessionFile: string,
+fileMtimeMs: number,
+startMs: number,
+now: Date
+): Map<string, Map<string, number>> {
+const dayModelInteractions = new Map<string, Map<string, number>>();
+const lines = content.trim().split('\n');
+const todayKey = this.utility.toUtcDayKey(now);
+let lineCount = 0;
+let processedLines = 0;
+for (const line of lines) {
+lineCount++;
+if (!line.trim()) { continue; }
+try {
+const event = JSON.parse(line);
+if (!event || typeof event !== 'object') { continue; }
+const normalizedTs = this.utility.normalizeTimestampToMs(event.timestamp);
+const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
+if (!eventMs || eventMs < startMs) { continue; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+const model = (event.model || 'gpt-4o').toString();
+const isFileFromToday = dayKey === todayKey;
+if (isFileFromToday && processedLines < 3) {
+this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} line ${lineCount}: eventMs=${new Date(eventMs).toISOString()}, dayKey=${dayKey}, type=${event.type}`);
+processedLines++;
+}
+// Track interaction for this day+model (count all events, not just user.message)
+if (!dayModelInteractions.has(dayKey)) {
+dayModelInteractions.set(dayKey, new Map());
+}
+const dayMap = dayModelInteractions.get(dayKey)!;
+dayMap.set(model, (dayMap.get(model) || 0) + 1);
+} catch {
+// skip malformed line
+}
+}
+return dayModelInteractions;
+}
 
-					const modelEntries = Object.entries(dayEntry.modelUsage).filter(([, mu]) =>
-						mu && ((mu.inputTokens || 0) > 0 || (mu.outputTokens || 0) > 0)
-					);
-					if (modelEntries.length === 0) { continue; }
+/**
+ * Build day→model interaction counts from VS Code delta-based JSONL format.
+ * Handles kind:0/1/2 events with per-request deduplication.
+ */
+private buildDayModelInteractionsFromDeltaJsonl(
+content: string,
+fileMtimeMs: number,
+startMs: number
+): Map<string, Map<string, number>> {
+const dayModelInteractions = new Map<string, Map<string, number>>();
+let defaultModel = 'unknown';
+const seenRequestIds = new Set<string>();
+const lines = content.trim().split('\n');
+for (const line of lines) {
+if (!line.trim()) { continue; }
+try {
+const event = JSON.parse(line);
+if (!event || typeof event !== 'object') { continue; }
+// Extract session-level default model (same logic as getModelUsageFromSession)
+if (event.kind === 0) {
+const modelId = event.v?.selectedModel?.identifier ||
+event.v?.selectedModel?.metadata?.id ||
+event.v?.inputState?.selectedModel?.metadata?.id;
+if (modelId) { defaultModel = modelId.replace(/^copilot\//, ''); }
+}
+if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'selectedModel') {
+const modelId = event.v?.identifier || event.v?.metadata?.id;
+if (modelId) { defaultModel = modelId.replace(/^copilot\//, ''); }
+}
+// kind:2, k[0]==='requests' events append new request(s)
+if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'requests' && Array.isArray(event.v)) {
+for (const request of event.v) {
+const req = request as ChatRequest;
+const reqId = (req as any).requestId as string | undefined;
+if (reqId && seenRequestIds.has(reqId)) { continue; }
+if (reqId) { seenRequestIds.add(reqId); }
+const normalizedTs = this.utility.normalizeTimestampToMs(
+typeof req.timestamp !== 'undefined' ? req.timestamp : undefined
+);
+const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
+if (!eventMs || eventMs < startMs) { continue; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+// Use per-request modelId if present, otherwise fall back to session default
+const rawModel = (req as any).modelId || (req as any).result?.metadata?.modelId;
+const model = rawModel ? (rawModel as string).replace(/^copilot\//, '') : defaultModel;
+if (!dayModelInteractions.has(dayKey)) {
+dayModelInteractions.set(dayKey, new Map());
+}
+const dayMap = dayModelInteractions.get(dayKey)!;
+dayMap.set(model, (dayMap.get(model) || 0) + 1);
+}
+}
+} catch {
+// skip malformed lines
+}
+}
+return dayModelInteractions;
+}
 
-					// Distribute this day's interactions across models proportionally by output token share.
-					const totalDayOutput = modelEntries.reduce((s, [, mu]) => s + (mu.outputTokens || 0), 0);
-					const dayFraction = totalSessionInteractions > 0 ? dayEntry.interactions / totalSessionInteractions : 1;
-					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, dayFraction);
+/**
+ * Build day→model interaction counts from regular JSON session format.
+ * Returns null if JSON parsing fails (logs a warning internally).
+ */
+private buildDayModelInteractionsFromJson(
+content: string,
+fileMtimeMs: number,
+startMs: number,
+sessionFile: string
+): Map<string, Map<string, number>> | null {
+try {
+const sessionJson = JSON.parse(content);
+if (!sessionJson || typeof sessionJson !== 'object') {
+return null;
+}
+const sessionObj = sessionJson as Record<string, unknown>;
+const requests = Array.isArray(sessionObj.requests) ? (sessionObj.requests as unknown[]) : [];
+const dayModelInteractions = new Map<string, Map<string, number>>();
+for (const request of requests) {
+const req = request as ChatRequest;
+const normalizedTs = this.utility.normalizeTimestampToMs(
+typeof req.timestamp !== 'undefined' ? req.timestamp : (sessionObj.lastMessageDate as unknown)
+);
+const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
+if (!eventMs || eventMs < startMs) { continue; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+const model = this.deps.getModelFromRequest(req);
+if (!dayModelInteractions.has(dayKey)) {
+dayModelInteractions.set(dayKey, new Map());
+}
+const dayMap = dayModelInteractions.get(dayKey)!;
+dayMap.set(model, (dayMap.get(model) || 0) + 1);
+}
+return dayModelInteractions;
+} catch (e) {
+this.deps.warn(`Backend sync: failed to parse JSON for ${sessionFile}: ${e}`);
+return null;
+}
+}
 
-					let remainingInteractions = dayEntry.interactions;
-					for (let i = 0; i < modelEntries.length; i++) {
-						const [model, mu] = modelEntries[i];
-						const isLast = i === modelEntries.length - 1;
-						const share = (!isLast && totalDayOutput > 0) ? (mu.outputTokens || 0) / totalDayOutput : 1;
-						const modelInteractions = isLast
-							? remainingInteractions
-							: Math.min(Math.round(dayEntry.interactions * share), remainingInteractions);
-						remainingInteractions -= modelInteractions;
+/**
+ * Remap event model names to cached model names when there is a mismatch.
+ * CLI sessions often omit the model in individual events while session.shutdown
+ * provides the actual model. Without remapping, token lookups silently fail.
+ */
+private remapUnmappedModels(
+dayModelInteractions: Map<string, Map<string, number>>,
+cachedModelUsage: ModelUsage
+): void {
+const cachedModelNames = Object.keys(cachedModelUsage);
+if (cachedModelNames.length === 0) { return; }
+const allEventModels = new Set<string>();
+for (const modelMap of dayModelInteractions.values()) {
+for (const m of modelMap.keys()) { allEventModels.add(m); }
+}
+const unmappedModels = new Set<string>();
+for (const m of allEventModels) {
+if (!cachedModelUsage[m]) { unmappedModels.add(m); }
+}
+if (unmappedModels.size === 0) { return; }
+const totalCachedTokens = cachedModelNames.reduce((sum, m) =>
+sum + cachedModelUsage[m].inputTokens + cachedModelUsage[m].outputTokens, 0);
+for (const [, modelMap] of dayModelInteractions) {
+let unmappedCount = 0;
+for (const um of unmappedModels) {
+unmappedCount += modelMap.get(um) || 0;
+modelMap.delete(um);
+}
+if (unmappedCount > 0) {
+for (const cm of cachedModelNames) {
+const ct = cachedModelUsage[cm].inputTokens + cachedModelUsage[cm].outputTokens;
+const share = totalCachedTokens > 0 ? ct / totalCachedTokens : 1 / cachedModelNames.length;
+const redistributed = Math.round(unmappedCount * share);
+if (redistributed > 0) {
+modelMap.set(cm, (modelMap.get(cm) || 0) + redistributed);
+}
+}
+}
+}
+}
 
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
-						upsertDailyRollup(rollups, key, {
-							inputTokens: mu.inputTokens || 0,
-							outputTokens: mu.outputTokens || 0,
-							interactions: Math.max(0, modelInteractions),
-							fluencyMetrics,
-						});
-					}
-				}
+/**
+ * Build daily rollup entries from day→model interaction counts and cached token data.
+ * Applies proportional fractions for multi-day sessions.
+ */
+private buildRollupsFromDayModelInteractions(
+dayModelInteractions: Map<string, Map<string, number>>,
+cachedData: SessionFileCache,
+sessionFile: string,
+workspaceId: string,
+machineId: string,
+userId: string | undefined,
+rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>,
+editor?: string
+): void {
+// Total interactions per model across all days — used to compute each day's fraction.
+const totalInteractionsPerModel = new Map<string, number>();
+for (const modelMap of dayModelInteractions.values()) {
+for (const [m, c] of modelMap) {
+totalInteractionsPerModel.set(m, (totalInteractionsPerModel.get(m) || 0) + c);
+}
+}
 
-				if (dayKeys.length > 1) {
-					this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} spans ${dayKeys.length} days (dailyRollups fast path): ${dayKeys.join(', ')}`);
-				}
-				return true;
-			}
+for (const [dayKey, modelMap] of dayModelInteractions) {
+for (const [model, interactions] of modelMap) {
+const cachedUsage = cachedData.modelUsage[model];
+if (!cachedUsage) { continue; }
 
-			// Slow path: parse the session file to get actual request timestamps and create per-day rollups.
-			// Used when dailyRollups is absent (old cache entries before CACHE_VERSION bump).
-			// Note: ecosystem sessions (Mistral Vibe, Claude Desktop Cowork) now always have dailyRollups
-			// populated via the firstInteraction fallback in getSessionFileDataCached, so they use the fast path above.
-			const content = await fs.promises.readFile(sessionFile, 'utf8');
-			
-			// Map to track per-day per-model interactions for proper distribution
-			const dayModelInteractions = new Map<string, Map<string, number>>();
-			
-			// Detect whether this is a delta-based (VS Code Insiders) JSONL file or a CLI JSONL file.
-			// Both can use .jsonl extension, but delta-based files have kind:0/1/2 numeric events
-			// while CLI files use event types like user.message, assistant.message, etc.
-			// Check the first non-empty line for a numeric "kind" property to distinguish.
-			let isDeltaBasedJsonl = false;
-			if (isJsonlContent(content)) {
-				const firstLine = content.trim().split('\n')[0]?.trim();
-				if (firstLine) {
-					try {
-						const firstEvent = JSON.parse(firstLine);
-						isDeltaBasedJsonl = typeof firstEvent.kind === 'number';
-					} catch { /* not valid JSON, leave as false */ }
-				}
-			}
+// Validate individual model token values — reject negative or non-finite values.
+const cachedInput = typeof cachedUsage.inputTokens === 'number' ? cachedUsage.inputTokens : NaN;
+const cachedOutput = typeof cachedUsage.outputTokens === 'number' ? cachedUsage.outputTokens : NaN;
+if (!Number.isFinite(cachedInput) || cachedInput < 0 ||
+!Number.isFinite(cachedOutput) || cachedOutput < 0) {
+this.deps.warn(`Backend sync: invalid inputTokens or outputTokens in model usage for ${sessionFile}`);
+continue;
+}
 
-			// Handle non-delta JSONL format (Copilot CLI)
-			if (sessionFile.endsWith('.jsonl') && !isDeltaBasedJsonl) {
-				const lines = content.trim().split('\n');
-			const todayKey = this.utility.toUtcDayKey(now);
-			let lineCount = 0;
-			let processedLines = 0;
-			
-			for (const line of lines) {
-				lineCount++;
-				if (!line.trim()) { continue; }
-				try {
-					const event = JSON.parse(line);
-					if (!event || typeof event !== 'object') { continue; }
-					
-					const normalizedTs = this.utility.normalizeTimestampToMs(event.timestamp);
-					const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
-					if (!eventMs || eventMs < startMs) { continue; }
-					
-					const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-					const model = (event.model || 'gpt-4o').toString();
-					const isFileFromToday = dayKey === todayKey;
-					if (isFileFromToday && processedLines < 3) {
-					this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} line ${lineCount}: eventMs=${new Date(eventMs).toISOString()}, dayKey=${dayKey}, type=${event.type}`);
-					processedLines++;
-				}
-						// Track interaction for this day+model (count all events, not just user.message)
-						if (!dayModelInteractions.has(dayKey)) {
-							dayModelInteractions.set(dayKey, new Map());
-						}
-						const dayMap = dayModelInteractions.get(dayKey)!;
-						dayMap.set(model, (dayMap.get(model) || 0) + 1);
-					} catch {
-						// skip malformed line
-					}
-				}
-			} else if (isDeltaBasedJsonl) {
-				// VS Code delta-based JSONL files (.json or .jsonl extension with kind:0/1/2 events).
-				// Process kind:2 events where k[0]==='requests' — each appends requests to the array.
-				// Deduplicate by requestId so incrementally-added requests are counted once.
-				// Track the session-level defaultModel from kind:0 and kind:2/selectedModel events so
-				// that requests without an explicit modelId still resolve to the correct model key
-				// (matching what getModelUsageFromSession stores in cachedData.modelUsage).
-				let defaultModel = 'unknown';
-				const seenRequestIds = new Set<string>();
-				const lines = content.trim().split('\n');
-				for (const line of lines) {
-					if (!line.trim()) { continue; }
-					try {
-						const event = JSON.parse(line);
-						if (!event || typeof event !== 'object') { continue; }
-						// Extract session-level default model (same logic as getModelUsageFromSession)
-						if (event.kind === 0) {
-							const modelId = event.v?.selectedModel?.identifier ||
-								event.v?.selectedModel?.metadata?.id ||
-								event.v?.inputState?.selectedModel?.metadata?.id;
-							if (modelId) { defaultModel = modelId.replace(/^copilot\//, ''); }
-						}
-						if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'selectedModel') {
-							const modelId = event.v?.identifier || event.v?.metadata?.id;
-							if (modelId) { defaultModel = modelId.replace(/^copilot\//, ''); }
-						}
-						// kind:2, k[0]==='requests' events append new request(s)
-						if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'requests' && Array.isArray(event.v)) {
-							for (const request of event.v) {
-								const req = request as ChatRequest;
-								const reqId = (req as any).requestId as string | undefined;
-								if (reqId && seenRequestIds.has(reqId)) { continue; }
-								if (reqId) { seenRequestIds.add(reqId); }
-								const normalizedTs = this.utility.normalizeTimestampToMs(
-									typeof req.timestamp !== 'undefined' ? req.timestamp : undefined
-								);
-								const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
-								if (!eventMs || eventMs < startMs) { continue; }
-								const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-								// Use per-request modelId if present, otherwise fall back to the session
-								// default model (mirrors getModelUsageFromSession delta logic)
-								const rawModel = (req as any).modelId || (req as any).result?.metadata?.modelId;
-								const model = rawModel ? (rawModel as string).replace(/^copilot\//, '') : defaultModel;
-								if (!dayModelInteractions.has(dayKey)) {
-									dayModelInteractions.set(dayKey, new Map());
-								}
-								const dayMap = dayModelInteractions.get(dayKey)!;
-								dayMap.set(model, (dayMap.get(model) || 0) + 1);
-							}
-						}
-					} catch {
-						// skip malformed lines
-					}
-				}
-			} else {
-				// Handle regular JSON format (VS Code Copilot Chat legacy / OpenCode JSON)
-				try {
-					const sessionJson = JSON.parse(content);
-					if (!sessionJson || typeof sessionJson !== 'object') {
-						return false;
-					}
-					const sessionObj = sessionJson as Record<string, unknown>;
-					const requests = Array.isArray(sessionObj.requests) ? (sessionObj.requests as unknown[]) : [];
-					
-					for (const request of requests) {
-						const req = request as ChatRequest;
-						const normalizedTs = this.utility.normalizeTimestampToMs(
-							typeof req.timestamp !== 'undefined' ? req.timestamp : (sessionObj.lastMessageDate as unknown)
-						);
-						const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
-						if (!eventMs || eventMs < startMs) { continue; }
-						
-						const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-						const model = this.deps.getModelFromRequest(req);
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
 
-						// Track interaction for this day+model
-						if (!dayModelInteractions.has(dayKey)) {
-							dayModelInteractions.set(dayKey, new Map());
-						}
-						const dayMap = dayModelInteractions.get(dayKey)!;
-						dayMap.set(model, (dayMap.get(model) || 0) + 1);
-					}
-				} catch (e) {
-					this.deps.warn(`Backend sync: failed to parse JSON for ${sessionFile}: ${e}`);
-					return false;
-				}
-			}
-			
-			// Remap event model names to cached model names when there is a mismatch.
-			// CLI sessions often omit the model in individual events (defaulting to 'gpt-4o')
-			// while session.shutdown provides the actual model (e.g. 'claude-sonnet-4.6').
-			// Without remapping, the lookup `cachedData.modelUsage[eventModel]` silently fails.
-			const cachedModelNames = Object.keys(cachedData.modelUsage);
-			if (cachedModelNames.length > 0) {
-				const allEventModels = new Set<string>();
-				for (const modelMap of dayModelInteractions.values()) {
-					for (const m of modelMap.keys()) { allEventModels.add(m); }
-				}
-				const unmappedModels = new Set<string>();
-				for (const m of allEventModels) {
-					if (!cachedData.modelUsage[m]) { unmappedModels.add(m); }
-				}
-				if (unmappedModels.size > 0) {
-					const totalCachedTokens = cachedModelNames.reduce((sum, m) =>
-						sum + cachedData.modelUsage[m].inputTokens + cachedData.modelUsage[m].outputTokens, 0);
-					for (const [, modelMap] of dayModelInteractions) {
-						let unmappedCount = 0;
-						for (const um of unmappedModels) {
-							unmappedCount += modelMap.get(um) || 0;
-							modelMap.delete(um);
-						}
-						if (unmappedCount > 0) {
-							for (const cm of cachedModelNames) {
-								const ct = cachedData.modelUsage[cm].inputTokens + cachedData.modelUsage[cm].outputTokens;
-								const share = totalCachedTokens > 0 ? ct / totalCachedTokens : 1 / cachedModelNames.length;
-								const redistributed = Math.round(unmappedCount * share);
-								if (redistributed > 0) {
-									modelMap.set(cm, (modelMap.get(cm) || 0) + redistributed);
-								}
-							}
-						}
-					}
-				}
-			}
+// Fraction of this model's interactions that fall on this day (for multi-day sessions).
+const totalModelInteractions = totalInteractionsPerModel.get(model) || 1;
+const dayFraction = totalModelInteractions > 0 ? interactions / totalModelInteractions : 1;
 
-			// Total interactions per model (across all days) — used to compute each day's fraction
-			// for multi-day sessions.
-			const totalInteractionsPerModel = new Map<string, number>();
-			for (const modelMap of dayModelInteractions.values()) {
-				for (const [m, c] of modelMap) {
-					totalInteractionsPerModel.set(m, (totalInteractionsPerModel.get(m) || 0) + c);
-				}
-			}
+const inputTokens = Math.round(cachedInput * dayFraction);
+const outputTokens = Math.round(cachedOutput * dayFraction);
 
-			for (const [dayKey, modelMap] of dayModelInteractions) {
-				for (const [model, interactions] of modelMap) {
-					const cachedUsage = cachedData.modelUsage[model] as any;
-					if (!cachedUsage) { continue; }
+const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, dayFraction);
+upsertDailyRollup(rollups, key, {
+inputTokens,
+outputTokens,
+interactions,
+fluencyMetrics
+});
+}
+}
 
-					// Validate individual model token values — reject negative or non-finite values.
-					const cachedInput = typeof cachedUsage.inputTokens === 'number' ? cachedUsage.inputTokens : NaN;
-					const cachedOutput = typeof cachedUsage.outputTokens === 'number' ? cachedUsage.outputTokens : NaN;
-					if (!Number.isFinite(cachedInput) || cachedInput < 0 ||
-						!Number.isFinite(cachedOutput) || cachedOutput < 0) {
-						this.deps.warn(`Backend sync: invalid inputTokens or outputTokens in model usage for ${sessionFile}`);
-						continue;
-					}
+// Log if this file had data for multiple days
+if (dayModelInteractions.size > 1) {
+const days = Array.from(dayModelInteractions.keys()).sort();
+this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} spans ${days.length} days: ${days.join(', ')}`);
+}
+}
 
-					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
+/**
+ * Process an OpenCode session file and add its data to the rollups map.
+ * Returns false if outside the lookback window or no handler is registered.
+ * Throws on data retrieval errors (caller should catch and log).
+ */
+private async processOpenCodeSession(
+sessionFile: string,
+fileMtimeMs: number,
+args: { machineId: string; userId: string | undefined; editorForFile: string | undefined; workspaceNamesById: Record<string, string>; rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>; startMs: number }
+): Promise<boolean> {
+if (!this.deps.getOpenCodeSessionData) { return false; }
+const data = await this.deps.getOpenCodeSessionData(sessionFile);
+const eventMs = data.timestamp || fileMtimeMs;
+if (!eventMs || eventMs < args.startMs) { return false; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+const workspaceId = this.utility.extractWorkspaceIdFromSessionPath(sessionFile);
+await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, args.workspaceNamesById);
+for (const [model, usage] of Object.entries(data.modelUsage)) {
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId: args.machineId, userId: args.userId, editor: args.editorForFile };
+upsertDailyRollup(args.rollups, key, {
+inputTokens: usage.inputTokens || 0,
+outputTokens: usage.outputTokens || 0,
+interactions: usage.interactions || 0,
+});
+}
+return true;
+}
 
-					// Fraction of this model's interactions that fall on this day (for multi-day sessions).
-					// For single-day sessions dayFraction = 1.0 and the full cached model usage is used.
-					const totalModelInteractions = totalInteractionsPerModel.get(model) || 1;
-					const dayFraction = totalModelInteractions > 0 ? interactions / totalModelInteractions : 1;
+/**
+ * Process a Crush session file and add its data to the rollups map.
+ * Returns false if outside the lookback window or no handler is registered.
+ * Throws on data retrieval errors (caller should catch and log).
+ */
+private async processCrushSession(
+sessionFile: string,
+fileMtimeMs: number,
+args: { machineId: string; userId: string | undefined; editorForFile: string | undefined; workspaceNamesById: Record<string, string>; rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>; startMs: number }
+): Promise<boolean> {
+if (!this.deps.getCrushSessionData) { return false; }
+const data = await this.deps.getCrushSessionData(sessionFile);
+const eventMs = data.timestamp || fileMtimeMs;
+if (!eventMs || eventMs < args.startMs) { return false; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+// Crush paths: <project>/.crush/crush.db#<id>  — no workspaceStorage segment
+const workspaceId = this.utility.extractWorkspaceIdFromSessionPath(sessionFile);
+await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, args.workspaceNamesById);
+for (const [model, usage] of Object.entries(data.modelUsage)) {
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId: args.machineId, userId: args.userId, editor: args.editorForFile };
+upsertDailyRollup(args.rollups, key, {
+inputTokens: usage.inputTokens || 0,
+outputTokens: usage.outputTokens || 0,
+interactions: usage.interactions || 0,
+});
+}
+return true;
+}
+/**
+ * Process a session file using cached data for token counts but extracting accurate timestamps.
+ * Returns true if successful, false if cache miss (caller should parse file).
+ * Validates all cached data at runtime to prevent injection/corruption.
+ *
+ * CRITICAL: We parse the file to extract actual interaction timestamps and create per-day
+ * rollups, but use cached token counts for performance. This ensures accurate day assignment
+ * while still benefiting from cached calculations.
+ */
+private async processCachedSessionFile(
+sessionFile: string,
+fileMtimeMs: number,
+fileSize: number,
+workspaceId: string,
+machineId: string,
+userId: string | undefined,
+rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>,
+startMs: number,
+now: Date,
+editor?: string
+): Promise<boolean> {
+try {
+const cachedData = await this.deps.getSessionFileDataCached!(sessionFile, fileMtimeMs, fileSize);
 
-					// Apply dayFraction directly to the cached per-model tokens.
-					// For API-actual data, cachedUsage already holds the exact per-model totals from the
-					// session, so no additional scaling is needed. For text-estimate sessions, both
-					// cachedData.tokens and cachedUsage are from the same estimation and are consistent.
-					const inputTokens = Math.round(cachedInput * dayFraction);
-					const outputTokens = Math.round(cachedOutput * dayFraction);
+// Validate cached data structure to prevent injection/corruption
+if (!cachedData || typeof cachedData !== 'object') {
+this.deps.warn(`Backend sync: invalid cached data structure for ${sessionFile}`);
+return false;
+}
+if (typeof cachedData.modelUsage !== 'object' || cachedData.modelUsage === null) {
+this.deps.warn(`Backend sync: invalid modelUsage in cached data for ${sessionFile}`);
+return false;
+}
+if (!Number.isFinite(cachedData.interactions) || cachedData.interactions < 0) {
+this.deps.warn(`Backend sync: invalid interactions count in cached data for ${sessionFile}`);
+return false;
+}
 
-					const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, dayFraction);
+// Fast path: use pre-computed dailyRollups (same data as extension stats — avoids re-parsing the file).
+if (cachedData.dailyRollups && Object.keys(cachedData.dailyRollups).length > 0) {
+const totalSessionInteractions = cachedData.interactions || 1;
+const dayKeys = Object.keys(cachedData.dailyRollups).sort();
 
-					upsertDailyRollup(rollups, key, {
-						inputTokens,
-						outputTokens,
-						interactions: interactions,
-						fluencyMetrics
-					});
-				}
-			}
-			
-			// Log if this file had data for multiple days (for debugging)
-			if (dayModelInteractions.size > 1) {
-				const days = Array.from(dayModelInteractions.keys()).sort();
-				this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} spans ${days.length} days: ${days.join(', ')}`);
-			}
-			
-			return true;
-		} catch (e) {
-			// Differentiate between cache miss (expected) and errors (unexpected)
-			const errorMessage = e instanceof Error ? e.message : String(e);
-			if (errorMessage.includes('ENOENT') || errorMessage.includes('not found')) {
-				// Expected cache miss - file doesn't exist or not cached yet
-				return false;
-			} else {
-				// Unexpected error - log as warning
-				this.deps.warn(`Backend sync: cache error for ${sessionFile}: ${errorMessage}`);
-				return false;
-			}
-		}
-	}
+for (const dayKey of dayKeys) {
+const dayEntry = cachedData.dailyRollups[dayKey];
+const dayStartMs = new Date(dayKey + 'T00:00:00Z').getTime();
+if (dayStartMs < startMs) { continue; }
 
+const modelEntries = Object.entries(dayEntry.modelUsage).filter(([, mu]) =>
+mu && ((mu.inputTokens || 0) > 0 || (mu.outputTokens || 0) > 0)
+);
+if (modelEntries.length === 0) { continue; }
+
+// Distribute this day's interactions across models proportionally by output token share.
+const totalDayOutput = modelEntries.reduce((s, [, mu]) => s + (mu.outputTokens || 0), 0);
+const dayFraction = totalSessionInteractions > 0 ? dayEntry.interactions / totalSessionInteractions : 1;
+const fluencyMetrics = this.extractFluencyMetricsFromCache(cachedData, dayFraction);
+
+let remainingInteractions = dayEntry.interactions;
+for (let i = 0; i < modelEntries.length; i++) {
+const [model, mu] = modelEntries[i];
+const isLast = i === modelEntries.length - 1;
+const share = (!isLast && totalDayOutput > 0) ? (mu.outputTokens || 0) / totalDayOutput : 1;
+const modelInteractions = isLast
+? remainingInteractions
+: Math.min(Math.round(dayEntry.interactions * share), remainingInteractions);
+remainingInteractions -= modelInteractions;
+
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor };
+upsertDailyRollup(rollups, key, {
+inputTokens: mu.inputTokens || 0,
+outputTokens: mu.outputTokens || 0,
+interactions: Math.max(0, modelInteractions),
+fluencyMetrics,
+});
+}
+}
+
+if (dayKeys.length > 1) {
+this.deps.log(`Backend sync: file ${sessionFile.split(/[/\\]/).pop()} spans ${dayKeys.length} days (dailyRollups fast path): ${dayKeys.join(', ')}`);
+}
+return true;
+}
+
+// Slow path: parse the session file to get actual request timestamps and create per-day rollups.
+// Used when dailyRollups is absent (old cache entries before CACHE_VERSION bump).
+const content = await fs.promises.readFile(sessionFile, 'utf8');
+
+// Detect whether this is a delta-based (VS Code Insiders) JSONL file or a CLI JSONL file.
+let isDeltaBasedJsonl = false;
+if (isJsonlContent(content)) {
+const firstLine = content.trim().split('\n')[0]?.trim();
+if (firstLine) {
+try {
+const firstEvent = JSON.parse(firstLine);
+isDeltaBasedJsonl = typeof firstEvent.kind === 'number';
+} catch { /* not valid JSON, leave as false */ }
+}
+}
+
+// Build the day→model interaction count map using the appropriate format handler.
+let dayModelInteractions: Map<string, Map<string, number>>;
+if (sessionFile.endsWith('.jsonl') && !isDeltaBasedJsonl) {
+// Copilot CLI non-delta JSONL format
+dayModelInteractions = this.buildDayModelInteractionsFromCliJsonl(content, sessionFile, fileMtimeMs, startMs, now);
+} else if (isDeltaBasedJsonl) {
+// VS Code delta-based JSONL format (kind:0/1/2 events)
+dayModelInteractions = this.buildDayModelInteractionsFromDeltaJsonl(content, fileMtimeMs, startMs);
+} else {
+// Regular JSON format (VS Code Copilot Chat legacy / OpenCode JSON)
+const result = this.buildDayModelInteractionsFromJson(content, fileMtimeMs, startMs, sessionFile);
+if (result === null) {
+return false;
+}
+dayModelInteractions = result;
+}
+
+// Remap event model names to cached model names when there is a mismatch.
+this.remapUnmappedModels(dayModelInteractions, cachedData.modelUsage);
+
+// Build rollups from the day/model interaction map using cached token counts.
+this.buildRollupsFromDayModelInteractions(dayModelInteractions, cachedData, sessionFile, workspaceId, machineId, userId, rollups, editor);
+
+return true;
+} catch (e) {
+// Differentiate between cache miss (expected) and errors (unexpected)
+const errorMessage = e instanceof Error ? e.message : String(e);
+if (errorMessage.includes('ENOENT') || errorMessage.includes('not found')) {
+// Expected cache miss - file doesn't exist or not cached yet
+return false;
+} else {
+// Unexpected error - log as warning
+this.deps.warn(`Backend sync: cache error for ${sessionFile}: ${errorMessage}`);
+return false;
+}
+}
+}
 	/**
 	 * Extract fluency metrics from cached session data and serialize for storage.
 	 * @param cachedData - The cached session file data
@@ -784,6 +902,193 @@ export class SyncService {
 		return resolved;
 	}
 
+
+/**
+ * Extract token counts from a chat request, preferring actual API-reported counts
+ * and falling back to text-based estimation.
+ * Handles multiple request formats (pre-Feb 2026, Feb 2026+, VS Code Insiders).
+ */
+private extractTokenCountsFromRequest(
+req: ChatRequest,
+model: string
+): { inputTokens: number; outputTokens: number } {
+let inputTokens = 0;
+let outputTokens = 0;
+const result = (req as any).result;
+if (result?.usage) {
+// OLD FORMAT (pre-Feb 2026)
+inputTokens = typeof result.usage.promptTokens === 'number' ? result.usage.promptTokens : 0;
+outputTokens = typeof result.usage.completionTokens === 'number' ? result.usage.completionTokens : 0;
+} else if (typeof result?.promptTokens === 'number' && typeof result?.outputTokens === 'number') {
+// NEW FORMAT (Feb 2026+)
+inputTokens = result.promptTokens;
+outputTokens = result.outputTokens;
+} else if (result?.metadata && typeof result.metadata.promptTokens === 'number' && typeof result.metadata.outputTokens === 'number') {
+// INSIDERS FORMAT (Feb 2026+): Tokens nested under result.metadata
+inputTokens = result.metadata.promptTokens;
+outputTokens = result.metadata.outputTokens;
+} else {
+// Fallback: text-based estimation — handles both flat text (delta format) and parts array (JSON format)
+const msgText = (req as any).message?.text;
+if (msgText) {
+inputTokens = this.deps.estimateTokensFromText(msgText, model);
+} else if (req.message?.parts) {
+for (const part of req.message.parts) {
+if (part?.text) { inputTokens += this.deps.estimateTokensFromText(part.text, model); }
+}
+}
+const response = (req as any).response ?? req.response;
+if (Array.isArray(response)) {
+for (const r of response) {
+if (typeof r?.value === 'string') { outputTokens += this.deps.estimateTokensFromText(r.value, model); }
+}
+}
+}
+return { inputTokens, outputTokens };
+}
+
+/**
+ * Process the fallback JSONL content when cached data is unavailable.
+ * Handles both VS Code delta-based and Copilot CLI JSONL formats, computing tokens directly.
+ */
+private processJsonlSessionFallback(
+content: string,
+sessionFile: string,
+fileMtimeMs: number,
+startMs: number,
+workspaceId: string,
+machineId: string,
+userId: string | undefined,
+editorForFile: string | undefined,
+rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>
+): void {
+let defaultModel = 'unknown';
+let isVsCodeFormat = false;
+const firstLine = content.trim().split('\n')[0]?.trim();
+if (firstLine) {
+try {
+const firstEv = JSON.parse(firstLine);
+isVsCodeFormat = typeof firstEv.kind === 'number';
+} catch { /* leave as false */ }
+}
+const seenReqIds = new Set<string>();
+const lines = content.trim().split('\n');
+for (const line of lines) {
+if (!line.trim()) { continue; }
+try {
+const event = JSON.parse(line);
+if (!event || typeof event !== 'object') { continue; }
+// VS Code delta-based format
+if (isVsCodeFormat) {
+if (event.kind === 0) {
+const mId = event.v?.selectedModel?.identifier || event.v?.selectedModel?.metadata?.id || event.v?.inputState?.selectedModel?.metadata?.id;
+if (mId) { defaultModel = mId.replace(/^copilot\//, ''); }
+}
+if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'selectedModel') {
+const mId = event.v?.identifier || event.v?.metadata?.id;
+if (mId) { defaultModel = mId.replace(/^copilot\//, ''); }
+}
+if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'requests' && Array.isArray(event.v)) {
+for (const request of event.v) {
+const req = request as ChatRequest;
+const reqId = (req as any).requestId as string | undefined;
+if (reqId && seenReqIds.has(reqId)) { continue; }
+if (reqId) { seenReqIds.add(reqId); }
+const normalizedTs = this.utility.normalizeTimestampToMs(typeof req.timestamp !== 'undefined' ? req.timestamp : undefined);
+const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
+if (!eventMs || eventMs < startMs) { continue; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+const rawModel = (req as any).modelId || (req as any).result?.metadata?.modelId;
+const model = rawModel ? (rawModel as string).replace(/^copilot\//, '') : defaultModel;
+const { inputTokens, outputTokens } = this.extractTokenCountsFromRequest(req, model);
+if (inputTokens === 0 && outputTokens === 0) { continue; }
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
+upsertDailyRollup(rollups, key, { inputTokens, outputTokens, interactions: 1 });
+}
+}
+continue; // processed as VS Code delta event; skip CLI logic below
+}
+// Copilot CLI non-delta format
+if (event.type === 'session.start' && typeof event.data?.selectedModel === 'string') {
+defaultModel = event.data.selectedModel;
+}
+if (event.type === 'session.model_change' && typeof event.data?.newModel === 'string') {
+defaultModel = event.data.newModel;
+}
+const normalizedTs = this.utility.normalizeTimestampToMs(event.timestamp);
+const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
+if (!eventMs || eventMs < startMs) { continue; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+const model = (event.data?.model || event.model || defaultModel).toString();
+let inputTokens = 0;
+let outputTokens = 0;
+let interactions = 0;
+if (event.type === 'user.message' && event.data?.content) {
+inputTokens = this.deps.estimateTokensFromText(event.data.content, model);
+interactions = 1;
+} else if (event.type === 'assistant.message' && event.data?.content) {
+outputTokens = this.deps.estimateTokensFromText(event.data.content, model);
+} else if (event.type === 'tool.result' && event.data?.output) {
+inputTokens = this.deps.estimateTokensFromText(event.data.output, model);
+}
+if (inputTokens === 0 && outputTokens === 0 && interactions === 0) { continue; }
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
+upsertDailyRollup(rollups, key, { inputTokens, outputTokens, interactions });
+} catch {
+// skip malformed line
+}
+}
+}
+
+/**
+ * Process the fallback JSON content when cached data is unavailable.
+ * Handles the VS Code Copilot Chat legacy JSON format.
+ * Returns false if the JSON cannot be parsed (a warning is logged internally).
+ */
+private processJsonSessionFallback(
+content: string,
+sessionFile: string,
+fileMtimeMs: number,
+startMs: number,
+workspaceId: string,
+machineId: string,
+userId: string | undefined,
+editorForFile: string | undefined,
+rollups: Map<string, { key: DailyRollupKey; value: DailyRollupValue }>
+): boolean {
+let sessionJson: unknown;
+try {
+sessionJson = JSON.parse(content);
+if (!sessionJson || typeof sessionJson !== 'object') {
+this.deps.warn(`Backend sync: session file has invalid JSON structure: ${sessionFile}`);
+return false;
+}
+} catch (e) {
+this.deps.warn(`Backend sync: failed to parse JSON session file ${sessionFile}: ${e}`);
+return false;
+}
+const sessionObj = sessionJson as Record<string, unknown>;
+const requests = Array.isArray(sessionObj.requests) ? (sessionObj.requests as unknown[]) : [];
+for (const request of requests) {
+try {
+const req = request as ChatRequest;
+const normalizedTs = this.utility.normalizeTimestampToMs(
+typeof req.timestamp !== 'undefined' ? req.timestamp : (sessionObj.lastMessageDate as unknown)
+);
+const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
+if (!eventMs || eventMs < startMs) { continue; }
+const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
+const model = this.deps.getModelFromRequest(req);
+const { inputTokens, outputTokens } = this.extractTokenCountsFromRequest(req, model);
+if (inputTokens === 0 && outputTokens === 0) { continue; }
+const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
+upsertDailyRollup(rollups, key, { inputTokens, outputTokens, interactions: 1 });
+} catch (e) {
+this.deps.warn(`Backend sync: failed to process request in ${sessionFile}: ${e}`);
+}
+}
+return true;
+}
 	/**
 	 * Compute daily rollups from local session files.
 	 * Uses cached session data when available to avoid re-parsing files.
@@ -866,75 +1171,28 @@ export class SyncService {
 
 			// Handle OpenCode sessions separately (different data format)
 			if (this.deps.isOpenCodeSession && this.deps.isOpenCodeSession(sessionFile)) {
-				if (!this.deps.getOpenCodeSessionData) {
-					filesSkipped++;
-					continue;
-				}
-				
+				const sessionArgs = this.makeSessionRollupArgs(machineId, userId, editorForFile, workspaceNamesById, rollups, startMs);
 				try {
-					const data = await this.deps.getOpenCodeSessionData(sessionFile);
-					const eventMs = data.timestamp || fileMtimeMs;
-					
-					if (!eventMs || eventMs < startMs) {
-						filesSkipped++;
-						continue;
-					}
-
-					const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-					const workspaceId = this.utility.extractWorkspaceIdFromSessionPath(sessionFile);
-					await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, workspaceNamesById);
-
-					// Process each model's usage with per-model interaction counts
-					for (const [model, usage] of Object.entries(data.modelUsage)) {
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
-						upsertDailyRollup(rollups as any, key, {
-							inputTokens: (usage as any).inputTokens || 0,
-							outputTokens: (usage as any).outputTokens || 0,
-							interactions: (usage as any).interactions || 0
-						});
-					}
-					continue;
+					const processed = await this.processOpenCodeSession(sessionFile, fileMtimeMs, sessionArgs);
+					if (!processed) { filesSkipped++; }
 				} catch (e) {
 					this.deps.warn(`Backend sync: failed to process OpenCode session ${sessionFile}: ${e}`);
-					continue;
 				}
+				continue;
 			}
 
 			// Handle Crush sessions separately (virtual paths pointing to crush.db SQLite entries)
 			if (this.deps.isCrushSession && this.deps.isCrushSession(sessionFile)) {
-				if (!this.deps.getCrushSessionData) {
-					filesSkipped++;
-					continue;
-				}
-
+				const sessionArgs = this.makeSessionRollupArgs(machineId, userId, editorForFile, workspaceNamesById, rollups, startMs);
 				try {
-					const data = await this.deps.getCrushSessionData(sessionFile);
-					const eventMs = data.timestamp || fileMtimeMs;
-
-					if (!eventMs || eventMs < startMs) {
-						filesSkipped++;
-						continue;
-					}
-
-					const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-					// Crush paths: <project>/.crush/crush.db#<id>  — no workspaceStorage segment
-					const workspaceId = this.utility.extractWorkspaceIdFromSessionPath(sessionFile);
-					await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, workspaceNamesById);
-
-					for (const [model, usage] of Object.entries(data.modelUsage)) {
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
-						upsertDailyRollup(rollups as any, key, {
-							inputTokens: (usage as any).inputTokens || 0,
-							outputTokens: (usage as any).outputTokens || 0,
-							interactions: (usage as any).interactions || 0,
-						});
-					}
-					continue;
+					const processed = await this.processCrushSession(sessionFile, fileMtimeMs, sessionArgs);
+					if (!processed) { filesSkipped++; }
 				} catch (e) {
 					this.deps.warn(`Backend sync: failed to process Crush session ${sessionFile}: ${e}`);
-					continue;
 				}
+				continue;
 			}
+
 
 			const workspaceId = this.utility.extractWorkspaceIdFromSessionPath(sessionFile);
 			await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, workspaceNamesById);
@@ -975,193 +1233,12 @@ export class SyncService {
 			}
 			// JSONL (Copilot CLI or VS Code chat .json/.jsonl with delta-based content)
 			if (sessionFile.endsWith('.jsonl') || isJsonlContent(content)) {
-				let defaultModel = 'unknown';
-				// Delta-based format can come from .json or .jsonl files; detect by first-line kind property
-				let isVsCodeFormat = false;
-				const firstJsonlLine = content.trim().split('\n')[0]?.trim();
-				if (firstJsonlLine) {
-					try {
-						const firstEv = JSON.parse(firstJsonlLine);
-						isVsCodeFormat = typeof firstEv.kind === 'number';
-					} catch { /* leave as false */ }
-				}
-				const seenReqIds = new Set<string>();
-				const lines = content.trim().split('\n');
-				for (const line of lines) {
-					if (!line.trim()) {
-						continue;
-					}
-					try {
-						const event = JSON.parse(line);
-						if (!event || typeof event !== 'object') {
-							continue;
-						}
-						// VS Code delta-based: track default model from session header events
-						if (isVsCodeFormat) {
-							if (event.kind === 0) {
-								const mId = event.v?.selectedModel?.identifier || event.v?.selectedModel?.metadata?.id || event.v?.inputState?.selectedModel?.metadata?.id;
-								if (mId) { defaultModel = mId.replace(/^copilot\//, ''); }
-							}
-							if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'selectedModel') {
-								const mId = event.v?.identifier || event.v?.metadata?.id;
-								if (mId) { defaultModel = mId.replace(/^copilot\//, ''); }
-							}
-							if (event.kind === 2 && Array.isArray(event.k) && event.k[0] === 'requests' && Array.isArray(event.v)) {
-								for (const request of event.v) {
-									const req = request as ChatRequest;
-									const reqId = (req as any).requestId as string | undefined;
-									if (reqId && seenReqIds.has(reqId)) { continue; }
-									if (reqId) { seenReqIds.add(reqId); }
-									const normalizedTs = this.utility.normalizeTimestampToMs(typeof req.timestamp !== 'undefined' ? req.timestamp : undefined);
-									const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
-									if (!eventMs || eventMs < startMs) { continue; }
-									const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-									const rawModel = (req as any).modelId || (req as any).result?.metadata?.modelId;
-									const model = rawModel ? (rawModel as string).replace(/^copilot\//, '') : defaultModel;
-
-									let inputTokens = 0;
-									let outputTokens = 0;
-									// Prefer actual API token counts when available in the request
-									const reqResult = (req as any).result;
-									if (reqResult?.usage) {
-										inputTokens = typeof reqResult.usage.promptTokens === 'number' ? reqResult.usage.promptTokens : 0;
-										outputTokens = typeof reqResult.usage.completionTokens === 'number' ? reqResult.usage.completionTokens : 0;
-									} else if (typeof reqResult?.promptTokens === 'number' && typeof reqResult?.outputTokens === 'number') {
-										inputTokens = reqResult.promptTokens;
-										outputTokens = reqResult.outputTokens;
-									} else if (reqResult?.metadata && typeof reqResult.metadata.promptTokens === 'number' && typeof reqResult.metadata.outputTokens === 'number') {
-										inputTokens = reqResult.metadata.promptTokens;
-										outputTokens = reqResult.metadata.outputTokens;
-									} else {
-										// Fallback to text-based estimation
-										if ((req as any).message?.text) {
-											inputTokens = this.deps.estimateTokensFromText((req as any).message.text, model);
-										}
-										if (Array.isArray((req as any).response)) {
-											for (const r of (req as any).response) {
-												if (typeof r?.value === 'string') { outputTokens += this.deps.estimateTokensFromText(r.value, model); }
-											}
-										}
-									}
-									if (inputTokens === 0 && outputTokens === 0) { continue; }
-									const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
-									upsertDailyRollup(rollups as any, key, { inputTokens, outputTokens, interactions: 1 });
-								}
-							}
-							continue; // processed as VS Code delta event; skip CLI logic below
-						}
-						// Copilot CLI non-delta format below
-						// Track model changes from session.start and session.model_change
-						if (event.type === 'session.start' && typeof event.data?.selectedModel === 'string') {
-							defaultModel = event.data.selectedModel;
-						}
-						if (event.type === 'session.model_change' && typeof event.data?.newModel === 'string') {
-							defaultModel = event.data.newModel;
-						}
-						const normalizedTs = this.utility.normalizeTimestampToMs(event.timestamp);
-						const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
-						if (!eventMs || eventMs < startMs) {
-							continue;
-						}
-						const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-						const model = (event.data?.model || event.model || defaultModel).toString();
-
-						let inputTokens = 0;
-						let outputTokens = 0;
-						let interactions = 0;
-						if (event.type === 'user.message' && event.data?.content) {
-							inputTokens = this.deps.estimateTokensFromText(event.data.content, model);
-							interactions = 1;
-						} else if (event.type === 'assistant.message' && event.data?.content) {
-							outputTokens = this.deps.estimateTokensFromText(event.data.content, model);
-						} else if (event.type === 'tool.result' && event.data?.output) {
-							inputTokens = this.deps.estimateTokensFromText(event.data.output, model);
-						}
-						if (inputTokens === 0 && outputTokens === 0 && interactions === 0) {
-							continue;
-						}
-
-						const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
-						upsertDailyRollup(rollups as any, key, { inputTokens, outputTokens, interactions });
-					} catch {
-						// skip malformed line
-					}
-				}
+				this.processJsonlSessionFallback(content, sessionFile, fileMtimeMs, startMs, workspaceId, machineId, userId, editorForFile, rollups);
 				continue;
 			}
 
 			// JSON (VS Code Copilot Chat)
-			let sessionJson: unknown;
-			try {
-				sessionJson = JSON.parse(content);
-				if (!sessionJson || typeof sessionJson !== 'object') {
-					this.deps.warn(`Backend sync: session file has invalid JSON structure: ${sessionFile}`);
-					continue;
-				}
-			} catch (e) {
-				this.deps.warn(`Backend sync: failed to parse JSON session file ${sessionFile}: ${e}`);
-				continue;
-			}
-			const sessionObj = sessionJson as Record<string, unknown>; // Safe due to check above
-
-			const requests = Array.isArray(sessionObj.requests) ? (sessionObj.requests as unknown[]) : [];
-			for (const request of requests) {
-				try {
-					// Cast to ChatRequest since it comes from validated JSON object
-					const req = request as ChatRequest;
-					const normalizedTs = this.utility.normalizeTimestampToMs(
-						typeof req.timestamp !== 'undefined' ? req.timestamp : (sessionObj.lastMessageDate as unknown)
-					);
-					const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
-					if (!eventMs || eventMs < startMs) {
-						continue;
-					}
-					const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
-					const model = this.deps.getModelFromRequest(req);
-
-					let inputTokens = 0;
-					let outputTokens = 0;
-					// Prefer actual API token counts when available
-					const result = (req as any).result;
-					if (result?.usage) {
-						// OLD FORMAT (pre-Feb 2026)
-						inputTokens = typeof result.usage.promptTokens === 'number' ? result.usage.promptTokens : 0;
-						outputTokens = typeof result.usage.completionTokens === 'number' ? result.usage.completionTokens : 0;
-					} else if (typeof result?.promptTokens === 'number' && typeof result?.outputTokens === 'number') {
-						// NEW FORMAT (Feb 2026+)
-						inputTokens = result.promptTokens;
-						outputTokens = result.outputTokens;
-					} else if (result?.metadata && typeof result.metadata.promptTokens === 'number' && typeof result.metadata.outputTokens === 'number') {
-						// INSIDERS FORMAT (Feb 2026+): Tokens nested under result.metadata
-						inputTokens = result.metadata.promptTokens;
-						outputTokens = result.metadata.outputTokens;
-					} else {
-						// Fallback to text-based estimation
-						if (req.message && req.message.parts) {
-							for (const part of req.message.parts) {
-								if (part?.text) {
-									inputTokens += this.deps.estimateTokensFromText(part.text, model);
-								}
-							}
-						}
-						if (req.response && Array.isArray(req.response)) {
-							for (const responseItem of req.response) {
-								if (typeof responseItem?.value === 'string') {
-									outputTokens += this.deps.estimateTokensFromText(responseItem.value, model);
-								}
-							}
-						}
-					}
-					if (inputTokens === 0 && outputTokens === 0) {
-						continue;
-					}
-
-					const key: DailyRollupKey = { day: dayKey, model, workspaceId, machineId, userId, editor: editorForFile };
-					upsertDailyRollup(rollups as any, key, { inputTokens, outputTokens, interactions: 1 });
-				} catch (e) {
-					this.deps.warn(`Backend sync: failed to process request in ${sessionFile}: ${e}`);
-				}
-			}
+			this.processJsonSessionFallback(content, sessionFile, fileMtimeMs, startMs, workspaceId, machineId, userId, editorForFile, rollups);
 		}
 
 		// Log cache performance statistics


### PR DESCRIPTION
## Summary

Refactored scode-extension/src/backend/services/syncService.ts (1531 lines) for improved quality, type safety, and maintainability.

## Changes

### Functions extracted / responsibilities separated
- **makeSessionRollupArgs** — DRY helper for shared argument bundle
- **uildDayModelInteractionsFromCliJsonl** — handles CLI JSONL format
- **uildDayModelInteractionsFromDeltaJsonl** — handles VS Code delta JSONL format
- **uildDayModelInteractionsFromJson** — handles VS Code JSON format
- **emapUnmappedModels** — model name remapping logic
- **uildRollupsFromDayModelInteractions** — rollup building
- **processOpenCodeSession** — OpenCode session processing
- **processCrushSession** — Crush session processing
- **xtractTokenCountsFromRequest** — deduplicates token-count logic (was used in 2 places)
- **processJsonlSessionFallback** — JSONL fallback parsing
- **processJsonSessionFallback** — JSON fallback parsing

### Type safety improvements
- ModelUsageEntry type alias replacing \ny\ in \SyncServiceDeps\
- \BlobUploadServiceLike.credential: any\ → \credential: unknown\
- Removed 3 unnecessary \ollups as any\ casts

### Impact on large functions
- **\processCachedSessionFile\**: 330 lines → ~130 lines
- **\computeDailyRollupsFromLocalSessions\**: ~80 lines removed inline

## Test Results
- ✅ 55/55 test files pass
- ✅ \	sc --noEmit\ reports 0 errors  
- ✅ 0 new lint errors