### PR TITLE
refactor: extract CLI command option parsing helpers to cli/src/commandUtils.ts

### DIFF
--- a/cli/src/commandUtils.ts
+++ b/cli/src/commandUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared utilities for CLI command option handling.
+ * Helpers are extracted here when used across 3+ command files.
+ */
+
+/**
+ * Returns true when the --json flag is present, suppressing human-readable output
+ * in favour of machine-consumable JSON written to stdout.
+ */
+export function shouldOutputJson(options: { json?: boolean }): boolean {
+	return options.json === true;
+}

--- a/cli/src/commands/all.ts
+++ b/cli/src/commands/all.ts
@@ -13,12 +13,13 @@ import {
 	buildCustomizationMatrix,
 } from '../helpers';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
+import { shouldOutputJson } from '../commandUtils';
 
 export const allCommand = new Command('all')
 	.description('Output all view data in a single JSON response (for Visual Studio extension)')
 	.option('--json', 'Output raw JSON (required)')
 	.action(async (options) => {
-		if (!options.json) {
+		if (!shouldOutputJson(options)) {
 			process.stderr.write('Use --json flag for all data output\n');
 			return;
 		}

--- a/cli/src/commands/chart.ts
+++ b/cli/src/commands/chart.ts
@@ -3,12 +3,13 @@
  */
 import { Command } from 'commander';
 import { discoverSessionFiles, calculateDailyStats, buildChartPayload } from '../helpers';
+import { shouldOutputJson } from '../commandUtils';
 
 export const chartCommand = new Command('chart')
 	.description('Output daily token usage data for the chart webview')
 	.option('--json', 'Output raw JSON (for machine consumption)')
 	.action(async (options) => {
-		if (!options.json) {
+		if (!shouldOutputJson(options)) {
 			// Human-readable not implemented yet; just emit JSON
 			process.stderr.write('Use --json flag for chart data output\n');
 			return;

--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -5,22 +5,24 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateUsageAnalysisStats, fmt, buildCustomizationMatrix } from '../helpers';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
+import { shouldOutputJson } from '../commandUtils';
 
 export const fluencyCommand = new Command('fluency')
 	.description('Show your Copilot Fluency Score and improvement tips')
 	.option('-t, --tips', 'Show improvement tips for each category')
 	.option('--json', 'Output raw JSON (for machine consumption)')
 	.action(async (options) => {
-		if (!options.json) {
+		const json = shouldOutputJson(options);
+		if (!json) {
 			console.log(chalk.bold.cyan('\n🎯 Copilot Token Tracker - Fluency Score\n'));
 		}
 
-		if (!options.json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
+		if (!json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
 		const files = await discoverSessionFiles();
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
 
 		if (files.length === 0) {
-			if (options.json) {
+			if (json) {
 				process.stdout.write('{}');
 			} else {
 				console.log(chalk.yellow('⚠️  No session files found.'));
@@ -28,11 +30,11 @@ export const fluencyCommand = new Command('fluency')
 			return;
 		}
 
-		if (!options.json) { process.stdout.write(chalk.dim('Analyzing usage patterns...')); }
+		if (!json) { process.stdout.write(chalk.dim('Analyzing usage patterns...')); }
 
 		// Calculate usage analysis stats
 		const usageStats = await calculateUsageAnalysisStats(files);
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
 
 		// Build a customization matrix from workspace folder paths inferred from session file paths.
 		// This matches what the VS Code extension does (scanning workspace folders for instructions files).
@@ -45,7 +47,7 @@ export const fluencyCommand = new Command('fluency')
 			false
 		);
 
-		if (options.json) {
+		if (json) {
 			// Machine-readable output: emit pure JSON to stdout and exit
 			const payload = {
 				overallStage: scores.overallStage,

--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -4,18 +4,20 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, processSessionFile, effectiveTokens, getDiagnosticPaths, fmt, formatTokens, getCacheStats } from '../helpers';
+import { shouldOutputJson } from '../commandUtils';
 
 export const statsCommand = new Command('stats')
 	.description('Show overview of discovered session files, sessions, chat turns, and tokens')
 	.option('-v, --verbose', 'Show detailed per-folder breakdown')
 	.option('--json', 'Output raw JSON (for machine consumption)')
 	.action(async (options) => {
-		if (!options.json) {
+		const json = shouldOutputJson(options);
+		if (!json) {
 			console.log(chalk.bold.cyan('\n🔍 Copilot Token Tracker - Session Statistics\n'));
 		}
 
 		// Show search paths if verbose
-		if (options.verbose && !options.json) {
+		if (options.verbose && !json) {
 			const paths = getDiagnosticPaths();
 			console.log(chalk.dim('Search paths:'));
 			for (const p of paths) {
@@ -26,12 +28,12 @@ export const statsCommand = new Command('stats')
 		}
 
 		// Discover session files
-		if (!options.json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
+		if (!json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
 		const files = await discoverSessionFiles();
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
 
 		if (files.length === 0) {
-			if (options.json) {
+			if (json) {
 				process.stdout.write('{}');
 			} else {
 				console.log(chalk.yellow('⚠️  No session files found.'));
@@ -40,7 +42,7 @@ export const statsCommand = new Command('stats')
 			return;
 		}
 
-		if (!options.json) {
+		if (!json) {
 			console.log(chalk.green(`📂 Found ${chalk.bold(fmt(files.length))} session file(s)\n`));
 		}
 
@@ -85,13 +87,13 @@ export const statsCommand = new Command('stats')
 			}
 
 			// Progress indicator (human-readable only)
-			if (!options.json && ((i + 1) % 50 === 0 || i === files.length - 1)) {
+			if (!json && ((i + 1) % 50 === 0 || i === files.length - 1)) {
 				process.stdout.write(`\r${chalk.dim(`Processing: ${i + 1}/${files.length}`)}`);
 			}
 		}
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
 
-		if (options.json) {
+		if (json) {
 			// Machine-readable output: emit pure JSON to stdout and exit
 			const payload = {
 				totalFiles: files.length,

--- a/cli/src/commands/usage-analysis.ts
+++ b/cli/src/commands/usage-analysis.ts
@@ -3,12 +3,13 @@
  */
 import { Command } from 'commander';
 import { discoverSessionFiles, calculateUsageAnalysisStats } from '../helpers';
+import { shouldOutputJson } from '../commandUtils';
 
 export const usageAnalysisCommand = new Command('usage-analysis')
 	.description('Output usage analysis stats for the usage analysis webview')
 	.option('--json', 'Output raw JSON (for machine consumption)')
 	.action(async (options) => {
-		if (!options.json) {
+		if (!shouldOutputJson(options)) {
 			process.stderr.write('Use --json flag for usage analysis data output\n');
 			return;
 		}

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { discoverSessionFiles, calculateDetailedStats, fmt, formatTokens, modelPricing } from '../helpers';
 import type { PeriodStats, ModelUsage } from '../../../vscode-extension/src/types';
 import { getModelTier } from '../../../vscode-extension/src/tokenEstimation';
+import { shouldOutputJson } from '../commandUtils';
 
 export const usageCommand = new Command('usage')
 	.description('Show token usage for today, current month, last month, and last 30 days')
@@ -18,7 +19,7 @@ export const usageCommand = new Command('usage')
 
 		const stats = await calculateStats(files, options);
 
-		if (options.json) {
+		if (shouldOutputJson(options)) {
 			// Machine-readable output: emit pure JSON to stdout and exit
 			const payload = {
 				today: stats.today,
@@ -51,15 +52,16 @@ export const usageCommand = new Command('usage')
 
 /** Discover session files (quiet when --json is set). */
 async function discoverFiles(options: { json?: boolean }) {
-	if (!options.json) {
+	const json = shouldOutputJson(options);
+	if (!json) {
 		process.stdout.write(chalk.dim('Scanning for session files...'));
 	}
 	const files = await discoverSessionFiles();
-	if (!options.json) {
+	if (!json) {
 		process.stdout.write('\r' + ' '.repeat(50) + '\r');
 	}
 	if (files.length === 0) {
-		if (options.json) {
+		if (json) {
 			process.stdout.write('{}');
 		} else {
 			console.log(chalk.yellow('⚠️  No session files found.'));
@@ -71,13 +73,14 @@ async function discoverFiles(options: { json?: boolean }) {
 
 /** Calculate detailed stats (quiet when --json is set). */
 async function calculateStats(files: string[], options: { json?: boolean }) {
-	if (!options.json) {
+	const json = shouldOutputJson(options);
+	if (!json) {
 		process.stdout.write(chalk.dim('Calculating token usage...'));
 	}
-	const stats = await calculateDetailedStats(files, options.json ? undefined : (completed, total) => {
+	const stats = await calculateDetailedStats(files, json ? undefined : (completed, total) => {
 		process.stdout.write(`\r${chalk.dim(`Processing: ${completed}/${total} files`)}`);
 	});
-	if (!options.json) {
+	if (!json) {
 		process.stdout.write('\r' + ' '.repeat(50) + '\r');
 	}
 	return stats;


### PR DESCRIPTION
Consolidate repeated --json flag handling into a shared commandUtils module. Reduces boilerplate across CLI commands.