### PR TITLE
feat(vscode): configurable status bar — show token counts and/or cost

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -339,6 +339,30 @@
           "default": true,
           "description": "Show times in 24-hour format (e.g. 14:30). When disabled, 12-hour AM/PM format is used (e.g. 2:30 PM)."
         },
+        "aiEngineeringFluency.display.statusBar.showTokens": {
+          "type": "string",
+          "enum": ["none", "today", "currentMonth", "both"],
+          "enumDescriptions": [
+            "Do not show token counts in the status bar",
+            "Show today's token count only",
+            "Show the last 30 days' token count only",
+            "Show both today's and last 30 days' token counts (default)"
+          ],
+          "default": "both",
+          "description": "Controls which token counts are shown in the status bar. Token counts are estimated from session log files."
+        },
+        "aiEngineeringFluency.display.statusBar.showCost": {
+          "type": "string",
+          "enum": ["none", "today", "currentMonth", "both"],
+          "enumDescriptions": [
+            "Do not show estimated cost in the status bar (default)",
+            "Show today's estimated cost only",
+            "Show the last 30 days' estimated cost only",
+            "Show both today's and last 30 days' estimated costs"
+          ],
+          "default": "none",
+          "description": "Controls which estimated costs (in USD) are shown in the status bar. Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing)."
+        },
         "aiEngineeringFluency.backend.enabled": {
           "type": "boolean",
           "default": false,

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -341,24 +341,28 @@
         },
         "aiEngineeringFluency.display.statusBar.showTokens": {
           "type": "string",
-          "enum": ["none", "today", "currentMonth", "both"],
+          "enum": ["none", "today", "last30days", "currentMonth", "both", "todayAndCurrentMonth"],
           "enumDescriptions": [
             "Do not show token counts in the status bar",
             "Show today's token count only",
-            "Show the last 30 days' token count only",
-            "Show both today's and last 30 days' token counts (default)"
+            "Show the last 30 days (rolling window) token count only",
+            "Show the current calendar month's token count only",
+            "Show both today's and last 30 days' token counts (default)",
+            "Show both today's and current calendar month's token counts"
           ],
           "default": "both",
           "description": "Controls which token counts are shown in the status bar. Token counts are estimated from session log files."
         },
         "aiEngineeringFluency.display.statusBar.showCost": {
           "type": "string",
-          "enum": ["none", "today", "currentMonth", "both"],
+          "enum": ["none", "today", "last30days", "currentMonth", "both", "todayAndCurrentMonth"],
           "enumDescriptions": [
             "Do not show estimated cost in the status bar (default)",
             "Show today's estimated cost only",
-            "Show the last 30 days' estimated cost only",
-            "Show both today's and last 30 days' estimated costs"
+            "Show the last 30 days (rolling window) estimated cost only",
+            "Show the current calendar month's estimated cost only",
+            "Show both today's and last 30 days' estimated costs",
+            "Show both today's and current calendar month's estimated costs"
           ],
           "default": "none",
           "description": "Controls which estimated costs (in USD) are shown in the status bar. Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing)."

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1618,7 +1618,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (detailedStats.today.sessions === 0 && detailedStats.last30Days.sessions === 0) {
 				this.setStatusBarText('$(symbol-numeric) No session data yet');
 			} else {
-				this.setStatusBarText(`$(symbol-numeric) ${this.formatCompact(detailedStats.today.tokens)} | ${this.formatCompact(detailedStats.last30Days.tokens)}`);
+				this.setStatusBarText(this.buildStatusBarText(detailedStats));
 			}
 
 			// Create detailed tooltip with improved style
@@ -2091,11 +2091,54 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('display.use24HourTime', true);
 	}
 
