### PR TITLE
fix(vscode): use getConfiguration() with full key for statusBar update() calls (v0.11.2)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7575,19 +7575,17 @@ ${hashtag}`;
         case "updateDisplaySetting":
           if (typeof message.key === 'string' && message.value !== undefined) {
             await this.dispatch('updateDisplaySetting:diagnostics', async () => {
-              // Map webview keys to leaf property names under aiEngineeringFluency.display.statusBar.
-              // Using getConfiguration('aiEngineeringFluency.display.statusBar').update('showTokens')
-              // instead of getConfiguration('aiEngineeringFluency').update('display.statusBar.showTokens')
-              // avoids VS Code rejecting multi-segment relative keys in update() as "not a registered
-              // configuration" even when the full key exists in contributes.configuration.properties.
-              const statusBarLeafKeyMap: Record<string, string> = {
-                'display.statusBar.showTokens': 'showTokens',
-                'display.statusBar.showCost': 'showCost',
+              // Map webview keys to fully-qualified setting names.
+              // Using getConfiguration() with no section + full key avoids VS Code rejecting
+              // multi-segment relative keys in update() as "not a registered configuration",
+              // which happens even when the key is declared in contributes.configuration.properties.
+              const fullKeyMap: Record<string, string> = {
+                'display.statusBar.showTokens': 'aiEngineeringFluency.display.statusBar.showTokens',
+                'display.statusBar.showCost': 'aiEngineeringFluency.display.statusBar.showCost',
               };
-              const leafKey = statusBarLeafKeyMap[message.key];
-              if (leafKey) {
-                const config = vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar');
-                await config.update(leafKey, message.value, vscode.ConfigurationTarget.Global);
+              const fullKey = fullKeyMap[message.key];
+              if (fullKey) {
+                await vscode.workspace.getConfiguration().update(fullKey, message.value, vscode.ConfigurationTarget.Global);
               }
             });
           }


### PR DESCRIPTION
## Problem

The previous fix in #1044 (shipped as v0.11.1) still triggers the same error:
> Unable to write to User Settings because `aiEngineeringFluency.display.statusBar.showTokens` is not a registered configuration.

### Root cause

Calling `getConfiguration('aiEngineeringFluency.display.statusBar').update('showTokens', ...)` still fails because VS Code internally resolves the section + key into `aiEngineeringFluency.display.statusBar.showTokens` (4 dot-separated segments) and then rejects it during key validation — even though the key is properly declared in `contributes.configuration.properties`.

## Fix

Use `getConfiguration()` with **no section prefix** and pass the **complete registered key** directly:

```typescript
await vscode.workspace.getConfiguration().update(
  'aiEngineeringFluency.display.statusBar.showTokens',
  value,
  vscode.ConfigurationTarget.Global
);
```

This bypasses VS Code's section-based key resolution path and resolves directly against the configuration registry, where the key is correctly registered.

## Changes
- `extension.ts`: `updateDisplaySetting` handler now uses `getConfiguration()` (no section) + full qualified key
- `package.json`: version bumped to 0.11.2

Closes #1047 (regression from #1044)
