### PR TITLE
chore: bump versions for release (vscode-extension, cli)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps patch version numbers for components that have changed since their last release tags.

| Component | Last tag | Old version | New version |
|-----------|----------|-------------|-------------|
| VS Code extension | \scode/v0.10.1\ | 0.10.1 | **0.10.2** |
| CLI (npm) | \cli/v0.0.8\* | 0.2.0 | **0.2.1** |

> *The CLI package.json was already at \