### PR TITLE
refactor: centralize sharing-server rate limit and cache config into config.ts

### DIFF
--- a/sharing-server/src/auth.ts
+++ b/sharing-server/src/auth.ts
@@ -1,8 +1,14 @@
 import { createHash } from 'crypto';
 import type { Context, Next } from 'hono';
 import { upsertUser, type UserRow } from './db.js';
-
-const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+import {
+	TOKEN_CACHE_TTL_MS,
+	NEGATIVE_CACHE_TTL_MS,
+	UPLOAD_RATE_MAX,
+	UPLOAD_RATE_WINDOW_MS,
+	IP_RATE_MAX,
+	IP_RATE_WINDOW_MS,
+} from './config.js';
 
 interface CachedAuth {
 	user: UserRow;
@@ -18,17 +24,12 @@ const tokenCache = new Map<string, CachedAuth>();
 
 // Negative cache: SHA-256(token) → bannedUntil timestamp (short TTL for bad tokens)
 const negativeCache = new Map<string, NegativeCacheEntry>();
-const NEGATIVE_TTL_MS = 60 * 1000; // 1 minute
 
 // Upload rate limiter: github_id → { count, resetAt }
 const uploadRateMap = new Map<number, { count: number; resetAt: number }>();
-const UPLOAD_RATE_MAX = 100;
-const UPLOAD_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour per user
 
 // Pre-auth IP rate limiter: IP → { count, resetAt }
 const ipRateMap = new Map<string, { count: number; resetAt: number }>();
-const IP_RATE_MAX = 200;
-const IP_RATE_WINDOW_MS = 60 * 1000; // 1 minute per IP
 
 /**
  * Validates a GitHub Bearer token supplied by the client (e.g. the VS Code extension).
@@ -69,7 +70,7 @@ export async function validateGitHubToken(token: string): Promise<UserRow | null
 	}
 
 	if (!response.ok) {
-		negativeCache.set(cacheKey, { bannedUntil: Date.now() + NEGATIVE_TTL_MS });
+		negativeCache.set(cacheKey, { bannedUntil: Date.now() + NEGATIVE_CACHE_TTL_MS });
 		return null;
 	}
 
@@ -80,14 +81,14 @@ export async function validateGitHubToken(token: string): Promise<UserRow | null
 	if (allowedOrg) {
 		const isMember = await checkOrgMembership(token, data.login, allowedOrg);
 		if (!isMember) {
-			negativeCache.set(cacheKey, { bannedUntil: Date.now() + NEGATIVE_TTL_MS });
+			negativeCache.set(cacheKey, { bannedUntil: Date.now() + NEGATIVE_CACHE_TTL_MS });
 			return null;
 		}
 	}
 
 	const user = upsertUser(data.id, data.login, data.name, data.avatar_url);
 
-	tokenCache.set(cacheKey, { user, expiresAt: Date.now() + CACHE_TTL_MS });
+	tokenCache.set(cacheKey, { user, expiresAt: Date.now() + TOKEN_CACHE_TTL_MS });
 	return user;
 }
 

--- a/sharing-server/src/config.ts
+++ b/sharing-server/src/config.ts
@@ -1,0 +1,59 @@
+/**
+ * Centralized configuration constants for the sharing server.
+ * Centralizes rate limits, cache TTLs, and other tunable parameters
+ * so they can be adjusted in one place for deployment flexibility.
+ */
+
+// ── Auth / Token Cache ────────────────────────────────────────────────────────
+
+/** How long (ms) a successfully validated GitHub token is cached. */
+export const TOKEN_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/** How long (ms) an invalid/rejected token is cached (negative cache). */
+export const NEGATIVE_CACHE_TTL_MS = 60 * 1000; // 1 minute
+
+// ── Rate Limits ───────────────────────────────────────────────────────────────
+
+/** Maximum upload requests allowed per user per UPLOAD_RATE_WINDOW_MS. */
+export const UPLOAD_RATE_MAX = 100;
+
+/** Duration (ms) of the per-user upload rate limit window. */
+export const UPLOAD_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+/** Maximum requests allowed per IP per IP_RATE_WINDOW_MS (pre-auth). */
+export const IP_RATE_MAX = 200;
+
+/** Duration (ms) of the per-IP rate limit window. */
+export const IP_RATE_WINDOW_MS = 60 * 1000; // 1 minute
+
+// ── Session / OAuth ───────────────────────────────────────────────────────────
+
+/** How long (seconds) a session cookie remains valid. */
+export const SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+/** Max age (seconds) for the OAuth state CSRF cookie. */
+export const OAUTH_STATE_MAX_AGE_SECONDS = 300; // 5 minutes
+
+// ── API Validation ────────────────────────────────────────────────────────────
+
+/** Maximum field lengths for upload entry string fields. */
+export const MAX_STRING_LENGTHS = {
+	model: 128,
+	workspaceId: 256,
+	workspaceName: 256,
+	machineId: 256,
+	machineName: 256,
+	datasetId: 128,
+	editor: 100,
+} as const;
+
+/** Maximum allowed value for token counts per upload entry. */
+export const MAX_TOKEN_VALUE = 2_000_000_000; // 2B tokens — large agent sessions can exceed 100M in one day
+
+/** Maximum number of entries allowed in a single upload request. */
+export const MAX_ENTRIES_PER_UPLOAD = 500;
+
+// ── Database / Backup ─────────────────────────────────────────────────────────
+
+/** How often (ms) the database is backed up to Azure Files. */
+export const BACKUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -1,18 +1,7 @@
 import { Hono } from 'hono';
 import { requireBearerAuth, checkUploadRateLimit, type AuthVariables } from '../auth.js';
 import { upsertUpload, deleteUploadsForDays, getUploadsForUser, getDb, upsertUserFluencyScore, type UploadEntry } from '../db.js';
-
-const MAX_STRING_LENGTHS = {
-	model: 128,
-	workspaceId: 256,
-	workspaceName: 256,
-	machineId: 256,
-	machineName: 256,
-	datasetId: 128,
-	editor: 100,
-};
-const MAX_TOKEN_VALUE = 2_000_000_000; // 2B tokens — large agent sessions can exceed 100M in one day
-const MAX_ENTRIES_PER_UPLOAD = 500;
+import { MAX_STRING_LENGTHS, MAX_TOKEN_VALUE, MAX_ENTRIES_PER_UPLOAD } from '../config.js';
 
 export const api = new Hono<{ Variables: AuthVariables }>();
 

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -11,6 +11,7 @@ import {
 	getAdminUserSummaries, getAdminDailyTotals,
 	type UploadRow, type UserRow, type UserUsageSummary, type AdminDailyRow,
 } from '../db.js';
+import { OAUTH_STATE_MAX_AGE_SECONDS } from '../config.js';
 export const dashboard = new Hono();
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID ?? '';
@@ -50,7 +51,7 @@ dashboard.get('/auth/github', (c) => {
 		httpOnly: true,
 		secure: process.env.NODE_ENV === 'production',
 		sameSite: 'Lax',
-		maxAge: 300, // 5 minutes
+		maxAge: OAUTH_STATE_MAX_AGE_SECONDS,
 		path: '/',
 	});
 	return c.redirect(`https://github.com/login/oauth/authorize?${params}`);

--- a/sharing-server/src/server.ts
+++ b/sharing-server/src/server.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { api } from './routes/api.js';
 import { dashboard } from './routes/dashboard.js';
 import { getDb, closeDb, restoreFromBackup, backupToAzureFiles, syncAdminLogins } from './db.js';
+import { BACKUP_INTERVAL_MS } from './config.js';
 
 const app = new Hono();
 
@@ -72,7 +73,7 @@ async function main(): Promise<void> {
 	await initDbWithRetry();
 	syncAdminLogins();
 	// Periodic backup every 5 minutes in case of unexpected SIGKILL.
-	setInterval(() => backupToAzureFiles(), 5 * 60 * 1000).unref();
+	setInterval(() => backupToAzureFiles(), BACKUP_INTERVAL_MS).unref();
 
 	const org = process.env.ALLOWED_GITHUB_ORG;
 	const adminLogins = process.env.ADMIN_GITHUB_LOGINS;

--- a/sharing-server/src/session.ts
+++ b/sharing-server/src/session.ts
@@ -1,9 +1,9 @@
 import { createHmac, timingSafeEqual } from 'crypto';
+import { SESSION_MAX_AGE_SECONDS } from './config.js';
 
 const SESSION_SECRET = process.env.SESSION_SECRET ?? 'dev-secret-change-me-in-production';
 export const COOKIE_NAME = 'sharing-session';
 export const OAUTH_STATE_COOKIE = 'oauth-state';
-const MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
 /** Minimal claims stored in the session cookie. User details are re-read from DB on every request. */
 export interface SessionClaims {
@@ -53,7 +53,7 @@ export function decodeSession(cookie: string): SessionClaims | null {
 
 export function makeClaims(userId: number): SessionClaims {
 	const now = Math.floor(Date.now() / 1000);
-	return { sub: userId, iat: now, exp: now + MAX_AGE_SECONDS };
+	return { sub: userId, iat: now, exp: now + SESSION_MAX_AGE_SECONDS };
 }
 
-export const SESSION_MAX_AGE = MAX_AGE_SECONDS;
+export const SESSION_MAX_AGE = SESSION_MAX_AGE_SECONDS;


### PR DESCRIPTION
## Summary

Centralizes all inline configuration constants (rate limits, cache TTLs, and other tunable parameters) from across the sharing-server source files into a single \sharing-server/src/config.ts\ module.

## Changes

### New file: \sharing-server/src/config.ts\
Contains all tunable constants organized by category:
- **Auth / Token Cache**: \TOKEN_CACHE_TTL_MS\, \NEGATIVE_CACHE_TTL_MS\
- **Rate Limits**: \UPLOAD_RATE_MAX\, \UPLOAD_RATE_WINDOW_MS\, \IP_RATE_MAX\, \IP_RATE_WINDOW_MS\
- **Session / OAuth**: \SESSION_MAX_AGE_SECONDS\, \OAUTH_STATE_MAX_AGE_SECONDS\
- **API Validation**: \MAX_STRING_LENGTHS\, \MAX_TOKEN_VALUE\, \MAX_ENTRIES_PER_UPLOAD\
- **Database / Backup**: \BACKUP_INTERVAL_MS\

### Updated files
- \uth.ts\ — imports rate limits and cache TTLs from config
- \session.ts\ — imports session max age from config
- \server.ts\ — imports backup interval from config
- \outes/api.ts\ — imports validation constants from config
- \outes/dashboard.ts\ — imports OAuth state cookie max age from config

## Verification
TypeScript type-check passes with \	sc --noEmit\.