### PR TITLE
refactor: replace unsafe type casting in usageAnalysis with type guards

### DIFF
--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -100,7 +100,7 @@ modelId?: string;
 }
 
 /** A parsed regular JSON session content */
-interface ParsedSessionJson {
+export interface ParsedSessionJson {
 requests?: unknown[];
 mode?: { id?: string };
 creationDate?: number;
@@ -116,6 +116,36 @@ endColumn?: number;
 }>;
 };
 selectedModel?: { metadata?: { id?: string }; identifier?: string };
+}
+
+/**
+ * Runtime type guard that validates the shape of an unknown value against ParsedSessionJson.
+ * Checks structural invariants for fields that could cause runtime errors if mistyped.
+ */
+export function isParsedSessionJson(obj: unknown): obj is ParsedSessionJson {
+	if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+		return false;
+	}
+	const o = obj as Record<string, unknown>;
+	if (o.requests != null && !Array.isArray(o.requests)) {
+		return false;
+	}
+	if (o.mode != null) {
+		if (typeof o.mode !== 'object' || Array.isArray(o.mode)) {
+			return false;
+		}
+		const mode = o.mode as Record<string, unknown>;
+		if (mode.id != null && typeof mode.id !== 'string') {
+			return false;
+		}
+	}
+	if (o.creationDate != null && typeof o.creationDate !== 'number') {
+		return false;
+	}
+	if (o.lastMessageDate != null && typeof o.lastMessageDate !== 'number') {
+		return false;
+	}
+	return true;
 }
 
 /** A JSONL event (delta-based or CLI format) */
@@ -1091,7 +1121,12 @@ export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'war
 		}
 		const isJsonl = sessionFile.endsWith('.jsonl') || isJsonlContent(fileContent);
 		if (!isJsonl) {
-			const sessionContent = (preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent) as unknown) as ParsedSessionJson;
+			const parsed: unknown = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
+			if (!isParsedSessionJson(parsed)) {
+				deps.warn(`Unexpected session format in ${sessionFile}`);
+				return;
+			}
+			const sessionContent = parsed;
 			if (sessionContent.requests && Array.isArray(sessionContent.requests)) {
 				let previousModel: string | null = null;
 				let switchCount = 0;
@@ -1281,7 +1316,12 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 			}
 		} else {
 			// Handle regular JSON files
-			const sessionContent = (preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent) as unknown) as ParsedSessionJson;
+			const parsed: unknown = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
+			if (!isParsedSessionJson(parsed)) {
+				deps.warn(`Unexpected session format in ${sessionFile}`);
+				return;
+			}
+			const sessionContent = parsed;
 			
 			// Extract timestamps
 			if (sessionContent.creationDate) { timestamps.push(sessionContent.creationDate); }
@@ -1599,7 +1639,12 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 		}
 
 		// Handle regular .json files
-		const sessionContent = (preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent) as unknown) as ParsedSessionJson;
+		const parsed: unknown = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
+		if (!isParsedSessionJson(parsed)) {
+			deps.warn(`Unexpected session format in ${sessionFile}`);
+			return analysis;
+		}
+		const sessionContent = parsed;
 
 		// Process requests for mode usage, context references, and tool/MCP invocations
 		processJsonSessionRequests(deps, sessionContent, analysis);
@@ -1895,7 +1940,12 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 		}
 
 		// Handle regular .json files
