### PR TITLE
refactor: extract CLI progress output to cli/src/progress.ts ProgressTracker

### DIFF
--- a/cli/src/commands/diagnostics.ts
+++ b/cli/src/commands/diagnostics.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as path from 'path';
 import { discoverSessionFiles, getDiagnosticPaths, processSessionFile, effectiveTokens, fmt, formatTokens } from '../helpers';
+import { ProgressTracker } from '../progress';
 import { normalizePathSeparators } from '../../../vscode-extension/src/workspaceHelpers';
 
 interface LocationStats {
@@ -108,9 +109,10 @@ export const diagnosticsCommand = new Command('diagnostics')
 		}
 
 		// --- Discover and process files ---
-		process.stdout.write(chalk.dim('Scanning for session files...'));
+		const progress = new ProgressTracker();
+		progress.show('Scanning for session files...');
 		const files = await discoverSessionFiles();
-		process.stdout.write('\r' + ' '.repeat(60) + '\r');
+		progress.done();
 
 		if (files.length === 0) {
 			console.log(chalk.yellow('⚠️  No session files found in any search path.'));
@@ -140,7 +142,7 @@ export const diagnosticsCommand = new Command('diagnostics')
 		for (let i = 0; i < files.length; i++) {
 			// Progress
 			if ((i + 1) % 25 === 0 || i === files.length - 1) {
-				process.stdout.write(`\r${chalk.dim(`Processing: ${i + 1}/${files.length} files...`)}`);
+				progress.update(`Processing: ${i + 1}/${files.length} files...`);
 			}
 
 			const match = matchToCandidatePath(files[i], candidates);
@@ -172,7 +174,7 @@ export const diagnosticsCommand = new Command('diagnostics')
 			}
 		}
 
-		process.stdout.write('\r' + ' '.repeat(60) + '\r');
+		progress.done();
 
 		// --- Per-location table ---
 		console.log(chalk.bold(`📊 Stats per Search Location`));

--- a/cli/src/commands/environmental.ts
+++ b/cli/src/commands/environmental.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateDetailedStats, formatTokens, ENVIRONMENTAL } from '../helpers';
+import { ProgressTracker } from '../progress';
 import type { PeriodStats } from '../../../vscode-extension/src/types';
 
 export const environmentalCommand = new Command('environmental')
