### PR TITLE
refactor: consolidate path normalization into shared utilities

### DIFF
--- a/cli/src/commands/diagnostics.ts
+++ b/cli/src/commands/diagnostics.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as path from 'path';
 import { discoverSessionFiles, getDiagnosticPaths, processSessionFile, effectiveTokens, fmt, formatTokens } from '../helpers';
+import { normalizePathSeparators } from '../../../vscode-extension/src/workspaceHelpers';
 
 interface LocationStats {
 	label: string;
@@ -23,7 +24,7 @@ function matchToCandidatePath(
 	filePath: string,
 	candidates: { path: string; exists: boolean; source: string }[]
 ): { path: string; source: string } | null {
-	const normalized = filePath.replace(/\\/g, '/');
+	const normalized = normalizePathSeparators(filePath);
 	// For OpenCode DB virtual paths, resolve to the db file path
 	const effectivePath = normalized.includes('opencode.db#') ? normalized.split('#')[0] : normalized;
 
@@ -31,7 +32,7 @@ function matchToCandidatePath(
 	let best: { path: string; source: string } | null = null;
 	let bestLen = 0;
 	for (const cand of candidates) {
-		const candNorm = cand.path.replace(/\\/g, '/');
+		const candNorm = normalizePathSeparators(cand.path);
 		if (effectivePath.startsWith(candNorm) && candNorm.length > bestLen) {
 			best = { path: cand.path, source: cand.source };
 			bestLen = candNorm.length;

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -17,7 +17,7 @@ import { MistralVibeDataAccess } from '../../vscode-extension/src/mistralvibe';
 import { GeminiCliDataAccess } from '../../vscode-extension/src/geminicli';
 import { buildAdapterRegistry } from '../../vscode-extension/src/adapters';
 import type { IEcosystemAdapter } from '../../vscode-extension/src/ecosystemAdapter';
-import { isMcpTool, extractMcpServerName } from '../../vscode-extension/src/workspaceHelpers';
+import { isMcpTool, extractMcpServerName, normalizePathForComparison } from '../../vscode-extension/src/workspaceHelpers';
 import { resolveFileUri } from '../../vscode-extension/src/workspacePathResolver';
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, getModelTier } from '../../vscode-extension/src/tokenEstimation';
@@ -193,7 +193,7 @@ async function statSessionFile(filePath: string): Promise<fs.Stats> {
 
 /** Determine editor source from file path */
 function getEditorSourceFromPath(filePath: string): string {
-	const normalized = filePath.toLowerCase().replace(/\\/g, '/');
+	const normalized = normalizePathForComparison(filePath);
 	if (normalized.includes('/cursor/')) { return 'cursor'; }
 	if (normalized.includes('/code - insiders/')) { return 'vscode-insiders'; }
 	if (normalized.includes('/code - exploration/')) { return 'vscode-exploration'; }

--- a/vscode-extension/src/adapters/visualStudioAdapter.ts
+++ b/vscode-extension/src/adapters/visualStudioAdapter.ts
@@ -4,7 +4,7 @@ import type { ModelUsage, ChatTurn } from '../types';
 import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
 import { VisualStudioDataAccess } from '../visualstudio';
 import { createEmptyContextRefs } from '../tokenEstimation';
-import { isMcpTool, normalizeMcpToolName, extractMcpServerName } from '../workspaceHelpers';
+import { isMcpTool, normalizeMcpToolName, extractMcpServerName, normalizePathForComparison } from '../workspaceHelpers';
 import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
 
 export class VisualStudioAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
@@ -21,7 +21,7 @@ export class VisualStudioAdapter implements IEcosystemAdapter, IDiscoverableEcos
 	}
 
 	getDisplayName(sessionFile: string): string {
-		const n = sessionFile.replace(/\\/g, '/').toLowerCase();
+		const n = normalizePathForComparison(sessionFile);
 		return n.includes('/ssmsgithubcopilot/') ? 'SSMS' : 'Visual Studio';
 	}
 

--- a/vscode-extension/src/backend/services/utilityService.ts
+++ b/vscode-extension/src/backend/services/utilityService.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { fileUriToPath } from '../../workspaceHelpers';
 
 const MAX_DISPLAY_NAME_LENGTH = 64;
 
@@ -208,21 +209,7 @@ export class BackendUtility {
 					}
 					
 					// Parse the URI string to get the file path
-					// This is a simplified version that doesn't require vscode.Uri
-					let fsPath: string;
-					if (uriStr.startsWith('file://')) {
-						// file:// URI - extract path after protocol
-						fsPath = uriStr.substring('file://'.length);
-						// Handle Windows drive letters (e.g., file:///C:/path -> C:/path)
-						if (fsPath.startsWith('/') && /^\/[a-zA-Z]:\//.test(fsPath)) {
-							fsPath = fsPath.substring(1);
-						}
-						// Decode URI components
-						fsPath = decodeURIComponent(fsPath);
-					} else {
-						// Assume it's already a file path
-						fsPath = uriStr;
-					}
+					const fsPath = uriStr.startsWith('file://') ? fileUriToPath(uriStr) : uriStr;
 					
 					if (!fsPath) {
 						continue;

--- a/vscode-extension/src/claudecode.ts
+++ b/vscode-extension/src/claudecode.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as os from 'os';
 import type { ModelUsage } from './types';
 import { withErrorRecoverySync } from './utils/errors';
+import { normalizePathForComparison } from './workspaceHelpers';
 
 /**
  * Normalize a Claude Code API model ID to the dot-notation format used throughout this codebase.
@@ -61,8 +62,8 @@ export class ClaudeCodeDataAccess {
 	 * false-positives on Cowork sessions that have a nested .claude/projects/ sub-path.
 	 */
 	isClaudeCodeSessionFile(filePath: string): boolean {
-		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
-		const projectsDir = this.getClaudeCodeProjectsDir().toLowerCase().replace(/\\/g, '/');
+		const normalized = normalizePathForComparison(filePath);
+		const projectsDir = normalizePathForComparison(this.getClaudeCodeProjectsDir());
 		return normalized.startsWith(projectsDir) && normalized.endsWith('.jsonl');
 	}
 

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -59,6 +59,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { normalizeClaudeModelId } from './claudecode';
 import type { ModelUsage } from './types';
+import { normalizePathForComparison } from './workspaceHelpers';
 
 /** Package name for the Claude Desktop Windows Store app. */
 const CLAUDE_DESKTOP_PACKAGE = 'Claude_pzs8sxrjxfjjc';
@@ -100,7 +101,7 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Cowork session files live inside local-agent-mode-sessions/ and end with .jsonl.
 	 */
 	isCoworkSessionFile(filePath: string): boolean {
-		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
+		const normalized = normalizePathForComparison(filePath);
 		return normalized.includes('/local-agent-mode-sessions/') && normalized.endsWith('.jsonl');
 	}
 

--- a/vscode-extension/src/continue.ts
+++ b/vscode-extension/src/continue.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { ModelUsage } from './types';
+import { normalizePathForComparison } from './workspaceHelpers';
 
 export class ContinueDataAccess {
 
@@ -29,7 +30,7 @@ export class ContinueDataAccess {
 	 * Check if a file path is a Continue session file.
 	 */
 	isContinueSessionFile(filePath: string): boolean {
-		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
+		const normalized = normalizePathForComparison(filePath);
 		return normalized.includes('/.continue/sessions/') && normalized.endsWith('.json');
 	}
 

--- a/vscode-extension/src/geminicli.ts
+++ b/vscode-extension/src/geminicli.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { ChatTurn, ModelUsage, PromptTokenDetail } from './types';
 import { createEmptyContextRefs } from './tokenEstimation';
+import { normalizePathForComparison } from './workspaceHelpers';
 
 interface GeminiCliSessionHeader {
 	sessionId: string;
@@ -132,8 +133,8 @@ export class GeminiCliDataAccess {
 	}
 
 	isGeminiCliSessionFile(filePath: string): boolean {
-		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
-		const tmpDir = this.getGeminiTmpDir().toLowerCase().replace(/\\/g, '/');
+		const normalized = normalizePathForComparison(filePath);
+		const tmpDir = normalizePathForComparison(this.getGeminiTmpDir());
 		return normalized.startsWith(tmpDir)
 			&& normalized.includes('/chats/session-')
 			&& normalized.endsWith('.jsonl');

--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import * as vscode from 'vscode';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
+import { normalizePathForComparison } from './workspaceHelpers';
 
 type OpenCodeDbCache = { db: any; mtimeMs: number; size: number; path: string };
 type OpenCodeModelUsageWithInteractions = {
@@ -47,7 +48,7 @@ export class OpenCodeDataAccess {
 	 * or referenced via virtual paths like opencode.db#ses_<id> (SQLite).
 	 */
 	isOpenCodeSessionFile(filePath: string): boolean {
-		const normalized = filePath.toLowerCase().replace(/\\/g, '/');
+		const normalized = normalizePathForComparison(filePath);
 		return normalized.includes('/opencode/storage/session/') || normalized.includes('/opencode/opencode.db#ses_');
 	}
 

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -20,10 +20,10 @@
  */
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { isDiscoverable } from './ecosystemAdapter';
+import { normalizePathForDedup } from './workspaceHelpers';
 
 export interface SessionDiscoveryDeps {
 	log: (message: string) => void;
@@ -31,21 +31,6 @@ export interface SessionDiscoveryDeps {
 	error: (message: string, error?: any) => void;
 	ecosystems: IEcosystemAdapter[];
 	sampleDataDirectoryOverride?: () => string | undefined;
-}
-
-/**
- * Normalize a filesystem path for deduplication.
- *
- * On Windows and macOS the filesystem is typically case-insensitive, so two
- * adapters that report the same file under different casings must collapse
- * to one entry. On Linux the FS is case-sensitive so we preserve case.
- *
- * Backslashes are normalized to forward slashes so comparisons are
- * platform-agnostic regardless of which adapter formatted the path.
- */
-function normalizePathForDedup(p: string): string {
-	const fwd = p.replace(/\\/g, '/');
-	return os.platform() === 'linux' ? fwd : fwd.toLowerCase();
 }
 
 export class SessionDiscovery {

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -36,6 +36,7 @@ import {
 	isMcpTool,
 	normalizeMcpToolName,
 	extractMcpServerName,
+	normalizePathForComparison,
 } from './workspaceHelpers';
 import { isJetBrainsSessionPath } from './adapters/jetbrainsAdapter';
 import { detectJetBrainsModeFromContent, type JetBrainsMode } from './jetbrains';
@@ -838,7 +839,7 @@ export function analyzeContentReferences(contentReferences: unknown[], refs: Con
 			const fsPath = reference.fsPath || reference.path;
 			if (typeof fsPath === 'string') {
 				// Normalize path separators for pattern matching
-				const normalizedPath = fsPath.replace(/\\/g, '/').toLowerCase();
+				const normalizedPath = normalizePathForComparison(fsPath);
 
 				// Track specific patterns - these are auto-attached, not user-explicit #file refs
 				if (normalizedPath.endsWith('/.github/copilot-instructions.md') ||
@@ -916,7 +917,7 @@ export function analyzeVariableData(variableData: unknown, refs: ContextReferenc
 			const fsPath = value.fsPath || value.path || value.external;
 
 			if (typeof fsPath === 'string') {
-				const normalizedPath = fsPath.replace(/\\/g, '/').toLowerCase();
+				const normalizedPath = normalizePathForComparison(fsPath);
 
 				// Track specific patterns (but don't double-count if already in contentReferences)
 				if (normalizedPath.endsWith('/.github/copilot-instructions.md') ||

--- a/vscode-extension/src/visualstudio.ts
+++ b/vscode-extension/src/visualstudio.ts
@@ -24,6 +24,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { decode, decodeMulti } from '@msgpack/msgpack';
 import type { ModelUsage } from './types';
+import { normalizePathForComparison } from './workspaceHelpers';
 
 /** Directory names to skip during filesystem scan (heavy / non-project dirs). */
 const SCAN_SKIP_DIRS = new Set([
@@ -40,7 +41,7 @@ export class VisualStudioDataAccess {
  * Detection: normalised path contains `/.vs/`, `/copilot-chat/`, and `/sessions/`.
  */
 isVSSessionFile(filePath: string): boolean {
-	const n = filePath.replace(/\\/g, '/').toLowerCase();
+	const n = normalizePathForComparison(filePath);
 	const isVS = n.includes('/.vs/') && n.includes('/copilot-chat/') && n.includes('/sessions/');
 	const isSsms = n.includes('/ssmsgithubcopilot/') && n.includes('/copilot-chat/') && n.includes('/sessions/');
 	return isVS || isSsms;

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -12,6 +12,66 @@ import { resolveFileUri } from './workspacePathResolver';
 import { withErrorRecoverySync } from './utils/errors';
 
 
+// ── Path normalisation utilities ─────────────────────────────────────────────
+
+/**
+ * Convert backslashes to forward slashes without any case-folding.
+ * Use when you need separator-normalised paths but must preserve case
+ * (e.g. for constructing or joining paths, not matching).
+ */
+export function normalizePathSeparators(p: string): string {
+	return p.replace(/\\/g, '/');
+}
+
+/**
+ * Normalize a filesystem path for case-insensitive substring/prefix matching.
+ * Converts backslashes to forward slashes and lower-cases the result.
+ *
+ * NOTE: This always lower-cases the path, which is correct for matching on
+ * case-insensitive filesystems (Windows, macOS). On Linux it may mask case
+ * differences — callers using this for structural pattern matching (e.g.
+ * detecting editor type from a known path fragment) accept that trade-off
+ * and match the existing inline behaviour being replaced.
+ */
+export function normalizePathForComparison(p: string): string {
+	return p.replace(/\\/g, '/').toLowerCase();
+}
+
+/**
+ * Normalize a filesystem path for deduplication across adapters.
+ *
+ * On Windows and macOS the filesystem is typically case-insensitive, so two
+ * adapters that report the same file under different casings must collapse
+ * to one entry. On Linux the FS is case-sensitive so we preserve case.
+ *
+ * Backslashes are normalised to forward slashes so comparisons are
+ * platform-agnostic regardless of which adapter formatted the path.
+ *
+ * The optional `platform` parameter exists for unit testing;
+ * defaults to `process.platform`.
+ */
+export function normalizePathForDedup(p: string, platform: NodeJS.Platform = process.platform as NodeJS.Platform): string {
+	const fwd = p.replace(/\\/g, '/');
+	return platform === 'linux' ? fwd : fwd.toLowerCase();
+}
+
+/**
+ * Convert a file:// URI to a plain filesystem path.
+ *
+ * Handles Windows drive letters, Unix paths, localhost authority, and
+ * percent-encoded characters. Delegates to resolveFileUri() for security
+ * (path traversal prevention, malformed percent-encoding rejection).
+ *
+ * Non-`file://` strings are returned unchanged.
+ */
+export function fileUriToPath(uri: string): string {
+	if (!uri.startsWith('file://')) { return uri; }
+	// Normalise localhost authority: file://localhost/path → file:///path
+	const normalized = uri.replace(/^file:\/\/localhost(\/|$)/, 'file:///');
+	return resolveFileUri(normalized) ?? uri;
+}
+
+
 // ── Local type definitions ────────────────────────────────────────────────
 
 /** Represents a VS Code Copilot interaction mode object read from session data. */
@@ -882,7 +942,7 @@ function detectVSCodeVariantFromPath(lowerPath: string): string | undefined {
  *          'Gemini CLI', 'Claude Desktop Cowork', 'Crush', or 'Unknown'.
  */
 export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
-	const lowerPath = filePath.toLowerCase().replace(/\\/g, '/');
+	const lowerPath = normalizePathForComparison(filePath);
 	return detectToolEditorFromPath(filePath, lowerPath, isOpenCodeSessionFile) ??
 		detectVSCodeVariantFromPath(lowerPath) ??
 		'Unknown';
@@ -909,7 +969,7 @@ function detectIDEEditorSource(lowerPath: string): string | undefined {
  * Detect which editor the session file belongs to based on its path.
  */
 export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
-	const lowerPath = filePath.toLowerCase().replace(/\\/g, '/');
+	const lowerPath = normalizePathForComparison(filePath);
 	if (lowerPath.includes('/.copilot/jb/')) { return 'JetBrains'; }
 	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -9,6 +9,11 @@ import {
     extractMcpServerName,
     extractCustomAgentName,
     getEditorNameFromRoot,
+    normalizePathSeparators,
+    normalizePathForComparison,
+    normalizePathForDedup,
+    fileUriToPath,
+    parseWorkspaceStorageJsonFile,
 } from '../../src/workspaceHelpers';
 
 // ---------------------------------------------------------------------------
@@ -616,8 +621,6 @@ fs.rmSync(tmpDir, { recursive: true, force: true });
 // parseWorkspaceStorageJsonFile — input validation
 // ---------------------------------------------------------------------------
 
-import { parseWorkspaceStorageJsonFile } from '../../src/workspaceHelpers';
-
 test('parseWorkspaceStorageJsonFile: returns undefined for null JSON content', () => {
     const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pwsjf-'));
     try {
@@ -656,4 +659,97 @@ test('parseWorkspaceStorageJsonFile: returns path from valid object', () => {
     } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+});
+
+// ---------------------------------------------------------------------------
+// normalizePathSeparators
+// ---------------------------------------------------------------------------
+
+test('normalizePathSeparators: converts backslashes to forward slashes', () => {
+    assert.equal(normalizePathSeparators('C:\\Users\\foo\\bar.txt'), 'C:/Users/foo/bar.txt');
+});
+
+test('normalizePathSeparators: preserves forward slashes unchanged', () => {
+    assert.equal(normalizePathSeparators('/home/user/file.txt'), '/home/user/file.txt');
+});
+
+test('normalizePathSeparators: preserves case', () => {
+    assert.equal(normalizePathSeparators('C:\\Users\\FooBar'), 'C:/Users/FooBar');
+});
+
+test('normalizePathSeparators: handles mixed separators', () => {
+    assert.equal(normalizePathSeparators('C:/Users\\foo/bar\\baz.txt'), 'C:/Users/foo/bar/baz.txt');
+});
+
+test('normalizePathSeparators: handles path with spaces', () => {
+    assert.equal(normalizePathSeparators('C:\\My Documents\\file.txt'), 'C:/My Documents/file.txt');
+});
+
+// ---------------------------------------------------------------------------
+// normalizePathForComparison
+// ---------------------------------------------------------------------------
+
+test('normalizePathForComparison: converts backslashes and lower-cases', () => {
+    assert.equal(normalizePathForComparison('C:\\Users\\Foo\\Bar.TXT'), 'c:/users/foo/bar.txt');
+});
+
+test('normalizePathForComparison: already forward-slash path gets lower-cased', () => {
+    assert.equal(normalizePathForComparison('/Home/User/File.TXT'), '/home/user/file.txt');
+});
+
+test('normalizePathForComparison: path with spaces', () => {
+    assert.equal(normalizePathForComparison('C:\\My Documents\\Test'), 'c:/my documents/test');
+});
+
+test('normalizePathForComparison: UNC-style path', () => {
+    assert.equal(normalizePathForComparison('\\\\Server\\Share\\Folder'), '//server/share/folder');
+});
+
+test('normalizePathForComparison: already normalised path is a no-op', () => {
+    assert.equal(normalizePathForComparison('/home/user/.claude/projects'), '/home/user/.claude/projects');
+});
+
+// ---------------------------------------------------------------------------
+// normalizePathForDedup
+// ---------------------------------------------------------------------------
+
+test('normalizePathForDedup: on linux preserves case but normalizes separators', () => {
+    assert.equal(normalizePathForDedup('C:\\Users\\Foo', 'linux'), 'C:/Users/Foo');
+});
+
+test('normalizePathForDedup: on win32 lower-cases and normalizes separators', () => {
+    assert.equal(normalizePathForDedup('C:\\Users\\Foo', 'win32'), 'c:/users/foo');
+});
+
+test('normalizePathForDedup: on darwin lower-cases and normalizes separators', () => {
+    assert.equal(normalizePathForDedup('/Users/Foo/Bar', 'darwin'), '/users/foo/bar');
+});
+
+test('normalizePathForDedup: forward-slash path on linux unchanged', () => {
+    assert.equal(normalizePathForDedup('/home/user/file', 'linux'), '/home/user/file');
+});
+
+// ---------------------------------------------------------------------------
+// fileUriToPath
+// ---------------------------------------------------------------------------
+
+test('fileUriToPath: returns non-file URIs unchanged', () => {
+    assert.equal(fileUriToPath('/plain/path'), '/plain/path');
+    assert.equal(fileUriToPath('C:\\plain\\path'), 'C:\\plain\\path');
+    assert.equal(fileUriToPath('https://example.com'), 'https://example.com');
+});
+
+test('fileUriToPath: unix path from file URI', () => {
+    const result = fileUriToPath('file:///home/user/file.txt');
+    assert.equal(result, '/home/user/file.txt');
+});
+
+test('fileUriToPath: decodes URI-encoded spaces', () => {
+    const result = fileUriToPath('file:///home/user/my%20file.txt');
+    assert.equal(result, '/home/user/my file.txt');
+});
+
+test('fileUriToPath: localhost authority is transparent', () => {
+    const result = fileUriToPath('file://localhost/home/user/file.txt');
+    assert.equal(result, '/home/user/file.txt');
 });


### PR DESCRIPTION
Consolidates all inline path normalization patterns into four shared utilities in workspaceHelpers.ts: normalizePathSeparators, normalizePathForComparison, normalizePathForDedup (OS-aware), and fileUriToPath. Replaced inline patterns in 14 files. Added 15 unit tests.