### PR TITLE
refactor: extract settings validation helpers to backend/settingsValidation.ts

### DIFF
--- a/vscode-extension/src/backend/settings.ts
+++ b/vscode-extension/src/backend/settings.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { MIN_LOOKBACK_DAYS, MAX_LOOKBACK_DAYS, DEFAULT_LOOKBACK_DAYS } from './constants';
 import type { BackendUserIdentityMode } from './identity';
 import { parseBackendSharingProfile, type BackendSharingProfile } from './sharingProfile';
+import { inferSharingProfile } from './settingsValidation';
 
 export type BackendType = 'storageTables' | 'sharingServer';
 
@@ -73,16 +74,7 @@ export function getBackendSettings(): BackendSettings {
 	// always default to teamAnonymized (hashed IDs, no user dimension, names off).
 	// Legacy shareWithTeam only affects the profile when an explicit userIdentityMode is set.
 	const backendEnabled = config.get<boolean>('backend.enabled', false);
-	const inferredSharingProfile: BackendSharingProfile = parsedSharingProfile
-		?? (
-			!backendEnabled
-				? 'off'
-				: (shareWithTeam && userIdentityMode !== 'pseudonymous'
-					? 'teamIdentified'
-					: (shareWithTeam && userIdentityMode === 'pseudonymous'
-						? 'teamPseudonymous'
-						: 'teamAnonymized'))
-		);
+	const inferredSharingProfile: BackendSharingProfile = inferSharingProfile(parsedSharingProfile, backendEnabled, shareWithTeam, userIdentityMode);
 
 	return {
 		enabled: config.get<boolean>('backend.enabled', false),

--- a/vscode-extension/src/backend/settingsValidation.ts
+++ b/vscode-extension/src/backend/settingsValidation.ts
@@ -1,0 +1,48 @@
+import { MIN_LOOKBACK_DAYS, MAX_LOOKBACK_DAYS } from './constants';
+import type { BackendUserIdentityMode } from './identity';
+import type { BackendSharingProfile } from './sharingProfile';
+import { type ValidationResult, validResult, invalidResult } from './validation';
+
+/**
+ * Infers the effective sharing profile from legacy settings when no explicit
+ * profile value has been persisted.
+ *
+ * Priority: explicit `parsedSharingProfile` wins; otherwise derive from
+ * `backendEnabled`, `shareWithTeam`, and `userIdentityMode`.
+ */
+export function inferSharingProfile(
+	parsedSharingProfile: BackendSharingProfile | undefined,
+	backendEnabled: boolean,
+	shareWithTeam: boolean,
+	userIdentityMode: BackendUserIdentityMode
+): BackendSharingProfile {
+	if (parsedSharingProfile !== undefined) {
+		return parsedSharingProfile;
+	}
+	if (!backendEnabled) {
+		return 'off';
+	}
+	if (shareWithTeam && userIdentityMode !== 'pseudonymous') {
+		return 'teamIdentified';
+	}
+	if (shareWithTeam) {
+		return 'teamPseudonymous';
+	}
+	return 'teamAnonymized';
+}
+
+/**
+ * Validates that `days` is a finite number within the allowed lookback range.
+ *
+ * Returns `valid: true` with the original value when valid, or `valid: false`
+ * with a human-readable error message when out of range or non-finite.
+ */
+export function validateLookbackDays(days: number): ValidationResult<number> {
+	if (!Number.isFinite(days)) {
+		return invalidResult('Lookback days must be a finite number.');
+	}
+	if (days < MIN_LOOKBACK_DAYS || days > MAX_LOOKBACK_DAYS) {
+		return invalidResult(`Lookback days must be between ${MIN_LOOKBACK_DAYS} and ${MAX_LOOKBACK_DAYS}.`);
+	}
+	return validResult(days);
+}

--- a/vscode-extension/test/unit/backend-settingsValidation.test.ts
+++ b/vscode-extension/test/unit/backend-settingsValidation.test.ts
@@ -1,0 +1,71 @@
+import './vscode-shim-register';
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { inferSharingProfile, validateLookbackDays } from '../../src/backend/settingsValidation';
+
+// ---------------------------------------------------------------------------
+// inferSharingProfile
+// ---------------------------------------------------------------------------
+
+test('inferSharingProfile returns explicit parsedSharingProfile when provided', () => {
+	assert.equal(inferSharingProfile('soloFull', true, false, 'pseudonymous'), 'soloFull');
+	assert.equal(inferSharingProfile('teamIdentified', false, false, 'pseudonymous'), 'teamIdentified');
+	assert.equal(inferSharingProfile('off', true, true, 'teamAlias'), 'off');
+});
+
+test('inferSharingProfile returns off when backend is disabled', () => {
+	assert.equal(inferSharingProfile(undefined, false, false, 'pseudonymous'), 'off');
+	assert.equal(inferSharingProfile(undefined, false, true, 'teamAlias'), 'off');
+});
+
+test('inferSharingProfile returns teamAnonymized when shareWithTeam is false', () => {
+	assert.equal(inferSharingProfile(undefined, true, false, 'pseudonymous'), 'teamAnonymized');
+	assert.equal(inferSharingProfile(undefined, true, false, 'teamAlias'), 'teamAnonymized');
+});
+
+test('inferSharingProfile returns teamPseudonymous when shareWithTeam and pseudonymous', () => {
+	assert.equal(inferSharingProfile(undefined, true, true, 'pseudonymous'), 'teamPseudonymous');
+});
+
+test('inferSharingProfile returns teamIdentified when shareWithTeam and non-pseudonymous identity', () => {
+	assert.equal(inferSharingProfile(undefined, true, true, 'entraObjectId'), 'teamIdentified');
+	assert.equal(inferSharingProfile(undefined, true, true, 'teamAlias'), 'teamIdentified');
+});
+
+// ---------------------------------------------------------------------------
+// validateLookbackDays
+// ---------------------------------------------------------------------------
+
+test('validateLookbackDays returns valid for in-range values', () => {
+	const r1 = validateLookbackDays(1);
+	assert.equal(r1.valid, true);
+	assert.equal((r1 as { valid: true; data: number }).data, 1);
+
+	const r90 = validateLookbackDays(90);
+	assert.equal(r90.valid, true);
+	assert.equal((r90 as { valid: true; data: number }).data, 90);
+
+	const r30 = validateLookbackDays(30);
+	assert.equal(r30.valid, true);
+	assert.equal((r30 as { valid: true; data: number }).data, 30);
+});
+
+test('validateLookbackDays returns invalid for values below minimum', () => {
+	const r = validateLookbackDays(0);
+	assert.equal(r.valid, false);
+	assert.ok((r as { valid: false; error: string }).error.length > 0);
+});
+
+test('validateLookbackDays returns invalid for values above maximum', () => {
+	const r = validateLookbackDays(91);
+	assert.equal(r.valid, false);
+	assert.ok((r as { valid: false; error: string }).error.length > 0);
+});
+
+test('validateLookbackDays returns invalid for non-finite values', () => {
+	for (const bad of [NaN, Infinity, -Infinity]) {
+		const r = validateLookbackDays(bad);
+		assert.equal(r.valid, false, `expected invalid for ${bad}`);
+	}
+});


### PR DESCRIPTION
Extract inline validation from getBackendSettings() into a dedicated, independently-testable module. Uses ValidationResult<T> for return types.