### PR TITLE
refactor: replace magic numeric sharing levels with SharingLevel enum

### DIFF
--- a/vscode-extension/src/backend/configurationFlow.ts
+++ b/vscode-extension/src/backend/configurationFlow.ts
@@ -72,21 +72,29 @@ export function deriveShareWithTeam(profile: BackendSharingProfile): boolean {
 	return profile === 'teamPseudonymous' || profile === 'teamIdentified';
 }
 
-export function sharingLevel(profile: BackendSharingProfile): number {
-	// Higher number => more permissive.
+/** Ordering of sharing profiles from least to most permissive. Higher value = more data leaves the machine. */
+export enum SharingLevel {
+	Off = 0,
+	TeamAnonymized = 10,
+	TeamPseudonymous = 20,
+	SoloFull = 25, // personal but includes readable names; sits between TeamPseudonymous and TeamIdentified
+	TeamIdentified = 30
+}
+
+export function sharingLevel(profile: BackendSharingProfile): SharingLevel {
 	switch (profile) {
 		case 'off':
-			return 0;
+			return SharingLevel.Off;
 		case 'teamAnonymized':
-			return 1;
+			return SharingLevel.TeamAnonymized;
 		case 'teamPseudonymous':
-			return 2;
+			return SharingLevel.TeamPseudonymous;
 		case 'teamIdentified':
-			return 3;
+			return SharingLevel.TeamIdentified;
 		case 'soloFull':
-			return 2.5; // personal but includes readable names
+			return SharingLevel.SoloFull;
 		default:
-			return 0;
+			return SharingLevel.Off;
 	}
 }
 

--- a/vscode-extension/test/unit/backend-configurationFlow.test.ts
+++ b/vscode-extension/test/unit/backend-configurationFlow.test.ts
@@ -7,6 +7,7 @@ import {
 	clampLookback,
 	deriveShareWithTeam,
 	sharingLevel,
+	SharingLevel,
 	needsConsent,
 	validateDraft,
 	applyDraftToSettings,
@@ -119,16 +120,21 @@ test('deriveShareWithTeam returns false for non-team profiles', () => {
 
 // ── sharingLevel ─────────────────────────────────────────────────────────
 
-test('sharingLevel returns correct numeric levels', () => {
-	assert.equal(sharingLevel('off'), 0);
-	assert.equal(sharingLevel('teamAnonymized'), 1);
-	assert.equal(sharingLevel('teamPseudonymous'), 2);
-	assert.equal(sharingLevel('soloFull'), 2.5);
-	assert.equal(sharingLevel('teamIdentified'), 3);
+test('sharingLevel returns correct enum levels', () => {
+	assert.equal(sharingLevel('off'), SharingLevel.Off);
+	assert.equal(sharingLevel('teamAnonymized'), SharingLevel.TeamAnonymized);
+	assert.equal(sharingLevel('teamPseudonymous'), SharingLevel.TeamPseudonymous);
+	assert.equal(sharingLevel('soloFull'), SharingLevel.SoloFull);
+	assert.equal(sharingLevel('teamIdentified'), SharingLevel.TeamIdentified);
 });
 
-test('sharingLevel returns 0 for unknown profiles', () => {
-	assert.equal(sharingLevel('unknown' as any), 0);
+test('sharingLevel returns Off for unknown profiles', () => {
+	assert.equal(sharingLevel('unknown' as any), SharingLevel.Off);
+});
+
+test('SharingLevel ordering: soloFull is between teamPseudonymous and teamIdentified', () => {
+	assert.ok(SharingLevel.TeamPseudonymous < SharingLevel.SoloFull);
+	assert.ok(SharingLevel.SoloFull < SharingLevel.TeamIdentified);
 });
 
 // ── needsConsent ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replace the magic numbers (0, 1, 2, 2.5, 3) returned by \sharingLevel()\ with a proper \SharingLevel\ numeric enum.

## Changes

- **\scode-extension/src/backend/configurationFlow.ts\**: Added \SharingLevel\ enum and updated \sharingLevel()\ return type from \
umber\ to \SharingLevel\
- **\scode-extension/test/unit/backend-configurationFlow.test.ts\**: Updated assertions to use enum values; added ordering invariant test

## Enum design

The enum uses multiples of 10 to preserve ordering room, with \SoloFull = 25\ sitting between \TeamPseudonymous (20)\ and \TeamIdentified (30)\ — matching the semantic intent of the previous \2.5\ value:

\\\	ypescript
export enum SharingLevel {
    Off = 0,
    TeamAnonymized = 10,
    TeamPseudonymous = 20,
    SoloFull = 25,
    TeamIdentified = 30
}
\\\

The \>\ comparison in \
eedsConsent()\ continues to work correctly since the ordering is preserved.