### PR TITLE
refactor: add explicit input validation with field length limits in sharing-server API

### DIFF
--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -14,6 +14,16 @@ const MAX_STRING_LENGTHS = {
 const MAX_TOKEN_VALUE = 2_000_000_000; // 2B tokens — large agent sessions can exceed 100M in one day
 const MAX_ENTRIES_PER_UPLOAD = 500;
 
+// Fluency score payload limits
+const MAX_FLUENCY_LABEL_LENGTH = 128;
+const MAX_FLUENCY_CATEGORIES = 100;
+const MAX_FLUENCY_CATEGORY_NAME_LENGTH = 128;
+const MAX_FLUENCY_ICON_LENGTH = 64;
+const MAX_FLUENCY_TIPS_PER_CATEGORY = 20;
+const MAX_FLUENCY_TIP_LENGTH = 512;
+const MAX_FLUENCY_SCORE_JSON_BYTES = 100_000; // 100 KB
+const MAX_FLUENCY_METRICS_JSON_BYTES = 10_000; // 10 KB per entry
+
 export const api = new Hono<{ Variables: AuthVariables }>();
 
 // GET /health — no auth required (mounted at root level, not here)
@@ -132,11 +142,45 @@ api.post('/fluency-score', requireBearerAuth, async (c) => {
 	}
 
 	const b = body as Record<string, unknown>;
-	if (typeof b.overallStage !== 'number' || !Array.isArray(b.categories)) {
-		return c.json({ error: '"overallStage" (number) and "categories" (array) are required.' }, 400);
+
+	if (!Number.isInteger(b.overallStage) || (b.overallStage as number) < 1 || (b.overallStage as number) > 4) {
+		return c.json({ error: '"overallStage" must be an integer between 1 and 4.' }, 400);
+	}
+	if (!Array.isArray(b.categories)) {
+		return c.json({ error: '"categories" must be an array.' }, 400);
+	}
+	if (b.categories.length > MAX_FLUENCY_CATEGORIES) {
+		return c.json({ error: `"categories" too long (max ${MAX_FLUENCY_CATEGORIES} items).` }, 400);
+	}
+	if (b.overallLabel !== undefined && b.overallLabel !== null) {
+		if (typeof b.overallLabel !== 'string') {
+			return c.json({ error: '"overallLabel" must be a string.' }, 400);
+		}
+		if (b.overallLabel.length > MAX_FLUENCY_LABEL_LENGTH) {
+			return c.json({ error: `"overallLabel" too long (max ${MAX_FLUENCY_LABEL_LENGTH}).` }, 400);
+		}
+	}
+	if (b.computedAt !== undefined && b.computedAt !== null) {
+		if (typeof b.computedAt !== 'string') {
+			return c.json({ error: '"computedAt" must be a string.' }, 400);
+		}
+		if (b.computedAt.length > 64) {
+			return c.json({ error: '"computedAt" too long (max 64 chars).' }, 400);
+		}
+	}
+	for (let i = 0; i < b.categories.length; i++) {
+		const catErr = validateFluencyCategory(b.categories[i], i);
+		if (catErr) {
+			return c.json({ error: catErr }, 400);
+		}
 	}
 
-	upsertUserFluencyScore(user.id, JSON.stringify(body));
+	const scoreJson = JSON.stringify(body);
+	if (Buffer.byteLength(scoreJson, 'utf8') > MAX_FLUENCY_SCORE_JSON_BYTES) {
+		return c.json({ error: `Fluency score payload too large (max ${MAX_FLUENCY_SCORE_JSON_BYTES} bytes).` }, 400);
+	}
+
+	upsertUserFluencyScore(user.id, scoreJson);
 	return c.json({ ok: true });
 });
 
@@ -176,10 +220,10 @@ function validateEntry(entry: unknown): string | null {
 		return `"machineId" too long (max ${MAX_STRING_LENGTHS.machineId})`;
 	}
 	if (!isNonNegativeInt(e.inputTokens) || (e.inputTokens as number) > MAX_TOKEN_VALUE) {
-		return '"inputTokens" must be a non-negative integer ≤ 100,000,000';
+		return `"inputTokens" must be a non-negative integer ≤ ${MAX_TOKEN_VALUE.toLocaleString()}`;
 	}
 	if (!isNonNegativeInt(e.outputTokens) || (e.outputTokens as number) > MAX_TOKEN_VALUE) {
-		return '"outputTokens" must be a non-negative integer ≤ 100,000,000';
+		return `"outputTokens" must be a non-negative integer ≤ ${MAX_TOKEN_VALUE.toLocaleString()}`;
 	}
 	if (!isNonNegativeInt(e.interactions) || (e.interactions as number) > 100_000) {
 		return '"interactions" must be a non-negative integer ≤ 100,000';
@@ -188,9 +232,11 @@ function validateEntry(entry: unknown): string | null {
 	// Optional string fields — truncate if too long (defensive, after length check)
 	if (e.workspaceName !== undefined && e.workspaceName !== null) {
 		if (typeof e.workspaceName !== 'string') return '"workspaceName" must be a string';
+		if (e.workspaceName.length > MAX_STRING_LENGTHS.workspaceName) return `"workspaceName" too long (max ${MAX_STRING_LENGTHS.workspaceName})`;
 	}
 	if (e.machineName !== undefined && e.machineName !== null) {
 		if (typeof e.machineName !== 'string') return '"machineName" must be a string';
+		if (e.machineName.length > MAX_STRING_LENGTHS.machineName) return `"machineName" too long (max ${MAX_STRING_LENGTHS.machineName})`;
 	}
 	if (e.datasetId !== undefined && e.datasetId !== null) {
 		if (typeof e.datasetId !== 'string') return '"datasetId" must be a string';
@@ -208,6 +254,9 @@ function validateEntry(entry: unknown): string | null {
 		if (typeof e.fluencyMetrics !== 'object' || Array.isArray(e.fluencyMetrics)) {
 			return '"fluencyMetrics" must be an object';
 		}
+		if (Buffer.byteLength(JSON.stringify(e.fluencyMetrics), 'utf8') > MAX_FLUENCY_METRICS_JSON_BYTES) {
+			return `"fluencyMetrics" too large (max ${MAX_FLUENCY_METRICS_JSON_BYTES} bytes)`;
+		}
 	}
 
 	return null;
@@ -215,4 +264,41 @@ function validateEntry(entry: unknown): string | null {
 
 function isNonNegativeInt(value: unknown): boolean {
 	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function validateFluencyCategory(cat: unknown, index: number): string | null {
+	if (typeof cat !== 'object' || cat === null || Array.isArray(cat)) {
+		return `categories[${index}] must be an object`;
+	}
+	const c = cat as Record<string, unknown>;
+	if (typeof c.category !== 'string' || c.category.length === 0) {
+		return `categories[${index}].category must be a non-empty string`;
+	}
+	if (c.category.length > MAX_FLUENCY_CATEGORY_NAME_LENGTH) {
+		return `categories[${index}].category too long (max ${MAX_FLUENCY_CATEGORY_NAME_LENGTH})`;
+	}
+	if (typeof c.icon !== 'string') {
+		return `categories[${index}].icon must be a string`;
+	}
+	if (c.icon.length > MAX_FLUENCY_ICON_LENGTH) {
+		return `categories[${index}].icon too long (max ${MAX_FLUENCY_ICON_LENGTH})`;
+	}
+	if (!Number.isInteger(c.stage) || (c.stage as number) < 1 || (c.stage as number) > 4) {
+		return `categories[${index}].stage must be an integer between 1 and 4`;
+	}
+	if (!Array.isArray(c.tips)) {
+		return `categories[${index}].tips must be an array`;
+	}
+	if (c.tips.length > MAX_FLUENCY_TIPS_PER_CATEGORY) {
+		return `categories[${index}].tips too long (max ${MAX_FLUENCY_TIPS_PER_CATEGORY} items)`;
+	}
+	for (let j = 0; j < c.tips.length; j++) {
+		if (typeof c.tips[j] !== 'string') {
+			return `categories[${index}].tips[${j}] must be a string`;
+		}
+		if ((c.tips[j] as string).length > MAX_FLUENCY_TIP_LENGTH) {
+			return `categories[${index}].tips[${j}] too long (max ${MAX_FLUENCY_TIP_LENGTH})`;
+		}
+	}
+	return null;
 }


### PR DESCRIPTION
## Summary

Adds comprehensive input validation to sharing-server/src/routes/api.ts.

### Changes

**Bug fixes:**
- Fix incorrect error messages for inputTokens/outputTokens that said max is 100,000,000 when the actual limit is 2,000,000,000

**Missing length checks in alidateEntry():**
- workspaceName: now enforces MAX_STRING_LENGTHS.workspaceName (256 chars)
- machineName: now enforces MAX_STRING_LENGTHS.machineName (256 chars)
- luencyMetrics: new 10KB byte-length guard (prevents oversized blobs per entry)

**Strengthened /api/fluency-score endpoint:**
- overallStage: must now be an **integer between 1 and 4** (was any number)
- overallLabel: validated as string ≤ 128 chars
- computedAt: validated as string ≤ 64 chars (if present)
- categories: max 100 items enforced
- Each category item validated via new alidateFluencyCategory() helper:
  - category: non-empty string ≤ 128 chars
  - icon: string ≤ 64 chars
  - stage: integer 1–4
  - 	ips: array, max 20 items, each string ≤ 512 chars
- 100KB byte-length guard on the full serialized score payload

**New helpers:**
- alidateFluencyCategory(cat, index) — validates a single category item

### Testing

TypeScript type check passes (
pm run check-types). No test suite exists for sharing-server.