### PR TITLE
fix: muting unknown tool is now instant, skips full stats recalc

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4878,7 +4878,9 @@ usageAnalysis: undefined
 							await config.update('suppressedUnknownTools', [...current, toolName], vscode.ConfigurationTarget.Global);
 							this.log(`🔇 Suppressed unknown tool: ${toolName}`);
 						}
-						await this.dispatch('refresh:analysis', () => this.refreshAnalysisPanel());
+						// Immediately update the webview UI without waiting for a full stats recalculation.
+						// The webview removes the tool chip directly from the DOM.
+						this.analysisPanel?.webview.postMessage({ command: 'toolSuppressed', toolName });
 					}
 					break;
 				}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1807,6 +1807,24 @@ registerMessageHandler<any>((message) => {
 			clearLoadingTimeout();
 			showLoadError('Failed to calculate usage analysis. Check the Output panel for details.');
 			break;
+		case 'toolSuppressed': {
+			// Immediately remove the suppressed tool chip from the DOM without a full re-render.
+			const suppressedName = message.toolName as string;
+			if (suppressedName) {
+				const section = document.getElementById('unknown-mcp-tools-section');
+				if (section) {
+					section.querySelectorAll<HTMLButtonElement>('button[data-suppress-tool]').forEach(btn => {
+						if (btn.getAttribute('data-suppress-tool') === suppressedName) {
+							btn.closest('span')?.remove();
+						}
+					});
+					if (section.querySelectorAll('button[data-suppress-tool]').length === 0) {
+						section.remove();
+					}
+				}
+			}
+			break;
+		}
 		case 'highlightUnknownTools': {
 			// Switch to tools tab
 			activeTab = 'tools';


### PR DESCRIPTION
## Problem

Clicking the 🔇 button to suppress an unknown tool in the Usage Analysis panel took several seconds to respond. The user had to wait for the entire stats recalculation loop to complete before the tool was removed from the UI.

## Root cause

\suppressUnknownTool\ → \efreshAnalysisPanel()\ → \calculateUsageAnalysisStats(false)\ (full filesystem scan of all session logs) → replaces entire webview HTML. The recalculation is expensive and completely unnecessary here, since suppression is just a display filter.

## Fix

- **Extension**: After saving the config, immediately post a lightweight \	oolSuppressed\ message to the webview. The expensive \efreshAnalysisPanel()\ call is removed from this path.
- **Webview**: Handle \	oolSuppressed\ by directly removing the tool's chip from the DOM (no re-render). If no unknown tools remain, the entire section is also removed.

The response is now instantaneous.