### PR TITLE
refactor: extract duplicate webview type definitions to webview/shared/types.ts

### DIFF
--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,7 +1,8 @@
-﻿// Log Viewer webview - displays session file details and chat turns
+// Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { getModelDisplayName } from '../shared/modelUtils';
+import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -48,9 +49,6 @@ actualUsage?: ActualUsage;
 thinkingEffort?: string;
 };
 
-type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 type ThinkingEffortUsage = { byEffort: { [effort: string]: number }; switchCount: number; defaultEffort: string | null };
 type SessionUsageAnalysis = {
 toolCalls: ToolCallUsage;

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -2,25 +2,9 @@
 import { buttonHtml } from '../shared/buttonConfig';
 import type { ContextReferenceUsage } from '../shared/contextRefUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
+import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
-
-// ── Types ──────────────────────────────────────────────────────────────
-
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
-type ModelSwitchingAnalysis = {
-	modelsPerSession: number[];
-	totalSessions: number;
-	averageModelsPerSession: number;
-	maxModelsPerSession: number;
-	switchingFrequency: number;
-	standardModels: string[];
-	premiumModels: string[];
-	unknownModels: string[];
-	mixedTierSessions: number;
-};
 
 type UsageAnalysisPeriod = {
 	sessions: number;

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared type definitions used across multiple webview panels.
+ */
+
+export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
+export type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
+export type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
+
+/** Common fields shared across all webviews that display model-switching data. */
+export type ModelSwitchingAnalysis = {
+	modelsPerSession: number[];
+	totalSessions: number;
+	averageModelsPerSession: number;
+	maxModelsPerSession: number;
+	switchingFrequency: number;
+	standardModels: string[];
+	premiumModels: string[];
+	unknownModels: string[];
+	mixedTierSessions: number;
+};

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4,25 +4,13 @@ import { buttonHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
 import { formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
+import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis as BaseModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
-
-type ModelSwitchingAnalysis = {
-	modelsPerSession: number[];
-	totalSessions: number;
-	averageModelsPerSession: number;
-	maxModelsPerSession: number;
+type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
-	switchingFrequency: number;
-	standardModels: string[];
-	premiumModels: string[];
-	unknownModels: string[];
-	mixedTierSessions: number;
 	standardRequests: number;
 	premiumRequests: number;
 	unknownRequests: number;


### PR DESCRIPTION
## Summary

Eliminates copy-pasted type definitions across three webview main files by extracting the common types into a new shared module.

## Changes

- **New file**: `vscode-extension/src/webview/shared/types.ts` - exports `ModeUsage`, `ToolCallUsage`, `McpToolUsage`, and the base `ModelSwitchingAnalysis` (common fields)
- **`maturity/main.ts`** - imports the 4 shared types, removes local definitions
- **`usage/main.ts`** - imports the 3 simple shared types; extends `ModelSwitchingAnalysis` via intersection type to add its extra required fields (`minModelsPerSession`, `standardRequests`, `premiumRequests`, `unknownRequests`, `totalRequests`)
- **`logviewer/main.ts`** - imports `ModeUsage`, `ToolCallUsage`, `McpToolUsage` from shared, removes local definitions

## Type-safety approach for ModelSwitchingAnalysis

`usage/main.ts` adds five extra required fields that `maturity/main.ts` does not use. Rather than making them optional (which would require null-checks throughout `usage/main.ts`), the shared type holds the common base and `usage/main.ts` defines a local intersection type that adds the extra required fields - preserving full type safety and zero runtime behavior change.

## Verification

- `tsc --noEmit`: all clear, no errors
- `node esbuild.js`: bundle builds cleanly
- `npm run test:node`: all 63 tests pass
