### PR TITLE
refactor: extract pathExists helper to utils/fsAsync.ts

### DIFF
--- a/vscode-extension/src/adapters/copilotChatAdapter.ts
+++ b/vscode-extension/src/adapters/copilotChatAdapter.ts
@@ -43,6 +43,7 @@ import {
 	isJsonlContent,
 	isUuidPointerFile,
 } from '../tokenEstimation';
+import { pathExists } from '../utils/fsAsync';
 
 /** VS Code variants probed across all platforms. */
 const VSCODE_VARIANTS = [
@@ -191,10 +192,6 @@ const NON_SESSION_PATTERNS = [
 function isNonSessionFile(filename: string): boolean {
 	const lower = filename.toLowerCase();
 	return NON_SESSION_PATTERNS.some(p => lower.includes(p));
-}
-
-async function pathExists(p: string): Promise<boolean> {
-	try { await fs.promises.access(p); return true; } catch { return false; }
 }
 
 async function runWithConcurrency<T>(

--- a/vscode-extension/src/adapters/copilotCliAdapter.ts
+++ b/vscode-extension/src/adapters/copilotCliAdapter.ts
@@ -27,6 +27,7 @@ import type {
 import { CopilotCliStoreAccess } from '../copilotCliStore';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
+import { pathExists } from '../utils/fsAsync';
 
 /** Returns the canonical Copilot CLI session-state directory (~/.copilot/session-state). */
 export function getCopilotCliSessionStateDir(): string {
@@ -37,10 +38,6 @@ export function getCopilotCliSessionStateDir(): string {
 export function isCopilotCliSessionPath(filePath: string): boolean {
 	const norm = filePath.replace(/\\/g, '/');
 	return norm.includes('/.copilot/session-state/');
-}
-
-async function pathExists(p: string): Promise<boolean> {
-	try { await fs.promises.access(p); return true; } catch { return false; }
 }
 
 export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {

--- a/vscode-extension/src/adapters/jetbrainsAdapter.ts
+++ b/vscode-extension/src/adapters/jetbrainsAdapter.ts
@@ -32,6 +32,7 @@ import type {
 	CandidatePath,
 } from '../ecosystemAdapter';
 import { parseJetBrainsPartition, type JetBrainsParsedSession, type JetBrainsToolCall } from '../jetbrains';
+import { pathExists } from '../utils/fsAsync';
 
 /** Returns the canonical JetBrains Copilot session directory (~/.copilot/jb). */
 export function getJetBrainsSessionDir(): string {
@@ -45,10 +46,6 @@ export function getJetBrainsSessionDir(): string {
 export function isJetBrainsSessionPath(filePath: string): boolean {
 	const norm = filePath.replace(/\\/g, '/');
 	return norm.includes('/.copilot/jb/') && /\/partition-\d+\.jsonl$/.test(norm);
-}
-
-async function pathExists(p: string): Promise<boolean> {
-	try { await fs.promises.access(p); return true; } catch { return false; }
 }
 
 export class JetBrainsAdapter implements IEcosystemAdapter, IDiscoverableEcosystem {

--- a/vscode-extension/src/adapters/openCodeAdapter.ts
+++ b/vscode-extension/src/adapters/openCodeAdapter.ts
@@ -6,6 +6,7 @@ import { OpenCodeDataAccess } from '../opencode';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
 import { withErrorRecovery } from '../utils/errors';
+import { pathExists } from '../utils/fsAsync';
 
 export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'opencode';
@@ -93,8 +94,7 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 		// Scan JSON session files
 		log(`📁 Checking OpenCode JSON path: ${sessionDir}`);
 		log(`📁 Checking OpenCode DB path: ${dbPath}`);
-		let sessionDirExists = false;
-		try { await fs.promises.access(sessionDir); sessionDirExists = true; } catch { /* sessionDir doesn't exist — skip */ }
+		const sessionDirExists = await pathExists(sessionDir);
 		if (sessionDirExists) {
 			const scanDir = async (dir: string) => {
 				let entries: fs.Dirent[] = [];
@@ -125,8 +125,7 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 		}
 
 		// Scan SQLite database for additional sessions (deduplicating against JSON)
-		let dbExists = false;
-		try { await fs.promises.access(dbPath); dbExists = true; } catch { /* DB doesn't exist — skip */ }
+		const dbExists = await pathExists(dbPath);
 		if (dbExists) {
 			try {
 				const existingIds = new Set(

--- a/vscode-extension/src/utils/fsAsync.ts
+++ b/vscode-extension/src/utils/fsAsync.ts
@@ -1,0 +1,6 @@
+import * as fs from 'fs';
+
+/** Returns true if the path exists and is accessible. */
+export async function pathExists(p: string): Promise<boolean> {
+	try { await fs.promises.access(p); return true; } catch { return false; }
+}


### PR DESCRIPTION
The async pathExists pattern (try { await fs.promises.access(p); return true; } catch { return false; }) is duplicated across 6+ adapter files. Centralise it in vscode-extension/src/utils/fsAsync.ts.