### PR TITLE
refactor: consolidate duplicated webview type definitions to shared/types.ts

### DIFF
--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -7,8 +7,7 @@ import { wireExtensionPointButtons } from "../shared/extensionPoints";
 import themeStyles from "../shared/theme.css";
 import styles from "./styles.css";
 import { getWindowData } from "../shared/dataLoader";
-
-type ModelUsage = Record<string, { inputTokens: number; outputTokens: number }>;
+import type { ModelUsage } from "../shared/types";
 
 interface UserSummary {
   userId: string;

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -12,8 +12,8 @@ import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 import { getWindowData } from '../shared/dataLoader';
 import { registerMessageHandler } from '../shared/messageHandler';
+import type { ModelUsage } from '../shared/types';
 
-type ModelUsage = Record<string, { inputTokens: number; outputTokens: number }>;
 type EditorUsage = Record<string, { tokens: number; sessions: number }>;
 type TableSortKey = 'name' | 'today' | 'last30Days' | 'lastMonth' | 'projected';
 type SortDir = 'asc' | 'desc';

--- a/vscode-extension/src/webview/fluency-level-viewer/main.ts
+++ b/vscode-extension/src/webview/fluency-level-viewer/main.ts
@@ -4,22 +4,9 @@ import { escapeHtml, markdownToHtml, STAGE_LABELS, STAGE_DESCRIPTIONS } from '..
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import styles from './styles.css';
 import { getWindowData } from '../shared/dataLoader';
+import type { CategoryLevelData } from '../shared/types';
 
 // ── Types ──────────────────────────────────────────────────────────────
-
-type CategoryLevelData = {
-	category: string;
-	icon: string;
-	levels: LevelInfo[];
-};
-
-type LevelInfo = {
-	stage: number;
-	label: string;
-	description: string;
-	thresholds: string[];
-	tips: string[];
-};
 
 type FluencyLevelData = {
 	categories: CategoryLevelData[];

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -3,7 +3,7 @@ import { buttonHtml } from '../shared/buttonConfig';
 import type { ContextReferenceUsage } from '../shared/contextRefUtils';
 import { escapeHtml, markdownToHtml, STAGE_LABELS, STAGE_DESCRIPTIONS } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
-import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
+import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis, ToolCallUsage, CategoryLevelData } from '../shared/types';
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 import { getWindowData } from '../shared/dataLoader';
@@ -30,12 +30,6 @@ type CategoryScore = {
 	stage: number;       // 1-4
 	evidence: string[];  // what signals led to this score
 	tips: string[];      // suggestions to reach next stage
-};
-
-type CategoryLevelData = {
-	category: string;
-	icon: string;
-	levels: Array<{ stage: number; label: string; description: string; thresholds: string[]; tips: string[] }>;
 };
 
 type MaturityData = {

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -2,6 +2,25 @@
  * Shared type definitions used across multiple webview panels.
  */
 
+/** Token usage breakdown by model. */
+export type ModelUsage = Record<string, { inputTokens: number; outputTokens: number }>;
+
+/** Individual level descriptor used in fluency/maturity category level data. */
+export type LevelInfo = {
+	stage: number;
+	label: string;
+	description: string;
+	thresholds: string[];
+	tips: string[];
+};
+
+/** Category level data used in fluency level viewer and maturity webviews. */
+export type CategoryLevelData = {
+	category: string;
+	icon: string;
+	levels: LevelInfo[];
+};
+
 export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
 export type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
 export type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };


### PR DESCRIPTION
Extract interface definitions that are copy-pasted across multiple webview entry points into a shared types module. Added ModelUsage, LevelInfo, and CategoryLevelData to shared/types.ts. Updated dashboard, details, fluency-level-viewer, and maturity webviews to import from the shared module.