### PR TITLE
refactor: replace `any` types with proper TypeScript types in core files

### DIFF
--- a/vscode-extension/src/sessionParser.ts
+++ b/vscode-extension/src/sessionParser.ts
@@ -34,6 +34,40 @@ return defaultModel;
 return trimmed.startsWith('copilot/') ? trimmed.substring('copilot/'.length) : trimmed;
 }
 
+interface MessagePart {
+  text?: string;
+}
+
+interface RequestMessage {
+  parts?: MessagePart[];
+  text?: string;
+}
+
+interface ResponseItem {
+  kind?: string;
+  value?: string;
+  content?: { value?: string };
+  message?: { parts?: MessagePart[] };
+}
+
+interface RequestResult {
+  usage?: { promptTokens?: number; completionTokens?: number };
+  promptTokens?: number;
+  outputTokens?: number;
+  metadata?: { promptTokens?: number; outputTokens?: number; modelId?: string };
+  details?: string;
+}
+
+interface ProcessableRequest {
+  modelId?: string;
+  selectedModel?: { identifier?: string };
+  model?: string;
+  message?: RequestMessage;
+  response?: ResponseItem[];
+  responses?: ResponseItem[];
+  result?: RequestResult;
+}
+
 /**
  * Apply a delta to reconstruct session state from delta-based JSONL
  * VS Code Insiders uses this format where:
@@ -48,9 +82,9 @@ if (!isObject(delta)) {
 return state;
 }
 
-const kind = (delta as any).kind;
-const k = (delta as any).k;
-const v = (delta as any).v;
+const kind = delta['kind'];
+const k = delta['k'];
+const v = delta['v'];
 
 if (kind === 0) {
 // Initial state - full replacement
@@ -68,15 +102,16 @@ return state;
 }
 }
 
-let root: any = isObject(state) ? state : Object.create(null);
-let current: any = root;
+let root: JsonObject | unknown[] = isObject(state) ? state : Object.create(null);
+let current: JsonObject | unknown[] = root;
 
-const ensureChildContainer = (parent: any, key: string, nextSeg: string): any => {
+const ensureChildContainer = (parent: JsonObject, key: string, nextSeg: string): JsonObject | unknown[] => {
 const wantsArray = isArrayIndexSegment(nextSeg);
-let existing = parent[key];
+const existing = parent[key];
 if (!isObject(existing)) {
-existing = wantsArray ? [] : Object.create(null);
-parent[key] = existing;
+const newNode: JsonObject | unknown[] = wantsArray ? [] : Object.create(null);
+parent[key] = newNode;
+return newNode;
 }
 return existing;
 };
@@ -88,12 +123,15 @@ const nextSeg = path[i + 1];
 
 if (Array.isArray(current) && isArrayIndexSegment(seg)) {
 const idx = Number(seg);
-let existing = current[idx];
-if (!isObject(existing)) {
-existing = isArrayIndexSegment(nextSeg) ? [] : Object.create(null);
-current[idx] = existing;
+const rawExisting = current[idx];
+let nextNode: JsonObject | unknown[];
+if (!isObject(rawExisting)) {
+nextNode = isArrayIndexSegment(nextSeg) ? [] : Object.create(null);
+current[idx] = nextNode;
+} else {
+nextNode = rawExisting;
 }
-current = existing;
+current = nextNode;
 continue;
 }
 
@@ -124,15 +162,15 @@ return root;
 
 if (kind === 2) {
 // Append value(s) to array at key path
-let target: any;
+let target: unknown[] | undefined;
 if (Array.isArray(current) && isArrayIndexSegment(lastSeg)) {
 const idx = Number(lastSeg);
 if (!Array.isArray(current[idx])) {
 current[idx] = [];
 }
-target = current[idx];
+target = current[idx] as unknown[];
 } else if (isObject(current)) {
-if (!Array.isArray((current as any)[lastSeg])) {
+if (!Array.isArray(current[lastSeg])) {
 // Use Object.defineProperty for safe assignment
 Object.defineProperty(current, lastSeg, {
 value: [],
@@ -141,7 +179,7 @@ enumerable: true,
 configurable: true
 });
 }
-target = (current as any)[lastSeg];
+target = current[lastSeg] as unknown[];
 }
 
 if (Array.isArray(target)) {
@@ -171,15 +209,16 @@ if (!isObject(item)) {
 continue;
 }
 // Separate thinking items from regular response text
-if ((item as any).kind === 'thinking') {
-const value = (item as any).value;
+if (item['kind'] === 'thinking') {
+const value = item['value'];
 if (typeof value === 'string' && value) {
 thinkingText += value;
 }
 continue;
 }
-const contentValue = isObject((item as any).content) ? (item as any).content.value : undefined;
-const value = (item as any).value;
+const content = item['content'];
+const contentValue = isObject(content) ? content['value'] : undefined;
+const value = item['value'];
 // Prefer content.value when present to avoid double-counting wrapper text.
 if (typeof contentValue === 'string' && contentValue) {
 responseText += contentValue;
@@ -196,7 +235,7 @@ export function parseSessionFileContent(
 sessionFilePath: string,
 fileContent: string,
 estimateTokensFromText: (text: string, model?: string) => number,
-getModelFromRequest?: (req: any) => string
+getModelFromRequest?: (req: ProcessableRequest) => string
 ) {
 // Aggregates and helpers are declared up front; the heavy lifting is delegated
 const modelUsage: ModelUsage = {};
@@ -206,7 +245,7 @@ let totalOutputTokens = 0;
 let totalThinkingTokens = 0;
 let totalActualTokens = 0;
 
-let sessionJson: any | undefined;
+let sessionJson: unknown;
 let defaultModel = 'unknown';
 
 const ensureModel = (m?: string) => (typeof m === 'string' && m ? m : defaultModel);
@@ -226,39 +265,40 @@ totalOutputTokens += t;
 };
 
 // Process a single request (used by both JSON and reconstructed delta flows)
-const processRequest = (request: any) => {
+const processRequest = (request: unknown) => {
 if (request == null || typeof request !== 'object') { return; }
+const req = request as ProcessableRequest;
 
-const rawRequestModel = request.modelId ?? request.selectedModel?.identifier ?? request.model;
+const rawRequestModel = req.modelId ?? req.selectedModel?.identifier ?? req.model;
 const requestModel = normalizeModelId(rawRequestModel, defaultModel);
 
 let model: string;
 if (typeof rawRequestModel === 'string' && rawRequestModel.trim()) {
 model = requestModel;
 } else {
-const callbackModelRaw = getModelFromRequest ? getModelFromRequest(request) : undefined;
+const callbackModelRaw = getModelFromRequest ? getModelFromRequest(req) : undefined;
 const callbackModel = normalizeModelId(callbackModelRaw, '');
 model = callbackModel || requestModel;
 }
 
 // Input parts
-if (request?.message?.parts) {
-for (const part of request.message.parts) {
+if (req.message?.parts) {
+for (const part of req.message.parts) {
 if (typeof part?.text === 'string' && part.text) { addInput(model, part.text); }
 }
-} else if (typeof request?.message?.text === 'string') {
-addInput(model, request.message.text);
+} else if (typeof req.message?.text === 'string') {
+addInput(model, req.message.text);
 }
 
 // Extract output and thinking text via extractResponseAndThinkingText, which handles
 // both plain .value and delta-format content.value shapes.
-const { responseText, thinkingText } = extractResponseAndThinkingText(request.response);
+const { responseText, thinkingText } = extractResponseAndThinkingText(req.response);
 if (responseText) { addOutput(model, responseText); }
 if (thinkingText) { totalThinkingTokens += estimateTokensFromText(thinkingText, model); }
 
 // Loop only for sub-agents and message.parts — skip .value and thinking items
 // because extractResponseAndThinkingText already counted them above.
-const responseItems = Array.isArray(request.response) ? request.response : (Array.isArray(request.responses) ? request.responses : []);
+const responseItems: ResponseItem[] = Array.isArray(req.response) ? req.response : (Array.isArray(req.responses) ? req.responses : []);
 for (const responseItem of responseItems) {
 const subAgent = extractSubAgentData(responseItem);
 if (subAgent) {
@@ -280,15 +320,15 @@ if (typeof p?.text === 'string' && p.text) { addOutput(model, p.text); }
 }
 
 // Actual token counts if present
-if (request?.result?.usage) {
-const u = request.result.usage;
+if (req.result?.usage) {
+const u = req.result.usage;
 const prompt = typeof u.promptTokens === 'number' ? u.promptTokens : 0;
 const completion = typeof u.completionTokens === 'number' ? u.completionTokens : 0;
 totalActualTokens += prompt + completion;
-} else if (typeof request?.result?.promptTokens === 'number' && typeof request?.result?.outputTokens === 'number') {
-totalActualTokens += request.result.promptTokens + request.result.outputTokens;
-} else if (request?.result?.metadata && typeof request?.result?.metadata?.promptTokens === 'number' && typeof request?.result?.metadata?.outputTokens === 'number') {
-totalActualTokens += request.result.metadata.promptTokens + request.result.metadata.outputTokens;
+} else if (typeof req.result?.promptTokens === 'number' && typeof req.result?.outputTokens === 'number') {
+totalActualTokens += req.result.promptTokens + req.result.outputTokens;
+} else if (req.result?.metadata && typeof req.result.metadata.promptTokens === 'number' && typeof req.result.metadata.outputTokens === 'number') {
+totalActualTokens += req.result.metadata.promptTokens + req.result.metadata.outputTokens;
 }
 };
 
@@ -306,9 +346,14 @@ for (const line of lines) {
 try { const delta = JSON.parse(line); sessionState = applyDelta(sessionState, delta); } catch { }
 }
 
-const requests = isObject(sessionState) && Array.isArray((sessionState as any).requests) ? ((sessionState as any).requests as unknown[]) : [];
+const sessionStateObj = isObject(sessionState) ? sessionState : null;
+const requests: unknown[] = sessionStateObj && Array.isArray(sessionStateObj['requests']) ? (sessionStateObj['requests'] as unknown[]) : [];
 // Count only requests that look like user interactions
-interactions = requests.filter((r) => isObject(r) && isObject((r as any).message) && typeof (r as any).message.text === 'string' && (r as any).message.text.trim()).length;
+interactions = requests.filter((r) => {
+if (!isObject(r)) { return false; }
+const msg = r['message'];
+return isObject(msg) && typeof msg['text'] === 'string' && (msg['text'] as string).trim();
+}).length;
 for (const r of requests) { processRequest(r); }
 return {
 tokens: totalInputTokens + totalOutputTokens + totalThinkingTokens,
@@ -328,7 +373,8 @@ if (!sessionJson) {
 try { sessionJson = JSON.parse(fileContent); } catch { return { tokens: 0, interactions: 0, modelUsage: {}, thinkingTokens: 0, actualTokens: 0 }; }
 }
 
-const requests = Array.isArray(sessionJson.requests) ? sessionJson.requests : (Array.isArray(sessionJson.history) ? sessionJson.history : []);
+const sj = isObject(sessionJson) ? sessionJson : null;
+const requests: unknown[] = sj && Array.isArray(sj['requests']) ? (sj['requests'] as unknown[]) : (sj && Array.isArray(sj['history']) ? (sj['history'] as unknown[]) : []);
 interactions = requests.length;
 for (const request of requests) { processRequest(request); }
 

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -4,6 +4,33 @@
  */
 import type { ModelUsage, ModelPricing, ContextReferenceUsage } from './types';
 