+	private getStatusBarShowTokensSetting(): 'none' | 'today' | 'currentMonth' | 'both' {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'currentMonth' | 'both'>('display.statusBar.showTokens', 'both');
+	}
+
+	private getStatusBarShowCostSetting(): 'none' | 'today' | 'currentMonth' | 'both' {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'currentMonth' | 'both'>('display.statusBar.showCost', 'none');
+	}
+
+	private buildStatusBarText(stats: DetailedStats): string {
+		const showTokens = this.getStatusBarShowTokensSetting();
+		const showCost = this.getStatusBarShowCostSetting();
+
+		const parts: string[] = [];
+
+		if (showTokens !== 'none') {
+			const tokenParts: string[] = [];
+			if (showTokens === 'today' || showTokens === 'both') {
+				tokenParts.push(this.formatCompact(stats.today.tokens));
+			}
+			if (showTokens === 'currentMonth' || showTokens === 'both') {
+				tokenParts.push(this.formatCompact(stats.last30Days.tokens));
+			}
+			parts.push(`$(symbol-numeric) ${tokenParts.join(' | ')}`);
+		}
+
+		if (showCost !== 'none') {
+			const costParts: string[] = [];
+			if (showCost === 'today' || showCost === 'both') {
+				costParts.push(`$${(stats.today.estimatedCostCopilot ?? 0).toFixed(2)}`);
+			}
+			if (showCost === 'currentMonth' || showCost === 'both') {
+				costParts.push(`$${(stats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)}`);
+			}
+			parts.push(`$(credit-card) ${costParts.join(' | ')}`);
+		}
+
+		if (parts.length === 0) {
+			return `$(symbol-numeric) AI Fluency`;
+		}
+
+		return parts.join('  ');
+	}
+
 	private refreshOpenPanelsForSettingChange(): void {
 		const stats = this.lastDetailedStats;
 		if (!stats) { return; }
-		// Refresh status bar text (respects new compact setting)
-		this.setStatusBarText(`$(symbol-numeric) ${this.formatCompact(stats.today.tokens)} | ${this.formatCompact(stats.last30Days.tokens)}`);
+		// Refresh status bar text (respects new display settings)
+		this.setStatusBarText(this.buildStatusBarText(stats));
 		if (this.detailsPanel) {
 			this.detailsPanel.webview.html = this.getDetailsHtml(this.detailsPanel.webview, stats);
 		}
@@ -7405,6 +7448,20 @@ ${hashtag}`;
             )
           );
           break;
+        case "updateDisplaySetting":
+          if (typeof message.key === 'string' && message.value !== undefined) {
+            await this.dispatch('updateDisplaySetting:diagnostics', async () => {
+              const allowedKeys = [
+                'display.statusBar.showTokens',
+                'display.statusBar.showCost',
+              ];
+              if (allowedKeys.includes(message.key)) {
+                const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
+                await config.update(message.key, message.value, vscode.ConfigurationTarget.Global);
+              }
+            });
+          }
+          break;
         case "resetDebugCounters":
           await this.dispatch('resetDebugCounters:diagnostics', async () => {
             await this.context.globalState.update('extension.openCount', 0);
@@ -7473,8 +7530,7 @@ ${hashtag}`;
           break;
         case "analyzeFolder":
           await this.dispatch('analyzeFolder:diagnostics', async () => {
-            const { folderPath, toolType } = message as { folderPath: string; toolType: string };
-            if (!folderPath) {
+            const { folderPath, toolType } = message as { folderPath: string; toolType: string };            if (!folderPath) {
               if (this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
                 this.diagnosticsPanel.webview.postMessage({
                   command: "folderAnalysisResult",
@@ -8086,6 +8142,10 @@ ${hashtag}`;
       backendConfigured: this.isBackendConfigured(),
       isDebugMode,
       globalStateCounters,
+      displaySettings: {
+        showTokens: this.getStatusBarShowTokensSetting(),
+        showCost: this.getStatusBarShowCostSetting(),
+      },
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2119,10 +2119,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (showCost !== 'none') {
 			const costParts: string[] = [];
 			if (showCost === 'today' || showCost === 'both') {
-				costParts.push(`$${(stats.today.estimatedCostCopilot ?? 0).toFixed(2)}`);
+				costParts.push(`$${(stats.today.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
 			}
 			if (showCost === 'currentMonth' || showCost === 'both') {
-				costParts.push(`$${(stats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)}`);
+				costParts.push(`$${(stats.last30Days.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
 			}
 			parts.push(`$(credit-card) ${costParts.join(' | ')}`);
 		}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2091,12 +2091,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('display.use24HourTime', true);
 	}
 
-	private getStatusBarShowTokensSetting(): 'none' | 'today' | 'currentMonth' | 'both' {
-		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'currentMonth' | 'both'>('display.statusBar.showTokens', 'both');
+	private getStatusBarShowTokensSetting(): 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth' {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth'>('display.statusBar.showTokens', 'both');
 	}
 
-	private getStatusBarShowCostSetting(): 'none' | 'today' | 'currentMonth' | 'both' {
-		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'currentMonth' | 'both'>('display.statusBar.showCost', 'none');
+	private getStatusBarShowCostSetting(): 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth' {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth'>('display.statusBar.showCost', 'none');
 	}
 
 	private buildStatusBarText(stats: DetailedStats): string {
@@ -2107,22 +2107,28 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		if (showTokens !== 'none') {
 			const tokenParts: string[] = [];
-			if (showTokens === 'today' || showTokens === 'both') {
+			if (showTokens === 'today' || showTokens === 'both' || showTokens === 'todayAndCurrentMonth') {
 				tokenParts.push(this.formatCompact(stats.today.tokens));
 			}
-			if (showTokens === 'currentMonth' || showTokens === 'both') {
+			if (showTokens === 'last30days' || showTokens === 'both') {
 				tokenParts.push(this.formatCompact(stats.last30Days.tokens));
+			}
+			if (showTokens === 'currentMonth' || showTokens === 'todayAndCurrentMonth') {
+				tokenParts.push(this.formatCompact(stats.month.tokens));
 			}
 			parts.push(`$(symbol-numeric) ${tokenParts.join(' | ')}`);
 		}
 
 		if (showCost !== 'none') {
 			const costParts: string[] = [];
-			if (showCost === 'today' || showCost === 'both') {
+			if (showCost === 'today' || showCost === 'both' || showCost === 'todayAndCurrentMonth') {
 				costParts.push(`$${(stats.today.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
 			}
-			if (showCost === 'currentMonth' || showCost === 'both') {
+			if (showCost === 'last30days' || showCost === 'both') {
 				costParts.push(`$${(stats.last30Days.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
+			}
+			if (showCost === 'currentMonth' || showCost === 'todayAndCurrentMonth') {
+				costParts.push(`$${(stats.month.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
 			}
 			parts.push(`$(credit-card) ${costParts.join(' | ')}`);
 		}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -184,6 +184,8 @@ type SessionFilePreload = {
 	details?: SessionFileDetails;
 };
 
+type StatusBarDisplaySetting = 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth';
+
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
 	private static readonly CACHE_VERSION = 46; // Restore CLI cache token propagation in tokenEstimation + usageAnalysis (was reverted in 7d9def8)
@@ -2091,53 +2093,56 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('display.use24HourTime', true);
 	}
 
-	private getStatusBarShowTokensSetting(): 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth' {
-		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth'>('display.statusBar.showTokens', 'both');
+	private getStatusBarShowTokensSetting(): StatusBarDisplaySetting {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<StatusBarDisplaySetting>('display.statusBar.showTokens', 'both');
 	}
 
-	private getStatusBarShowCostSetting(): 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth' {
-		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth'>('display.statusBar.showCost', 'none');
+	private getStatusBarShowCostSetting(): StatusBarDisplaySetting {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<StatusBarDisplaySetting>('display.statusBar.showCost', 'none');
+	}
+
+	private buildTokenParts(show: StatusBarDisplaySetting, stats: DetailedStats): string[] {
+		const parts: string[] = [];
+		if (show === 'today' || show === 'both' || show === 'todayAndCurrentMonth') {
+			parts.push(this.formatCompact(stats.today.tokens));
+		}
+		if (show === 'last30days' || show === 'both') {
+			parts.push(this.formatCompact(stats.last30Days.tokens));
+		}
+		if (show === 'currentMonth' || show === 'todayAndCurrentMonth') {
+			parts.push(this.formatCompact(stats.month.tokens));
+		}
+		return parts;
+	}
+
+	private buildCostParts(show: StatusBarDisplaySetting, stats: DetailedStats): string[] {
+		const fmt = (v: number) => `$${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+		const parts: string[] = [];
+		if (show === 'today' || show === 'both' || show === 'todayAndCurrentMonth') {
+			parts.push(fmt(stats.today.estimatedCostCopilot ?? 0));
+		}
+		if (show === 'last30days' || show === 'both') {
+			parts.push(fmt(stats.last30Days.estimatedCostCopilot ?? 0));
+		}
+		if (show === 'currentMonth' || show === 'todayAndCurrentMonth') {
+			parts.push(fmt(stats.month.estimatedCostCopilot ?? 0));
+		}
+		return parts;
 	}
 
 	private buildStatusBarText(stats: DetailedStats): string {
 		const showTokens = this.getStatusBarShowTokensSetting();
 		const showCost = this.getStatusBarShowCostSetting();
-
 		const parts: string[] = [];
 
 		if (showTokens !== 'none') {
-			const tokenParts: string[] = [];
-			if (showTokens === 'today' || showTokens === 'both' || showTokens === 'todayAndCurrentMonth') {
-				tokenParts.push(this.formatCompact(stats.today.tokens));
-			}
-			if (showTokens === 'last30days' || showTokens === 'both') {
-				tokenParts.push(this.formatCompact(stats.last30Days.tokens));
-			}
-			if (showTokens === 'currentMonth' || showTokens === 'todayAndCurrentMonth') {
-				tokenParts.push(this.formatCompact(stats.month.tokens));
-			}
-			parts.push(`$(symbol-numeric) ${tokenParts.join(' | ')}`);
+			parts.push(`$(symbol-numeric) ${this.buildTokenParts(showTokens, stats).join(' | ')}`);
 		}
-
 		if (showCost !== 'none') {
-			const costParts: string[] = [];
-			if (showCost === 'today' || showCost === 'both' || showCost === 'todayAndCurrentMonth') {
-				costParts.push(`$${(stats.today.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
-			}
-			if (showCost === 'last30days' || showCost === 'both') {
-				costParts.push(`$${(stats.last30Days.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
-			}
-			if (showCost === 'currentMonth' || showCost === 'todayAndCurrentMonth') {
-				costParts.push(`$${(stats.month.estimatedCostCopilot ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
-			}
-			parts.push(`$(credit-card) ${costParts.join(' | ')}`);
+			parts.push(`$(credit-card) ${this.buildCostParts(showCost, stats).join(' | ')}`);
 		}
 
-		if (parts.length === 0) {
-			return `$(symbol-numeric) AI Fluency`;
-		}
-
-		return parts.join('  ');
+		return parts.length > 0 ? parts.join('  ') : `$(symbol-numeric) AI Fluency`;
 	}
 
 	private refreshOpenPanelsForSettingChange(): void {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -95,7 +95,7 @@ type SessionFolder = {
   editorName?: string;
 };
 
-type StatusBarShowOption = 'none' | 'today' | 'currentMonth' | 'both';
+type StatusBarShowOption = 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth';
 
 type DisplaySettings = {
   showTokens: StatusBarShowOption;
@@ -2159,8 +2159,10 @@ Choose what to show in the VS Code status bar toolbar. You can show token counts
   <select id="select-show-tokens" class="settings-select" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px;">
     <option value="none" ${(data.displaySettings?.showTokens ?? 'both') === 'none' ? 'selected' : ''}>None</option>
     <option value="today" ${(data.displaySettings?.showTokens ?? 'both') === 'today' ? 'selected' : ''}>Today only</option>
-    <option value="currentMonth" ${(data.displaySettings?.showTokens ?? 'both') === 'currentMonth' ? 'selected' : ''}>Last 30 days only</option>
-    <option value="both" ${(data.displaySettings?.showTokens ?? 'both') === 'both' ? 'selected' : ''}>Both (today + last 30 days)</option>
+    <option value="last30days" ${(data.displaySettings?.showTokens ?? 'both') === 'last30days' ? 'selected' : ''}>Last 30 days only</option>
+    <option value="currentMonth" ${(data.displaySettings?.showTokens ?? 'both') === 'currentMonth' ? 'selected' : ''}>Current calendar month only</option>
+    <option value="both" ${(data.displaySettings?.showTokens ?? 'both') === 'both' ? 'selected' : ''}>Today + last 30 days (default)</option>
+    <option value="todayAndCurrentMonth" ${(data.displaySettings?.showTokens ?? 'both') === 'todayAndCurrentMonth' ? 'selected' : ''}>Today + current calendar month</option>
   </select>
 </div>
 <div style="display: flex; align-items: center; gap: 12px;">
@@ -2168,8 +2170,10 @@ Choose what to show in the VS Code status bar toolbar. You can show token counts
   <select id="select-show-cost" class="settings-select" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px;">
     <option value="none" ${(data.displaySettings?.showCost ?? 'none') === 'none' ? 'selected' : ''}>None (hidden)</option>
     <option value="today" ${(data.displaySettings?.showCost ?? 'none') === 'today' ? 'selected' : ''}>Today only</option>
-    <option value="currentMonth" ${(data.displaySettings?.showCost ?? 'none') === 'currentMonth' ? 'selected' : ''}>Last 30 days only</option>
-    <option value="both" ${(data.displaySettings?.showCost ?? 'none') === 'both' ? 'selected' : ''}>Both (today + last 30 days)</option>
+    <option value="last30days" ${(data.displaySettings?.showCost ?? 'none') === 'last30days' ? 'selected' : ''}>Last 30 days only</option>
+    <option value="currentMonth" ${(data.displaySettings?.showCost ?? 'none') === 'currentMonth' ? 'selected' : ''}>Current calendar month only</option>
+    <option value="both" ${(data.displaySettings?.showCost ?? 'none') === 'both' ? 'selected' : ''}>Today + last 30 days</option>
+    <option value="todayAndCurrentMonth" ${(data.displaySettings?.showCost ?? 'none') === 'todayAndCurrentMonth' ? 'selected' : ''}>Today + current calendar month</option>
   </select>
 </div>
 </div>

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -95,6 +95,13 @@ type SessionFolder = {
   editorName?: string;
 };
 
+type StatusBarShowOption = 'none' | 'today' | 'currentMonth' | 'both';
+
+type DisplaySettings = {
+  showTokens: StatusBarShowOption;
+  showCost: StatusBarShowOption;
+};
+
 type DiagnosticsData = {
   report: string;
   sessionFiles: { file: string; size: number; modified: string }[];
@@ -106,6 +113,7 @@ type DiagnosticsData = {
   globalStateCounters?: GlobalStateCounters;
   githubAuth?: GitHubAuthStatus;
   sessionFolders?: SessionFolder[];
+  displaySettings?: DisplaySettings;
 };
 
 type DiagnosticsViewState = {
@@ -1466,6 +1474,22 @@ function setupBackendButtonHandlers(): void {
     });
 }
 
+function setupDisplaySettingHandlers(): void {
+  document
+    .getElementById("select-show-tokens")
+    ?.addEventListener("change", (e) => {
+      const value = (e.target as HTMLSelectElement).value;
+      vscode.postMessage({ command: "updateDisplaySetting", key: "display.statusBar.showTokens", value });
+    });
+
+  document
+    .getElementById("select-show-cost")
+    ?.addEventListener("change", (e) => {
+      const value = (e.target as HTMLSelectElement).value;
+      vscode.postMessage({ command: "updateDisplaySetting", key: "display.statusBar.showCost", value });
+    });
+}
+
 function setupSubtabHandlers(): void {
   document.querySelectorAll(".subtab").forEach((subtab) => {
     subtab.addEventListener("click", () => {
@@ -2122,7 +2146,34 @@ ${renderGitHubAuthPanel(data.githubAuth)}
 <div id="tab-display" class="tab-content">
 <div class="info-box">
 <div class="info-box-title">⚙️ Display Settings</div>
-<div>Configure how numbers are displayed across the extension. Changes take effect immediately in the Settings editor and are applied the next time a view is opened or refreshed.</div>
+<div>Configure what is shown in the status bar at the bottom of VS Code. Changes take effect immediately — no data refresh needed.</div>
+</div>
+<div class="backend-card">
+<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📊 Status Bar Display</h4>
+<p style="color: #ccc; margin-bottom: 16px;">
+Choose what to show in the VS Code status bar toolbar. You can show token counts, estimated costs, both, or neither for each period.
+</p>
+<div style="display: grid; gap: 16px;">
+<div style="display: flex; align-items: center; gap: 12px;">
+  <label style="color: #ccc; min-width: 160px; font-size: 13px;">🔢 Token counts:</label>
+  <select id="select-show-tokens" class="settings-select" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px;">
+    <option value="none" ${(data.displaySettings?.showTokens ?? 'both') === 'none' ? 'selected' : ''}>None</option>
+    <option value="today" ${(data.displaySettings?.showTokens ?? 'both') === 'today' ? 'selected' : ''}>Today only</option>
+    <option value="currentMonth" ${(data.displaySettings?.showTokens ?? 'both') === 'currentMonth' ? 'selected' : ''}>Last 30 days only</option>
+    <option value="both" ${(data.displaySettings?.showTokens ?? 'both') === 'both' ? 'selected' : ''}>Both (today + last 30 days)</option>
+  </select>
+</div>
+<div style="display: flex; align-items: center; gap: 12px;">
+  <label style="color: #ccc; min-width: 160px; font-size: 13px;">💰 Estimated cost (USD):</label>
+  <select id="select-show-cost" class="settings-select" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px;">
+    <option value="none" ${(data.displaySettings?.showCost ?? 'none') === 'none' ? 'selected' : ''}>None (hidden)</option>
+    <option value="today" ${(data.displaySettings?.showCost ?? 'none') === 'today' ? 'selected' : ''}>Today only</option>
+    <option value="currentMonth" ${(data.displaySettings?.showCost ?? 'none') === 'currentMonth' ? 'selected' : ''}>Last 30 days only</option>
+    <option value="both" ${(data.displaySettings?.showCost ?? 'none') === 'both' ? 'selected' : ''}>Both (today + last 30 days)</option>
+  </select>
+</div>
+</div>
+<p style="color: #888; font-size: 11px; margin-top: 12px;">Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing). Changes apply to the status bar immediately.</p>
 </div>
 <div class="backend-card">
 <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">🔢 Number Formatting</h4>
@@ -2168,6 +2219,7 @@ ${renderFolderAnalyzerTab()}
   setupGitHubAuthHandlers();
   setupFolderAnalyzerHandlers();
   setupButtonHandlers();
+  setupDisplaySettingHandlers();
 
   const savedState = diagState.restore();
   if (savedState?.activeTab && !activateTab(savedState.activeTab)) {


### PR DESCRIPTION
Adds two new VS Code settings to control what is displayed in the status bar. See commit message for details.