### PR TITLE
refactor: implement async data-access interface

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -16,6 +16,7 @@ import { ClaudeDesktopCoworkDataAccess } from '../../vscode-extension/src/claude
 import { MistralVibeDataAccess } from '../../vscode-extension/src/mistralvibe';
 import { GeminiCliDataAccess } from '../../vscode-extension/src/geminicli';
 import { buildAdapterRegistry } from '../../vscode-extension/src/adapters';
+import type { IEcosystemAdapter } from '../../vscode-extension/src/ecosystemAdapter';
 import { isMcpTool, extractMcpServerName } from '../../vscode-extension/src/workspaceHelpers';
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, getModelTier } from '../../vscode-extension/src/tokenEstimation';
@@ -45,76 +46,31 @@ const log = (msg: string) => { /* quiet by default */ };
 const warn = (msg: string) => { /* quiet by default */ };
 const error = (msg: string, err?: any) => console.error(chalk.red(msg), err || '');
 
-/** Create OpenCode data access instance for CLI */
-function createOpenCode(): OpenCodeDataAccess {
+/** Synchronous lazy-initialized ecosystem registry — created once on first use. */
+let _ecosystems: IEcosystemAdapter[] | null = null;
+
+/** Returns the shared ecosystem adapter registry, creating it on first call. */
+function getEcosystems(): IEcosystemAdapter[] {
+	if (_ecosystems) { return _ecosystems; }
 	const fakeUri = vscodeStub.Uri.file(__dirname);
-	return new OpenCodeDataAccess(fakeUri as any);
+	_ecosystems = buildAdapterRegistry({
+		openCode: new OpenCodeDataAccess(fakeUri as any),
+		crush: new CrushDataAccess(fakeUri as any),
+		continue_: new ContinueDataAccess(),
+		visualStudio: new VisualStudioDataAccess(),
+		claudeCode: new ClaudeCodeDataAccess(),
+		claudeDesktopCowork: new ClaudeDesktopCoworkDataAccess(),
+		mistralVibe: new MistralVibeDataAccess(),
+		geminiCli: new GeminiCliDataAccess(),
+		estimateTokens: (t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators),
+		isMcpTool,
+		extractMcpServerName,
+	});
+	return _ecosystems;
 }
-
-/** Create Crush data access instance for CLI */
-function createCrush(): CrushDataAccess {
-	const fakeUri = vscodeStub.Uri.file(__dirname);
-	return new CrushDataAccess(fakeUri as any);
-}
-
-/** Create Continue data access instance for CLI */
-function createContinue(): ContinueDataAccess {
-	return new ContinueDataAccess();
-}
-
-/** Create Visual Studio data access instance for CLI */
-function createVisualStudio(): VisualStudioDataAccess {
-	return new VisualStudioDataAccess();
-}
-
-/** Create Claude Code data access instance for CLI */
-function createClaudeCode(): ClaudeCodeDataAccess {
-	return new ClaudeCodeDataAccess();
-}
-
-/** Create Claude Desktop Cowork data access instance for CLI */
-function createClaudeDesktopCowork(): ClaudeDesktopCoworkDataAccess {
-	return new ClaudeDesktopCoworkDataAccess();
-}
-
-/** Create Mistral Vibe data access instance for CLI */
-function createMistralVibe(): MistralVibeDataAccess {
-	return new MistralVibeDataAccess();
-}
-
-/** Create Gemini CLI data access instance for CLI */
-function createGeminiCli(): GeminiCliDataAccess {
-	return new GeminiCliDataAccess();
-}
-
-// Module-level singletons so sql.js WASM is only initialised once across all session files
-const _openCodeInstance = createOpenCode();
-const _crushInstance = createCrush();
-const _continueInstance = createContinue();
-const _visualStudioInstance = createVisualStudio();
-const _claudeCodeInstance = createClaudeCode();
-const _claudeDesktopCoworkInstance = createClaudeDesktopCowork();
-const _mistralVibeInstance = createMistralVibe();
-const _geminiCliInstance = createGeminiCli();
-
-/** Ordered registry of ecosystem adapters — first match wins. */
-const _ecosystems = buildAdapterRegistry({
-	openCode: _openCodeInstance,
-	crush: _crushInstance,
-	continue_: _continueInstance,
-	visualStudio: _visualStudioInstance,
-	claudeCode: _claudeCodeInstance,
-	claudeDesktopCowork: _claudeDesktopCoworkInstance,
-	mistralVibe: _mistralVibeInstance,
-	geminiCli: _geminiCliInstance,
-	estimateTokens: (t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators),
-	isMcpTool: isMcpTool,
-	extractMcpServerName: extractMcpServerName,
-});
-
 /** Create session discovery instance for CLI */
 function createSessionDiscovery(): SessionDiscovery {
-	return new SessionDiscovery({ log, warn, error, ecosystems: _ecosystems });
+	return new SessionDiscovery({ log, warn, error, ecosystems: getEcosystems() });
 }
 
 /** Discover all session files on this machine */
@@ -221,7 +177,7 @@ function resolveModel(request: any): string {
  * Virtual DB paths are resolved to the actual DB file.
  */
 async function statSessionFile(filePath: string): Promise<fs.Stats> {
-	const eco = _ecosystems.find(e => e.handles(filePath));
+	const eco = getEcosystems().find(e => e.handles(filePath));
 	if (eco) { return eco.stat(filePath); }
 	return fs.promises.stat(filePath);
 }
@@ -322,7 +278,7 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 		}
 
 		// Dispatch to ecosystem adapters (OpenCode, Crush, VS, Continue, ClaudeDesktop, ClaudeCode, MistralVibe)
-		const eco = _ecosystems.find(e => e.handles(filePath));
+		const eco = getEcosystems().find(e => e.handles(filePath));
 		if (eco) {
 			const [tokenResult, interactions, modelUsage] = await Promise.all([
 				eco.getTokens(filePath),
@@ -567,7 +523,7 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 		tokenEstimators,
 		modelPricing,
 		toolNameMap,
-		ecosystems: _ecosystems,
+		ecosystems: getEcosystems(),
 	};
 
 	const now = new Date();

--- a/vscode-extension/src/crush.ts
+++ b/vscode-extension/src/crush.ts
@@ -26,6 +26,7 @@ export interface CrushProject {
 
 export class CrushDataAccess {
 	private _sqlJsModule: any = null;
+	private _sqlJsInitPromise: Promise<any> | null = null;
 	private _dbCache: Map<string, CrushDbCacheEntry> = new Map();
 	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
 	private readonly extensionUri: vscode.Uri;
@@ -40,6 +41,7 @@ export class CrushDataAccess {
 		}
 		this._dbCache.clear();
 		this._dbCacheInflight.clear();
+		this._sqlJsInitPromise = null;
 	}
 
 	private closeDb(db: any): void {
@@ -189,16 +191,29 @@ export class CrushDataAccess {
 
 	/**
 	 * Lazily initialise and cache the sql.js module.
+	 *
+	 * Promise-caches the in-flight load so concurrent callers share a single
+	 * WASM initialization rather than each starting an independent load.
+	 * The cache is reset on failure so a transient error is retryable.
 	 */
 	async initSqlJs(): Promise<any> {
 		if (this._sqlJsModule) { return this._sqlJsModule; }
-		const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
-		let wasmBinary: Uint8Array | undefined;
-		if (fs.existsSync(wasmPath)) {
-			wasmBinary = fs.readFileSync(wasmPath);
+		if (!this._sqlJsInitPromise) {
+			this._sqlJsInitPromise = (async () => {
+				const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+				let wasmBinary: Uint8Array | undefined;
+				if (fs.existsSync(wasmPath)) {
+					wasmBinary = fs.readFileSync(wasmPath);
+				}
+				const module = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
+				this._sqlJsModule = module;
+				return module;
+			})().catch(err => {
+				this._sqlJsInitPromise = null;
+				throw err;
+			});
 		}
-		this._sqlJsModule = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
-		return this._sqlJsModule;
+		return this._sqlJsInitPromise;
 	}
 
 	/**

--- a/vscode-extension/src/ecosystemAdapter.ts
+++ b/vscode-extension/src/ecosystemAdapter.ts
@@ -8,6 +8,11 @@
  * Adding a new ecosystem only requires:
  *   1. Implementing this interface in a new file under src/adapters/
  *   2. Adding an instance to the registry in extension.ts (and cli/src/helpers.ts)
+ *
+ * Concurrency contract: all async methods must be safe for concurrent invocation.
+ * Implementations that load heavyweight resources (e.g. WASM, SQLite databases) must
+ * cache the in-flight Promise — not just the resolved value — to prevent duplicate
+ * initialization when multiple callers await the same method simultaneously.
  */
 import type * as fsModule from 'fs';
 import type { ModelUsage, ChatTurn, SessionUsageAnalysis, ModelPricing } from './types';

--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -16,6 +16,7 @@ type OpenCodeModelUsageWithInteractions = {
 
 export class OpenCodeDataAccess {
 	private _sqlJsModule: any = null;
+	private _sqlJsInitPromise: Promise<any> | null = null;
 	private _dbCache: OpenCodeDbCache | null = null;
 	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
 	private readonly extensionUri: vscode.Uri;
@@ -60,21 +61,35 @@ export class OpenCodeDataAccess {
 
 	/**
 	 * Lazily initialize and return the sql.js SQL module.
+	 *
+	 * Promise-caches the in-flight load so concurrent callers share a single
+	 * WASM initialization rather than each starting an independent load.
+	 * The cache is reset on failure so a transient error is retryable.
 	 */
 	async initSqlJs(): Promise<any> {
 		if (this._sqlJsModule) { return this._sqlJsModule; }
-		const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
-		let wasmBinary: Uint8Array | undefined;
-		if (fs.existsSync(wasmPath)) {
-			wasmBinary = fs.readFileSync(wasmPath);
+		if (!this._sqlJsInitPromise) {
+			this._sqlJsInitPromise = (async () => {
+				const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+				let wasmBinary: Uint8Array | undefined;
+				if (fs.existsSync(wasmPath)) {
+					wasmBinary = fs.readFileSync(wasmPath);
+				}
+				const module = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
+				this._sqlJsModule = module;
+				return module;
+			})().catch(err => {
+				this._sqlJsInitPromise = null;
+				throw err;
+			});
 		}
-		this._sqlJsModule = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
-		return this._sqlJsModule;
+		return this._sqlJsInitPromise;
 	}
 
 	dispose(): void {
 		this.closeDbCache();
 		this._dbCacheInflight.clear();
+		this._sqlJsInitPromise = null;
 	}
 
 	private closeDb(db: any): void {


### PR DESCRIPTION
## Summary

Fixes the concurrent initialization race condition in the SQL.js data-access classes and unifies the CLI initialization pattern with the extension.

### Changes

**scode-extension/src/opencode.ts and crush.ts**
- Fixed initSqlJs() race condition: both classes cached only the *resolved* module, so two concurrent callers racing past the if (this._sqlJsModule) guard would each start an independent WASM load.
- Now caches the in-flight *Promise* so all concurrent callers share a single load.
- Cache is reset on rejection (transient failures are retryable).
- dispose() clears _sqlJsInitPromise.

**cli/src/helpers.ts**
- Replaced 8 eager module-level DataAccess singletons and the pre-built IEcosystemAdapter[] array with a single synchronous lazy getEcosystems() getter.
- Instances are now created on first use (not at module-import time), eliminating import side-effects and making the initialization flow easier to follow.
- All four internal call sites updated to use getEcosystems().

**scode-extension/src/ecosystemAdapter.ts**
- Added a concurrency contract to the IEcosystemAdapter JSDoc: implementations that load heavyweight resources must cache the in-flight Promise to prevent duplicate initialization under concurrent calls.

### Tests
All 25 unit tests pass.