### PR TITLE
chore: bump versions for release (CLI v0.2.3, VS Code v0.11.0)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,18 +1,60 @@
 # Change Log
 
-All notable changes to the CLI (`@rajbos/ai-engineering-fluency`) will be documented in this file.
+All notable changes to the CLI (@rajbos/ai-engineering-fluency) will be documented in this file.
+
+## [0.2.3] - 2026-05-22
+
+### Features & Improvements
+- Added oh-my-posh segment command and Copilot CLI statusline support (#876)
+- Removed cost estimate row and renamed TBB to UBB for clearer billing terminology (#847)
+- Added billion (B) tier to token display formatters for very large token counts (#899)
+
+### Bug Fixes
+- Reduced OMP segment cache TTL from 15 min to 5 min for fresher status-bar data (#936)
+
+### Maintenance
+- Extracted CLI helpers into focused modules: progress.ts (ProgressTracker), formatting.ts, commandUtils.ts, and analysis.ts (#1016, #1026, #1027, #1028)
+- Replaced synchronous fs calls with async alternatives in CLI helpers
+- Extracted CachePolicy strategy from cacheManager and cliCache
+- Extracted WorkspacePathResolver for safe file:// URI handling (#965)
+- Extracted buildAdapterRegistry factory to eliminate adapter duplication (#959)
+- Extracted withErrorRecovery helper to replace silent catch blocks
+- Replaced any type casts with proper types throughout CLI helpers
+- Centralised ecosystem adapter data-access instantiation
+- Added null checks and input validation to output formatting functions
+- Bumped @types/node dependencies
+
+## [0.2.2] - 2026-05-13
+
+### Maintenance
+- Internal refactoring: extract cache invalidation policy and error-handling wrapper
+
+## [0.2.0] - 2026-05-11
+
+### Maintenance
+- Internal refactoring and dependency updates
+
+## [0.1.3] - 2026-05-10
+
+### Features & Improvements
+- Added oh-my-posh segment command and Copilot CLI statusline support (#876)
+
+## [0.1.2] - 2026-05-09
+
+### Features & Improvements
+- Removed cost estimate row and renamed TBB to UBB (#847)
 
 ## [0.1.1] - 2026-05-09
 
-### ✨ Features & Improvements
-- Added `--json` output option to the `stats` command (#818)
+### Features & Improvements
+- Added --json output option to the stats command (#818)
 
-### 🔧 Maintenance
+### Maintenance
 - Bumped @types/node from 25.6.0 to 25.6.2
 
 ## [0.1.0] - 2026-05-04
 
-### ✨ Features & Improvements
+### Features & Improvements
 - Added Gemini CLI support as a trackable ecosystem
 - Added JetBrains adapter to CLI ecosystem registry
 - Added Mistral Vibe session support
@@ -21,72 +63,17 @@ All notable changes to the CLI (`@rajbos/ai-engineering-fluency`) will be docume
 - Added dedicated CLI interaction mode in Usage Analysis (#659)
 - Added macOS path support for Claude Desktop Cowork sessions (#714)
 - Improved fluency spiderweb chart for Claude-only users
-- Renamed cost labels: (API) → (est.) and (Copilot) → (TBB) with explainer tooltips
-- Display CO2 in kg when ≥ 1000g for readability
+- Renamed cost labels: (API) to (est.) and (Copilot) to (TBB) with explainer tooltips
+- Display CO2 in kg when >= 1000g for readability
 
-### 🐛 Bug Fixes
+### Bug Fixes
 - Fixed: align token counting with VS Code extension
 - Fixed: use actual tokens for all periods; increased session timeout to 120s
-- Fixed: prefer `actualTokens` from `session.shutdown` over estimates
+- Fixed: prefer actualTokens from session.shutdown over estimates
 - Fixed: use UTC date boundaries for period attribution
-- Fixed: extract per-model usage from `session.shutdown` events
+- Fixed: extract per-model usage from session.shutdown events
 - Fixed: populate estimated cost data in chart view for all periods
 
-### 🔧 Maintenance
+### Maintenance
 - Migrated to IEcosystemAdapter registry pattern for improved extensibility
 - Bumped cache version to 3 to reflect SessionData shape changes
-
-## [0.0.14] - 2026-04-30
-
-### ✨ Features & Improvements
-- Added macOS path support for Claude Desktop Cowork sessions (#714)
-- Added dedicated CLI interaction mode in Usage Analysis (#659)
-- Added GitHub Copilot AI-Credit pricing alongside provider pricing
-- Added Mistral Vibe session support
-- Improved fluency spiderweb chart for Claude-only users
-- Renamed cost labels: `(API)` → `(est.)` and `(Copilot)` → `(TBB)` with explainer tooltips
-- Display CO2 in kg when ≥ 1000g for readability
-
-### 🔧 Maintenance
-- Migrated to IEcosystemAdapter registry pattern for improved extensibility
-
-## [0.0.8] - 2026-04-11
-
-### ✨ Features & Improvements
-- Added Claude Desktop Cowork session support as a usage analysis data source (#572)
-- Added thinking effort (reasoning effort) tracking for sessions that use reasoning models
-- Added missing friendly display names for 14 tools (#584)
-
-### 🐛 Bug Fixes
-- Fixed token usage tracking from sub-agent calls in Copilot agent mode (#567, #573)
-- Fixed Copilot CLI sessions falling back to first user message as title when no explicit title is set
-- Fixed 0-interaction sessions being shown in diagnostics view; documented CLI session format
-- Fixed potential client-side cross-site scripting vulnerability in usage webview (#579)
-
-## [0.0.7] - 2026-04-08
-
-### ✨ Features & Improvements
-- Added npmjs package link to CLI documentation (#536)
-
-### 🔧 Maintenance
-- Bumped esbuild from 0.27.4 → 0.28.0
-- Bumped @types/node from 25.5.0 → 25.5.2
-
-## [0.0.6] - 2026-04-01
-
-### ✨ Features & Improvements
-- Automatic tools are now annotated and excluded from fluency scoring (#529)
-- Parallelized session discovery and file processing for improved performance
-
-## [0.0.5] - 2026-03-28
-
-### ✨ Features & Improvements
-- Added Claude Code session file support as a usage analysis data source
-- Added formatting options (number formatting) to stats output
-- Fixed CLI output references
-
-## [0.0.4] - 2026-03-26
-
-### ✨ Features & Improvements
-- Added Continue.dev as a usage analysis data source
-- Updated tsconfig module resolution to `bundler` for improved ESM compatibility

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
+## [0.11.0] - 2026-05-22
+
+### Features
+- Configurable status bar: independently show token counts and/or cost (#1036)
+- Added 17+ friendly tool names for Claude in Chrome, Cowork, M365 Connector, and other tools (#1037, #1038, #1039)
+
+### Security
+- Added HTML escaping to prevent XSS in configPanel webview
+
+### Maintenance
+- Enhanced token tracking: extract all tokens from debug log and update session cache structure (#1040)
+- Centralised adapter session path predicates to adapterPredicates.ts (#1034)
+- Refactored extension.ts activate() into focused registration helpers (#1035)
+- Extracted pathExists helper to utils/fsAsync.ts (#1031)
+- Extracted settings validation helpers to backend/settingsValidation.ts (#1030)
+- Consolidated path normalisation helpers to utils/pathUtils.ts (#1032)
+- Consolidated duplicated webview type definitions to shared/types.ts (#1033)
+- Added isNonNegativeInt type guard and safeJsonParse utility (#1029, #1013)
+- Extracted registerMessageHandler helper from webview message listeners (#1022)
+- Centralised Azure error classification in azureErrorClassifier.ts (#1017)
+- Introduced ValidationResult<T> discriminated union for type-safe validation (#1021)
+- Extracted Azure Storage endpoint URL builders to shared utility (#1005)
+- Multiple additional refactoring improvements for maintainability and type safety
+
+## [0.10.2] - 2026-05-13
+
+### Maintenance
+- Internal refactoring and dependency updates
+
 ## [0.10.1] - 2026-05-19
 
 ### Bug Fixes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {
@@ -341,7 +341,14 @@
         },
         "aiEngineeringFluency.display.statusBar.showTokens": {
           "type": "string",
-          "enum": ["none", "today", "last30days", "currentMonth", "both", "todayAndCurrentMonth"],
+          "enum": [
+            "none",
+            "today",
+            "last30days",
+            "currentMonth",
+            "both",
+            "todayAndCurrentMonth"
+          ],
           "enumDescriptions": [
             "Do not show token counts in the status bar",
             "Show today's token count only",
@@ -355,7 +362,14 @@
         },
         "aiEngineeringFluency.display.statusBar.showCost": {
           "type": "string",
-          "enum": ["none", "today", "last30days", "currentMonth", "both", "todayAndCurrentMonth"],
+          "enum": [
+            "none",
+            "today",
+            "last30days",
+            "currentMonth",
+            "both",
+            "todayAndCurrentMonth"
+          ],
           "enumDescriptions": [
             "Do not show estimated cost in the status bar (default)",
             "Show today's estimated cost only",


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers and updates changelogs for two components that have changed since their last release tags.

| Component | Last tag | Old version | New version | Bump type |
|-----------|----------|-------------|-------------|-----------|
| CLI | \cli/v0.0.8\ | 0.2.2 | **0.2.3** | patch |
| VS Code extension | \scode/v0.10.2\ | 0.10.2 | **0.11.0** | minor |

### What changed

**VS Code extension (0.10.2 → 0.11.0 — minor)**
- 🆕 Configurable status bar: independently show token counts and/or cost (#1036)
- 🆕 Added 17+ friendly tool names for Claude in Chrome, Cowork, M365 Connector, and other tools (#1037, #1038, #1039)
- 🔐 Added HTML escaping to prevent XSS in configPanel webview
- 🔧 Enhanced token tracking + extensive refactoring improvements (#1040, #1034, #1035, #1031, #1030, #1032, #1033, and more)

**CLI (0.2.2 → 0.2.3 — patch)**
- 🔧 Extracted CLI helpers into focused modules: \progress.ts\, \ormatting.ts\, \commandUtils.ts\, \nalysis.ts\ (#1016, #1026, #1027, #1028)
- 🔧 Replaced sync fs calls with async alternatives, extracted CachePolicy, WorkspacePathResolver, buildAdapterRegistry, withErrorRecovery
- 📝 Backfilled CHANGELOG entries for intermediate versions 0.1.2, 0.1.3, 0.2.0, 0.2.2 (which were bumped without changelog entries)

---

### After merging, run these workflows:

#### 1. VS Code Extension
- Go to **Actions → Extensions - Release → Run workflow** (on \main\)
- This publishes VS Code extension **v0.11.0** to the VS Code Marketplace

#### 2. CLI
- Go to **Actions → CLI - Publish to npm and GitHub → Run workflow** (on \main\)
- This publishes **@rajbos/ai-engineering-fluency@0.2.3** to npm