### PR TITLE
refactor: extract buildAdapterRegistry factory to eliminate adapter duplication

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -15,8 +15,7 @@ import { ClaudeCodeDataAccess } from '../../vscode-extension/src/claudecode';
 import { ClaudeDesktopCoworkDataAccess } from '../../vscode-extension/src/claudedesktop';
 import { MistralVibeDataAccess } from '../../vscode-extension/src/mistralvibe';
 import { GeminiCliDataAccess } from '../../vscode-extension/src/geminicli';
-import type { IEcosystemAdapter } from '../../vscode-extension/src/ecosystemAdapter';
-import { OpenCodeAdapter, CrushAdapter, ContinueAdapter, ClaudeDesktopAdapter, ClaudeCodeAdapter, VisualStudioAdapter, MistralVibeAdapter, GeminiCliAdapter, CopilotChatAdapter, CopilotCliAdapter, JetBrainsAdapter } from '../../vscode-extension/src/adapters';
+import { buildAdapterRegistry } from '../../vscode-extension/src/adapters';
 import { isMcpTool, extractMcpServerName } from '../../vscode-extension/src/workspaceHelpers';
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, getModelTier } from '../../vscode-extension/src/tokenEstimation';
@@ -99,27 +98,19 @@ const _mistralVibeInstance = createMistralVibe();
 const _geminiCliInstance = createGeminiCli();
 
 /** Ordered registry of ecosystem adapters — first match wins. */
