### PR TITLE
fix(vscode): use leaf-key getConfiguration for statusBar settings to fix 'not registered' error

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2096,11 +2096,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private getStatusBarShowTokensSetting(): StatusBarDisplaySetting {
-		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<StatusBarDisplaySetting>('display.statusBar.showTokens', 'both');
+		return vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar').get<StatusBarDisplaySetting>('showTokens', 'both');
 	}
 
 	private getStatusBarShowCostSetting(): StatusBarDisplaySetting {
-		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<StatusBarDisplaySetting>('display.statusBar.showCost', 'none');
+		return vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar').get<StatusBarDisplaySetting>('showCost', 'none');
 	}
 
 	private buildTokenParts(show: StatusBarDisplaySetting, stats: DetailedStats): string[] {
@@ -7573,13 +7573,19 @@ ${hashtag}`;
         case "updateDisplaySetting":
           if (typeof message.key === 'string' && message.value !== undefined) {
             await this.dispatch('updateDisplaySetting:diagnostics', async () => {
-              const allowedKeys = [
-                'display.statusBar.showTokens',
-                'display.statusBar.showCost',
-              ];
-              if (allowedKeys.includes(message.key)) {
-                const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
-                await config.update(message.key, message.value, vscode.ConfigurationTarget.Global);
+              // Map webview keys to leaf property names under aiEngineeringFluency.display.statusBar.
+              // Using getConfiguration('aiEngineeringFluency.display.statusBar').update('showTokens')
+              // instead of getConfiguration('aiEngineeringFluency').update('display.statusBar.showTokens')
+              // avoids VS Code rejecting multi-segment relative keys in update() as "not a registered
+              // configuration" even when the full key exists in contributes.configuration.properties.
+              const statusBarLeafKeyMap: Record<string, string> = {
+                'display.statusBar.showTokens': 'showTokens',
+                'display.statusBar.showCost': 'showCost',
+              };
+              const leafKey = statusBarLeafKeyMap[message.key];
+              if (leafKey) {
+                const config = vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar');
+                await config.update(leafKey, message.value, vscode.ConfigurationTarget.Global);
               }
             });
           }


### PR DESCRIPTION
## Problem

When changing the new status bar display options (Show Tokens / Show Cost) from the Diagnostics panel, VS Code throws:

> Operation failed: Unable to write to User Settings because aiEngineeringFluency.display.statusBar.showTokens is not a registered configuration.

Both showTokens and showCost fail with the same error.

## Root Cause

VS Code's WorkspaceConfiguration.update() rejects multi-segment relative keys when the full qualified key has 4 or more dot-separated segments. The original code:

`	ypescript
const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
await config.update('display.statusBar.showTokens', value, vscode.ConfigurationTarget.Global);
`

produces the full key aiEngineeringFluency.display.statusBar.showTokens (4 segments), which VS Code fails to look up in its configuration registry even though the key IS declared in contributes.configuration.properties.

This is consistent with how VS Code resolves relative keys: single-segment keys work fine (e.g. update('suppressedUnknownTools', ...)), but 3-segment relative keys fail validation.

## Fix

Use getConfiguration('aiEngineeringFluency.display.statusBar') with the leaf key name:

`	ypescript
const config = vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar');
await config.update('showTokens', value, vscode.ConfigurationTarget.Global);
`

Both approaches construct the same full key, but the single-segment relative key avoids the validation bug. The package.json configuration declarations remain unchanged.

The getter methods are also updated to use the same specific section prefix for consistency. The onDidChangeConfiguration listener on 'aiEngineeringFluency.display' continues to fire correctly since the full key still starts with that prefix.

## Changes

- vscode-extension/src/extension.ts: Updated getStatusBarShowTokensSetting(), getStatusBarShowCostSetting(), and the updateDisplaySetting message handler to use getConfiguration('aiEngineeringFluency.display.statusBar') with leaf-only key names
