### PR TITLE
security: add HTML escaping to prevent XSS in configPanel webview

### DIFF
--- a/vscode-extension/src/backend/configPanel.ts
+++ b/vscode-extension/src/backend/configPanel.ts
@@ -381,7 +381,7 @@ function buildScriptHtml(nonce: string, toolkitUri: string, initialState: string
 	return `	<script type="module" nonce="${nonce}">
 		// Register toolkit components before main script runs
 		try {
-			const { provideVSCodeDesignSystem, vsCodeButton, vsCodeBadge } = await import('${toolkitUri}');
+			const { provideVSCodeDesignSystem, vsCodeButton, vsCodeBadge } = await import(${safeJsonForInlineScript(toolkitUri)});
 			provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeBadge());
 		} catch (error) {
 			console.warn('Failed to load VS Code Webview UI Toolkit:', error);

--- a/vscode-extension/test/unit/backend-configPanel.test.ts
+++ b/vscode-extension/test/unit/backend-configPanel.test.ts
@@ -125,6 +125,51 @@ test('renderBackendConfigHtml renders error messages when present', () => {
 	assert.ok(html.includes('Dataset ID is required.'));
 });
 
+// ── XSS prevention tests ──────────────────────────────────────────────────
+
+test('renderBackendConfigHtml does not inject raw XSS payload from privacyBadge', () => {
+	const xss = '<script>alert(1)</script>';
+	const state = makeState({ privacyBadge: xss });
+	const html = renderBackendConfigHtml(makeWebview(), state);
+	// Raw script tag must not appear verbatim; safeJsonForInlineScript encodes < and >
+	assert.ok(!html.includes(xss), 'XSS payload in privacyBadge must not appear raw in HTML');
+});
+
+test('renderBackendConfigHtml does not inject raw XSS payload from authStatus', () => {
+	const xss = '"><img src=x onerror=alert(1)>';
+	const state = makeState({ authStatus: xss });
+	const html = renderBackendConfigHtml(makeWebview(), state);
+	assert.ok(!html.includes(xss), 'XSS payload in authStatus must not appear raw in HTML');
+});
+
+test('renderBackendConfigHtml does not inject raw XSS payload from draft fields', () => {
+	const xss = '</script><script>alert(1)</script>';
+	const state = makeState({
+		draft: { ...toDraft(baseSettings), storageAccount: xss, userId: xss, datasetId: 'safe-id' }
+	});
+	const html = renderBackendConfigHtml(makeWebview(), state);
+	assert.ok(!html.includes(xss), 'XSS payload in draft fields must not appear raw in HTML');
+});
+
+test('renderBackendConfigHtml CSP is restrictive with default-src none', () => {
+	const html = renderBackendConfigHtml(makeWebview(), makeState());
+	assert.ok(html.includes("default-src 'none'"), "CSP must include default-src 'none'");
+	assert.ok(html.includes('Content-Security-Policy'), 'CSP meta tag must be present');
+});
+
+test('renderBackendConfigHtml embeds toolkitUri as JSON-encoded string in import', () => {
+	const webview = {
+		cspSource: 'test-csp-source',
+		asWebviewUri: (_uri: any) => ({
+			toString: () => "vscode-webview://test-toolkit.js"
+		})
+	} as any;
+	const html = renderBackendConfigHtml(webview, makeState());
+	// After our fix, toolkitUri must appear as a JSON double-quoted string in import()
+	assert.ok(html.includes('await import("vscode-webview://test-toolkit.js")'),
+		'toolkitUri must be embedded as a JSON-encoded string in the import() call');
+});
+
 // ── BackendConfigPanel class tests ───────────────────────────────────────
 
 function makeDraft() {


### PR DESCRIPTION
## Summary

Audited vscode-extension/src/backend/configPanel.ts for XSS risks in webview HTML generation.

### Findings

The existing code already had strong XSS protection in most areas:
- safeJsonForInlineScript() is used for all state data embedded in script tags
- The webview JavaScript uses escHtml() for all innerHTML operations in updateReviewSummary()
- All other DOM updates use safe .textContent / .innerText APIs

**One unsafe interpolation was identified:** toolkitUri was interpolated directly into the JavaScript import() statement as a raw single-quoted string literal. While the URI comes from VS Code internal API and is safe in practice, any special character in the URI could cause a syntax error or injection.

### Changes

- **configPanel.ts**: Replace the raw single-quoted toolkitUri in the import() call with safeJsonForInlineScript(toolkitUri) to ensure the URI is JSON-encoded (double-quoted, all special characters escaped) before being embedded in JavaScript.

- **backend-configPanel.test.ts**: Add 5 XSS prevention tests:
  - XSS payloads in privacyBadge, authStatus, and draft fields do not appear raw in HTML output
  - CSP meta tag includes default-src 'none'
  - toolkitUri is embedded as a JSON double-quoted string in the import() call

### Security checklist
- [x] XSS protection for webview content
- [x] CSP present and restrictive (default-src 'none')
- [x] All user-controlled values go through safe encoding before HTML/JS embedding
- [x] Tests validate XSS prevention