### PR TITLE
refactor: extract withTimeout promise utility to utils/promises.ts

### DIFF
--- a/vscode-extension/src/backend/services/dataPlaneService.ts
+++ b/vscode-extension/src/backend/services/dataPlaneService.ts
@@ -8,6 +8,7 @@ import { AzureNamedKeyCredential } from "@azure/core-auth";
 import { TableClient, TableServiceClient } from "@azure/data-tables";
 import * as vscode from "vscode";
 import { withErrorHandling, getErrorStatusCode, getErrorCode } from "../../utils/errors";
+import { withTimeout } from "../../utils/promises";
 import { AZURE_SDK_QUERY_TIMEOUT_MS } from "../constants";
 import type { BackendSettings } from "../settings";
 import type {
@@ -18,34 +19,6 @@ import type {
   listAggDailyEntitiesFromTableClient,
 } from "../storageTables";
 import { BackendUtility } from "./utilityService";
-
-/**
- * Wraps a promise with a timeout to prevent indefinite hangs.
- * @param promise - The promise to wrap
- * @param timeoutMs - Timeout in milliseconds
- * @param operation - Description of the operation for error messages
- * @returns Promise that rejects if timeout is exceeded
- */
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  operation: string,
-): Promise<T> {
-  let timeoutHandle: NodeJS.Timeout | undefined;
-  return Promise.race([
-    promise.finally(() => {
-      if (timeoutHandle) {
-        clearTimeout(timeoutHandle);
-      }
-    }),
-    new Promise<never>((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`${operation} timed out after ${timeoutMs}ms`)),
-        timeoutMs,
-      );
-    }),
-  ]);
-}
 
 /**
  * DataPlaneService manages Azure Table Storage clients and operations.

--- a/vscode-extension/src/utils/promises.ts
+++ b/vscode-extension/src/utils/promises.ts
@@ -1,0 +1,34 @@
+/**
+ * Promise utility helpers.
+ */
+
+/**
+ * Wraps a promise with a timeout to prevent indefinite hangs.
+ * The timeout handle is cleared via `.finally()` to prevent memory leaks when
+ * the promise settles before the timeout fires.
+ *
+ * @param promise - The promise to wrap
+ * @param timeoutMs - Timeout in milliseconds
+ * @param operation - Description of the operation (used in the rejection error message)
+ * @returns A promise that rejects with a descriptive error if `timeoutMs` elapses before `promise` settles
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string,
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  return Promise.race([
+    promise.finally(() => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }),
+    new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () => reject(new Error(`${operation} timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    }),
+  ]);
+}


### PR DESCRIPTION
Move the generic withTimeout<T> helper out of dataPlaneService.ts and
into vscode-extension/src/utils/promises.ts so it can be reused across
the extension without coupling it to a specific service.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
