### PR TITLE
refactor: extract type guard helpers from sessionParser.ts to utils/typeGuards.ts

### DIFF
--- a/vscode-extension/src/backend/rollups.ts
+++ b/vscode-extension/src/backend/rollups.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DailyRollupValue } from './types';
+import { isObject } from '../utils/typeGuards';
 
 /**
  * Key identifying a unique daily rollup (dimensions).
@@ -175,10 +176,6 @@ function _mergeJsonFluencyMetrics(ex: FluencyMetrics, val: FluencyMetrics): void
 	}
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null;
-}
-
 function mergeNumericValues(existing: unknown, delta: number): number {
 	return (typeof existing === 'number' ? existing : 0) + delta;
 }
@@ -201,7 +198,7 @@ function mergeMetricEntry(existing: unknown, incoming: unknown): unknown {
 	if (typeof incoming === 'number') {
 		return mergeNumericValues(existing, incoming);
 	}
-	if (isPlainObject(incoming) && isPlainObject(existing)) {
+	if (isObject(incoming) && isObject(existing)) {
 		return mergeNestedObject(existing, incoming);
 	}
 	return incoming;

--- a/vscode-extension/src/sessionParser.ts
+++ b/vscode-extension/src/sessionParser.ts
@@ -3,36 +3,7 @@ export interface ModelUsage {
 }
 
 import { extractSubAgentData } from './tokenEstimation';
-
-type JsonObject = Record<string, unknown>;
-
-function isObject(value: unknown): value is JsonObject {
-return typeof value === 'object' && value !== null;
-}
-
-function isSafePathSegment(seg: string): boolean {
-// Prevent prototype pollution and other surprising behavior.
-if (typeof seg !== 'string') {
-return false;
-}
-const forbidden = ['__proto__', 'prototype', 'constructor', 'hasOwnProperty'];
-return !forbidden.includes(seg) && !seg.startsWith('__');
-}
-
-function isArrayIndexSegment(seg: string): boolean {
-return /^\d+$/.test(seg);
-}
-
-function normalizeModelId(model: unknown, defaultModel: string): string {
-if (typeof model !== 'string') {
-return defaultModel;
-}
-const trimmed = model.trim();
-if (!trimmed) {
-return defaultModel;
-}
-return trimmed.startsWith('copilot/') ? trimmed.substring('copilot/'.length) : trimmed;
-}
+import { type JsonObject, isObject, isSafePathSegment, isArrayIndexSegment, normalizeModelId } from './utils/typeGuards';
 
 interface MessagePart {
   text?: string;

--- a/vscode-extension/src/utils/typeGuards.ts
+++ b/vscode-extension/src/utils/typeGuards.ts
@@ -1,0 +1,52 @@
+/**
+ * A plain JSON object with string keys and unknown values.
+ */
+export type JsonObject = Record<string, unknown>;
+
+/**
+ * Returns true when `value` is a non-null object (i.e. a plain object or array).
+ * Use this as a type guard before accessing dynamic keys on `unknown` values.
+ */
+export function isObject(value: unknown): value is JsonObject {
+	return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Returns true when `seg` is safe to use as a property key.
+ * Guards against prototype pollution by rejecting well-known dangerous names
+ * (`__proto__`, `prototype`, `constructor`, `hasOwnProperty`) and any segment
+ * that starts with `__`.
+ */
+export function isSafePathSegment(seg: string): boolean {
+	if (typeof seg !== 'string') {
+		return false;
+	}
+	const forbidden = ['__proto__', 'prototype', 'constructor', 'hasOwnProperty'];
+	return !forbidden.includes(seg) && !seg.startsWith('__');
+}
+
+/**
+ * Returns true when `seg` is a non-negative integer string (e.g. `"0"`, `"42"`).
+ * Used to decide whether a path segment should address an array index.
+ */
+export function isArrayIndexSegment(seg: string): boolean {
+	return /^\d+$/.test(seg);
+}
+
+/**
+ * Normalise a raw model identifier to a canonical string.
+ *
+ * - Non-string values fall back to `defaultModel`.
+ * - Empty / whitespace-only strings fall back to `defaultModel`.
+ * - Strings prefixed with `"copilot/"` have that prefix stripped.
+ */
+export function normalizeModelId(model: unknown, defaultModel: string): string {
+	if (typeof model !== 'string') {
+		return defaultModel;
+	}
+	const trimmed = model.trim();
+	if (!trimmed) {
+		return defaultModel;
+	}
+	return trimmed.startsWith('copilot/') ? trimmed.substring('copilot/'.length) : trimmed;
+}

--- a/vscode-extension/test/unit/utils-typeGuards.test.ts
+++ b/vscode-extension/test/unit/utils-typeGuards.test.ts
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import {
+	isObject,
+	isSafePathSegment,
+	isArrayIndexSegment,
+	normalizeModelId,
+	type JsonObject
+} from '../../src/utils/typeGuards';
+
+// ── isObject ────────────────────────────────────────────────────────────────
+
+test('isObject: returns true for plain objects', () => {
+	assert.ok(isObject({}));
+	assert.ok(isObject({ a: 1 }));
+});
+
+test('isObject: returns true for arrays (they are objects)', () => {
+	assert.ok(isObject([]));
+	assert.ok(isObject([1, 2, 3]));
+});
+
+test('isObject: returns false for null', () => {
+	assert.equal(isObject(null), false);
+});
+
+test('isObject: returns false for primitives', () => {
+	assert.equal(isObject(undefined), false);
+	assert.equal(isObject(42), false);
+	assert.equal(isObject('string'), false);
+	assert.equal(isObject(true), false);
+});
+
+test('isObject: narrows to JsonObject so key access compiles', () => {
+	const value: unknown = { key: 'value' };
+	if (isObject(value)) {
+		const typed: JsonObject = value;
+		assert.equal(typed['key'], 'value');
+	} else {
+		assert.fail('Expected isObject to return true');
+	}
+});
+
+// ── isSafePathSegment ────────────────────────────────────────────────────────
+
+test('isSafePathSegment: accepts normal string keys', () => {
+	assert.ok(isSafePathSegment('foo'));
+	assert.ok(isSafePathSegment('bar123'));
+	assert.ok(isSafePathSegment('0'));
+	assert.ok(isSafePathSegment('hello-world'));
+});
+
+test('isSafePathSegment: rejects forbidden prototype pollution keys', () => {
+	assert.equal(isSafePathSegment('__proto__'), false);
+	assert.equal(isSafePathSegment('prototype'), false);
+	assert.equal(isSafePathSegment('constructor'), false);
+	assert.equal(isSafePathSegment('hasOwnProperty'), false);
+});
+
+test('isSafePathSegment: rejects any key starting with double underscore', () => {
+	assert.equal(isSafePathSegment('__anything'), false);
+	assert.equal(isSafePathSegment('__defineGetter__'), false);
+});
+
+test('isSafePathSegment: returns false for non-string values', () => {
+	// The function signature is `seg: string` but it guards at runtime too.
+	assert.equal(isSafePathSegment(null as unknown as string), false);
+	assert.equal(isSafePathSegment(undefined as unknown as string), false);
+	assert.equal(isSafePathSegment(42 as unknown as string), false);
+});
+
+// ── isArrayIndexSegment ──────────────────────────────────────────────────────
+
+test('isArrayIndexSegment: returns true for digit-only strings', () => {
+	assert.ok(isArrayIndexSegment('0'));
+	assert.ok(isArrayIndexSegment('1'));
+	assert.ok(isArrayIndexSegment('42'));
+	assert.ok(isArrayIndexSegment('100'));
+});
+
+test('isArrayIndexSegment: returns false for non-digit strings', () => {
+	assert.equal(isArrayIndexSegment(''), false);
+	assert.equal(isArrayIndexSegment('abc'), false);
+	assert.equal(isArrayIndexSegment('1a'), false);
+	assert.equal(isArrayIndexSegment('-1'), false);
+	assert.equal(isArrayIndexSegment('1.5'), false);
+});
+
+// ── normalizeModelId ─────────────────────────────────────────────────────────
+
+test('normalizeModelId: returns defaultModel for non-string values', () => {
+	assert.equal(normalizeModelId(null, 'default'), 'default');
+	assert.equal(normalizeModelId(undefined, 'default'), 'default');
+	assert.equal(normalizeModelId(42, 'default'), 'default');
+	assert.equal(normalizeModelId({}, 'default'), 'default');
+});
+
+test('normalizeModelId: returns defaultModel for empty or whitespace strings', () => {
+	assert.equal(normalizeModelId('', 'default'), 'default');
+	assert.equal(normalizeModelId('   ', 'default'), 'default');
+});
+
+test('normalizeModelId: strips copilot/ prefix', () => {
+	assert.equal(normalizeModelId('copilot/gpt-4o', 'default'), 'gpt-4o');
+	assert.equal(normalizeModelId('copilot/claude-3.5-sonnet', 'default'), 'claude-3.5-sonnet');
+});
+
+test('normalizeModelId: trims whitespace before stripping prefix', () => {
+	assert.equal(normalizeModelId('  copilot/gpt-4o  ', 'default'), 'gpt-4o');
+});
+
+test('normalizeModelId: returns trimmed value for non-prefixed models', () => {
+	assert.equal(normalizeModelId('gpt-4o', 'default'), 'gpt-4o');
+	assert.equal(normalizeModelId('  gpt-4o  ', 'default'), 'gpt-4o');
+});
+
+test('normalizeModelId: does not strip copilot/ that appears mid-string', () => {
+	assert.equal(normalizeModelId('my-copilot/model', 'default'), 'my-copilot/model');
+});


### PR DESCRIPTION
- Created vscode-extension/src/utils/typeGuards.ts with exported, JSDoc-documented:
  JsonObject, isObject, isSafePathSegment, isArrayIndexSegment, normalizeModelId
- Updated sessionParser.ts to import from the new module (removed local definitions)
- Updated rollups.ts to use isObject from typeGuards instead of local isPlainObject
- Added 17 unit tests in test/unit/utils-typeGuards.test.ts

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
