### PR TITLE
chore: bump vscode-extension to v0.11.1

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
+## [0.11.1] - 2026-05-22
+
+### Bug Fixes
+- fix(vscode): use leaf-key getConfiguration for statusBar settings to fix 'not registered' error (#1044)
+- fix: muting unknown tool now instant, skips full stats recalc (#1043)
+
 ## [0.11.0] - 2026-05-22
 
 ### Features

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bump

This PR bumps the VS Code extension version for a patch release containing two bug fixes.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.11.0 | v0.11.1 |

### Changes included since \scode/v0.11.0\

- fix(vscode): use leaf-key getConfiguration for statusBar settings to fix 'not registered' error (#1044)
- fix: muting unknown tool now instant, skips full stats recalc (#1043)

### After merging, run this workflow:

- **Extensions - Release** (\elease.yml\) — Go to **Actions → Extensions - Release → Run workflow** (on \main\) to publish VS Code extension **v0.11.1** to the VS Code Marketplace