### PR TITLE
refactor: extract upload entry validation to sharing-server/validation/uploadSchema.ts

### DIFF
--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { requireBearerAuth, checkUploadRateLimit, type AuthVariables } from '../auth.js';
 import { upsertUpload, deleteUploadsForDays, getUploadsForUser, getDb, upsertUserFluencyScore, type UploadEntry } from '../db.js';
-import { MAX_STRING_LENGTHS, MAX_TOKEN_VALUE, MAX_ENTRIES_PER_UPLOAD } from '../config.js';
+import { MAX_ENTRIES_PER_UPLOAD } from '../config.js';
+import { validateEntry } from '../validation/uploadSchema.js';
 
 // Fluency score payload limits
 const MAX_FLUENCY_LABEL_LENGTH = 128;
@@ -11,7 +12,6 @@ const MAX_FLUENCY_ICON_LENGTH = 64;
 const MAX_FLUENCY_TIPS_PER_CATEGORY = 20;
 const MAX_FLUENCY_TIP_LENGTH = 512;
 const MAX_FLUENCY_SCORE_JSON_BYTES = 100_000; // 100 KB
-const MAX_FLUENCY_METRICS_JSON_BYTES = 10_000; // 10 KB per entry
 
 export const api = new Hono<{ Variables: AuthVariables }>();
 
