### PR TITLE
fix(validation): guard JSON.parse null/array roots in sessionParser and workspaceHelpers

### DIFF
--- a/vscode-extension/src/sessionParser.ts
+++ b/vscode-extension/src/sessionParser.ts
@@ -328,6 +328,10 @@ if (!sessionJson) {
 try { sessionJson = JSON.parse(fileContent); } catch { return { tokens: 0, interactions: 0, modelUsage: {}, thinkingTokens: 0, actualTokens: 0 }; }
 }
 
+if (!isObject(sessionJson) || Array.isArray(sessionJson)) {
+return { tokens: 0, interactions: 0, modelUsage: {}, thinkingTokens: 0, actualTokens: 0 };
+}
+
 const requests = Array.isArray(sessionJson.requests) ? sessionJson.requests : (Array.isArray(sessionJson.history) ? sessionJson.history : []);
 interactions = requests.length;
 for (const request of requests) { processRequest(request); }

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -61,9 +61,11 @@ interface CustomizationPatternsConfig {
  */
 // Helper: read a workspaceStorage JSON file and extract a candidate folder path from configured keys
 export function parseWorkspaceStorageJsonFile(jsonPath: string, candidateKeys: string[]): string | undefined {
+	if (typeof jsonPath !== 'string' || !jsonPath || !Array.isArray(candidateKeys)) { return undefined; }
 	try {
 		const raw = fs.readFileSync(jsonPath, 'utf8');
 		const obj = JSON.parse(raw);
+		if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) { return undefined; }
 		for (const key of candidateKeys) {
 			const candidate = obj[key];
 			if (typeof candidate !== 'string') { continue; }

--- a/vscode-extension/test/unit/sessionParser.test.ts
+++ b/vscode-extension/test/unit/sessionParser.test.ts
@@ -302,6 +302,38 @@ test('invalid JSON returns zeros', () => {
 	assert.equal(result.interactions, 0);
 });
 
+// ── Input validation tests ──────────────────────────────────────────────
+
+test('null JSON content returns zeros without throwing (JSON path)', () => {
+	// JSON.parse("null") returns null — accessing .requests on null must not throw
+	const result = parseSessionFileContent('s.json', 'null', estimateTokensByLength);
+	assert.equal(result.tokens, 0);
+	assert.equal(result.interactions, 0);
+	assert.deepEqual(result.modelUsage, {});
+});
+
+test('null JSON content returns zeros without throwing (JSONL fallback path)', () => {
+	// .jsonl file whose content parses to null via the fallback (non-delta) branch
+	const result = parseSessionFileContent('s.jsonl', 'null', estimateTokensByLength);
+	assert.equal(result.tokens, 0);
+	assert.equal(result.interactions, 0);
+	assert.deepEqual(result.modelUsage, {});
+});
+
+test('empty fileContent returns zeros without throwing', () => {
+	const result = parseSessionFileContent('s.json', '', estimateTokensByLength);
+	assert.equal(result.tokens, 0);
+	assert.equal(result.interactions, 0);
+});
+
+test('array root JSON returns zeros without throwing', () => {
+	// An array at the root is not a valid session object
+	const result = parseSessionFileContent('s.json', '[]', estimateTokensByLength);
+	assert.equal(result.tokens, 0);
+	assert.equal(result.interactions, 0);
+	assert.deepEqual(result.modelUsage, {});
+});
+
 test('JSON session: missing model defaults to unknown', () => {
 	const content = JSON.stringify({
 		requests: [

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -611,3 +611,49 @@ assert.equal(opencodeFile?.category, 'non-copilot');
 fs.rmSync(tmpDir, { recursive: true, force: true });
 }
 });
+
+// ---------------------------------------------------------------------------
+// parseWorkspaceStorageJsonFile — input validation
+// ---------------------------------------------------------------------------
+
+import { parseWorkspaceStorageJsonFile } from '../../src/workspaceHelpers';
+
+test('parseWorkspaceStorageJsonFile: returns undefined for null JSON content', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pwsjf-'));
+    try {
+        const tmpFile = nodePath.join(tmpDir, 'workspace.json');
+        fs.writeFileSync(tmpFile, 'null', 'utf8');
+        // JSON.parse("null") returns null — must not throw accessing obj[key]
+        assert.equal(parseWorkspaceStorageJsonFile(tmpFile, ['folder', 'workspace']), undefined);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('parseWorkspaceStorageJsonFile: returns undefined for array JSON content', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pwsjf-'));
+    try {
+        const tmpFile = nodePath.join(tmpDir, 'workspace.json');
+        fs.writeFileSync(tmpFile, '["item1", "item2"]', 'utf8');
+        assert.equal(parseWorkspaceStorageJsonFile(tmpFile, ['folder']), undefined);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('parseWorkspaceStorageJsonFile: returns undefined for empty jsonPath', () => {
+    assert.equal(parseWorkspaceStorageJsonFile('', ['folder']), undefined);
+});
+
+test('parseWorkspaceStorageJsonFile: returns path from valid object', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pwsjf-'));
+    try {
+        const tmpFile = nodePath.join(tmpDir, 'workspace.json');
+        // Use a file:// URI as the value so vscode.Uri.parse can resolve it
+        fs.writeFileSync(tmpFile, JSON.stringify({ folder: 'file:///home/user/myproject' }), 'utf8');
+        const result = parseWorkspaceStorageJsonFile(tmpFile, ['folder']);
+        assert.ok(typeof result === 'string' && result.length > 0, 'should return a non-empty path string');
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Why

`JSON.parse("null")` returns `null` without throwing -- it succeeds but produces a non-object value. In two places in the extension, code then immediately accessed properties on the parsed result without checking whether it was actually an object, which would throw a `TypeError` on any file whose content is the literal string `"null"` (or any other JSON primitive).

## What changed

**`sessionParser.ts`** -- added an `isObject(sessionJson) && !Array.isArray(sessionJson)` guard after both JSON parse paths (`non-delta .jsonl` fallback and standard `.json`). The `isObject` helper was already present in the file; this simply applies it before the `.requests` / `.history` property access.

**`workspaceHelpers.ts` (`parseWorkspaceStorageJsonFile`)** -- added:
- An early return for empty `jsonPath` or a non-array `candidateKeys` argument
- A post-parse check rejecting null, array, and primitive JSON roots before iterating over candidate keys

## Tests (8 new)

`sessionParser.test.ts`:
- `"null"` content on the `.json` path -- no throw, returns zeros
- `"null"` content on the `.jsonl` fallback path -- no throw, returns zeros
- empty file content -- no throw, returns zeros
- `"[]"` array root -- no throw, returns zeros

`workspaceHelpers.test.ts`:
- file containing `"null"` -- returns `undefined`
- file containing `["item1"]` -- returns `undefined`
- empty `jsonPath` -- returns `undefined`
- valid object file -- returns a non-empty path string (positive case)

All 30 test suites pass.