### PR TITLE
refactor: fix catch(error: any) to use unknown with proper type narrowing

### DIFF
--- a/vscode-extension/src/backend/services/azureResourceService.ts
+++ b/vscode-extension/src/backend/services/azureResourceService.ts
@@ -90,9 +90,9 @@ export class AzureResourceService {
 		try {
 			await credential.getToken('https://management.azure.com/.default');
 			return true;
-		} catch (e: any) {
+		} catch (e: unknown) {
 			vscode.window.showErrorMessage(
-				`Azure authentication failed. Sign in using Azure CLI (az login) or VS Code Azure Account, then retry. Details: ${e?.message ?? e}`
+				`Azure authentication failed. Sign in using Azure CLI (az login) or VS Code Azure Account, then retry. Details: ${safeStringifyError(e)}`
 			);
 			return false;
 		}
@@ -164,9 +164,9 @@ export class AzureResourceService {
 
 		try {
 			await resourceClient.resourceGroups.createOrUpdate(name, { location: loc });
-		} catch (e: any) {
+		} catch (e: unknown) {
 			vscode.window.showErrorMessage(
-				`Failed to create resource group. You may need 'Contributor' on the subscription or appropriate RG permissions. Details: ${e?.message ?? e}`
+				`Failed to create resource group. You may need 'Contributor' on the subscription or appropriate RG permissions. Details: ${safeStringifyError(e)}`
 			);
 			return null;
 		}
@@ -252,12 +252,12 @@ export class AzureResourceService {
 		try {
 			await storageMgmt.storageAccounts.beginCreateAndWait(resourceGroup, name, createStorageAccountParams as any);
 			return name;
-		} catch (e: any) {
+		} catch (e: unknown) {
 			if (isAzurePolicyDisallowedError(e) || isStorageLocalAuthDisallowedByPolicyError(e)) {
 				return this._handlePolicyBlockedStorageCreation(e, saNames, resourceGroup);
 			}
 			vscode.window.showErrorMessage(
-				`Failed to create storage account. You may need 'Storage Account Contributor' (or 'Contributor') on the resource group. Details: ${e?.message ?? e}`
+				`Failed to create storage account. You may need 'Storage Account Contributor' (or 'Contributor') on the resource group. Details: ${safeStringifyError(e)}`
 			);
 			return null;
 		}
@@ -446,7 +446,7 @@ export class AzureResourceService {
 			}
 			await this.dataPlaneService.ensureTableExists(finalSettings, creds.tableCredential);
 			await this.dataPlaneService.validateAccess(finalSettings, creds.tableCredential);
-		} catch (e: any) {
+		} catch (e: unknown) {
 			vscode.window.showErrorMessage(`Backend sync configured, but access validation failed: ${safeStringifyError(e)}`);
 			return;
 		}

--- a/vscode-extension/src/backend/services/blobUploadService.ts
+++ b/vscode-extension/src/backend/services/blobUploadService.ts
@@ -10,7 +10,7 @@ import * as zlib from 'zlib';
 import { promisify } from 'util';
 import type { TokenCredential } from '@azure/core-auth';
 import { BlobServiceClient, ContainerClient, StorageSharedKeyCredential } from '@azure/storage-blob';
-import { safeStringifyError } from '../../utils/errors';
+import { safeStringifyError, getErrorStatusCode, getErrorCode } from '../../utils/errors';
 
 const gzip = promisify(zlib.gzip);
 
@@ -85,7 +85,7 @@ export class BlobUploadService {
 				access: undefined // Private access by default (no public access)
 			});
 			this.log(`Blob upload: container '${containerName}' ready`);
-		} catch (error: any) {
+		} catch (error: unknown) {
 			this.warn(`Blob upload: failed to ensure container exists: ${safeStringifyError(error)}`);
 			throw error;
 		}
@@ -157,12 +157,12 @@ export class BlobUploadService {
 						settings.compressFiles
 					);
 					filesUploaded++;
