### PR TITLE
refactor: extract CLI output formatting helpers to cli/src/formatting.ts

### DIFF
--- a/cli/src/commands/diagnostics.ts
+++ b/cli/src/commands/diagnostics.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as path from 'path';
 import { discoverSessionFiles, getDiagnosticPaths, processSessionFile, effectiveTokens, fmt, formatTokens } from '../helpers';
+import { clearLine, writeProgress, writeProgressCount } from '../formatting';
 import { normalizePathSeparators } from '../../../vscode-extension/src/workspaceHelpers';
 
 interface LocationStats {
@@ -108,9 +109,9 @@ export const diagnosticsCommand = new Command('diagnostics')
 		}
 
 		// --- Discover and process files ---
-		process.stdout.write(chalk.dim('Scanning for session files...'));
+		writeProgress('Scanning for session files...');
 		const files = await discoverSessionFiles();
-		process.stdout.write('\r' + ' '.repeat(60) + '\r');
+		clearLine(60);
 
 		if (files.length === 0) {
 			console.log(chalk.yellow('⚠️  No session files found in any search path.'));
@@ -140,7 +141,7 @@ export const diagnosticsCommand = new Command('diagnostics')
 		for (let i = 0; i < files.length; i++) {
 			// Progress
 			if ((i + 1) % 25 === 0 || i === files.length - 1) {
-				process.stdout.write(`\r${chalk.dim(`Processing: ${i + 1}/${files.length} files...`)}`);
+				writeProgressCount(i + 1, files.length);
 			}
 
 			const match = matchToCandidatePath(files[i], candidates);
@@ -172,7 +173,7 @@ export const diagnosticsCommand = new Command('diagnostics')
 			}
 		}
 
-		process.stdout.write('\r' + ' '.repeat(60) + '\r');
+		clearLine(60);
 
 		// --- Per-location table ---
 		console.log(chalk.bold(`📊 Stats per Search Location`));

--- a/cli/src/commands/environmental.ts
+++ b/cli/src/commands/environmental.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateDetailedStats, formatTokens, ENVIRONMENTAL } from '../helpers';
+import { clearLine, writeProgress, writeProgressCount } from '../formatting';
 import type { PeriodStats } from '../../../vscode-extension/src/types';
 
 export const environmentalCommand = new Command('environmental')
@@ -12,20 +13,20 @@ export const environmentalCommand = new Command('environmental')
 	.action(async () => {
 		console.log(chalk.bold.cyan('\n🌍 Copilot Token Tracker - Environmental Impact\n'));
 
-		process.stdout.write(chalk.dim('Scanning for session files...'));
+		writeProgress('Scanning for session files...');
 		const files = await discoverSessionFiles();
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
+		clearLine();
 
 		if (files.length === 0) {
 			console.log(chalk.yellow('⚠️  No session files found.'));
 			return;
 		}
 
-		process.stdout.write(chalk.dim('Calculating usage...'));
+		writeProgress('Calculating usage...');
 		const stats = await calculateDetailedStats(files, (completed, total) => {
-			process.stdout.write(`\r${chalk.dim(`Processing: ${completed}/${total} files`)}`);
+			writeProgressCount(completed, total);
 		});
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
+		clearLine();
 
 		const periods: { label: string; emoji: string; stats: PeriodStats }[] = [
 			{ label: 'Today', emoji: '📅', stats: stats.today },

--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateUsageAnalysisStats, fmt, buildCustomizationMatrix } from '../helpers';
+import { clearLine, writeProgress } from '../formatting';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
 
 export const fluencyCommand = new Command('fluency')
@@ -15,9 +16,9 @@ export const fluencyCommand = new Command('fluency')
 			console.log(chalk.bold.cyan('\n🎯 Copilot Token Tracker - Fluency Score\n'));
 		}
 
-		if (!options.json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
+		if (!options.json) { writeProgress('Scanning for session files...'); }
 		const files = await discoverSessionFiles();
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!options.json) { clearLine(); }
 
 		if (files.length === 0) {
 			if (options.json) {
@@ -28,11 +29,11 @@ export const fluencyCommand = new Command('fluency')
 			return;
 		}
 
-		if (!options.json) { process.stdout.write(chalk.dim('Analyzing usage patterns...')); }
+		if (!options.json) { writeProgress('Analyzing usage patterns...'); }
 
 		// Calculate usage analysis stats
 		const usageStats = await calculateUsageAnalysisStats(files);
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!options.json) { clearLine(); }
 
 		// Build a customization matrix from workspace folder paths inferred from session file paths.
 		// This matches what the VS Code extension does (scanning workspace folders for instructions files).

--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, processSessionFile, effectiveTokens, getDiagnosticPaths, fmt, formatTokens, getCacheStats } from '../helpers';
+import { clearLine, writeProgress, writeProgressCount } from '../formatting';
 
 export const statsCommand = new Command('stats')
 	.description('Show overview of discovered session files, sessions, chat turns, and tokens')
