### PR TITLE
refactor: centralise adapter session path predicates to adapterPredicates.ts

### DIFF
--- a/vscode-extension/src/adapters/adapterPredicates.ts
+++ b/vscode-extension/src/adapters/adapterPredicates.ts
@@ -1,0 +1,84 @@
+/**
+ * adapterPredicates.ts — path predicates for all ecosystem adapters.
+ *
+ * Each predicate recognises the file paths belonging to a specific editor's
+ * session storage. Centralised here so that callers outside the adapter layer
+ * (e.g. extension.ts, usageAnalysis.ts) do not need to import from individual
+ * adapter implementation files.
+ */
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Copilot Chat
+// ---------------------------------------------------------------------------
+
+/** Filenames we explicitly skip when recursively scanning Copilot Chat globalStorage. */
+const COPILOT_CHAT_NON_SESSION_PATTERNS = [
+	'embeddings',
+	'index',
+	'cache',
+	'preferences',
+	'settings',
+	'config',
+	'workspacesessions',
+	'globalsessions',
+	'api.json',
+];
+
+/** Returns true for filenames that are not Copilot Chat session files. */
+export function isCopilotChatNonSessionFile(filename: string): boolean {
+	const lower = filename.toLowerCase();
+	return COPILOT_CHAT_NON_SESSION_PATTERNS.some(p => lower.includes(p));
+}
+
+/**
+ * Path predicate that recognises Copilot Chat session storage shapes. Kept
+ * narrow so it never accidentally claims unrelated VS Code files.
+ */
+export function isCopilotChatSessionPath(filePath: string): boolean {
+	const norm = filePath.replace(/\\/g, '/');
+	if (!/\.jsonl?$/.test(norm)) { return false; }
+
+	// workspaceStorage/<hash>/chatSessions/<file>  (legacy)
+	if (/\/workspaceStorage\/[^/]+\/chatSessions\/[^/]+$/.test(norm)) {
+		return true;
+	}
+	// workspaceStorage/<hash>/{extension}/chatSessions/<file>
+	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/chatSessions\/[^/]+$/.test(norm)) {
+		return true;
+	}
+	// workspaceStorage/<hash>/{extension}/debug-logs/<file>
+	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/debug-logs\/[^/]+$/.test(norm)) {
+		return true;
+	}
+	// globalStorage/emptyWindowChatSessions/<file>
+	if (/\/globalStorage\/emptyWindowChatSessions\/[^/]+$/.test(norm)) { return true; }
+	// globalStorage/{GitHub,github}.copilot-chat/** and {GitHub,github}.copilot/**
+	if (/\/globalStorage\/(?:GitHub|github)\.copilot(?:-chat)?\/.+$/.test(norm)) {
+		return !isCopilotChatNonSessionFile(path.basename(norm));
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Copilot CLI
+// ---------------------------------------------------------------------------
+
+/** Path predicate matching any file under ~/.copilot/session-state/ (any depth). */
+export function isCopilotCliSessionPath(filePath: string): boolean {
+	const norm = filePath.replace(/\\/g, '/');
+	return norm.includes('/.copilot/session-state/');
+}
+
+// ---------------------------------------------------------------------------
+// JetBrains
+// ---------------------------------------------------------------------------
+
+/**
+ * Path predicate matching JetBrains partition files under ~/.copilot/jb/.
+ * Matches paths containing /.copilot/jb/ that end with /partition-{n}.jsonl.
+ */
+export function isJetBrainsSessionPath(filePath: string): boolean {
+	const norm = filePath.replace(/\\/g, '/');
+	return norm.includes('/.copilot/jb/') && /\/partition-\d+\.jsonl$/.test(norm);
+}

--- a/vscode-extension/src/adapters/copilotChatAdapter.ts
+++ b/vscode-extension/src/adapters/copilotChatAdapter.ts
@@ -43,6 +43,7 @@ import {
 	isJsonlContent,
 	isUuidPointerFile,
 } from '../tokenEstimation';
+import { isCopilotChatNonSessionFile } from './adapterPredicates';
 
 /** VS Code variants probed across all platforms. */
 const VSCODE_VARIANTS = [
@@ -175,24 +176,6 @@ function getWSLWindowsPathsSync(): string[] {
 	return out;
 }
 
-/** Filenames we explicitly skip when recursively scanning Copilot Chat globalStorage. */
-const NON_SESSION_PATTERNS = [
-	'embeddings',
-	'index',
-	'cache',
-	'preferences',
-	'settings',
-	'config',
-	'workspacesessions',
-	'globalsessions',
-	'api.json',
-];
-
-function isNonSessionFile(filename: string): boolean {
-	const lower = filename.toLowerCase();
-	return NON_SESSION_PATTERNS.some(p => lower.includes(p));
-}
-
 async function pathExists(p: string): Promise<boolean> {
 	try { await fs.promises.access(p); return true; } catch { return false; }
 }
@@ -237,41 +220,12 @@ async function scanGlobalStorageRecursively(
 			continue;
 		}
 		if (!entry.name.endsWith('.json') && !entry.name.endsWith('.jsonl')) { continue; }
-		if (isNonSessionFile(entry.name)) { continue; }
+		if (isCopilotChatNonSessionFile(entry.name)) { continue; }
 		try {
 			const stats = await fs.promises.stat(full);
 			if (stats.size > 0) { out.push(full); }
 		} catch { /* ignore */ }
 	}
-}
-
-/**
- * Path predicate that recognises Copilot Chat session storage shapes. Kept
- * narrow so it never accidentally claims unrelated VS Code files.
- */
-export function isCopilotChatSessionPath(filePath: string): boolean {
-	const norm = filePath.replace(/\\/g, '/');
-	if (!/\.jsonl?$/.test(norm)) { return false; }
-
-	// workspaceStorage/<hash>/chatSessions/<file>  (legacy)
-	if (/\/workspaceStorage\/[^/]+\/chatSessions\/[^/]+$/.test(norm)) {
-		return true;
-	}
-	// workspaceStorage/<hash>/{extension}/chatSessions/<file>
-	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/chatSessions\/[^/]+$/.test(norm)) {
-		return true;
-	}
-	// workspaceStorage/<hash>/{extension}/debug-logs/<file>
-	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/debug-logs\/[^/]+$/.test(norm)) {
-		return true;
-	}
-	// globalStorage/emptyWindowChatSessions/<file>
-	if (/\/globalStorage\/emptyWindowChatSessions\/[^/]+$/.test(norm)) { return true; }
-	// globalStorage/{GitHub,github}.copilot-chat/** and {GitHub,github}.copilot/**
-	if (/\/globalStorage\/(?:GitHub|github)\.copilot(?:-chat)?\/.+$/.test(norm)) {
-		return !isNonSessionFile(path.basename(norm));
-	}
-	return false;
 }
 
 export class CopilotChatAdapter implements IEcosystemAdapter, IDiscoverableEcosystem {

--- a/vscode-extension/src/adapters/copilotCliAdapter.ts
+++ b/vscode-extension/src/adapters/copilotCliAdapter.ts
@@ -33,12 +33,6 @@ export function getCopilotCliSessionStateDir(): string {
 	return path.join(os.homedir(), '.copilot', 'session-state');
 }
 
-/** Path predicate matching any file under ~/.copilot/session-state/ (any depth). */
-export function isCopilotCliSessionPath(filePath: string): boolean {
-	const norm = filePath.replace(/\\/g, '/');
-	return norm.includes('/.copilot/session-state/');
-}
-
 async function pathExists(p: string): Promise<boolean> {
 	try { await fs.promises.access(p); return true; } catch { return false; }
 }

--- a/vscode-extension/src/adapters/jetbrainsAdapter.ts
+++ b/vscode-extension/src/adapters/jetbrainsAdapter.ts
@@ -38,15 +38,6 @@ export function getJetBrainsSessionDir(): string {
 	return path.join(os.homedir(), '.copilot', 'jb');
 }
 
-/**
- * Path predicate matching JetBrains partition files under ~/.copilot/jb/.
- * Matches paths containing /.copilot/jb/ that end with /partition-{n}.jsonl.
- */
-export function isJetBrainsSessionPath(filePath: string): boolean {
-	const norm = filePath.replace(/\\/g, '/');
-	return norm.includes('/.copilot/jb/') && /\/partition-\d+\.jsonl$/.test(norm);
-}
-
 async function pathExists(p: string): Promise<boolean> {
 	try { await fs.promises.access(p); return true; } catch { return false; }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -81,7 +81,7 @@ import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { getEcosystemDisplayName } from './ecosystemAdapter';
 import { buildAdapterRegistry, createDataAccessInstances } from './adapters';
 import { getVSCodeUserPaths } from './adapters/copilotChatAdapter';
-import { isJetBrainsSessionPath } from './adapters/jetbrainsAdapter';
+import { isJetBrainsSessionPath } from './adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from './jetbrains';
 import {
   estimateTokensFromText as _estimateTokensFromText,

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -40,7 +40,7 @@ import {
 	extractMcpServerName,
 	normalizePathForComparison,
 } from './workspaceHelpers';
-import { isJetBrainsSessionPath } from './adapters/jetbrainsAdapter';
+import { isJetBrainsSessionPath } from './adapters/adapterPredicates';
 import { detectJetBrainsModeFromContent, type JetBrainsMode } from './jetbrains';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { isAnalyzable } from './ecosystemAdapter';

--- a/vscode-extension/test/unit/copilotChatAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotChatAdapter.test.ts
@@ -19,10 +19,10 @@ import * as os from 'node:os';
 
 import {
     CopilotChatAdapter,
-    isCopilotChatSessionPath,
     getVSCodeUserPaths,
     isWSL,
 } from '../../src/adapters/copilotChatAdapter';
+import { isCopilotChatSessionPath } from '../../src/adapters/adapterPredicates';
 import { isDiscoverable } from '../../src/ecosystemAdapter';
 
 const adapter = new CopilotChatAdapter();

--- a/vscode-extension/test/unit/copilotCliAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotCliAdapter.test.ts
@@ -10,9 +10,9 @@ import * as os from 'node:os';
 
 import {
     CopilotCliAdapter,
-    isCopilotCliSessionPath,
     getCopilotCliSessionStateDir,
 } from '../../src/adapters/copilotCliAdapter';
+import { isCopilotCliSessionPath } from '../../src/adapters/adapterPredicates';
 import { isDiscoverable } from '../../src/ecosystemAdapter';
 
 const adapter = new CopilotCliAdapter();

--- a/vscode-extension/test/unit/jetbrainsAdapter.test.ts
+++ b/vscode-extension/test/unit/jetbrainsAdapter.test.ts
@@ -10,9 +10,9 @@ import * as os from 'node:os';
 
 import {
 	JetBrainsAdapter,
-	isJetBrainsSessionPath,
 	getJetBrainsSessionDir,
 } from '../../src/adapters/jetbrainsAdapter';
+import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { isDiscoverable } from '../../src/ecosystemAdapter';
 
 const adapter = new JetBrainsAdapter();


### PR DESCRIPTION
Move isXxxSessionPath predicate functions used across module boundaries into a single adapterPredicates.ts module.