@@ -142,80 +142,6 @@ function clampDays(raw: string | undefined): number {
 	const n = parseInt(raw ?? '30', 10);
 	if (!Number.isFinite(n)) return 30;
 	return Math.min(Math.max(n, 1), 90);
-}
-
-function validateEntry(entry: unknown): string | null {
-	if (typeof entry !== 'object' || entry === null) {
-		return 'must be an object';
-	}
-	const e = entry as Record<string, unknown>;
-
-	if (typeof e.day !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(e.day)) {
-		return '"day" must be a YYYY-MM-DD string';
-	}
-	if (typeof e.model !== 'string' || e.model.length === 0) {
-		return '"model" must be a non-empty string';
-	}
-	if (e.model.length > MAX_STRING_LENGTHS.model) {
-		return `"model" too long (max ${MAX_STRING_LENGTHS.model})`;
-	}
-	if (typeof e.workspaceId !== 'string' || e.workspaceId.length === 0) {
-		return '"workspaceId" must be a non-empty string';
-	}
-	if (e.workspaceId.length > MAX_STRING_LENGTHS.workspaceId) {
-		return `"workspaceId" too long (max ${MAX_STRING_LENGTHS.workspaceId})`;
-	}
-	if (typeof e.machineId !== 'string' || e.machineId.length === 0) {
-		return '"machineId" must be a non-empty string';
-	}
-	if (e.machineId.length > MAX_STRING_LENGTHS.machineId) {
-		return `"machineId" too long (max ${MAX_STRING_LENGTHS.machineId})`;
-	}
-	if (!isNonNegativeInt(e.inputTokens) || (e.inputTokens as number) > MAX_TOKEN_VALUE) {
-		return `"inputTokens" must be a non-negative integer ≤ ${MAX_TOKEN_VALUE.toLocaleString()}`;
-	}
-	if (!isNonNegativeInt(e.outputTokens) || (e.outputTokens as number) > MAX_TOKEN_VALUE) {
-		return `"outputTokens" must be a non-negative integer ≤ ${MAX_TOKEN_VALUE.toLocaleString()}`;
-	}
-	if (!isNonNegativeInt(e.interactions) || (e.interactions as number) > 100_000) {
-		return '"interactions" must be a non-negative integer ≤ 100,000';
-	}
-
-	// Optional string fields — truncate if too long (defensive, after length check)
-	if (e.workspaceName !== undefined && e.workspaceName !== null) {
-		if (typeof e.workspaceName !== 'string') return '"workspaceName" must be a string';
-		if (e.workspaceName.length > MAX_STRING_LENGTHS.workspaceName) return `"workspaceName" too long (max ${MAX_STRING_LENGTHS.workspaceName})`;
-	}
-	if (e.machineName !== undefined && e.machineName !== null) {
-		if (typeof e.machineName !== 'string') return '"machineName" must be a string';
-		if (e.machineName.length > MAX_STRING_LENGTHS.machineName) return `"machineName" too long (max ${MAX_STRING_LENGTHS.machineName})`;
-	}
-	if (e.datasetId !== undefined && e.datasetId !== null) {
-		if (typeof e.datasetId !== 'string') return '"datasetId" must be a string';
-		if (e.datasetId.length > MAX_STRING_LENGTHS.datasetId) {
-			return `"datasetId" too long (max ${MAX_STRING_LENGTHS.datasetId})`;
-		}
-	}
-	if (e.editor !== undefined && e.editor !== null) {
-		if (typeof e.editor !== 'string') return '"editor" must be a string';
-		if (e.editor.length > MAX_STRING_LENGTHS.editor) {
-			return `"editor" too long (max ${MAX_STRING_LENGTHS.editor})`;
-		}
-	}
-	if (e.fluencyMetrics !== undefined && e.fluencyMetrics !== null) {
-		if (typeof e.fluencyMetrics !== 'object' || Array.isArray(e.fluencyMetrics)) {
-			return '"fluencyMetrics" must be an object';
-		}
-		if (Buffer.byteLength(JSON.stringify(e.fluencyMetrics), 'utf8') > MAX_FLUENCY_METRICS_JSON_BYTES) {
-			return `"fluencyMetrics" too large (max ${MAX_FLUENCY_METRICS_JSON_BYTES} bytes)`;
-		}
-	}
-
-	return null;
-}
-
-function isNonNegativeInt(value: unknown): boolean {
-	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }
 
 /**

--- a/sharing-server/src/validation/uploadSchema.ts
+++ b/sharing-server/src/validation/uploadSchema.ts
@@ -1,0 +1,89 @@
+import { MAX_STRING_LENGTHS, MAX_TOKEN_VALUE } from '../config.js';
+import type { UploadEntry } from '../db.js';
+
+// Re-export the canonical upload entry type for consumers of this module.
+export type { UploadEntry };
+
+/** Maximum allowed value for the interactions field per upload entry. */
+export const MAX_INTERACTIONS = 100_000;
+
+/** Maximum JSON payload size (bytes) for the fluencyMetrics field per entry. */
+export const MAX_FLUENCY_METRICS_JSON_BYTES = 10_000; // 10 KB per entry
+
+/**
+ * Validates an individual upload entry from the request body.
+ * Returns null when valid, or an error message describing the first failure.
+ */
+export function validateEntry(entry: unknown): string | null {
+	if (typeof entry !== 'object' || entry === null) {
+		return 'must be an object';
+	}
+	const e = entry as Record<string, unknown>;
+
+	if (typeof e.day !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(e.day)) {
+		return '"day" must be a YYYY-MM-DD string';
+	}
+	if (typeof e.model !== 'string' || e.model.length === 0) {
+		return '"model" must be a non-empty string';
+	}
+	if (e.model.length > MAX_STRING_LENGTHS.model) {
+		return `"model" too long (max ${MAX_STRING_LENGTHS.model})`;
+	}
+	if (typeof e.workspaceId !== 'string' || e.workspaceId.length === 0) {
+		return '"workspaceId" must be a non-empty string';
+	}
+	if (e.workspaceId.length > MAX_STRING_LENGTHS.workspaceId) {
+		return `"workspaceId" too long (max ${MAX_STRING_LENGTHS.workspaceId})`;
+	}
+	if (typeof e.machineId !== 'string' || e.machineId.length === 0) {
+		return '"machineId" must be a non-empty string';
+	}
+	if (e.machineId.length > MAX_STRING_LENGTHS.machineId) {
+		return `"machineId" too long (max ${MAX_STRING_LENGTHS.machineId})`;
+	}
+	if (!isNonNegativeInt(e.inputTokens) || (e.inputTokens as number) > MAX_TOKEN_VALUE) {
+		return `"inputTokens" must be a non-negative integer ≤ ${MAX_TOKEN_VALUE.toLocaleString()}`;
+	}
+	if (!isNonNegativeInt(e.outputTokens) || (e.outputTokens as number) > MAX_TOKEN_VALUE) {
+		return `"outputTokens" must be a non-negative integer ≤ ${MAX_TOKEN_VALUE.toLocaleString()}`;
+	}
+	if (!isNonNegativeInt(e.interactions) || (e.interactions as number) > MAX_INTERACTIONS) {
+		return `"interactions" must be a non-negative integer ≤ ${MAX_INTERACTIONS.toLocaleString()}`;
+	}
+
+	// Optional string fields — validate type and length
+	if (e.workspaceName !== undefined && e.workspaceName !== null) {
+		if (typeof e.workspaceName !== 'string') return '"workspaceName" must be a string';
+		if (e.workspaceName.length > MAX_STRING_LENGTHS.workspaceName) return `"workspaceName" too long (max ${MAX_STRING_LENGTHS.workspaceName})`;
+	}
+	if (e.machineName !== undefined && e.machineName !== null) {
+		if (typeof e.machineName !== 'string') return '"machineName" must be a string';
+		if (e.machineName.length > MAX_STRING_LENGTHS.machineName) return `"machineName" too long (max ${MAX_STRING_LENGTHS.machineName})`;
+	}
+	if (e.datasetId !== undefined && e.datasetId !== null) {
+		if (typeof e.datasetId !== 'string') return '"datasetId" must be a string';
+		if (e.datasetId.length > MAX_STRING_LENGTHS.datasetId) {
+			return `"datasetId" too long (max ${MAX_STRING_LENGTHS.datasetId})`;
+		}
+	}
+	if (e.editor !== undefined && e.editor !== null) {
+		if (typeof e.editor !== 'string') return '"editor" must be a string';
+		if (e.editor.length > MAX_STRING_LENGTHS.editor) {
+			return `"editor" too long (max ${MAX_STRING_LENGTHS.editor})`;
+		}
+	}
+	if (e.fluencyMetrics !== undefined && e.fluencyMetrics !== null) {
+		if (typeof e.fluencyMetrics !== 'object' || Array.isArray(e.fluencyMetrics)) {
+			return '"fluencyMetrics" must be an object';
+		}
+		if (Buffer.byteLength(JSON.stringify(e.fluencyMetrics), 'utf8') > MAX_FLUENCY_METRICS_JSON_BYTES) {
+			return `"fluencyMetrics" too large (max ${MAX_FLUENCY_METRICS_JSON_BYTES} bytes)`;
+		}
+	}
+
+	return null;
+}
+
+function isNonNegativeInt(value: unknown): boolean {
+	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}


### PR DESCRIPTION
Move validateEntry() and related constants out of api.ts into a dedicated validation module. Magic numbers become named constants. Enables reuse in tests and future endpoints.