@@ -26,9 +27,9 @@ export const statsCommand = new Command('stats')
 		}
 
 		// Discover session files
-		if (!options.json) { process.stdout.write(chalk.dim('Scanning for session files...')); }
+		if (!options.json) { writeProgress('Scanning for session files...'); }
 		const files = await discoverSessionFiles();
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!options.json) { clearLine(); }
 
 		if (files.length === 0) {
 			if (options.json) {
@@ -86,10 +87,10 @@ export const statsCommand = new Command('stats')
 
 			// Progress indicator (human-readable only)
 			if (!options.json && ((i + 1) % 50 === 0 || i === files.length - 1)) {
-				process.stdout.write(`\r${chalk.dim(`Processing: ${i + 1}/${files.length}`)}`);
+				writeProgressCount(i + 1, files.length);
 			}
 		}
-		if (!options.json) { process.stdout.write('\r' + ' '.repeat(50) + '\r'); }
+		if (!options.json) { clearLine(); }
 
 		if (options.json) {
 			// Machine-readable output: emit pure JSON to stdout and exit

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { discoverSessionFiles, calculateDetailedStats, fmt, formatTokens, modelPricing } from '../helpers';
+import { clearLine, writeProgress, writeProgressCount } from '../formatting';
 import type { PeriodStats, ModelUsage } from '../../../vscode-extension/src/types';
 import { getModelTier } from '../../../vscode-extension/src/tokenEstimation';
 
@@ -52,11 +53,11 @@ export const usageCommand = new Command('usage')
 /** Discover session files (quiet when --json is set). */
 async function discoverFiles(options: { json?: boolean }) {
 	if (!options.json) {
-		process.stdout.write(chalk.dim('Scanning for session files...'));
+		writeProgress('Scanning for session files...');
 	}
 	const files = await discoverSessionFiles();
 	if (!options.json) {
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
+		clearLine();
 	}
 	if (files.length === 0) {
 		if (options.json) {
@@ -72,13 +73,13 @@ async function discoverFiles(options: { json?: boolean }) {
 /** Calculate detailed stats (quiet when --json is set). */
 async function calculateStats(files: string[], options: { json?: boolean }) {
 	if (!options.json) {
-		process.stdout.write(chalk.dim('Calculating token usage...'));
+		writeProgress('Calculating token usage...');
 	}
 	const stats = await calculateDetailedStats(files, options.json ? undefined : (completed, total) => {
-		process.stdout.write(`\r${chalk.dim(`Processing: ${completed}/${total} files`)}`);
+		writeProgressCount(completed, total);
 	});
 	if (!options.json) {
-		process.stdout.write('\r' + ' '.repeat(50) + '\r');
+		clearLine();
 	}
 	return stats;
 }

--- a/cli/src/formatting.ts
+++ b/cli/src/formatting.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared CLI output formatting helpers.
+ * Centralises repeated progress-line patterns used across CLI command files.
+ */
+import chalk from 'chalk';
+
+/** Width used to blank out a progress line. */
+const DEFAULT_CLEAR_WIDTH = 50;
+
+/**
+ * Overwrite the current terminal line with spaces to erase a progress message.
+ * Uses a carriage return so the cursor stays on the same line.
+ */
+export function clearLine(width = DEFAULT_CLEAR_WIDTH): void {
+	process.stdout.write('\r' + ' '.repeat(width) + '\r');
+}
+
+/**
+ * Write a dim progress message to stdout without a trailing newline.
+ * Pair with {@link clearLine} to erase it when the operation completes.
+ */
+export function writeProgress(msg: string): void {
+	process.stdout.write(chalk.dim(msg));
+}
+
+/**
+ * Overwrite the current line with a "Processing: X/Y files" counter.
+ * Designed to be called repeatedly inside a loop — the carriage return
+ * keeps all updates on the same line.
+ */
+export function writeProgressCount(completed: number, total: number): void {
+	process.stdout.write(`\r${chalk.dim(`Processing: ${completed}/${total} files`)}`);
+}


### PR DESCRIPTION
Consolidate progress-output patterns duplicated across CLI command files into a shared formatting module.

Created cli/src/formatting.ts with three helpers:
- clearLine(width) - replaces inline carriage-return/space clear pattern (10 call sites)
- writeProgress(msg) - replaces process.stdout.write(chalk.dim(msg)) (8 call sites)  
- writeProgressCount(completed, total) - replaces inline Processing: X/Y files writes (4 call sites)

Updated: usage.ts, stats.ts, fluency.ts, environmental.ts, diagnostics.ts

truncatePath and printTable in diagnostics.ts were left in place - single call site each.

Build and tests pass.