### PR TITLE
refactor: externalize hardcoded GitHub API endpoints and headers to named constants

### DIFF
--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -1,4 +1,5 @@
 import * as https from 'https';
+import { GITHUB_API_HOSTNAME, buildGitHubApiHeaders } from './githubApiConfig';
 
 export type AgentSessionSource = 'cloud-agent' | 'cli-remote' | 'unknown';
 
@@ -89,14 +90,9 @@ export function fetchAgentTasksPage(
 
 		const req = https.request(
 			{
-				hostname: 'api.github.com',
+				hostname: GITHUB_API_HOSTNAME,
 				path: `/agents/repos/${owner}/${repo}/tasks?${queryParams}`,
-				headers: {
-					Authorization: `Bearer ${token}`,
-					'User-Agent': 'copilot-token-tracker',
-					Accept: 'application/vnd.github.v3+json',
-					'X-GitHub-Api-Version': '2022-11-28',
-				},
+				headers: buildGitHubApiHeaders(token),
 			},
 			(res) => {
 				let data = '';
@@ -135,14 +131,9 @@ export function fetchAgentTaskDetail(
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: 'api.github.com',
+				hostname: GITHUB_API_HOSTNAME,
 				path: `/agents/repos/${owner}/${repo}/tasks/${encodeURIComponent(taskId)}`,
-				headers: {
-					Authorization: `Bearer ${token}`,
-					'User-Agent': 'copilot-token-tracker',
-					Accept: 'application/vnd.github.v3+json',
-					'X-GitHub-Api-Version': '2022-11-28',
-				},
+				headers: buildGitHubApiHeaders(token),
 			},
 			(res) => {
 				let data = '';

--- a/vscode-extension/src/githubApiConfig.ts
+++ b/vscode-extension/src/githubApiConfig.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared configuration constants for GitHub REST API requests.
+ * Used by agentSessionsService.ts and githubPrService.ts.
+ */
+
+/** GitHub REST API hostname. */
+export const GITHUB_API_HOSTNAME = 'api.github.com';
+
+/** User-Agent header value sent with all GitHub API requests. */
+export const GITHUB_API_USER_AGENT = 'copilot-token-tracker';
+
+/** Accept header for standard GitHub REST API v3 JSON responses. */
+export const GITHUB_API_ACCEPT_V3 = 'application/vnd.github.v3+json';
+
+/** GitHub API version header value (required by the agent/copilot endpoints). */
+export const GITHUB_API_VERSION = '2022-11-28';
+
+/**
+ * Build standard headers for a GitHub REST API request that requires the
+ * versioned agent endpoints (includes X-GitHub-Api-Version).
+ */
+export function buildGitHubApiHeaders(token: string): Record<string, string> {
+	return {
+		Authorization: `Bearer ${token}`,
+		'User-Agent': GITHUB_API_USER_AGENT,
+		Accept: GITHUB_API_ACCEPT_V3,
+		'X-GitHub-Api-Version': GITHUB_API_VERSION,
+	};
+}

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -1,5 +1,6 @@
 import * as https from 'https';
 import * as childProcess from 'child_process';
+import { GITHUB_API_HOSTNAME, GITHUB_API_USER_AGENT, GITHUB_API_ACCEPT_V3 } from './githubApiConfig';
 
 export type RepoPrDetail = {
 	number: number;
@@ -47,11 +48,11 @@ function fetchCopilotPlanInfoPage(token: string): Promise<CopilotPlanResult> {
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: 'api.github.com',
+				hostname: GITHUB_API_HOSTNAME,
 				path: '/copilot_internal/user',
 				headers: {
 					Authorization: `Bearer ${token}`,
-					'User-Agent': 'copilot-token-tracker',
+					'User-Agent': GITHUB_API_USER_AGENT,
 					Accept: 'application/json',
 				},
 			},
@@ -117,12 +118,12 @@ export function fetchRepoPrsPage(
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: 'api.github.com',
+				hostname: GITHUB_API_HOSTNAME,
 				path: `/repos/${owner}/${repo}/pulls?state=all&per_page=100&sort=created&direction=desc&page=${page}`,
 				headers: {
 					Authorization: `Bearer ${token}`,
-					'User-Agent': 'copilot-token-tracker',
-					Accept: 'application/vnd.github.v3+json',
+					'User-Agent': GITHUB_API_USER_AGENT,
+					Accept: GITHUB_API_ACCEPT_V3,
 				},
 			},
 			(res) => {


### PR DESCRIPTION
## Summary

Extract hardcoded HTTP configuration values from \gentSessionsService.ts\ and \githubPrService.ts\ into a new shared module \scode-extension/src/githubApiConfig.ts\.

## Changes

### New file: \scode-extension/src/githubApiConfig.ts\
- \GITHUB_API_HOSTNAME\ — \'api.github.com'\
- \GITHUB_API_USER_AGENT\ — \'copilot-token-tracker'\
- \GITHUB_API_ACCEPT_V3\ — \'application/vnd.github.v3+json'\
- \GITHUB_API_VERSION\ — \'2022-11-28'\
- \uildGitHubApiHeaders(token)\ — helper that builds the versioned-endpoint headers object

### Updated: \scode-extension/src/agentSessionsService.ts\
Uses \GITHUB_API_HOSTNAME\ and \uildGitHubApiHeaders()\ — eliminates two duplicate inline header objects.

### Updated: \scode-extension/src/githubPrService.ts\
Uses shared constants for hostname and user-agent (Accept values kept as-is since they differ per endpoint).

## Verification
- \	sc --noEmit\ passes with no errors
- All 58 unit tests pass (\
pm run test:node\)