### PR TITLE
refactor: remove duplicate BlobUploadServiceLike interface from syncService.ts

### DIFF
--- a/vscode-extension/src/backend/services/blobUploadService.ts
+++ b/vscode-extension/src/backend/services/blobUploadService.ts
@@ -27,10 +27,26 @@ export interface BlobUploadSettings {
 /**
  * Upload status tracking per machine.
  */
-interface UploadStatus {
+export interface UploadStatus {
 	lastUploadTime: number; // Timestamp in ms
 	filesUploaded: number;
 	lastError?: string;
+}
+
+/**
+ * Interface for the blob upload service, enabling DI and testability.
+ */
+export interface IBlobUploadService {
+	uploadSessionFiles(
+		storageAccount: string,
+		settings: BlobUploadSettings,
+		credential: TokenCredential | StorageSharedKeyCredential,
+		sessionFiles: string[],
+		machineId: string,
+		datasetId: string
+	): Promise<{ success: boolean; filesUploaded: number; message: string }>;
+	shouldUpload(machineId: string, settings: BlobUploadSettings): boolean;
+	getUploadStatus(machineId: string): UploadStatus | undefined;
 }
 
 /**

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -21,28 +21,12 @@ import { CredentialService } from './credentialService';
 import { DataPlaneService } from './dataPlaneService';
 import { BackendUtility } from './utilityService';
 import { SharingServerUploadService, type SharingServerEntry } from './sharingServerUploadService';
+import { type IBlobUploadService } from './blobUploadService';
 import { isJsonlContent } from '../../tokenEstimation';
 import { getEditorTypeFromPath } from '../../workspaceHelpers';
 
 /** Ecosystem session per-model usage entry (input, output, optional interactions). */
 type ModelUsageEntry = { inputTokens: number; outputTokens: number; interactions?: number };
-
-
-/**
- * Interface for blob upload service to avoid circular dependency.
- */
-interface BlobUploadServiceLike {
-	uploadSessionFiles(
-		storageAccount: string,
-		settings: { enabled: boolean; containerName: string; uploadFrequencyHours: number; compressFiles: boolean },
-		credential: unknown,
-		sessionFiles: string[],
-		machineId: string,
-		datasetId: string
-	): Promise<{ success: boolean; filesUploaded: number; message: string }>;
-	shouldUpload(machineId: string, settings: { enabled: boolean; uploadFrequencyHours: number }): boolean;
-	getUploadStatus(machineId: string): { lastUploadTime: number; filesUploaded: number; lastError?: string } | undefined;
-}
 
 /**
  * Validate and normalize consent timestamp.
@@ -131,7 +115,7 @@ export class SyncService {
 		private readonly deps: SyncServiceDeps,
 		private readonly credentialService: CredentialService,
 		private readonly dataPlaneService: DataPlaneService,
-		private readonly blobUploadService: BlobUploadServiceLike | undefined,
+		private readonly blobUploadService: IBlobUploadService | undefined,
 		private readonly utility: typeof BackendUtility,
 		private readonly sharingServerUploadService: SharingServerUploadService | undefined,
 	) {}


### PR DESCRIPTION
## Summary

The local BlobUploadServiceLike interface in \syncService.ts\ was a partial duplicate of the \BlobUploadService\ class shape defined in \lobUploadService.ts\. This PR eliminates that duplication by creating a single source of truth.

## Changes

- **\lobUploadService.ts\**: Export the UploadStatus interface (previously unexported) and add a new exported \IBlobUploadService\ interface that captures exactly the methods SyncService depends on
- **\syncService.ts\**: Remove the local \BlobUploadServiceLike\ interface and replace it with an import of \IBlobUploadService\ from \lobUploadService.ts\; update the constructor parameter type accordingly

## Why Option A (exported interface)

Using an interface rather than the concrete class keeps SyncService testable with mock implementations — the constructor still accepts \IBlobUploadService | undefined\.

## Verification

- \	sc --noEmit\ passes cleanly
- All 60 unit tests pass (\
pm run test:node\)