-		const sessionContent = (preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent) as unknown) as ParsedSessionJson;
+		const parsed: unknown = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
+		if (!isParsedSessionJson(parsed)) {
+			deps.warn(`Unexpected session format in ${sessionFile}`);
+			return modelUsage;
+		}
+		const sessionContent = parsed;
 
 		if (sessionContent.requests && Array.isArray(sessionContent.requests)) {
 			for (const requestRaw of sessionContent.requests) {

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -11,6 +11,7 @@ import {
     analyzeSessionUsage,
     getModelUsageFromSession,
     deriveConversationPatterns,
+    isParsedSessionJson,
     type UsageAnalysisDeps,
 } from '../../src/usageAnalysis';
 import type {
@@ -966,3 +967,75 @@ test('analyzeSessionUsage: empty requests array returns empty analysis', async (
     assert.equal(result.toolCalls.total, 0);
 });
 
+// ---------------------------------------------------------------------------
+// isParsedSessionJson
+// ---------------------------------------------------------------------------
+
+test('isParsedSessionJson: null returns false', () => {
+    assert.equal(isParsedSessionJson(null), false);
+});
+
+test('isParsedSessionJson: string returns false', () => {
+    assert.equal(isParsedSessionJson('{"requests":[]}'), false);
+});
+
+test('isParsedSessionJson: number returns false', () => {
+    assert.equal(isParsedSessionJson(42), false);
+});
+
+test('isParsedSessionJson: array returns false', () => {
+    assert.equal(isParsedSessionJson([{ requests: [] }]), false);
+});
+
+test('isParsedSessionJson: empty object returns true', () => {
+    assert.equal(isParsedSessionJson({}), true);
+});
+
+test('isParsedSessionJson: valid session with requests array returns true', () => {
+    assert.equal(isParsedSessionJson({ requests: [] }), true);
+});
+
+test('isParsedSessionJson: requests as non-array (string) returns false', () => {
+    assert.equal(isParsedSessionJson({ requests: 'not-an-array' }), false);
+});
+
+test('isParsedSessionJson: requests as non-array (number) returns false', () => {
+    assert.equal(isParsedSessionJson({ requests: 42 }), false);
+});
+
+test('isParsedSessionJson: creationDate as string returns false', () => {
+    assert.equal(isParsedSessionJson({ creationDate: '2024-01-01' }), false);
+});
+
+test('isParsedSessionJson: creationDate as number returns true', () => {
+    assert.equal(isParsedSessionJson({ creationDate: 1700000000000 }), true);
+});
+
+test('isParsedSessionJson: lastMessageDate as string returns false', () => {
+    assert.equal(isParsedSessionJson({ lastMessageDate: 'now' }), false);
+});
+
+test('isParsedSessionJson: mode as non-object (string) returns false', () => {
+    assert.equal(isParsedSessionJson({ mode: 'agent' }), false);
+});
+
+test('isParsedSessionJson: mode as array returns false', () => {
+    assert.equal(isParsedSessionJson({ mode: [] }), false);
+});
+
+test('isParsedSessionJson: mode as object returns true', () => {
+    assert.equal(isParsedSessionJson({ mode: { id: 'copilot.agentMode' } }), true);
+});
+
+test('isParsedSessionJson: mode with numeric id returns false', () => {
+    assert.equal(isParsedSessionJson({ mode: { id: 123 } }), false);
+});
+
+test('isParsedSessionJson: full valid session object returns true', () => {
+    assert.equal(isParsedSessionJson({
+        requests: [{ modelId: 'gpt-4o' }],
+        mode: { id: 'copilot.askMode' },
+        creationDate: 1700000000000,
+        lastMessageDate: 1700000060000,
+    }), true);
+});


### PR DESCRIPTION
## Summary

Replaces unsafe double-casts in `usageAnalysis.ts` with a proper runtime type guard.

## Changes

### `vscode-extension/src/usageAnalysis.ts`
- Export `ParsedSessionJson` interface (was internal)
- Add `isParsedSessionJson(obj: unknown): obj is ParsedSessionJson` type guard that validates:
  - The value is a non-null, non-array object
  - `requests`, if present, is an array
  - `mode`, if present, is a non-array object with a string `id` if present
  - `creationDate` / `lastMessageDate`, if present, are numbers
- Replace 4 unsafe casts in `calculateModelSwitching`, `trackEnhancedMetrics`, `analyzeSessionUsage`, and `getModelUsageFromSession` with the type guard; invalid inputs log a warning and return early gracefully

### `vscode-extension/test/unit/usageAnalysis.test.ts`
- Import `isParsedSessionJson`
- Add 15 unit tests covering valid and invalid inputs

## Verification
- `tsc --noEmit` passed (0 errors)
- `npm run test:node` passed (all 59 test files pass)
