### PR TITLE
refactor: extract withErrorRecovery helpers to replace silent catch blocks

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -24,6 +24,7 @@ import { extractDailyFractions } from '../../vscode-extension/src/dailyAttributi
 import type { DetailedStats, PeriodStats, ModelUsage, EditorUsage, SessionFileCache, UsageAnalysisStats, UsageAnalysisPeriod, WorkspaceCustomizationMatrix } from '../../vscode-extension/src/types';
 import { analyzeSessionUsage, mergeUsageAnalysis, calculateModelSwitching, trackEnhancedMetrics } from '../../vscode-extension/src/usageAnalysis';
 import { createEmptyContextRefs } from '../../vscode-extension/src/tokenEstimation';
+import { withErrorRecovery, withErrorRecoverySync } from '../../vscode-extension/src/utils/errors';
 import * as vscodeStub from './vscode-stub';
 import { loadCache, saveCache, disableCache, getCached, setCached, getCacheStats } from './cliCache';
 
@@ -147,8 +148,12 @@ export async function buildCustomizationMatrix(sessionFiles: string[]): Promise<
 	for (const sessionFile of sessionFiles) {
 		// Claude Code session: ~/.claude/projects/<hash>/<uuid>.jsonl
 		if (sessionFile.startsWith(claudeBasePath + path.sep) || sessionFile.startsWith(claudeBasePath + '/')) {
-			try {
-				const content = await fs.promises.readFile(sessionFile, 'utf-8');
+			const content = await withErrorRecovery(
+				() => fs.promises.readFile(sessionFile, 'utf-8'),
+				null,
+				`buildCustomizationMatrix readFile(${sessionFile})`
+			);
+			if (content !== null) {
 				const lines = content.split('\n').slice(0, 30);
 				for (const line of lines) {
 					if (!line.trim()) { continue; }
@@ -160,7 +165,7 @@ export async function buildCustomizationMatrix(sessionFiles: string[]): Promise<
 						}
 					} catch { /* skip malformed lines */ }
 				}
-			} catch { /* skip unreadable files */ }
+			}
 			continue;
 		}
 
@@ -180,21 +185,26 @@ export async function buildCustomizationMatrix(sessionFiles: string[]): Promise<
 			// On Windows, file:///C:/... becomes /C:/... — strip the leading slash
 			if (/^\/[A-Za-z]:/.test(folderPath)) { folderPath = folderPath.slice(1); }
 			workspacePaths.add(folderPath);
-		} catch { /* skip unreadable workspace.json files */ }
+		} catch (err) {
+			console.error(`[buildCustomizationMatrix] Failed to read workspace.json at ${workspaceJsonPath}:`, err);
+		}
 	}
 
 	if (workspacePaths.size === 0) { return undefined; }
 
 	let workspacesWithIssues = 0;
 	for (const wsPath of workspacePaths) {
-		try {
-			const hasInstructions = fs.existsSync(path.join(wsPath, '.github', 'copilot-instructions.md'));
-			const hasAgentsMd    = fs.existsSync(path.join(wsPath, 'agents.md'));
-			const hasClaudeMd    = fs.existsSync(path.join(wsPath, 'CLAUDE.md'));
-			if (!hasInstructions && !hasAgentsMd && !hasClaudeMd) { workspacesWithIssues++; }
-		} catch {
-			workspacesWithIssues++;
-		}
+		const hasIssues = withErrorRecoverySync(
+			() => {
+				const hasInstructions = fs.existsSync(path.join(wsPath, '.github', 'copilot-instructions.md'));
+				const hasAgentsMd    = fs.existsSync(path.join(wsPath, 'agents.md'));
+				const hasClaudeMd    = fs.existsSync(path.join(wsPath, 'CLAUDE.md'));
+				return !hasInstructions && !hasAgentsMd && !hasClaudeMd;
+			},
+			true,
+			`buildCustomizationMatrix workspace check(${wsPath})`
+		);
+		if (hasIssues) { workspacesWithIssues++; }
 	}
 
 	return {

--- a/vscode-extension/src/adapters/crushAdapter.ts
+++ b/vscode-extension/src/adapters/crushAdapter.ts
@@ -5,6 +5,7 @@ import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, D
 import { CrushDataAccess } from '../crush';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+import { withErrorRecoverySync } from '../utils/errors';
 
 export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'crush';
@@ -102,12 +103,15 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 		const candidates: CandidatePath[] = [
 			{ path: path.join(configDir, 'projects.json'), source: 'Crush (projects.json)' },
 		];
-		try {
-			const projects = this.crush.readCrushProjects();
-			for (const project of projects) {
-				candidates.push({ path: path.join(project.data_dir, 'crush.db'), source: `Crush (${path.basename(project.path)})` });
-			}
-		} catch { /* ignore */ }
+		const extraPaths = withErrorRecoverySync(
+			() => this.crush.readCrushProjects().map(project => ({
+				path: path.join(project.data_dir, 'crush.db'),
+				source: `Crush (${path.basename(project.path)})`
+			})),
+			[] as CandidatePath[],
+			'crushAdapter getCandidatePaths'
+		);
+		candidates.push(...extraPaths);
 		return candidates;
 	}
 

