### PR TITLE
refactor: consolidate path normalization helpers to utils/pathUtils.ts

### DIFF
--- a/vscode-extension/src/adapters/copilotChatAdapter.ts
+++ b/vscode-extension/src/adapters/copilotChatAdapter.ts
@@ -43,6 +43,7 @@ import {
 	isJsonlContent,
 	isUuidPointerFile,
 } from '../tokenEstimation';
+import { normalizePath } from '../utils/pathUtils';
 
 /** VS Code variants probed across all platforms. */
 const VSCODE_VARIANTS = [
@@ -250,7 +251,7 @@ async function scanGlobalStorageRecursively(
  * narrow so it never accidentally claims unrelated VS Code files.
  */
 export function isCopilotChatSessionPath(filePath: string): boolean {
-	const norm = filePath.replace(/\\/g, '/');
+	const norm = normalizePath(filePath);
 	if (!/\.jsonl?$/.test(norm)) { return false; }
 
 	// workspaceStorage/<hash>/chatSessions/<file>  (legacy)
@@ -329,7 +330,7 @@ export class CopilotChatAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 
 	getEditorRoot(sessionFile: string): string {
 		// Walk up from the session file to the VS Code "User" directory.
-		const norm = sessionFile.replace(/\\/g, '/');
+		const norm = normalizePath(sessionFile);
 		const userIdx = norm.lastIndexOf('/User/');
 		if (userIdx >= 0) {
 			return norm.substring(0, userIdx + '/User'.length);

--- a/vscode-extension/src/adapters/copilotCliAdapter.ts
+++ b/vscode-extension/src/adapters/copilotCliAdapter.ts
@@ -27,6 +27,7 @@ import type {
 import { CopilotCliStoreAccess } from '../copilotCliStore';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
+import { normalizePath } from '../utils/pathUtils';
 
 /** Returns the canonical Copilot CLI session-state directory (~/.copilot/session-state). */
 export function getCopilotCliSessionStateDir(): string {
@@ -35,7 +36,7 @@ export function getCopilotCliSessionStateDir(): string {
 
 /** Path predicate matching any file under ~/.copilot/session-state/ (any depth). */
 export function isCopilotCliSessionPath(filePath: string): boolean {
-	const norm = filePath.replace(/\\/g, '/');
+	const norm = normalizePath(filePath);
 	return norm.includes('/.copilot/session-state/');
 }
 

--- a/vscode-extension/src/adapters/jetbrainsAdapter.ts
+++ b/vscode-extension/src/adapters/jetbrainsAdapter.ts
@@ -32,6 +32,7 @@ import type {
 	CandidatePath,
 } from '../ecosystemAdapter';
 import { parseJetBrainsPartition, type JetBrainsParsedSession, type JetBrainsToolCall } from '../jetbrains';
+import { normalizePath } from '../utils/pathUtils';
 
 /** Returns the canonical JetBrains Copilot session directory (~/.copilot/jb). */
 export function getJetBrainsSessionDir(): string {
@@ -43,7 +44,7 @@ export function getJetBrainsSessionDir(): string {
  * Matches paths containing /.copilot/jb/ that end with /partition-{n}.jsonl.
  */
 export function isJetBrainsSessionPath(filePath: string): boolean {
-	const norm = filePath.replace(/\\/g, '/');
+	const norm = normalizePath(filePath);
 	return norm.includes('/.copilot/jb/') && /\/partition-\d+\.jsonl$/.test(norm);
 }
 

--- a/vscode-extension/src/backend/services/utilityService.ts
+++ b/vscode-extension/src/backend/services/utilityService.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { fileUriToPath } from '../../workspaceHelpers';
+import { fileUriToPath, normalizePath } from '../../workspaceHelpers';
 import {
 	CODE_WORKSPACE_EXTENSION,
 	DAY_KEY_REGEX,
@@ -163,7 +163,7 @@ export class BackendUtility {
 	 * Extract workspace ID from a session file path.
 	 */
 	static extractWorkspaceIdFromSessionPath(sessionFile: string): string {
-		const normalized = sessionFile.replace(/\\/g, '/');
+		const normalized = normalizePath(sessionFile);
 		const parts = normalized.split('/');
 		const idx = parts.findIndex(p => p.toLowerCase() === 'workspacestorage');
 		if (idx >= 0 && parts[idx + 1]) {
@@ -186,7 +186,7 @@ export class BackendUtility {
 	 */
 	static async tryResolveWorkspaceNameFromSessionPath(sessionFile: string): Promise<string | undefined> {
 		try {
-			const normalized = sessionFile.replace(/\\/g, '/');
+			const normalized = normalizePath(sessionFile);
 			const marker = '/workspacestorage/';
 			const idx = normalized.toLowerCase().indexOf(marker);
 			if (idx < 0) {

--- a/vscode-extension/src/claudedesktop.ts
+++ b/vscode-extension/src/claudedesktop.ts
@@ -59,7 +59,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { normalizeClaudeModelId } from './claudecode';
 import type { ModelUsage } from './types';
-import { normalizePathForComparison } from './workspaceHelpers';
+import { normalizePathForComparison, normalizePath } from './workspaceHelpers';
 
 /** Package name for the Claude Desktop Windows Store app. */
 const CLAUDE_DESKTOP_PACKAGE = 'Claude_pzs8sxrjxfjjc';
@@ -288,7 +288,7 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Metadata:  .../local-agent-mode-sessions/<app>/<machine>/local_<id>.json
 	 */
 	private getMetadataPathFromJsonl(jsonlPath: string): string | null {
-		const normalized = jsonlPath.replace(/\\/g, '/');
+		const normalized = normalizePath(jsonlPath);
 		const parts = normalized.split('/');
 		// Find the index of '.claude' — session directory is just before it
 		const dotClaudeIdx = parts.lastIndexOf('.claude');

--- a/vscode-extension/src/crush.ts
+++ b/vscode-extension/src/crush.ts
@@ -16,6 +16,7 @@ import * as os from 'os';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import type { UriLike } from './opencode';
+import { normalizePath } from './utils/pathUtils';
 
 // Access SqlJsStatic and Database via the globally declared initSqlJs namespace.
 type SqlJsStatic = initSqlJs.SqlJsStatic;
@@ -171,7 +172,7 @@ export class CrushDataAccess {
 	 * Virtual paths contain the substring `/.crush/crush.db#` (with OS path separators normalised).
 	 */
 	isCrushSessionFile(filePath: string): boolean {
-		const normalized = filePath.replace(/\\/g, '/');
+		const normalized = normalizePath(filePath);
 		return normalized.includes('/.crush/crush.db#');
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -140,6 +140,7 @@ import {
   isMcpTool as _isMcpTool,
   normalizeMcpToolName as _normalizeMcpToolName,
   extractMcpServerName as _extractMcpServerName,
+  normalizePath as _normalizePath,
 } from './workspaceHelpers';
 import {
   createViewRegressionProbeScript,
@@ -2573,7 +2574,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				// (Unix-style absolute path, e.g. "/workspaces/repo" or "/home/user/repo")
 				const isRemotePath = (p: string) => {
 					if (process.platform !== 'win32') { return false; }
-					const normalized = p.replace(/\\/g, '/');
+					const normalized = _normalizePath(p);
 					return normalized.startsWith('/');
 				};
 
@@ -4373,7 +4374,7 @@ usageAnalysis: undefined
 	 * Returns 0 when no debug log is found or contains no cached-token data.
 	 */
 	private async readCachedTokensFromDebugLog(sessionFilePath: string): Promise<number> {
-		const norm = sessionFilePath.replace(/\\/g, '/');
+		const norm = _normalizePath(sessionFilePath);
 		const sessionId = path.basename(sessionFilePath, path.extname(sessionFilePath));
 		// Only process UUID-named session files (e.g. e84b3e82-c1fb-43de-8f52-367f4c74826a)
 		if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {

--- a/vscode-extension/src/geminicli.ts
+++ b/vscode-extension/src/geminicli.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { ChatTurn, ModelUsage, PromptTokenDetail } from './types';
 import { createEmptyContextRefs } from './tokenEstimation';
-import { normalizePathForComparison } from './workspaceHelpers';
+import { normalizePathForComparison, normalizePath } from './workspaceHelpers';
 
 interface GeminiCliSessionHeader {
 	sessionId: string;
@@ -465,7 +465,7 @@ export class GeminiCliDataAccess {
 	}
 
 	private getProjectBucketFromPath(sessionFilePath: string): string | undefined {
-		const normalized = sessionFilePath.replace(/\\/g, '/');
+		const normalized = normalizePath(sessionFilePath);
 		const parts = normalized.split('/').filter(part => part.length > 0);
 		const chatsIndex = parts.lastIndexOf('chats');
 		if (chatsIndex > 0) {
@@ -560,7 +560,7 @@ export class GeminiCliDataAccess {
 	}
 
 	private looksLikePath(value: string): boolean {
-		const normalized = value.replace(/\\/g, '/');
+		const normalized = normalizePath(value);
 		return /^[a-zA-Z]:/.test(value) || normalized.startsWith('/') || normalized.startsWith('~') || normalized.startsWith('file://');
 	}
 

--- a/vscode-extension/src/mistralvibe.ts
+++ b/vscode-extension/src/mistralvibe.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { ModelUsage } from './types';
+import { normalizePath } from './utils/pathUtils';
 
 export class MistralVibeDataAccess {
 
@@ -48,7 +49,7 @@ return path.join(this.getVibeHomeDir(), 'logs', 'session');
  * Session files are meta.json files under ~/.vibe/logs/session/
  */
 isVibeSessionFile(filePath: string): boolean {
-const normalized = filePath.replace(/\\/g, '/');
+const normalized = normalizePath(filePath);
 return normalized.includes('/.vibe/logs/session/') && normalized.endsWith('/meta.json');
 }
 

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -23,6 +23,7 @@ import { withErrorRecoverySync } from './utils/errors';
 
 export {
 	fileUriToPath,
+	normalizePath,
 	normalizePathForComparison,
 	normalizePathForDedup,
 	normalizePathSeparators


### PR DESCRIPTION
Extract repeated path normalization patterns into a shared utility module. Only functions with >=2 call sites are extracted. See PR description for details.