### PR TITLE
refactor: define proper TokenEstimator interface to replace implicit any

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -67,6 +67,7 @@ import type {
   SessionLogData,
   WorkspaceCustomizationSummary,
   AgentSessionsResult,
+  TokenEstimator,
 } from './types';
 import type { OpenCodeDataAccess } from './opencode';
 import type { CrushDataAccess } from './crush';
@@ -267,7 +268,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private lastChartView: 'total' | 'model' | 'editor' | 'repository' | 'cost' = 'total';
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private lastDashboardData: any | undefined;
-	private tokenEstimators: { [key: string]: number } = tokenEstimatorsData.estimators;
+	private tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsData.estimators;
 	private co2Per1kTokens = 0.2; // gCO2e per 1000 tokens, a rough estimate
 	private co2AbsorptionPerTreePerYear = 21000; // grams of CO2 per tree per year
 	private waterUsagePer1kTokens = 0.3; // liters of water per 1000 tokens, based on data center usage estimates

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -2,7 +2,7 @@
  * Token estimation and model-related utility functions.
  * Pure or near-pure functions extracted from CopilotTokenTracker for reusability.
  */
-import type { ModelUsage, ModelPricing, ContextReferenceUsage } from './types';
+import type { ModelUsage, ModelPricing, ContextReferenceUsage, TokenEstimator } from './types';
 
 /** Minimum request shape needed by getModelFromRequest. */
 interface ModelRequestSource {
@@ -58,7 +58,7 @@ function isSubAgentToolSpecificData(obj: unknown): obj is SubAgentToolSpecificDa
 	return (obj as SubAgentToolSpecificData).kind === 'subagent';
 }
 
-export function estimateTokensFromText(text: string, model: string = 'gpt-4', tokenEstimators: { [key: string]: number } = {}): number {
+export function estimateTokensFromText(text: string, model: string = 'gpt-4', tokenEstimators: Record<string, TokenEstimator> = {}): number {
 	// Token estimation based on character count and model
 	let tokensPerChar = 0.25; // default
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -3,6 +3,13 @@
  * Extracted from extension.ts to reduce file size and improve reusability.
  */
 
+/**
+ * Character-to-token ratio for a specific AI model.
+ * The value is a multiplier applied to the character count to estimate token count
+ * (e.g. 0.25 means ~4 characters per token).
+ */
+export type TokenEstimator = number;
+
 export interface TokenUsageStats {
   todayTokens: number;
   monthTokens: number;

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -18,6 +18,7 @@ import type {
 	ModelUsage,
 	UsageAnalysisPeriod,
 	ModelPricing,
+	TokenEstimator,
 } from './types';
 import {
 	applyDelta,
@@ -185,7 +186,7 @@ interface ResponseItemRaw {
 export interface UsageAnalysisDeps {
 	warn: (msg: string) => void;
 	ecosystems: IEcosystemAdapter[];
-	tokenEstimators: { [key: string]: number };
+	tokenEstimators: Record<string, TokenEstimator>;
 	modelPricing: { [key: string]: ModelPricing };
 	toolNameMap: { [key: string]: string };
 }
@@ -1656,7 +1657,7 @@ function accumulateSubAgentTokenUsage(
 	responseItems: ResponseItemRaw[],
 	baseModel: string,
 	modelUsage: ModelUsage,
-	tokenEstimators: { [key: string]: number }
+	tokenEstimators: Record<string, TokenEstimator>
 ): void {
 	for (const responseItem of responseItems) {
 		const subAgent = extractSubAgentData(responseItem);

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -1,7 +1,8 @@
 // @ts-ignore
 import tokenEstimatorsJson from '../../tokenEstimators.json';
+import type { TokenEstimator } from '../../types';
 
-const tokenEstimators: Record<string, number> = tokenEstimatorsJson.estimators;
+const tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsJson.estimators;
 let currentLocale: string | undefined;
 let compactNumbersEnabled = true;
 


### PR DESCRIPTION
Add a named TokenEstimator type alias to replace the inline { [key: string]: number } usages for token estimator maps. All 60 tests pass.