### PR TITLE
refactor: consolidate duplicate escapeHtml/formatFileSize/getTimeSince into webview/shared

### DIFF
--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -1,7 +1,7 @@
 // Import shared utilities
 import { BUTTONS } from "../shared/buttonConfig";
 import { createButton, el } from "../shared/domUtils";
-import { formatCost, formatNumber, formatCompact, setCompactNumbers } from "../shared/formatUtils";
+import { escapeHtml, formatCost, formatNumber, formatCompact, setCompactNumbers } from "../shared/formatUtils";
 import { getModelDisplayName } from "../shared/modelUtils";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
 import themeStyles from "../shared/theme.css";
@@ -573,14 +573,6 @@ function getFluencyStageIcon(stage: number): string {
 		4: '🎯'  // Strategist
 	};
 	return icons[stage] || '❓';
-}
-
-function escapeHtml(text: string): string {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
 }
 
 function markdownToHtml(text: string): string {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1,6 +1,7 @@
-﻿// Diagnostics Report webview with tabbed interface
+// Diagnostics Report webview with tabbed interface
 import { buttonHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
+import { escapeHtml, formatFileSize, getTimeSince } from "../shared/formatUtils";
 import { createViewStateManager } from "../shared/viewState";
 // CSS imported as text via esbuild
 import themeStyles from "../shared/theme.css";
@@ -153,15 +154,6 @@ let isLoading = true;
 let currentBackendInfo: BackendStorageInfo | undefined;
 let currentGithubAuth: GitHubAuthStatus | undefined;
 
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
-
 function removeSessionFilesSection(reportText: string): string {
   return reportText.replace(SESSION_FILES_SECTION_REGEX, "");
 }
@@ -175,51 +167,6 @@ function formatDate(isoString: string | null): string {
   } catch {
     return escapeHtml(isoString);
   }
-}
-
-function getTimeSince(isoString: string): string {
-  try {
-    const now = Date.now();
-    const then = new Date(isoString).getTime();
-    const diffMs = now - then;
-
-    if (diffMs < 0) {
-      return "Just now";
-    }
-
-    const seconds = Math.floor(diffMs / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-
-    if (days > 0) {
-      return `${days} day${days !== 1 ? "s" : ""} ago`;
-    }
-    if (hours > 0) {
-      return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
-    }
-    if (minutes > 0) {
-      return `${minutes} minute${minutes !== 1 ? "s" : ""} ago`;
-    }
-    return `${seconds} second${seconds !== 1 ? "s" : ""} ago`;
-  } catch {
-    return "Unknown";
-  }
-}
-
-function formatFileSize(bytes: number): string {
-  const numericBytes = Number(bytes);
-  if (!Number.isFinite(numericBytes) || numericBytes < 0) {
-    // Fallback for unexpected or untrusted values
-    return "N/A";
-  }
-  if (numericBytes < 1024) {
-    return `${numericBytes} B`;
-  }
-  if (numericBytes < 1024 * 1024) {
-    return `${(numericBytes / 1024).toFixed(1)} KB`;
-  }
-  return `${(numericBytes / (1024 * 1024)).toFixed(2)} MB`;
 }
 
 function sanitizeNumber(value: number | undefined | null): string {

--- a/vscode-extension/src/webview/fluency-level-viewer/main.ts
+++ b/vscode-extension/src/webview/fluency-level-viewer/main.ts
@@ -1,5 +1,6 @@
 // Fluency Level Viewer webview
 import { buttonHtml } from '../shared/buttonConfig';
+import { escapeHtml } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import styles from './styles.css';
 
@@ -55,15 +56,6 @@ const STAGE_DESCRIPTIONS: Record<number, string> = {
 	3: 'Regular, purposeful use across multiple features',
 	4: 'Strategic, advanced use leveraging the full AI ecosystem'
 };
-
-function escapeHtml(text: string): string {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#039;');
-}
 
 /**
  * Convert markdown links to HTML links while escaping other HTML.

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,6 +1,6 @@
 ﻿// Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
-import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
+import { escapeHtml, formatCompact, formatFileSize, setCompactNumbers } from '../shared/formatUtils';
 import { getModelDisplayName } from '../shared/modelUtils';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
@@ -170,15 +170,6 @@ return id;
 return TOOL_NAME_MAP[id] ?? TOOL_NAME_MAP[id.toLowerCase()] ?? id;
 }
 
-function escapeHtml(text: string): string {
-return text
-.replace(/&/g, '&amp;')
-.replace(/</g, '&lt;')
-.replace(/>/g, '&gt;')
-.replace(/"/g, '&quot;')
-.replace(/'/g, '&#039;');
-}
-
 function getEffortDisplayName(level: string): string {
 return EFFORT_DISPLAY_NAMES[level] ?? level;
 }
@@ -190,12 +181,6 @@ return new Date(isoString).toLocaleString();
 } catch {
 return isoString;
 }
-}
-
-function formatFileSize(bytes: number): string {
-if (bytes < 1024) { return `${bytes} B`; }
-if (bytes < 1024 * 1024) { return `${(bytes / 1024).toFixed(1)} KB`; }
-return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
 }
 
 function getContextRefBadges(refs: ContextReferenceUsage): string {

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -1,6 +1,7 @@
 // Maturity Score webview
 import { buttonHtml } from '../shared/buttonConfig';
 import type { ContextReferenceUsage } from '../shared/contextRefUtils';
+import { escapeHtml } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -185,15 +186,6 @@ function stageColor(stage: number): string {
 		case 4: return '#10b981';
 		default: return '#666';
 	}
-}
-
-function escapeHtml(text: string): string {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#039;');
 }
 
 /**

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -104,3 +104,65 @@ export function formatCost(value: number): string {
 		maximumFractionDigits: 2
 	}).format(value);
 }
+
+/**
+ * Escapes HTML special characters in a string to prevent XSS.
+ */
+export function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;');
+}
+
+/**
+ * Formats a byte count as a human-readable file size string.
+ */
+export function formatFileSize(bytes: number): string {
+	const numericBytes = Number(bytes);
+	if (!Number.isFinite(numericBytes) || numericBytes < 0) {
+		return 'N/A';
+	}
+	if (numericBytes < 1024) {
+		return `${numericBytes} B`;
+	}
+	if (numericBytes < 1024 * 1024) {
+		return `${(numericBytes / 1024).toFixed(1)} KB`;
+	}
+	return `${(numericBytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+/**
+ * Returns a human-readable "time since" string for an ISO timestamp.
+ */
+export function getTimeSince(isoString: string): string {
+	try {
+		const now = Date.now();
+		const then = new Date(isoString).getTime();
+		const diffMs = now - then;
+
+		if (diffMs < 0) {
+			return 'Just now';
+		}
+
+		const seconds = Math.floor(diffMs / 1000);
+		const minutes = Math.floor(seconds / 60);
+		const hours = Math.floor(minutes / 60);
+		const days = Math.floor(hours / 24);
+
+		if (days > 0) {
+			return `${days} day${days !== 1 ? 's' : ''} ago`;
+		}
+		if (hours > 0) {
+			return `${hours} hour${hours !== 1 ? 's' : ''} ago`;
+		}
+		if (minutes > 0) {
+			return `${minutes} minute${minutes !== 1 ? 's' : ''} ago`;
+		}
+		return `${seconds} second${seconds !== 1 ? 's' : ''} ago`;
+	} catch {
+		return 'Unknown';
+	}
+}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -2,7 +2,7 @@
 import { el } from '../shared/domUtils';
 import { buttonHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
-import { formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
+import { escapeHtml, formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
@@ -264,15 +264,6 @@ type AgentSessionsResult = {
   since: string;
   fetchedAt: string;
 };
-
-function escapeHtml(text: string): string {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#039;');
-}
 
 const EFFORT_DISPLAY_NAMES: Record<string, string> = {
 	xhigh: 'Extra High',


### PR DESCRIPTION
## Summary

Consolidates three utility functions that were copy-pasted across webview files into the shared formatUtils module.

### Functions moved to webview/shared/formatUtils.ts

- escapeHtml: removed from 6 files (dashboard, maturity, logviewer, diagnostics, fluency-level-viewer, usage). The canonical version includes all 5 HTML entity replacements (including single-quote &#039;) for consistent XSS safety.
- formatFileSize: removed from logviewer and diagnostics. Uses the more robust diagnostics version with NaN/negative-value guards.
- getTimeSince: removed from diagnostics (was only there; moved to shared for future reuse).

### Verification
- npm run compile passes (tsc + eslint + esbuild)
- All 62 unit tests pass (npm run test:node)