+/** Minimum request shape needed by getModelFromRequest. */
+interface ModelRequestSource {
+	modelId?: string;
+	result?: {
+		metadata?: { modelId?: string };
+		details?: string;
+	};
+}
+
+/** Shape of a single delta event line in a JSONL session file. */
+interface DeltaEvent {
+	kind?: number;
+	/** Key path (array of path segments). */
+	k?: unknown;
+	/** Value to set or append. */
+	v?: unknown;
+}
+
+/** Per-model metrics from a session.shutdown event. */
+interface ShutdownModelMetrics {
+	usage?: {
+		inputTokens?: number;
+		outputTokens?: number;
+		cacheReadTokens?: number;
+		cacheWriteTokens?: number;
+	};
+}
 
 export function estimateTokensFromText(text: string, model: string = 'gpt-4', tokenEstimators: { [key: string]: number } = {}): number {
 	// Token estimation based on character count and model
@@ -78,7 +105,7 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 	// For delta-based formats, reconstruct full state to reliably extract actual usage.
 	// Usage data can arrive at many different delta path levels, so line-by-line matching
 	// is fragile. Reconstructing the state (like the logviewer does) is the reliable approach.
-	let sessionState: any = {};
+	let sessionState: Record<string, unknown> = {};
 	let isDeltaBased = false;
 	let parseFailedLines = 0;
 	// For CLI (non-delta) format: accumulate actual token totals from session.shutdown
@@ -102,14 +129,14 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 			// Detect and reconstruct delta-based format in parallel with estimation
 			if (typeof event.kind === 'number') {
 				isDeltaBased = true;
-				sessionState = applyDelta(sessionState, event);
+				sessionState = applyDelta(sessionState, event) as Record<string, unknown>;
 			}
 
 			// Copilot CLI: session.shutdown contains exact token totals per model
 			if (event.type === 'session.shutdown' && event.data?.modelMetrics) {
 				if (!cliShutdownModelUsage) { cliShutdownModelUsage = {}; }
 				let shutdownTotal = 0;
-				for (const [modelName, metrics] of Object.entries(event.data.modelMetrics) as [string, any][]) {
+				for (const [modelName, metrics] of Object.entries(event.data.modelMetrics) as [string, ShutdownModelMetrics][]) {
 					const usage = metrics?.usage;
 					if (usage) {
 						const input = typeof usage.inputTokens === 'number' ? usage.inputTokens : 0;
@@ -238,14 +265,15 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 	let totalActualTokens = 0;
 	if (isDeltaBased) {
 		const rawUsageFallback = parseFailedLines > 0 ? extractPerRequestUsageFromRawLines(lines) : new Map<number, { promptTokens: number; outputTokens: number }>();
-		const requests = (sessionState.requests && Array.isArray(sessionState.requests)) ? sessionState.requests : [];
+		const rawRequests = sessionState['requests'];
+		const requests = Array.isArray(rawRequests) ? rawRequests as unknown[] : [];
 		// Determine highest request index: max of reconstructed array length and regex-extracted keys
 		let maxIndex = requests.length;
 		for (const idx of rawUsageFallback.keys()) {
 			if (idx + 1 > maxIndex) { maxIndex = idx + 1; }
 		}
 		for (let i = 0; i < maxIndex; i++) {
-			const request = requests[i];
+			const request = requests[i] as { result?: { promptTokens?: number; outputTokens?: number; metadata?: { promptTokens?: number; outputTokens?: number }; usage?: { promptTokens?: number; completionTokens?: number } } } | undefined;
 			let found = false;
 			// Try reconstructed state first
 			if (request?.result) {
@@ -281,10 +309,12 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
 	// For delta-based sessions, extract sub-agent token estimates from the fully reconstructed state.
 	// Sub-agent results are built up char-by-char via delta events and are only complete in sessionState.
 	if (isDeltaBased) {
-		const requests = Array.isArray(sessionState.requests) ? sessionState.requests : [];
+		const rawReqs = sessionState['requests'];
+		const requests = Array.isArray(rawReqs) ? rawReqs as unknown[] : [];
 		for (const request of requests) {
-			if (!request?.response || !Array.isArray(request.response)) { continue; }
-			for (const responseItem of request.response) {
+			const req = request as { response?: unknown[] } | undefined;
+			if (!req?.response || !Array.isArray(req.response)) { continue; }
+			for (const responseItem of req.response) {
 				const subAgent = extractSubAgentData(responseItem);
 				if (subAgent) {
 					if (subAgent.prompt) { totalTokens += estimateTokensFromText(subAgent.prompt); }
@@ -303,7 +333,7 @@ export function estimateTokensFromJsonlSession(fileContent: string): { tokens: n
  * extension host's single-threaded event loop on large files.
  */
 export async function reconstructJsonlStateAsync(lines: string[], yieldInterval = 500): Promise<{ sessionState: any; isDeltaBased: boolean }> {
-	let sessionState: any = {};
+	let sessionState: Record<string, unknown> = {};
 	let isDeltaBased = false;
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
@@ -312,7 +342,7 @@ export async function reconstructJsonlStateAsync(lines: string[], yieldInterval 
 			const delta = JSON.parse(line);
 			if (typeof delta.kind === 'number') {
 				isDeltaBased = true;
-				sessionState = applyDelta(sessionState, delta);
+				sessionState = applyDelta(sessionState, delta) as Record<string, unknown>;
 			}
 		} catch {
 			// Skip invalid lines
@@ -387,13 +417,15 @@ export function buildReasoningEffortTimeline(lines: string[]): {
 
   for (const line of lines) {
     if (!line.trim()) { continue; }
-    let delta: any;
-    try { delta = JSON.parse(line); } catch { continue; }
+    let delta: DeltaEvent;
+    try { delta = JSON.parse(line) as DeltaEvent; } catch { continue; }
     if (typeof delta.kind !== 'number') { continue; }
 
     if (delta.kind === 0) {
       // Initial state: extract model from inputState.selectedModel
-      const model = delta.v?.inputState?.selectedModel;
+      const v = delta.v as Record<string, unknown> | undefined;
+      const inputState = v?.['inputState'] as Record<string, unknown> | undefined;
+      const model = inputState?.['selectedModel'];
       const effort = extractEffortFromModel(model);
       if (effort !== null) {
         currentEffort = effort;
@@ -453,7 +485,7 @@ export function extractPerRequestUsageFromRawLines(lines: string[]): Map<number,
 	return usage;
 }
 
-export function getModelFromRequest(request: any, modelPricing: { [key: string]: ModelPricing } = {}): string {
+export function getModelFromRequest(request: ModelRequestSource, modelPricing: { [key: string]: ModelPricing } = {}): string {
 	// Try to determine model from request metadata (most reliable source)
 	// First check the top-level modelId field (VS Code format)
 	if (request.modelId) {
@@ -531,12 +563,13 @@ export function isUuidPointerFile(content: string): boolean {
  * - k = key path (array of strings)
  * - v = value
  */
-export function applyDelta(state: any, delta: any): any {
+export function applyDelta(state: unknown, delta: unknown): unknown {
 	if (typeof delta !== 'object' || delta === null) {
 		return state;
 	}
 
-	const { kind, k, v } = delta;
+	const d = delta as Record<string, unknown>;
+	const { kind, k, v } = d;
 
 	if (kind === 0) {
 		// Initial state - full replacement
@@ -548,8 +581,8 @@ export function applyDelta(state: any, delta: any): any {
 	}
 
 	const pathArr = k.map(String);
-	let root = typeof state === 'object' && state !== null ? state : {};
-	let current: any = root;
+	let root: Record<string, unknown> | unknown[] = typeof state === 'object' && state !== null ? state as Record<string, unknown> | unknown[] : {};
+	let current: Record<string, unknown> | unknown[] = root;
 
 	// Traverse to the parent of the target location
 	for (let i = 0; i < pathArr.length - 1; i++) {
@@ -562,12 +595,12 @@ export function applyDelta(state: any, delta: any): any {
 			if (!current[idx] || typeof current[idx] !== 'object') {
 				current[idx] = wantsArray ? [] : {};
 			}
-			current = current[idx];
+			current = current[idx] as Record<string, unknown> | unknown[];
 		} else {
 			if (!current[seg] || typeof current[seg] !== 'object') {
 				current[seg] = wantsArray ? [] : {};
 			}
-			current = current[seg];
+			current = current[seg] as Record<string, unknown> | unknown[];
 		}
 	}
 
@@ -585,22 +618,22 @@ export function applyDelta(state: any, delta: any): any {
 
 	if (kind === 2) {
 		// Append value(s) to array at key path
-		let target: any[];
+		let target: unknown[];
 		if (Array.isArray(current)) {
 			const idx = Number(lastSeg);
 			if (!Array.isArray(current[idx])) {
 				current[idx] = [];
 			}
-			target = current[idx];
+			target = current[idx] as unknown[];
 		} else {
 			if (!Array.isArray(current[lastSeg])) {
 				current[lastSeg] = [];
 			}
-			target = current[lastSeg];
+			target = current[lastSeg] as unknown[];
 		}
 
 		if (Array.isArray(v)) {
-			target.push(...v);
+			target.push(...(v as unknown[]));
 		} else {
 			target.push(v);
 		}

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1002,7 +1002,7 @@ export function readClaudeCodeEventsForAnalysis(sessionFilePath: string): any[] 
 	try {
 		const content = fs.readFileSync(sessionFilePath, 'utf8');
 		const lines = content.trim().split('\n');
-		const events: any[] = [];
+		const events: unknown[] = [];
 		for (const line of lines) {
 			if (!line.trim()) { continue; }
 			try { events.push(JSON.parse(line)); } catch { /* skip */ }
@@ -1266,13 +1266,11 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 				for (const line of lines) {
 					try {
 						const delta = JSON.parse(line);
-						sessionState = applyDelta(sessionState, delta);
+						sessionState = applyDelta(sessionState, delta) as DeltaSessionState;
 					} catch {
 						// Skip invalid lines
 					}
 				}
-				
-				// Extract timestamps
 				if (sessionState.creationDate !== undefined) { timestamps.push(sessionState.creationDate); }
 				if (sessionState.lastMessageDate !== undefined) { timestamps.push(sessionState.lastMessageDate); }
 				
@@ -1404,7 +1402,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 				for (const line of lines) {
 					try {
 						const delta = JSON.parse(line);
-						sessionState = applyDelta(sessionState, delta);
+						sessionState = applyDelta(sessionState, delta) as DeltaSessionState;
 					} catch {
 						// Skip invalid lines
 					}
@@ -1715,7 +1713,7 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 					// Detect and reconstruct delta-based format
 					if (typeof event.kind === 'number') {
 						isDeltaBased = true;
-						sessionState = applyDelta(sessionState, event);
+						sessionState = applyDelta(sessionState, event) as DeltaSessionState;
 					}
 
 					// Copilot CLI session.start carries the selected model


### PR DESCRIPTION
## Motivation

The codebase had 40+ `any` type annotations across three core files, reducing type safety and IDE support. This PR replaces them all with proper TypeScript types, `unknown` with explicit casts, and discriminated interfaces -- making the code safer and easier to maintain.

## What changed

### `tokenEstimation.ts`
- Added three interfaces: `ModelRequestSource`, `DeltaEvent`, and `ShutdownModelMetrics`
- `applyDelta`: signature changed from `(any, any): any` to `(unknown, unknown): unknown`; traversal variables typed as `Record<string, unknown> | unknown[]`
- `getModelFromRequest`: parameter typed as `ModelRequestSource` instead of `any`
- `reconstructJsonlStateAsync`: internal `sessionState` changed from `any` to `Record<string, unknown>` (public return type kept as `{ sessionState: any }` to avoid breaking `extension.ts` callers)
- `buildReasoningEffortTimeline`: `let delta: any` replaced with `let delta: DeltaEvent`; nested property access uses explicit intermediate casts

### `sessionParser.ts`
- Added `MessagePart`, `RequestMessage`, `ResponseItem`, `RequestResult`, and `ProcessableRequest` interfaces
- `applyDelta` traversal variables typed as `JsonObject | unknown[]` using the existing `isObject` type guard; all `(x as any).prop` casts replaced with direct indexed access
- `processRequest`: parameter changed from `any` to `unknown` with an internal cast to `ProcessableRequest`
- `sessionJson`: changed from `any` to `unknown` with `isObject` narrowing at access points

### `usageAnalysis.ts`
- Internal `events` variable in `readClaudeCodeEventsForAnalysis` changed from `any[]` to `unknown[]` (public return type kept as `any[]` since adapter callers are out of scope)
- Added `as DeltaSessionState` casts at all three `applyDelta` call sites where the result is assigned to a `DeltaSessionState`-typed variable

## Non-obvious decisions

- **Boundary `any` types preserved**: `reconstructJsonlStateAsync` and `readClaudeCodeEventsForAnalysis` keep `any` in their *public* return types. Changing those would cascade into `extension.ts` and two adapter files that are intentionally out of scope for this refactor.
- **No behavior changes**: All changes are type-only. Runtime logic is identical.

## Verification

All 55 unit tests pass and `tsc --noEmit` reports zero errors.