### PR TITLE
refactor: replace double type assertions with proper type guards in copilotCliStore

### DIFF
--- a/vscode-extension/src/copilotCliStore.ts
+++ b/vscode-extension/src/copilotCliStore.ts
@@ -36,6 +36,27 @@ export interface CliStoreTurn {
 	timestamp: string | null;
 }
 
+export function isCliStoreSession(obj: unknown): obj is CliStoreSession {
+	if (typeof obj !== 'object' || obj === null) { return false; }
+	const r = obj as Record<string, unknown>;
+	return typeof r['id'] === 'string'
+		&& (r['repository'] === null || typeof r['repository'] === 'string')
+		&& (r['branch'] === null || typeof r['branch'] === 'string')
+		&& (r['summary'] === null || typeof r['summary'] === 'string')
+		&& (r['created_at'] === null || typeof r['created_at'] === 'string')
+		&& (r['updated_at'] === null || typeof r['updated_at'] === 'string');
+}
+
+export function isCliStoreTurn(obj: unknown): obj is CliStoreTurn {
+	if (typeof obj !== 'object' || obj === null) { return false; }
+	const r = obj as Record<string, unknown>;
+	return typeof r['session_id'] === 'string'
+		&& typeof r['turn_index'] === 'number'
+		&& (r['user_message'] === null || typeof r['user_message'] === 'string')
+		&& (r['assistant_response'] === null || typeof r['assistant_response'] === 'string')
+		&& (r['timestamp'] === null || typeof r['timestamp'] === 'string');
+}
+
 export class CopilotCliStoreAccess {
 	private _sqlJsModule: any = null;
 
@@ -131,7 +152,8 @@ export class CopilotCliStoreAccess {
 				const row = result[0].values[0];
 				const obj: Record<string, unknown> = {};
 				cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
-				return obj as unknown as CliStoreSession;
+				if (!isCliStoreSession(obj)) { return null; }
+				return obj;
 			} finally {
 				db.close();
 			}
@@ -156,11 +178,15 @@ export class CopilotCliStoreAccess {
 				);
 				if (result.length === 0) { return []; }
 				const cols = result[0].columns;
-				return (result[0].values as unknown[][]).map(row => {
+				const turns: CliStoreTurn[] = [];
+				for (const row of (result[0].values as unknown[][])) {
 					const obj: Record<string, unknown> = {};
 					cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
-					return obj as unknown as CliStoreTurn;
-				});
+					if (isCliStoreTurn(obj)) {
+						turns.push(obj);
+					}
+				}
+				return turns;
 			} finally {
 				db.close();
 			}


### PR DESCRIPTION
## Summary
- add runtime type guard helpers `isCliStoreSession` and `isCliStoreTurn` in `copilotCliStore.ts`
- replace unsafe double assertions (`as unknown as`) when reading SQLite rows
- return `null` for invalid session row shapes and skip invalid turn row shapes

## Validation
- `npm run check-types`
- `npx eslint src/copilotCliStore.ts`
- `npm run test:node`