-				} catch (error: any) {
+				} catch (error: unknown) {
 					const fileName = path.basename(sessionFile);
 					const errorMsg = safeStringifyError(error);
 
 					// Stop immediately on authorization errors — retrying other files won't help.
-					if (error?.statusCode === 403 || error?.code === 'AuthorizationPermissionMismatch') {
+					if (getErrorStatusCode(error) === 403 || getErrorCode(error) === 'AuthorizationPermissionMismatch') {
 						const isEntraId = !('accountName' in credential);
 						const hint = isEntraId
 							? 'Your Entra ID identity needs the "Storage Blob Data Contributor" role on this storage account. '
@@ -202,7 +202,7 @@ export class BlobUploadService {
 			this.log(`Blob upload: ${message}`);
 			return { success: errors.length === 0, filesUploaded, message };
 
-		} catch (error: any) {
+		} catch (error: unknown) {
 			const errorMsg = safeStringifyError(error);
 			this.warn(`Blob upload: failed: ${errorMsg}`);
 			// Do not update lastUploadTime on failure — allow the next sync cycle to retry.

--- a/vscode-extension/src/backend/services/dataPlaneService.ts
+++ b/vscode-extension/src/backend/services/dataPlaneService.ts
@@ -7,7 +7,7 @@ import type { TokenCredential } from "@azure/core-auth";
 import { AzureNamedKeyCredential } from "@azure/core-auth";
 import { TableClient, TableServiceClient } from "@azure/data-tables";
 import * as vscode from "vscode";
-import { withErrorHandling } from "../../utils/errors";
+import { withErrorHandling, getErrorStatusCode, getErrorCode } from "../../utils/errors";
 import { AZURE_SDK_QUERY_TIMEOUT_MS } from "../constants";
 import type { BackendSettings } from "../settings";
 import type {
@@ -109,10 +109,10 @@ export class DataPlaneService {
         try {
           await serviceClient.createTable(settings.aggTable);
           this.log(`Backend sync: created table ${settings.aggTable}`);
-        } catch (e: any) {
+        } catch (e: unknown) {
           // 409 = already exists
-          const status = e?.statusCode ?? e?.code;
-          if (status === 409 || e?.code === "TableAlreadyExists") {
+          const status = getErrorStatusCode(e) ?? getErrorCode(e);
+          if (status === 409 || getErrorCode(e) === "TableAlreadyExists") {
             this.log(
               `Backend sync: table ${settings.aggTable} already exists (OK)`,
             );
@@ -160,8 +160,8 @@ export class DataPlaneService {
         AZURE_SDK_QUERY_TIMEOUT_MS,
         "Table entity delete",
       );
-    } catch (e: any) {
-      const status = e?.statusCode;
+    } catch (e: unknown) {
+      const status = getErrorStatusCode(e);
       if (status === 403) {
         throw new Error(
           `Missing Azure RBAC data-plane permissions for Tables. Assign 'Storage Table Data Contributor' (read/write) or 'Storage Table Data Reader' (read-only) on the Storage account or table service.`,
@@ -352,7 +352,7 @@ export class DataPlaneService {
           "Table entity delete",
         );
         deletedCount++;
-      } catch (error: any) {
+      } catch (error: unknown) {
         const err = error instanceof Error ? error : new Error(String(error));
         errors.push({ partitionKey, rowKey, error: err });
         this.log(
@@ -437,11 +437,11 @@ export class DataPlaneService {
           "Table entity upsert",
         );
         return; // Success
-      } catch (error: any) {
+      } catch (error: unknown) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
         // Check if error is retryable (429 throttling, 503 unavailable)
-        const statusCode = error?.statusCode ?? error?.code;
+        const statusCode = getErrorStatusCode(error) ?? getErrorCode(error);
         const isRetryable =
           statusCode === 429 ||
           statusCode === 503 ||

--- a/vscode-extension/src/backend/services/queryService.ts
+++ b/vscode-extension/src/backend/services/queryService.ts
@@ -9,6 +9,7 @@ import type { ModelUsage, SessionStats, StatsForPeriod } from '../types';
 import { CredentialService } from './credentialService';
 import { DataPlaneService } from './dataPlaneService';
 import { BackendUtility } from './utilityService';
+import { safeStringifyError } from '../../utils/errors';
 
 export interface BackendQueryResultLike {
 	stats: SessionStats;
@@ -278,8 +279,8 @@ export class QueryService {
 				month: monthResult.stats.today,
 				lastUpdated: new Date()
 			};
-		} catch (e: any) {
-			this.deps.warn(`Backend query failed: ${e?.message ?? e}`);
+		} catch (e: unknown) {
+			this.deps.warn(`Backend query failed: ${safeStringifyError(e)}`);
 			return undefined;
 		}
 	}
@@ -309,8 +310,8 @@ export class QueryService {
 				month: monthResult.stats.today,
 				lastUpdated: new Date()
 			};
-		} catch (e: any) {
-			this.deps.warn(`Backend query failed: ${e?.message ?? e}`);
+		} catch (e: unknown) {
+			this.deps.warn(`Backend query failed: ${safeStringifyError(e)}`);
 			return undefined;
 		}
 	}

--- a/vscode-extension/src/backend/services/sharingServerUploadService.ts
+++ b/vscode-extension/src/backend/services/sharingServerUploadService.ts
@@ -3,6 +3,8 @@
  * Sends daily rollup data to a configured endpoint using a GitHub Bearer token.
  */
 
+import { safeStringifyError } from '../../utils/errors';
+
 export interface SharingServerEntry {
 	day: string;
 	model: string;
@@ -67,8 +69,8 @@ export class SharingServerUploadService {
 			const message = `Uploaded ${totalUploaded} entries`;
 			log(`Sharing server upload: ${message}`);
 			return { success: true, entriesUploaded: totalUploaded, message };
-		} catch (e: any) {
-			const message = `Upload failed: ${e?.message ?? e}`;
+		} catch (e: unknown) {
+			const message = `Upload failed: ${safeStringifyError(e)}`;
 			warn(`Sharing server upload: ${message}`);
 			return { success: false, entriesUploaded: 0, message };
 		}
@@ -102,8 +104,8 @@ export class SharingServerUploadService {
 				return;
 			}
 			log('Sharing server fluency-score upload: ok');
-		} catch (e: any) {
-			warn(`Sharing server fluency-score upload failed: ${e?.message ?? e}`);
+		} catch (e: unknown) {
+			warn(`Sharing server fluency-score upload failed: ${safeStringifyError(e)}`);
 		}
 	}
 }

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1486,14 +1486,14 @@ return true;
 				if (settings.sharingServerEnabled && settings.sharingServerEndpointUrl) {
 					try {
 						await this.syncToSharingServer(settings, sharingPolicy);
-					} catch (ssErr: any) {
-						this.deps.warn(`Sharing server sync: failed - ${ssErr?.message ?? ssErr}`);
+					} catch (ssErr: unknown) {
+						this.deps.warn(`Sharing server sync: failed - ${safeStringifyError(ssErr)}`);
 					}
 				}
 
 				// DO NOT trigger UI refresh here - it causes redundant analysis and blocks UI
 				// The periodic timer in extension.ts will handle UI updates
-			} catch (e: any) {
+			} catch (e: unknown) {
 				// Keep local mode functional.
 				const secretsToRedact = await this.credentialService.getBackendSecretsToRedactForError(settings);
 				this.deps.warn(`Backend sync: ${safeStringifyError(e, secretsToRedact)}`);
@@ -1502,8 +1502,8 @@ return true;
 				if (settings.sharingServerEnabled && settings.sharingServerEndpointUrl) {
 					try {
 						await this.syncToSharingServer(settings, sharingPolicy);
-					} catch (ssErr: any) {
-						this.deps.warn(`Sharing server sync: failed - ${ssErr?.message ?? ssErr}`);
+					} catch (ssErr: unknown) {
+						this.deps.warn(`Sharing server sync: failed - ${safeStringifyError(ssErr)}`);
 					}
 				}
 			} finally {

--- a/vscode-extension/src/utils/errors.ts
+++ b/vscode-extension/src/utils/errors.ts
@@ -98,6 +98,28 @@ export function safeStringifyError(error: unknown, secretsToRedact?: string[]): 
 }
 
 /**
+ * Extracts the HTTP status code from an unknown error (e.g. Azure SDK RestError has a `statusCode` property).
+ * @param error - The error to inspect
+ * @returns The numeric status code, or undefined if not present
+ */
+export function getErrorStatusCode(error: unknown): number | undefined {
+	if (!error || typeof error !== 'object') { return undefined; }
+	const sc = (error as Record<string, unknown>)['statusCode'];
+	return typeof sc === 'number' ? sc : undefined;
+}
+
+/**
+ * Extracts the error code from an unknown error (e.g. Azure SDK errors expose a `code` string).
+ * @param error - The error to inspect
+ * @returns The code as a string or number, or undefined if not present
+ */
+export function getErrorCode(error: unknown): string | number | undefined {
+	if (!error || typeof error !== 'object') { return undefined; }
+	const code = (error as Record<string, unknown>)['code'];
+	return typeof code === 'string' || typeof code === 'number' ? code : undefined;
+}
+
+/**
  * Checks if an error is an Azure Policy "RequestDisallowedByPolicy" error.
  * @param error - The error to check
  * @returns True if this is an Azure Policy disallowed error


### PR DESCRIPTION
Fixes TypeScript type safety in catch blocks across backend services. Replaces catch (error: any) with catch (error: unknown) and adds getErrorStatusCode/getErrorCode helpers to utils/errors.ts for safely extracting Azure SDK error properties. All 59 tests pass.