-const _ecosystems: IEcosystemAdapter[] = [
-	new OpenCodeAdapter(_openCodeInstance),
-	new CrushAdapter(_crushInstance),
-	new VisualStudioAdapter(_visualStudioInstance, (t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators)),
-	new ContinueAdapter(_continueInstance),
-	new ClaudeDesktopAdapter(
-		_claudeDesktopCoworkInstance,
-		isMcpTool,
-		extractMcpServerName,
-		(t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators)
-	),
-	new ClaudeCodeAdapter(_claudeCodeInstance),
-	new MistralVibeAdapter(_mistralVibeInstance),
-	new GeminiCliAdapter(_geminiCliInstance),
-	// Copilot Chat / CLI adapters: discovery-only. Their handles() returns
-	// false so processSessionFile() falls through to the shared parser path
-	// for VS Code Copilot Chat and CLI files. See issue #654.
-	new CopilotChatAdapter(),
-	new CopilotCliAdapter(),
-	new JetBrainsAdapter(),
-];
+const _ecosystems = buildAdapterRegistry({
+	openCode: _openCodeInstance,
+	crush: _crushInstance,
+	continue_: _continueInstance,
+	visualStudio: _visualStudioInstance,
+	claudeCode: _claudeCodeInstance,
+	claudeDesktopCowork: _claudeDesktopCoworkInstance,
+	mistralVibe: _mistralVibeInstance,
+	geminiCli: _geminiCliInstance,
+	estimateTokens: (t, m) => estimateTokensFromText(t, m ?? 'gpt-4', tokenEstimators),
+	isMcpTool: isMcpTool,
+	extractMcpServerName: extractMcpServerName,
+});
 
 /** Create session discovery instance for CLI */
 function createSessionDiscovery(): SessionDiscovery {

--- a/vscode-extension/src/adapters/adapterRegistry.ts
+++ b/vscode-extension/src/adapters/adapterRegistry.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared factory for building the ordered adapter registry.
+ *
+ * Both the VS Code extension and the CLI use an identical list of ecosystem
+ * adapters in the same order (first match wins). This factory centralises that
+ * list so adding a new adapter only requires a single change here instead of
+ * one change per consumer.
+ */
+import type { IEcosystemAdapter } from '../ecosystemAdapter';
+import type { OpenCodeDataAccess } from '../opencode';
+import type { CrushDataAccess } from '../crush';
+import type { ContinueDataAccess } from '../continue';
+import type { VisualStudioDataAccess } from '../visualstudio';
+import type { ClaudeCodeDataAccess } from '../claudecode';
+import type { ClaudeDesktopCoworkDataAccess } from '../claudedesktop';
+import type { MistralVibeDataAccess } from '../mistralvibe';
+import type { GeminiCliDataAccess } from '../geminicli';
+
+import { OpenCodeAdapter } from './openCodeAdapter';
+import { CrushAdapter } from './crushAdapter';
+import { VisualStudioAdapter } from './visualStudioAdapter';
+import { ContinueAdapter } from './continueAdapter';
+import { ClaudeDesktopAdapter } from './claudeDesktopAdapter';
+import { ClaudeCodeAdapter } from './claudeCodeAdapter';
+import { MistralVibeAdapter } from './mistralVibeAdapter';
+import { GeminiCliAdapter } from './geminiCliAdapter';
+import { CopilotChatAdapter } from './copilotChatAdapter';
+import { CopilotCliAdapter } from './copilotCliAdapter';
+import { JetBrainsAdapter } from './jetbrainsAdapter';
+
+/** Data-access instances and callbacks required to build the adapter registry. */
+export interface AdapterRegistryDeps {
+	openCode: OpenCodeDataAccess;
+	crush: CrushDataAccess;
+	continue_: ContinueDataAccess;
+	visualStudio: VisualStudioDataAccess;
+	claudeCode: ClaudeCodeDataAccess;
+	claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
+	mistralVibe: MistralVibeDataAccess;
+	geminiCli: GeminiCliDataAccess;
+	/** Estimates token count from raw text for a given model. */
+	estimateTokens: (text: string, model?: string) => number;
+	/** Returns true when the tool name identifies an MCP server tool. */
+	isMcpTool: (toolName: string) => boolean;
+	/** Extracts the MCP server name from a namespaced tool name. */
+	extractMcpServerName: (toolName: string) => string;
+}
+
+/**
+ * Builds the ordered registry of ecosystem adapters — first match wins.
+ *
+ * Centralises adapter instantiation so both the CLI and the VS Code extension
+ * use identical registration order and constructor wiring.
+ */
+export function buildAdapterRegistry(deps: AdapterRegistryDeps): IEcosystemAdapter[] {
+	return [
+		new OpenCodeAdapter(deps.openCode),
+		new CrushAdapter(deps.crush),
+		new VisualStudioAdapter(deps.visualStudio, deps.estimateTokens),
+		new ContinueAdapter(deps.continue_),
+		new ClaudeDesktopAdapter(
+			deps.claudeDesktopCowork,
+			deps.isMcpTool,
+			deps.extractMcpServerName,
+			deps.estimateTokens
+		),
+		new ClaudeCodeAdapter(deps.claudeCode),
+		new MistralVibeAdapter(deps.mistralVibe),
+		new GeminiCliAdapter(deps.geminiCli),
+		// Copilot Chat / CLI adapters: discovery-only. Their handles() returns
+		// false so processSessionFile() falls through to the shared parser path
+		// for VS Code Copilot Chat and CLI files. See issue #654.
+		new CopilotChatAdapter(),
+		new CopilotCliAdapter(),
+		new JetBrainsAdapter(),
+	];
+}

--- a/vscode-extension/src/adapters/index.ts
+++ b/vscode-extension/src/adapters/index.ts
@@ -1,3 +1,5 @@
+export { buildAdapterRegistry } from './adapterRegistry';
+export type { AdapterRegistryDeps } from './adapterRegistry';
 export { OpenCodeAdapter } from './openCodeAdapter';
 export { CrushAdapter } from './crushAdapter';
 export { ContinueAdapter } from './continueAdapter';

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -78,19 +78,7 @@ import { MistralVibeDataAccess } from './mistralvibe';
 import { GeminiCliDataAccess } from './geminicli';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { getEcosystemDisplayName } from './ecosystemAdapter';
-import {
-	OpenCodeAdapter,
-	CrushAdapter,
-	ContinueAdapter,
-	ClaudeDesktopAdapter,
-	ClaudeCodeAdapter,
-	VisualStudioAdapter,
-	MistralVibeAdapter,
-	GeminiCliAdapter,
-	CopilotChatAdapter,
-	CopilotCliAdapter,
-	JetBrainsAdapter,
-} from './adapters';
+import { buildAdapterRegistry } from './adapters';
 import { getVSCodeUserPaths } from './adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from './adapters/jetbrainsAdapter';
 import { detectJetBrainsModelHintFromContent } from './jetbrains';
@@ -907,23 +895,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.claudeDesktopCowork = new ClaudeDesktopCoworkDataAccess();
 		this.mistralVibe = new MistralVibeDataAccess();
 		this.geminiCli = new GeminiCliDataAccess();
-		this.ecosystems = [
-			new OpenCodeAdapter(this.openCode),
-			new CrushAdapter(this.crush),
-			new VisualStudioAdapter(this.visualStudio, (t, m) => this.estimateTokensFromText(t, m)),
-			new ContinueAdapter(this.continue_),
-			new ClaudeDesktopAdapter(this.claudeDesktopCowork, (t) => this.isMcpTool(t), (t) => this.extractMcpServerName(t), (t, m) => this.estimateTokensFromText(t, m)),
-			new ClaudeCodeAdapter(this.claudeCode),
-			new MistralVibeAdapter(this.mistralVibe),
-			new GeminiCliAdapter(this.geminiCli),
-			// Copilot Chat / CLI adapters: discovery-only. Their handles() returns
-			// false so the existing fallback parsing in this file continues to
-			// own per-session parsing for VS Code Copilot Chat and CLI files.
-			// See issue #654.
-			new CopilotChatAdapter(),
-			new CopilotCliAdapter(),
-			new JetBrainsAdapter(),
-		];
+		this.ecosystems = buildAdapterRegistry({
+			openCode: this.openCode,
+			crush: this.crush,
+			continue_: this.continue_,
+			visualStudio: this.visualStudio,
+			claudeCode: this.claudeCode,
+			claudeDesktopCowork: this.claudeDesktopCowork,
+			mistralVibe: this.mistralVibe,
+			geminiCli: this.geminiCli,
+			estimateTokens: (t, m) => this.estimateTokensFromText(t, m),
+			isMcpTool: (t) => this.isMcpTool(t),
+			extractMcpServerName: (t) => this.extractMcpServerName(t),
+		});
 		this.cacheManager = new CacheManager(context, { log: (m: string) => this.log(m), warn: (m: string) => this.warn(m), error: (m: string) => this.error(m) }, CopilotTokenTracker.CACHE_VERSION);
 		this.sessionDiscovery = new SessionDiscovery({
 			log: (m) => this.log(m),


### PR DESCRIPTION
## Summary

Both \cli/src/helpers.ts\ and \scode-extension/src/extension.ts\ contained an identical ordered list of ecosystem adapter instantiations. This made adding a new adapter error-prone — changes had to be applied in two places.

## Changes

### New file: \scode-extension/src/adapters/adapterRegistry.ts\
- \AdapterRegistryDeps\ interface capturing all data-access instances and the three callbacks that differ between CLI and extension contexts (\stimateTokens\, \isMcpTool\, \xtractMcpServerName\)
- \uildAdapterRegistry(deps)\ factory that returns the canonical \IEcosystemAdapter[]\ with the correct registration order (first match wins)

### Updated: \scode-extension/src/adapters/index.ts\
- Exports \uildAdapterRegistry\ and \AdapterRegistryDeps\

### Updated: \scode-extension/src/extension.ts\
- Replaces the 15-line inline \	his.ecosystems = [...]\  block with a single \uildAdapterRegistry({...})\ call

### Updated: \cli/src/helpers.ts\
- Replaces the 15-line inline \_ecosystems = [...]\  block with a single \uildAdapterRegistry({...})\ call

## Verification
- All 25 unit tests remain green
- Extension build produces 0 errors