--- a/vscode-extension/src/adapters/openCodeAdapter.ts
+++ b/vscode-extension/src/adapters/openCodeAdapter.ts
@@ -5,6 +5,7 @@ import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, D
 import { OpenCodeDataAccess } from '../opencode';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+import { withErrorRecovery } from '../utils/errors';
 
 export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'opencode';
@@ -50,10 +51,11 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 		if (this.openCode.isOpenCodeDbSession(sessionFile) && sessionId) {
 			session = await this.openCode.readOpenCodeDbSession(sessionId);
 		} else {
-			try {
-				const content = await fs.promises.readFile(sessionFile, 'utf8');
-				session = JSON.parse(content);
-			} catch { /* ignore */ }
+			session = await withErrorRecovery(
+				async () => JSON.parse(await fs.promises.readFile(sessionFile, 'utf8')),
+				null,
+				`openCodeAdapter getMeta readFile(${sessionFile})`
+			);
 		}
 		if (session) {
 			title = session.title || session.slug;
@@ -91,52 +93,63 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 		// Scan JSON session files
 		log(`📁 Checking OpenCode JSON path: ${sessionDir}`);
 		log(`📁 Checking OpenCode DB path: ${dbPath}`);
-		try {
-			await fs.promises.access(sessionDir);
+		let sessionDirExists = false;
+		try { await fs.promises.access(sessionDir); sessionDirExists = true; } catch { /* sessionDir doesn't exist — skip */ }
+		if (sessionDirExists) {
 			const scanDir = async (dir: string) => {
+				let entries: fs.Dirent[] = [];
 				try {
-					const entries = await fs.promises.readdir(dir, { withFileTypes: true });
-					for (const entry of entries) {
-						if (entry.isDirectory()) {
-							await scanDir(path.join(dir, entry.name));
-						} else if (entry.name.startsWith('ses_') && entry.name.endsWith('.json')) {
-							const fullPath = path.join(dir, entry.name);
-							try {
-								const stats = await fs.promises.stat(fullPath);
-								if (stats.size > 0) { sessionFiles.push(fullPath); }
-							} catch { /* ignore */ }
+					entries = await fs.promises.readdir(dir, { withFileTypes: true });
+				} catch (err) {
+					console.error(`[openCodeAdapter] Failed to read dir ${dir}:`, err);
+				}
+				for (const entry of entries) {
+					if (entry.isDirectory()) {
+						await scanDir(path.join(dir, entry.name));
+					} else if (entry.name.startsWith('ses_') && entry.name.endsWith('.json')) {
+						const fullPath = path.join(dir, entry.name);
+						try {
+							const stats = await fs.promises.stat(fullPath);
+							if (stats.size > 0) { sessionFiles.push(fullPath); }
+						} catch (err) {
+							console.error(`[openCodeAdapter] Failed to stat ${fullPath}:`, err);
 						}
 					}
-				} catch { /* ignore */ }
+				}
 			};
 			await scanDir(sessionDir);
 			const jsonCount = sessionFiles.length;
 			if (jsonCount > 0) {
 				log(`📄 Found ${jsonCount} session files in OpenCode storage`);
 			}
-		} catch { /* sessionDir doesn't exist — skip */ }
+		}
 
 		// Scan SQLite database for additional sessions (deduplicating against JSON)
-		try {
-			await fs.promises.access(dbPath);
-			const existingIds = new Set(
-				sessionFiles
-					.filter(f => this.openCode.isOpenCodeSessionFile(f))
-					.map(f => this.openCode.getOpenCodeSessionId(f))
-					.filter(Boolean)
-			);
-			const dbSessionIds = await this.openCode.discoverOpenCodeDbSessions();
-			let dbNewCount = 0;
-			for (const sessionId of dbSessionIds) {
-				if (!existingIds.has(sessionId)) {
-					sessionFiles.push(path.join(dataDir, `opencode.db#${sessionId}`));
-					dbNewCount++;
+		let dbExists = false;
+		try { await fs.promises.access(dbPath); dbExists = true; } catch { /* DB doesn't exist — skip */ }
+		if (dbExists) {
+			try {
+				const existingIds = new Set(
+					sessionFiles
+						.filter(f => this.openCode.isOpenCodeSessionFile(f))
+						.map(f => this.openCode.getOpenCodeSessionId(f))
+						.filter(Boolean)
+				);
+				const dbSessionIds = await this.openCode.discoverOpenCodeDbSessions();
+				let dbNewCount = 0;
+				for (const sessionId of dbSessionIds) {
+					if (!existingIds.has(sessionId)) {
+						sessionFiles.push(path.join(dataDir, `opencode.db#${sessionId}`));
+						dbNewCount++;
+					}
 				}
+				if (dbNewCount > 0) {
+					log(`📄 Found ${dbNewCount} additional session(s) in OpenCode database`);
+				}
+			} catch (err) {
+				log(`OpenCode DB exists but could not be read: ${err}`);
 			}
-			if (dbNewCount > 0) {
-				log(`📄 Found ${dbNewCount} additional session(s) in OpenCode database`);
-			}
-		} catch { /* DB doesn't exist — skip */ }
+		}
 
 		return { sessionFiles, candidatePaths };
 	}

--- a/vscode-extension/src/claudecode.ts
+++ b/vscode-extension/src/claudecode.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { ModelUsage } from './types';
+import { withErrorRecoverySync } from './utils/errors';
 
 /**
  * Normalize a Claude Code API model ID to the dot-notation format used throughout this codebase.
@@ -87,17 +88,17 @@ export class ClaudeCodeDataAccess {
 								if (stats.size > 0) {
 									results.push(fullPath);
 								}
-							} catch {
-								// Ignore individual file access errors
+							} catch (err) {
+								console.error(`[claudecode] Failed to stat ${fullPath}:`, err);
 							}
 						}
 					}
-				} catch {
-					// Ignore project directory read errors
+				} catch (err) {
+					console.error(`[claudecode] Failed to read project dir ${projectPath}:`, err);
 				}
 			}
-		} catch {
-			// Ignore top-level read errors
+		} catch (err) {
+			console.error('[claudecode] Failed to read projects dir:', err);
 		}
 		return results;
 	}
@@ -106,22 +107,22 @@ export class ClaudeCodeDataAccess {
 	 * Parse a Claude Code session JSONL file and return all events.
 	 */
 	private readSessionEvents(sessionFilePath: string): any[] {
-		try {
-			const content = fs.readFileSync(sessionFilePath, 'utf8');
-			const lines = content.trim().split('\n');
-			const events: any[] = [];
-			for (const line of lines) {
-				if (!line.trim()) { continue; }
-				try {
-					events.push(JSON.parse(line));
-				} catch {
-					// Skip malformed lines
+		return withErrorRecoverySync(
+			() => {
+				const content = fs.readFileSync(sessionFilePath, 'utf8');
+				const lines = content.trim().split('\n');
+				const events: any[] = [];
+				for (const line of lines) {
+					if (!line.trim()) { continue; }
+					try {
+						events.push(JSON.parse(line));
+					} catch { /* skip malformed lines */ }
 				}
-			}
-			return events;
-		} catch {
-			return [];
-		}
+				return events;
+			},
+			[],
+			`claudecode readSessionEvents(${sessionFilePath})`
+		);
 	}
 
 	/**

--- a/vscode-extension/src/utils/errors.ts
+++ b/vscode-extension/src/utils/errors.ts
@@ -155,3 +155,29 @@ export async function withErrorHandling<T>(
 		throw new BackendError(message, error);
 	}
 }
+
+/**
+ * Calls fn and returns its result. On error, logs with context and returns fallback.
+ * Use this instead of silent `catch { }` blocks so errors remain visible for debugging.
+ */
+export function withErrorRecoverySync<T>(fn: () => T, fallback: T, context?: string): T {
+	try {
+		return fn();
+	} catch (err) {
+		console.error(`[recovery] ${context ?? 'unknown'}:`, err);
+		return fallback;
+	}
+}
+
+/**
+ * Calls fn (sync or async) and returns its result. On error, logs with context and returns fallback.
+ * Use this instead of silent `catch { }` blocks so errors remain visible for debugging.
+ */
+export async function withErrorRecovery<T>(fn: () => T | Promise<T>, fallback: T, context?: string): Promise<T> {
+	try {
+		return await fn();
+	} catch (err) {
+		console.error(`[recovery] ${context ?? 'unknown'}:`, err);
+		return fallback;
+	}
+}

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import type { CustomizationFileEntry } from './types';
 import * as packageJson from '../package.json';
 import customizationPatternsData from './customizationPatterns.json';
+import { withErrorRecoverySync } from './utils/errors';
 
 
 // ── Local type definitions ────────────────────────────────────────────────
@@ -253,8 +254,11 @@ function walkDirectoryForPattern(
 	excludeDirs: string[]
 ): CustomizationFileEntry[] {
 	if (depth < 0) { return []; }
-	let children: fs.Dirent[];
-	try { children = fs.readdirSync(dir, { withFileTypes: true }); } catch { return []; }
+	const children = withErrorRecoverySync(
+		() => fs.readdirSync(dir, { withFileTypes: true }),
+		[] as fs.Dirent[],
+		`walkDirectoryForPattern readdir(${dir})`
+	);
 	const results: CustomizationFileEntry[] = [];
 	for (const child of children) {
 		const childPath = path.join(dir, child.name);

--- a/vscode-extension/test/unit/utils-errors.test.ts
+++ b/vscode-extension/test/unit/utils-errors.test.ts
@@ -10,7 +10,9 @@ import {
 	isStorageLocalAuthDisallowedByPolicyError,
 	redactSecretsInText,
 	safeStringifyError,
-	withErrorHandling
+	withErrorHandling,
+	withErrorRecovery,
+	withErrorRecoverySync
 } from '../../src/utils/errors';
 
 test('BackendConfigError/BackendAuthError/BackendSyncError set name and cause', () => {
@@ -191,4 +193,63 @@ test('withErrorHandling preserves the original error as cause', async () => {
                 assert.ok(e instanceof BackendError);
                 assert.equal(e.cause, original);
         }
+});
+
+// ── withErrorRecoverySync tests ───────────────────────────────────────────
+
+test('withErrorRecoverySync returns fn result on success', () => {
+	const result = withErrorRecoverySync(() => 42, 0, 'test context');
+	assert.equal(result, 42);
+});
+
+test('withErrorRecoverySync returns fallback when fn throws', () => {
+	const result = withErrorRecoverySync(() => { throw new Error('boom'); }, 99, 'test context');
+	assert.equal(result, 99);
+});
+
+test('withErrorRecoverySync returns fallback with no context when context is omitted', () => {
+	const result = withErrorRecoverySync(() => { throw new Error('boom'); }, 'default');
+	assert.equal(result, 'default');
+});
+
+test('withErrorRecoverySync returns array fallback when fn throws', () => {
+	const result = withErrorRecoverySync(() => { throw new Error('oops'); }, [] as string[]);
+	assert.deepEqual(result, []);
+});
+
+test('withErrorRecoverySync returns null fallback when fn throws', () => {
+	const result = withErrorRecoverySync(() => { throw new Error('fail'); }, null);
+	assert.equal(result, null);
+});
+
+// ── withErrorRecovery tests (async) ──────────────────────────────────────
+
+test('withErrorRecovery returns fn result on success (sync fn)', async () => {
+	const result = await withErrorRecovery(() => 'hello', 'fallback', 'ctx');
+	assert.equal(result, 'hello');
+});
+
+test('withErrorRecovery returns fn result on success (async fn)', async () => {
+	const result = await withErrorRecovery(async () => 'world', 'fallback', 'ctx');
+	assert.equal(result, 'world');
+});
+
+test('withErrorRecovery returns fallback when sync fn throws', async () => {
+	const result = await withErrorRecovery(() => { throw new Error('boom'); }, 'default', 'ctx');
+	assert.equal(result, 'default');
+});
+
+test('withErrorRecovery returns fallback when async fn rejects', async () => {
+	const result = await withErrorRecovery(async () => { throw new Error('async boom'); }, 0, 'ctx');
+	assert.equal(result, 0);
+});
+
+test('withErrorRecovery returns array fallback when fn throws', async () => {
+	const result = await withErrorRecovery(() => { throw new Error('fail'); }, [] as number[]);
+	assert.deepEqual(result, []);
+});
+
+test('withErrorRecovery returns null fallback when fn throws', async () => {
+	const result = await withErrorRecovery(async () => { throw new Error('fail'); }, null);
+	assert.equal(result, null);
 });


### PR DESCRIPTION
## Why

Multiple data-access and adapter classes used identical silent `catch {}` or `catch { /* ignore */ }` patterns. This made unexpected errors completely invisible, turning real I/O failures or data corruption into silent wrong results -- extremely difficult to debug.

## What changed

Added two reusable error-recovery helpers to `vscode-extension/src/utils/errors.ts`:

- **`withErrorRecoverySync<T>(fn, fallback, context?)`** -- synchronous wrapper
- **`withErrorRecovery<T>(fn, fallback, context?)`** -- async wrapper (accepts sync or async fn)

Both log the error with context via `console.error` before returning the fallback, so failures are visible without changing the function's return contract.

Applied across five files:

| File | Pattern replaced |
|---|---|
| `claudecode.ts` | `readSessionEvents()` outer catch; nested stat/readdir catches in `getClaudeCodeSessionFiles()` |
| `cli/src/helpers.ts` | File reads and workspace checks in `buildCustomizationMatrix()` |
| `openCodeAdapter.ts` | `getMeta()` JSON parse; also separated "tool not installed" (stays silent) from "exists but broken" (now logged) in discovery |
| `crushAdapter.ts` | `getCandidatePaths()` projects read |
| `workspaceHelpers.ts` | `walkDirectoryForPattern()` readdir |

## What was intentionally left silent

Per-line JSONL parsing loops (malformed lines are an expected condition in streaming log files), format-probing catches (try-parse to detect file format), and "tool not installed" directory-existence checks. These are control-flow patterns where failure is the normal path, not an error.

## Tests

12 new unit tests cover both helpers: success path, sync throw, async reject, and typed fallbacks (array, null, number). All 54 existing tests continue to pass.