### PR TITLE
refactor: replace \s any\ type casts in CLI helpers with proper types

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -56,8 +56,8 @@ function getEcosystems(): IEcosystemAdapter[] {
 	if (_ecosystems) { return _ecosystems; }
 	const fakeUri = vscodeStub.Uri.file(__dirname);
 	_ecosystems = buildAdapterRegistry({
-		openCode: new OpenCodeDataAccess(fakeUri as any),
-		crush: new CrushDataAccess(fakeUri as any),
+		openCode: new OpenCodeDataAccess(fakeUri),
+		crush: new CrushDataAccess(fakeUri),
 		continue_: new ContinueDataAccess(),
 		visualStudio: new VisualStudioDataAccess(),
 		claudeCode: new ClaudeCodeDataAccess(),

--- a/vscode-extension/src/crush.ts
+++ b/vscode-extension/src/crush.ts
@@ -12,9 +12,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import * as vscode from 'vscode';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
+import type { UriLike } from './opencode';
 
 type CrushDbCacheEntry = { db: any; mtimeMs: number; size: number };
 
@@ -29,9 +29,9 @@ export class CrushDataAccess {
 	private _sqlJsInitPromise: Promise<any> | null = null;
 	private _dbCache: Map<string, CrushDbCacheEntry> = new Map();
 	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
-	private readonly extensionUri: vscode.Uri;
+	private readonly extensionUri: UriLike;
 
-	constructor(extensionUri: vscode.Uri) {
+	constructor(extensionUri: UriLike) {
 		this.extensionUri = extensionUri;
 	}
 

--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -5,10 +5,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import * as vscode from 'vscode';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import { normalizePathForComparison } from './workspaceHelpers';
+
+/** Minimal URI interface required by OpenCodeDataAccess (subset of vscode.Uri). */
+export interface UriLike {
+	readonly fsPath: string;
+	readonly path: string;
+	readonly scheme: string;
+}
 
 type OpenCodeDbCache = { db: any; mtimeMs: number; size: number; path: string };
 type OpenCodeModelUsageWithInteractions = {
@@ -20,9 +26,9 @@ export class OpenCodeDataAccess {
 	private _sqlJsInitPromise: Promise<any> | null = null;
 	private _dbCache: OpenCodeDbCache | null = null;
 	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
-	private readonly extensionUri: vscode.Uri;
+	private readonly extensionUri: UriLike;
 
-	constructor(extensionUri: vscode.Uri) {
+	constructor(extensionUri: UriLike) {
 		this.extensionUri = extensionUri;
 	}
 

--- a/vscode-extension/test/unit/crush-cache.test.ts
+++ b/vscode-extension/test/unit/crush-cache.test.ts
@@ -85,7 +85,7 @@ function createHarness(options: HarnessOptions = {}) {
 		}
 	}
 
-	const access = new CrushDataAccess(null as any);
+	const access = new CrushDataAccess({ fsPath: '', path: '', scheme: 'file' });
 	(access as any).initSqlJs = async () => {
 		initCalls++;
 		if (options.delayInit) {

--- a/vscode-extension/test/unit/opencode-cache.test.ts
+++ b/vscode-extension/test/unit/opencode-cache.test.ts
@@ -77,7 +77,7 @@ function createHarness(options: HarnessOptions = {}) {
 		}
 	}
 
-	const access = new OpenCodeDataAccess(null as any);
+	const access = new OpenCodeDataAccess({ fsPath: '', path: '', scheme: 'file' });
 	(access as any).getOpenCodeDataDir = () => tmpDir;
 	(access as any).initSqlJs = async () => {
 		initCalls++;


### PR DESCRIPTION
## Summary

Replaces \s any\ type casts used when constructing \OpenCodeDataAccess\ and \CrushDataAccess\ in \cli/src/helpers.ts\.

## Changes

- **\scode-extension/src/opencode.ts\** — Added exported \UriLike\ interface (\sPath\, \path\, \scheme\); constructor now accepts \UriLike\ instead of \scode.Uri\; removed \scode\ import
- **\scode-extension/src/crush.ts\** — Imports and uses \UriLike\ from \opencode.ts\; removed \scode\ import
- **\cli/src/helpers.ts\** — Removed \s any\ casts (lines 59–60); \scodeStub.Uri\ now satisfies \UriLike\ directly
- **\scode-extension/test/unit/opencode-cache.test.ts\** — Replaced \
ull as any\ with a proper \UriLike\ object
- **\scode-extension/test/unit/crush-cache.test.ts\** — Same fix

## Verification

- CLI build passes (\
pm run build\ from \cli/\)
- \	sc --noEmit\ passes for \scode-extension\
- All 14 opencode + crush cache unit tests pass