### PR TITLE
refactor: add proper return types to initSqlJs and SQL.js database usage

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -30,6 +30,7 @@
         "@stryker-mutator/core": "^9.6.1",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.5.0",
+        "@types/sql.js": "1.4.11",
         "@types/vscode": "1.110.0",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.42.0",
@@ -3359,6 +3360,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -3430,6 +3438,17 @@
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -545,6 +545,7 @@
     "@stryker-mutator/core": "^9.6.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.5.0",
+    "@types/sql.js": "1.4.11",
     "@types/vscode": "1.110.0",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.42.0",

--- a/vscode-extension/src/copilotCliStore.ts
+++ b/vscode-extension/src/copilotCliStore.ts
@@ -14,10 +14,16 @@
  * The '#' character acts as a separator identical to the pattern used by Crush
  * (crush.db#<uuid>) and OpenCode (opencode.db#ses_<id>).
  */
+/// <reference types="sql.js" />
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import initSqlJs from 'sql.js';
+
+// Access SqlJsStatic and Database via the globally declared initSqlJs namespace
+// (made available by the /// <reference types="sql.js" /> directive above).
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+type SqlDatabase = initSqlJs.Database;
 
 export interface CliStoreSession {
 	id: string;
@@ -37,7 +43,7 @@ export interface CliStoreTurn {
 }
 
 export class CopilotCliStoreAccess {
-	private _sqlJsModule: any = null;
+	private _sqlJsModule: SqlJsStatic | null = null;
 
 	/** Absolute path to ~/.copilot/session-store.db. */
 	getDbPath(): string {
@@ -75,15 +81,16 @@ export class CopilotCliStoreAccess {
 	}
 
 	/** Lazily initialise and cache the sql.js WASM module. */
-	async initSqlJs(): Promise<any> {
+	async initSqlJs(): Promise<SqlJsStatic> {
 		if (this._sqlJsModule) { return this._sqlJsModule; }
 		const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
 		let wasmBinary: Uint8Array | undefined;
 		if (fs.existsSync(wasmPath)) {
 			wasmBinary = fs.readFileSync(wasmPath);
 		}
-		this._sqlJsModule = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
-		return this._sqlJsModule;
+		const sqlJs = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
+		this._sqlJsModule = sqlJs;
+		return sqlJs;
 	}
 
 	/**
@@ -101,7 +108,7 @@ export class CopilotCliStoreAccess {
 			try {
 				const result = db.exec('SELECT id FROM sessions ORDER BY updated_at DESC');
 				if (result.length === 0) { return []; }
-				return (result[0].values as unknown[][])
+				return result[0].values
 					.map(row => row[0] as string)
 					.filter(id => !knownUuids.has(id));
 			} finally {
@@ -156,7 +163,7 @@ export class CopilotCliStoreAccess {
 				);
 				if (result.length === 0) { return []; }
 				const cols = result[0].columns;
-				return (result[0].values as unknown[][]).map(row => {
+				return result[0].values.map(row => {
 					const obj: Record<string, unknown> = {};
 					cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
 					return obj as unknown as CliStoreTurn;

--- a/vscode-extension/src/crush.ts
+++ b/vscode-extension/src/crush.ts
@@ -9,6 +9,7 @@
  * Virtual path scheme: `<data_dir>/crush.db#<session_uuid>`
  * Example: `C:\...\repo\.crush\crush.db#c2582fbf-eed8-4fe2-8b30-80129e7373bc`
  */
+/// <reference types="sql.js" />
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -16,7 +17,11 @@ import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import type { UriLike } from './opencode';
 
-type CrushDbCacheEntry = { db: any; mtimeMs: number; size: number };
+// Access SqlJsStatic and Database via the globally declared initSqlJs namespace.
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+type SqlDatabase = initSqlJs.Database;
+
+type CrushDbCacheEntry = { db: SqlDatabase; mtimeMs: number; size: number };
 
 export interface CrushProject {
 	path: string;
@@ -25,10 +30,10 @@ export interface CrushProject {
 }
 
 export class CrushDataAccess {
-	private _sqlJsModule: any = null;
-	private _sqlJsInitPromise: Promise<any> | null = null;
+	private _sqlJsModule: SqlJsStatic | null = null;
+	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
 	private _dbCache: Map<string, CrushDbCacheEntry> = new Map();
-	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
+	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
 	private readonly extensionUri: UriLike;
 
 	constructor(extensionUri: UriLike) {
@@ -44,7 +49,7 @@ export class CrushDataAccess {
 		this._sqlJsInitPromise = null;
 	}
 
-	private closeDb(db: any): void {
+	private closeDb(db: SqlDatabase): void {
 		try { db.close(); } catch { /* ignore */ }
 	}
 
@@ -78,8 +83,8 @@ export class CrushDataAccess {
 		return left.mtimeMs === right.mtimeMs && left.size === right.size;
 	}
 
-	private async refreshCrushDb(dbPath: string, stats: fs.Stats): Promise<any | null> {
-		let db: any;
+	private async refreshCrushDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
+		let db: SqlDatabase;
 		try {
 			const SQL = await this.initSqlJs();
 			const buffer = fs.readFileSync(dbPath);
@@ -108,7 +113,7 @@ export class CrushDataAccess {
 	 * Uses single-flight deduplication to prevent concurrent callers from each
 	 * re-reading the DB file and leaving instances unclosed.
 	 */
-	private async getCrushDb(dbPath: string): Promise<any | null> {
+	private async getCrushDb(dbPath: string): Promise<SqlDatabase | null> {
 		const stats = this.statCrushDb(dbPath);
 		if (!stats) { return this._dbCache.get(dbPath)?.db ?? null; }
 
@@ -196,7 +201,7 @@ export class CrushDataAccess {
 	 * WASM initialization rather than each starting an independent load.
 	 * The cache is reset on failure so a transient error is retryable.
 	 */
-	async initSqlJs(): Promise<any> {
+	async initSqlJs(): Promise<SqlJsStatic> {
 		if (this._sqlJsModule) { return this._sqlJsModule; }
 		if (!this._sqlJsInitPromise) {
 			this._sqlJsInitPromise = (async () => {

--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -2,12 +2,17 @@
  * OpenCode data access layer.
  * Handles reading session data from OpenCode's JSON files and SQLite database.
  */
+/// <reference types="sql.js" />
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import { normalizePathForComparison } from './workspaceHelpers';
+
+// Access SqlJsStatic and Database via the globally declared initSqlJs namespace.
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+type SqlDatabase = initSqlJs.Database;
 
 /** Minimal URI interface required by OpenCodeDataAccess (subset of vscode.Uri). */
 export interface UriLike {
@@ -16,16 +21,16 @@ export interface UriLike {
 	readonly scheme: string;
 }
 
-type OpenCodeDbCache = { db: any; mtimeMs: number; size: number; path: string };
+type OpenCodeDbCache = { db: SqlDatabase; mtimeMs: number; size: number; path: string };
 type OpenCodeModelUsageWithInteractions = {
 	[modelName: string]: ModelUsage[string] & { interactions?: number };
 };
 
 export class OpenCodeDataAccess {
-	private _sqlJsModule: any = null;
-	private _sqlJsInitPromise: Promise<any> | null = null;
+	private _sqlJsModule: SqlJsStatic | null = null;
+	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
 	private _dbCache: OpenCodeDbCache | null = null;
-	private _dbCacheInflight: Map<string, Promise<any | null>> = new Map();
+	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
 	private readonly extensionUri: UriLike;
 
 	constructor(extensionUri: UriLike) {
@@ -73,7 +78,7 @@ export class OpenCodeDataAccess {
 	 * WASM initialization rather than each starting an independent load.
 	 * The cache is reset on failure so a transient error is retryable.
 	 */
-	async initSqlJs(): Promise<any> {
+	async initSqlJs(): Promise<SqlJsStatic> {
 		if (this._sqlJsModule) { return this._sqlJsModule; }
 		if (!this._sqlJsInitPromise) {
 			this._sqlJsInitPromise = (async () => {
@@ -99,7 +104,7 @@ export class OpenCodeDataAccess {
 		this._sqlJsInitPromise = null;
 	}
 
-	private closeDb(db: any): void {
+	private closeDb(db: SqlDatabase): void {
 		try { db.close(); } catch { /* ignore */ }
 	}
 
@@ -110,7 +115,7 @@ export class OpenCodeDataAccess {
 		}
 	}
 
-	private getCachedDbForPath(dbPath: string): any | null {
+	private getCachedDbForPath(dbPath: string): SqlDatabase | null {
 		return this._dbCache?.path === dbPath ? this._dbCache.db : null;
 	}
 
@@ -144,8 +149,8 @@ export class OpenCodeDataAccess {
 		return left.mtimeMs === right.mtimeMs && left.size === right.size;
 	}
 
-	private async refreshOpenCodeDb(dbPath: string, stats: fs.Stats): Promise<any | null> {
-		let db: any;
+	private async refreshOpenCodeDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
+		let db: SqlDatabase;
 		try {
 			const SQL = await this.initSqlJs();
 			const buffer = fs.readFileSync(dbPath);
@@ -176,7 +181,7 @@ export class OpenCodeDataAccess {
 	 * Uses single-flight deduplication to prevent concurrent calls from each re-reading
 	 * the DB file and leaving instances unclosed.
 	 */
-	private async getOpenCodeDb(): Promise<any | null> {
+	private async getOpenCodeDb(): Promise<SqlDatabase | null> {
 		const dbPath = path.join(this.getOpenCodeDataDir(), 'opencode.db');
 		const stats = this.statOpenCodeDb(dbPath);
 		if (!stats) { return this.getCachedDbForPath(dbPath); }


### PR DESCRIPTION
## Summary

Replaces `any` types in SQL.js-related code across three source files in the VS Code extension.

## Changes

- **`vscode-extension/package.json`**: Added `@types/sql.js` as devDependency
- **`vscode-extension/src/copilotCliStore.ts`**: Replace `Promise<any>` return type on `initSqlJs()` with `Promise<SqlJsStatic>`, `_sqlJsModule: any` with `SqlJsStatic | null`, remove unnecessary casts
- **`vscode-extension/src/crush.ts`**: Same SQL.js type fixes plus typed `CrushDbCacheEntry.db`, `closeDb()`, `refreshCrushDb()`, `getCrushDb()`
- **`vscode-extension/src/opencode.ts`**: Same SQL.js type fixes plus typed `OpenCodeDbCache.db`, `closeDb()`, `getCachedDbForPath()`, `refreshOpenCodeDb()`, `getOpenCodeDb()`

## Technical Details

The module resolution issue (`module: Node16` + `sql.js` exports field blocking `@types` fallback) is resolved by adding a `/// <reference types="sql.js" />` triple-slash directive at the top of each file. This makes the UMD global namespace `initSqlJs` available for type aliases like `type SqlJsStatic = initSqlJs.SqlJsStatic`.

## Testing

- `tsc --noEmit` passes
- `node esbuild.js` passes
- `npm run test:node`: all 60 tests pass
- ESLint on modified files: no new errors (only pre-existing complexity warnings in `opencode.ts`)
