### PR TITLE
refactor(commands): remove redundant convenience wrapper methods

### DIFF
--- a/vscode-extension/src/backend/commands.ts
+++ b/vscode-extension/src/backend/commands.ts
@@ -50,43 +50,9 @@ export class BackendCommandHandler {
 		}
 	}
 
-	// Convenience methods matching the old interface
-	async configureBackend(): Promise<void> {
-		return this.handleConfigureBackend();
-	}
-
-	async copyBackendConfig(): Promise<void> {
-		return this.handleCopyBackendConfig();
-	}
-
-	async exportCurrentView(): Promise<void> {
-		return this.handleExportCurrentView();
-	}
-
-	async setBackendSharedKey(): Promise<void> {
-		return this.handleSetBackendSharedKey();
-	}
-
-	async rotateBackendSharedKey(): Promise<void> {
-		return this.handleRotateBackendSharedKey();
-	}
-
-	async clearBackendSharedKey(): Promise<void> {
-		return this.handleClearBackendSharedKey();
-	}
-
-	async toggleBackendWorkspaceMachineNameSync(): Promise<void> {
-		return this.handleToggleBackendWorkspaceMachineNameSync();
-	}
-
-	async enableTeamSharing(): Promise<void> {
-		return this.handleEnableTeamSharing();
-	}
-
-	async disableTeamSharing(): Promise<void> {
-		return this.handleDisableTeamSharing();
-	}
-
+	/**
+	 * Handles the "Toggle Workspace/Machine Name Sync" command.
+	 */
 	async handleToggleBackendWorkspaceMachineNameSync(): Promise<void> {
 		try {
 			await this.facade.toggleBackendWorkspaceMachineNameSync();
@@ -96,14 +62,9 @@ export class BackendCommandHandler {
 		}
 	}
 
-	async setSharingProfile(): Promise<void> {
-		return this.handleSetSharingProfile();
-	}
-
-	async clearAzureSettings(): Promise<void> {
-		return this.handleClearAzureSettings();
-	}
-
+	/**
+	 * Handles the "Set Sharing Profile" command.
+	 */
 	async handleSetSharingProfile(): Promise<void> {
 		try {
 			await this.facade.setSharingProfileCommand();

--- a/vscode-extension/test/unit/backend-commands.test.ts
+++ b/vscode-extension/test/unit/backend-commands.test.ts
@@ -162,15 +162,6 @@ describe('backend/commands', { concurrency: false }, () => {
 	(vscode as any).__mock.setNextPick('Remove Key');
 	await handler.handleClearBackendSharedKey();
 	assert.equal(cleared, true);
-
-	// Convenience wrappers
-	(vscode as any).__mock.reset();
-	await handler.configureBackend();
-	await handler.copyBackendConfig();
-	await handler.exportCurrentView();
-	await handler.setBackendSharedKey();
-	await handler.rotateBackendSharedKey();
-	await handler.clearBackendSharedKey();
 	});
 
 	test('BackendCommandHandler error paths: configure failure, query disabled, export failures, and confirm cancellations', async () => {
@@ -520,44 +511,6 @@ describe('backend/commands', { concurrency: false }, () => {
 	});
 	await handler.handleQueryBackend();
 	assert.ok((vscode as any).__mock.state.lastErrorMessages.some((m: string) => m.includes('query') || m.includes('Query')));
-	});
-
-	test('convenience aliases delegate to handle methods', async () => {
-	(vscode as any).__mock.reset();
-	let sharingCalled = false;
-	let toggleCalled = false;
-	let clearCalled = false;
-	let enableCalled = false;
-	let disableCalled = false;
-	const handler = new BackendCommandHandler({
-		facade: createMockFacade({
-			setSharingProfileCommand: async () => { sharingCalled = true; },
-			toggleBackendWorkspaceMachineNameSync: async () => { toggleCalled = true; },
-			clearAzureSettingsCommand: async () => { clearCalled = true; },
-		}),
-		integration: {},
-		calculateEstimatedCost: () => 0,
-		warn: () => undefined,
-		log: () => undefined
-	});
-
-	await handler.setSharingProfile();
-	assert.ok(sharingCalled);
-
-	await handler.toggleBackendWorkspaceMachineNameSync();
-	assert.ok(toggleCalled);
-
-	(vscode as any).__mock.setNextPick('Clear Settings');
-	await handler.clearAzureSettings();
-	assert.ok(clearCalled);
-
-	(vscode as any).__mock.reset();
-	(vscode as any).__mock.setNextPick('I Understand, Continue');
-	await handler.enableTeamSharing();
-
-	(vscode as any).__mock.reset();
-	(vscode as any).__mock.setNextPick('Switch to Anonymized');
-	await handler.disableTeamSharing();
 	});
 
 	test('handleExportCurrentView respects non-identifying policy', async () => {


### PR DESCRIPTION
`BackendCommandHandler` had 11 pass-through methods (e.g. `configureBackend()`, `setSharingProfile()`, `enableTeamSharing()`, ...) whose entire body was `return this.handle*()`. These wrappers were never called in production -- `extension.ts` already invoked the `handle*` methods directly. They added dead surface area and made the class harder to navigate.

**What changed**

- Remove all 11 convenience wrapper methods from `BackendCommandHandler`
- Add missing JSDoc to `handleToggleBackendWorkspaceMachineNameSync` and `handleSetSharingProfile`, which previously had no doc comment
- Remove the test block that exercised the deleted wrappers ("convenience aliases delegate to handle methods")

**No behaviour change.** All 55 unit tests still pass.