@@ -12,20 +13,21 @@ export const environmentalCommand = new Command('environmental')
 	.action(async () => {
 		console.log(chalk.bold.cyan('\n🌍 Copilot Token Tracker - Environmental Impact\n'));
 
-		process.stdout.write(chalk.dim('Scanning for session files...'));
+		const progress = new ProgressTracker();
+		progress.show('Scanning for session files...');
 		const files = await discoverSessionFiles();
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
+		progress.done();
 
 		if (files.length === 0) {
 			console.log(chalk.yellow('⚠️  No session files found.'));
 			return;
 		}
 
-		process.stdout.write(chalk.dim('Calculating usage...'));
+		progress.show('Calculating usage...');
 		const stats = await calculateDetailedStats(files, (completed, total) => {
-			process.stdout.write(`\r${chalk.dim(`Processing: ${completed}/${total} files`)}`);
+			progress.update(`Processing: ${completed}/${total} files`);
 		});
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
+		progress.done();
 
 		const periods: { label: string; emoji: string; stats: PeriodStats }[] = [
 			{ label: 'Today', emoji: '📅', stats: stats.today },

--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateUsageAnalysisStats, fmt, buildCustomizationMatrix } from '../helpers';
+import { ProgressTracker } from '../progress';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
 
 export const fluencyCommand = new Command('fluency')
@@ -15,9 +16,10 @@ export const fluencyCommand = new Command('fluency')
 			console.log(chalk.bold.cyan('\n🎯 Copilot Token Tracker - Fluency Score\n'));
 		}
 
-		if (!options.json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
+		const progress = new ProgressTracker(!!options.json);
+		progress.show('Scanning for session files...');
 		const files = await discoverSessionFiles();
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		progress.done();
 
 		if (files.length === 0) {
 			if (options.json) {
@@ -28,11 +30,11 @@ export const fluencyCommand = new Command('fluency')
 			return;
 		}
 
-		if (!options.json) { process.stdout.write(chalk.dim('Analyzing usage patterns...')); }
+		progress.show('Analyzing usage patterns...');
 
 		// Calculate usage analysis stats
 		const usageStats = await calculateUsageAnalysisStats(files);
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		progress.done();
 
 		// Build a customization matrix from workspace folder paths inferred from session file paths.
 		// This matches what the VS Code extension does (scanning workspace folders for instructions files).

--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, processSessionFile, effectiveTokens, getDiagnosticPaths, fmt, formatTokens, getCacheStats } from '../helpers';
+import { ProgressTracker } from '../progress';
 
 export const statsCommand = new Command('stats')
 	.description('Show overview of discovered session files, sessions, chat turns, and tokens')
@@ -26,9 +27,10 @@ export const statsCommand = new Command('stats')
 		}
 
 		// Discover session files
-		if (!options.json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
+		const progress = new ProgressTracker(!!options.json);
+		progress.show('Scanning for session files...');
 		const files = await discoverSessionFiles();
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		progress.done();
 
 		if (files.length === 0) {
 			if (options.json) {
@@ -85,12 +87,11 @@ export const statsCommand = new Command('stats')
 			}
 
 			// Progress indicator (human-readable only)
-			if (!options.json && ((i + 1) % 50 === 0 || i === files.length - 1)) {
-				process.stdout.write(`\r${chalk.dim(`Processing: ${i + 1}/${files.length}`)}`);
+			if ((i + 1) % 50 === 0 || i === files.length - 1) {
+				progress.update(`Processing: ${i + 1}/${files.length}`);
 			}
 		}
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
-
+		progress.done();
 		if (options.json) {
 			// Machine-readable output: emit pure JSON to stdout and exit
 			const payload = {

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateDetailedStats, fmt, formatTokens, modelPricing } from '../helpers';
+import { ProgressTracker } from '../progress';
 import type { PeriodStats, ModelUsage } from '../../../vscode-extension/src/types';
 import { getModelTier } from '../../../vscode-extension/src/tokenEstimation';
 
@@ -51,13 +52,10 @@ export const usageCommand = new Command('usage')
 
 /** Discover session files (quiet when --json is set). */
 async function discoverFiles(options: { json?: boolean }) {
-	if (!options.json) {
-		process.stdout.write(chalk.dim('Scanning for session files...'));
-	}
+	const progress = new ProgressTracker(!!options.json);
+	progress.show('Scanning for session files...');
 	const files = await discoverSessionFiles();
-	if (!options.json) {
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
-	}
+	progress.done();
 	if (files.length === 0) {
 		if (options.json) {
 			process.stdout.write('{}');
@@ -71,15 +69,12 @@ async function discoverFiles(options: { json?: boolean }) {
 
 /** Calculate detailed stats (quiet when --json is set). */
 async function calculateStats(files: string[], options: { json?: boolean }) {
-	if (!options.json) {
-		process.stdout.write(chalk.dim('Calculating token usage...'));
-	}
-	const stats = await calculateDetailedStats(files, options.json ? undefined : (completed, total) => {
-		process.stdout.write(`\r${chalk.dim(`Processing: ${completed}/${total} files`)}`);
+	const progress = new ProgressTracker(!!options.json);
+	progress.show('Calculating token usage...');
+	const stats = await calculateDetailedStats(files, (completed, total) => {
+		progress.update(`Processing: ${completed}/${total} files`);
 	});
-	if (!options.json) {
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
-	}
+	progress.done();
 	return stats;
 }
 

--- a/cli/src/progress.ts
+++ b/cli/src/progress.ts
@@ -1,0 +1,38 @@
+/**
+ * ProgressTracker - Reusable inline progress output for CLI commands.
+ *
+ * Writes dimmed progress messages to stdout using carriage-return overwriting.
+ * Construct with `silent = true` to suppress all output (e.g. when --json is active).
+ */
+import chalk from 'chalk';
+
+const CLEAR_LINE_WIDTH = 80;
+
+export class ProgressTracker {
+	private readonly silent: boolean;
+
+	constructor(silent = false) {
+		this.silent = silent;
+	}
+
+	/** Write a progress message inline (no newline). */
+	show(msg: string): void {
+		if (!this.silent) {
+			process.stdout.write(chalk.dim(msg));
+		}
+	}
+
+	/** Overwrite the current line with an updated progress message. */
+	update(msg: string): void {
+		if (!this.silent) {
+			process.stdout.write(`\r${chalk.dim(msg)}`);
+		}
+	}
+
+	/** Clear the current progress line. */
+	done(): void {
+		if (!this.silent) {
+			process.stdout.write('\r' + ' '.repeat(CLEAR_LINE_WIDTH) + '\r');
+		}
+	}
+}


### PR DESCRIPTION
Consolidate duplicated stdout progress-line patterns across CLI commands into a reusable ProgressTracker class.

## Changes
- New cli/src/progress.ts with ProgressTracker class
- Updated 5 command files: diagnostics.ts, environmental.ts, fluency.ts, stats.ts, usage.ts
- Build passes