### PR TITLE
refactor: extract duplicate webview type definitions to webview/shared/types.ts

### DIFF
--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,7 +1,8 @@
-﻿// Log Viewer webview - displays session file details and chat turns
+// Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { getModelDisplayName } from '../shared/modelUtils';
+import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -48,9 +49,6 @@ actualUsage?: ActualUsage;
 thinkingEffort?: string;
 };
 
-type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 type ThinkingEffortUsage = { byEffort: { [effort: string]: number }; switchCount: number; defaultEffort: string | null };
 type SessionUsageAnalysis = {
 toolCalls: ToolCallUsage;

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -2,25 +2,9 @@
 import { buttonHtml } from '../shared/buttonConfig';
 import type { ContextReferenceUsage } from '../shared/contextRefUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
+import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
-
-// ── Types ──────────────────────────────────────────────────────────────
-
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
-type ModelSwitchingAnalysis = {
-	modelsPerSession: number[];
-	totalSessions: number;
-	averageModelsPerSession: number;
-	maxModelsPerSession: number;
-	switchingFrequency: number;
-	standardModels: string[];
-	premiumModels: string[];
-	unknownModels: string[];
-	mixedTierSessions: number;
-};
 
 type UsageAnalysisPeriod = {
 	sessions: number;

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared type definitions used across multiple webview panels.
+ */
+
+export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
+export type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
+export type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
+
+/** Common fields shared across all webviews that display model-switching data. */
+export type ModelSwitchingAnalysis = {
+	modelsPerSession: number[];
+	totalSessions: number;
+	averageModelsPerSession: number;
+	maxModelsPerSession: number;
+	switchingFrequency: number;
+	standardModels: string[];
+	premiumModels: string[];
+	unknownModels: string[];
+	mixedTierSessions: number;
+};

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4,25 +4,13 @@ import { buttonHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
 import { formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
+import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis as BaseModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 
-type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
-type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
-
-type ModelSwitchingAnalysis = {
-	modelsPerSession: number[];
-	totalSessions: number;
-	averageModelsPerSession: number;
-	maxModelsPerSession: number;
+type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
-	switchingFrequency: number;
-	standardModels: string[];
-	premiumModels: string[];
-	unknownModels: string[];
-	mixedTierSessions: number;
 	standardRequests: number;
 	premiumRequests: number;
 	unknownRequests: number;


### PR DESCRIPTION
Move ModeUsage, ToolCallUsage, McpToolUsage, and ModelSwitchingAnalysis
(common fields) to a new shared types module. Update maturity/main.ts,
usage/main.ts, and logviewer/main.ts to import from the shared file.

- usage/main.ts extends ModelSwitchingAnalysis with its extra required
  fields (minModelsPerSession, standardRequests, premiumRequests,
  unknownRequests, totalRequests) via intersection type
- Eliminates 3 copies of ModeUsage, ToolCallUsage, and McpToolUsage
- Eliminates 2 copies of the base ModelSwitchingAnalysis shape

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
