### PR TITLE
refactor(tests): add shared vscode-test-helpers and remove inline mocks

### DIFF
--- a/vscode-extension/test/unit/backend-blobUploadService.test.ts
+++ b/vscode-extension/test/unit/backend-blobUploadService.test.ts
@@ -2,27 +2,10 @@ import './vscode-shim-register';
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import * as vscode from 'vscode';
+import { createMockExtensionContext } from './vscode-test-helpers';
 import { BlobUploadService, type BlobUploadSettings } from '../../src/backend/services/blobUploadService';
 
-function makeGlobalState(): vscode.Memento & { setKeysForSync?(keys: readonly string[]): void } {
-	const state = new Map<string, unknown>();
-	return {
-		keys: () => [...state.keys()],
-		get<T>(key: string, fallback?: T): T {
-			return (state.has(key) ? state.get(key) : fallback) as T;
-		},
-		async update(key: string, value: unknown) {
-			state.set(key, value);
-		}
-	};
-}
-
-function makeContext(): vscode.ExtensionContext {
-	return {
-		globalState: makeGlobalState()
-	} as unknown as vscode.ExtensionContext;
-}
+function makeContext() { return createMockExtensionContext(); }
 
 const enabledSettings: BlobUploadSettings = {
 	enabled: true,

--- a/vscode-extension/test/unit/backend-displayNames.test.ts
+++ b/vscode-extension/test/unit/backend-displayNames.test.ts
@@ -5,18 +5,10 @@
 import './vscode-shim-register';
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as vscode from 'vscode';
+import { createMockMemento } from './vscode-test-helpers';
 import { DisplayNameStore } from '../../src/backend/displayNames';
 
-function makeGlobalState(): vscode.Memento & { storage: Map<string, any> } {
-	const storage = new Map<string, any>();
-	return {
-		storage,
-		get: (key: string, defaultValue?: any) => storage.get(key) ?? defaultValue,
-		update: async (key: string, value: any) => { storage.set(key, value); },
-		keys: () => Array.from(storage.keys())
-	};
-}
+const makeGlobalState = () => createMockMemento();
 
 // ── getWorkspaceName / getMachineName ─────────────────────────────────────
 

--- a/vscode-extension/test/unit/cacheManager-lock.test.ts
+++ b/vscode-extension/test/unit/cacheManager-lock.test.ts
@@ -6,15 +6,13 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { CacheManager } from '../../src/cacheManager';
+import { createMockMemento } from './vscode-test-helpers';
 
 function makeManager(dir: string): CacheManager {
 	const context: any = {
 		extensionMode: 1, // Production
 		globalStorageUri: { fsPath: dir },
-		globalState: {
-			get: () => undefined,
-			update: async () => {}
-		}
+		globalState: createMockMemento()
 	};
 	const deps = { log: () => {}, warn: () => {}, error: () => {} };
 	return new CacheManager(context, deps, 1);
@@ -26,7 +24,7 @@ function makeDirAndManager(): { dir: string; manager: CacheManager; logs: string
 	const context: any = {
 		extensionMode: 1,
 		globalStorageUri: { fsPath: dir },
-		globalState: { get: () => undefined, update: async () => {} }
+		globalState: createMockMemento()
 	};
 	const deps = { log: (m: string) => logs.push(m), warn: () => {}, error: () => {} };
 	const manager = new CacheManager(context, deps, 1);
@@ -130,3 +128,4 @@ test('releaseCacheLock: only releases own lock', async () => {
 	// Clean up
 	fs.unlinkSync(lockPath);
 });
+

--- a/vscode-extension/test/unit/vscode-test-helpers.ts
+++ b/vscode-extension/test/unit/vscode-test-helpers.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared VS Code mock factories for unit tests.
+ *
+ * Import these helpers instead of defining inline mock objects in each test
+ * file so there is a single, consistent implementation to maintain.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Creates a lightweight in-memory implementation of `vscode.Memento`.
+ * The internal store is exposed as `_store` so tests can inspect or
+ * pre-populate state without going through the public API.
+ */
+export function createMockMemento(): vscode.Memento & { _store: Map<string, unknown> } {
+const store = new Map<string, unknown>();
+return {
+_store: store,
+get<T>(key: string, defaultValue?: T): T {
+return (store.get(key) ?? defaultValue) as T;
+},
+update(key: string, value: unknown): Thenable<void> {
+store.set(key, value);
+return Promise.resolve();
+},
+keys(): readonly string[] {
+return [...store.keys()];
+}
+};
+}
+
+/**
+ * Creates a minimal `vscode.ExtensionContext` stub with independent
+ * `globalState` and `workspaceState` Memento instances.
+ */
+export function createMockExtensionContext(): vscode.ExtensionContext {
+return {
+globalState: createMockMemento(),
+workspaceState: createMockMemento()
+} as unknown as vscode.ExtensionContext;
+}


### PR DESCRIPTION
## Summary

Introduces a shared test helper module to eliminate duplicated inline VS Code mock definitions across unit test files.

## Changes

### New file: \scode-extension/test/unit/vscode-test-helpers.ts\

Exports two factory functions:
- \createMockMemento()\ — in-memory \scode.Memento\ implementation with an exposed \_store: Map<string, unknown>\ for test introspection
- \createMockExtensionContext()\ — minimal \scode.ExtensionContext\ stub with independent \globalState\ and \workspaceState\ instances

### Updated test files

Three files had clearly duplicated inline mock code that is now replaced with imports from the helper:

| File | Before | After |
|---|---|---|
| \ackend-blobUploadService.test.ts\ | \makeGlobalState()\ + \makeContext()\ defined inline | \createMockExtensionContext()\ |
| \ackend-displayNames.test.ts\ | \makeGlobalState()\ defined inline | \createMockMemento()\ |
| \cacheManager-lock.test.ts\ | Two \{ get: () => undefined, update: async () => {} }\ object literals | \createMockMemento()\ |

## Test results

- TypeScript compiles cleanly (\	sc -p tsconfig.tests.json\ exits 0)
- All three modified test files pass: \ackend-blobUploadService.test.js\, \ackend-displayNames.test.js\, \cacheManager-lock.test.js\
- Pre-existing failures in \crush-cache.test.js\ (\ccess.dispose is not a function\) are unrelated to this change and present on the base branch

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>