### PR TITLE
refactor: extract duplicate response text extraction logic into shared utility

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,4 +1,4 @@
-﻿import * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import type { AiFluencyExtensionApi, ExtensionPointButton } from './extensionPoints';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -98,6 +98,7 @@ import {
   extractSubAgentData as _extractSubAgentData,
   buildReasoningEffortTimeline as _buildReasoningEffortTimeline,
   extractCachedTokensFromDebugLog as _extractCachedTokensFromDebugLog,
+  extractResponseItemText as _extractResponseItemText,
 } from './tokenEstimation';
 import { SessionDiscovery } from './sessionDiscovery';
 import { CacheManager } from './cacheManager';
@@ -4205,19 +4206,12 @@ usageAnalysis: undefined
 		const mcpTools: { server: string; tool: string }[] = [];
 
 		for (const item of response) {
-			// Separate thinking items
-			if (item.kind === 'thinking') {
-				if (item.value && typeof item.value === 'string') {
-					thinkingText += item.value;
-				}
-				continue;
-			}
-
-			// Extract text content
-			if (item.value && typeof item.value === 'string') {
-				responseText += item.value;
-			} else if (item.kind === 'markdownContent' && item.content?.value) {
-				responseText += item.content.value;
+			if (!item || typeof item !== 'object') { continue; }
+			// Extract text content and thinking via shared utility
+			const { text: itemText, isThinking: itemIsThinking } = _extractResponseItemText(item);
+			if (itemText) {
+				if (itemIsThinking) { thinkingText += itemText; }
+				else { responseText += itemText; }
 			}
 
 			// Extract tool invocations
@@ -4310,11 +4304,6 @@ usageAnalysis: undefined
 					// Estimate tokens from assistant response (output)
 					if (request.response && Array.isArray(request.response)) {
 						for (const responseItem of request.response) {
-							// Separate thinking tokens
-							if (responseItem.kind === 'thinking' && responseItem.value) {
-								totalThinkingTokens += this.estimateTokensFromText(responseItem.value, this.getModelFromRequest(request));
-								continue;
-							}
 							// Sub-agent invocations: count prompt (input) + result (output)
 							const subAgent = _extractSubAgentData(responseItem);
 							if (subAgent) {
@@ -4323,8 +4312,13 @@ usageAnalysis: undefined
 								if (subAgent.result) { totalOutputTokens += this.estimateTokensFromText(subAgent.result, saModel); }
 								continue;
 							}
-							if (responseItem.value) {
-								totalOutputTokens += this.estimateTokensFromText(responseItem.value, this.getModelFromRequest(request));
+							const { text, isThinking } = _extractResponseItemText(responseItem);
+							if (text) {
+								if (isThinking) {
+									totalThinkingTokens += this.estimateTokensFromText(text, this.getModelFromRequest(request));
+								} else {
+									totalOutputTokens += this.estimateTokensFromText(text, this.getModelFromRequest(request));
+								}
 							}
 						}
 					}

--- a/vscode-extension/src/sessionParser.ts
+++ b/vscode-extension/src/sessionParser.ts
@@ -2,7 +2,7 @@ export interface ModelUsage {
     [model: string]: { inputTokens: number; outputTokens: number };
 }
 
-import { extractSubAgentData } from './tokenEstimation';
+import { extractSubAgentData, extractResponseItemText } from './tokenEstimation';
 
 type JsonObject = Record<string, unknown>;
 
@@ -205,27 +205,10 @@ return { responseText: '', thinkingText: '' };
 let responseText = '';
 let thinkingText = '';
 for (const item of response) {
-if (!isObject(item)) {
-continue;
-}
-// Separate thinking items from regular response text
-if (item['kind'] === 'thinking') {
-const value = item['value'];
-if (typeof value === 'string' && value) {
-thinkingText += value;
-}
-continue;
-}
-const content = item['content'];
-const contentValue = isObject(content) ? content['value'] : undefined;
-const value = item['value'];
-// Prefer content.value when present to avoid double-counting wrapper text.
-if (typeof contentValue === 'string' && contentValue) {
-responseText += contentValue;
-continue;
-}
-if (typeof value === 'string' && value) {
-responseText += value;
+const { text, isThinking } = extractResponseItemText(item);
+if (text) {
+if (isThinking) { thinkingText += text; }
+else { responseText += text; }
 }
 }
 return { responseText, thinkingText };

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -114,6 +114,37 @@ export function extractSubAgentData(item: unknown): { prompt: string; result: st
 	return (prompt || result) ? { prompt, result, modelName } : null;
 }
 
+/**
+ * Extract text content from a single response item, separating thinking from regular response text.
+ * Prefers content.value over value to avoid double-counting when both are present.
+ *
+ * @returns text - the extracted text, or empty string if none
+ * @returns isThinking - true if this is a thinking (extended reasoning) item
+ */
+export function extractResponseItemText(item: unknown): { text: string; isThinking: boolean } {
+	if (typeof item !== 'object' || item === null) {
+		return { text: '', isThinking: false };
+	}
+	const obj = item as Record<string, unknown>;
+	if (obj['kind'] === 'thinking') {
+		const value = obj['value'];
+		return { text: typeof value === 'string' ? value : '', isThinking: true };
+	}
+	// Prefer content.value when present to avoid double-counting wrapper text.
+	const content = obj['content'];
+	if (typeof content === 'object' && content !== null) {
+		const contentValue = (content as Record<string, unknown>)['value'];
+		if (typeof contentValue === 'string' && contentValue) {
+			return { text: contentValue, isThinking: false };
+		}
+	}
+	const value = obj['value'];
+	if (typeof value === 'string' && value) {
+		return { text: value, isThinking: false };
+	}
+	return { text: '', isThinking: false };
+}
+
 /** Return type for all token estimation strategies. */
 export type TokenEstimationResult = {
 	tokens: number;
@@ -166,16 +197,12 @@ export class DeltaTokenStrategy implements TokenEstimationStrategy {
 				// Incremental response items (kind:2 append to response array)
 				if (event.kind === 2 && event.k?.includes('response') && Array.isArray(event.v)) {
 					for (const responseItem of event.v) {
-						if (responseItem.kind === 'thinking' && responseItem.value) {
-							totalThinkingTokens += estimateTokensFromText(responseItem.value);
-							continue;
-						}
 						// Sub-agent results are incomplete mid-stream; count from reconstructed state below.
 						if (extractSubAgentData(responseItem)) { continue; }
-						if (responseItem.value) {
-							totalTokens += estimateTokensFromText(responseItem.value);
-						} else if (responseItem.kind === 'markdownContent' && responseItem.content?.value) {
-							totalTokens += estimateTokensFromText(responseItem.content.value);
+						const { text, isThinking } = extractResponseItemText(responseItem);
+						if (text) {
+							if (isThinking) { totalThinkingTokens += estimateTokensFromText(text); }
+							else { totalTokens += estimateTokensFromText(text); }
 						}
 					}
 				}

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -30,6 +30,7 @@ import {
 	createEmptyContextRefs,
 	extractSubAgentData,
 	buildReasoningEffortTimeline,
+	extractResponseItemText,
 } from './tokenEstimation';
 import {
 	getModeType,
@@ -1863,8 +1864,10 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 						}
 						if (request.response && Array.isArray(request.response)) {
 							for (const responseItem of request.response as ResponseItemRaw[]) {
-								if (responseItem?.value) {
-									modelUsage[requestModel].outputTokens += estimateTokensFromText(responseItem.value, requestModel, deps.tokenEstimators);
+								// Thinking counts as output for model usage; ignore isThinking flag
+								const { text } = extractResponseItemText(responseItem);
+								if (text) {
+									modelUsage[requestModel].outputTokens += estimateTokensFromText(text, requestModel, deps.tokenEstimators);
 								}
 							}
 						}
@@ -1920,8 +1923,10 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 					}
 					if (request.response && Array.isArray(request.response)) {
 						for (const responseItem of request.response as ResponseItemRaw[]) {
-							if (responseItem?.value) {
-								modelUsage[model].outputTokens += estimateTokensFromText(responseItem.value, model, deps.tokenEstimators);
+							// Thinking counts as output for model usage; ignore isThinking flag
+							const { text } = extractResponseItemText(responseItem);
+							if (text) {
+								modelUsage[model].outputTokens += estimateTokensFromText(text, model, deps.tokenEstimators);
 							}
 						}
 					}

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { extractSubAgentData, normalizeDisplayModelName } from '../../src/tokenEstimation';
+import { extractSubAgentData, normalizeDisplayModelName, extractResponseItemText } from '../../src/tokenEstimation';
 
 test('normalizeDisplayModelName: lowercases and replaces spaces with hyphens', () => {
 	assert.equal(normalizeDisplayModelName('Claude Haiku 4.5'), 'claude-haiku-4.5');
@@ -82,6 +82,64 @@ test('extractSubAgentData: handles missing modelName gracefully', () => {
 });
 
 // ── Mutation-killing tests ──────────────────────────────────────────────
+
+// ── extractResponseItemText ──────────────────────────────────────────────
+
+test('extractResponseItemText: null returns empty non-thinking', () => {
+	const result = extractResponseItemText(null);
+	assert.equal(result.text, '');
+	assert.equal(result.isThinking, false);
+});
+
+test('extractResponseItemText: non-object returns empty non-thinking', () => {
+	assert.deepEqual(extractResponseItemText('string'), { text: '', isThinking: false });
+	assert.deepEqual(extractResponseItemText(42), { text: '', isThinking: false });
+	assert.deepEqual(extractResponseItemText(undefined), { text: '', isThinking: false });
+});
+
+test('extractResponseItemText: thinking item returns isThinking=true with text', () => {
+	const result = extractResponseItemText({ kind: 'thinking', value: 'extended reasoning here' });
+	assert.equal(result.text, 'extended reasoning here');
+	assert.equal(result.isThinking, true);
+});
+
+test('extractResponseItemText: thinking item with empty value returns empty string', () => {
+	const result = extractResponseItemText({ kind: 'thinking', value: '' });
+	assert.equal(result.text, '');
+	assert.equal(result.isThinking, true);
+});
+
+test('extractResponseItemText: prefers content.value over value to avoid double-counting', () => {
+	const result = extractResponseItemText({ kind: 'markdownContent', value: 'WRAPPER', content: { value: 'ACTUAL' } });
+	assert.equal(result.text, 'ACTUAL');
+	assert.equal(result.isThinking, false);
+});
+
+test('extractResponseItemText: falls back to value when content.value is empty', () => {
+	const result = extractResponseItemText({ kind: 'markdownContent', value: 'fallback', content: { value: '' } });
+	assert.equal(result.text, 'fallback');
+	assert.equal(result.isThinking, false);
+});
+
+test('extractResponseItemText: uses value when no content property', () => {
+	const result = extractResponseItemText({ kind: 'markdownContent', value: 'response text' });
+	assert.equal(result.text, 'response text');
+	assert.equal(result.isThinking, false);
+});
+
+test('extractResponseItemText: content.value works for any kind, not just markdownContent', () => {
+	const result = extractResponseItemText({ kind: 'otherKind', value: 'WRAPPER', content: { value: 'INNER' } });
+	assert.equal(result.text, 'INNER');
+	assert.equal(result.isThinking, false);
+});
+
+test('extractResponseItemText: returns empty for item with no text fields', () => {
+	const result = extractResponseItemText({ kind: 'toolInvocationSerialized', toolId: 'someTool' });
+	assert.equal(result.text, '');
+	assert.equal(result.isThinking, false);
+});
+
+
 
 import {
         estimateTokensFromText,


### PR DESCRIPTION
Extracts duplicated response/thinking text extraction into a shared extractResponseItemText() helper in tokenEstimation.ts, replacing 5 duplicate inline loops across 4 files. Also fixes a behavioral inconsistency where content.value preference was not applied consistently across all consumers. Adds 9 unit tests.