### PR TITLE
chore(vscode): bump version to 0.11.3

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
+## [0.11.3] - 2026-05-22
+
+### Maintenance
+- Patch version bump
+
+## [0.11.2] - 2026-05-22
+
+### Bug Fixes
+- fix(vscode): use getConfiguration() with full key for statusBar update() calls (#1046)
+
 ## [0.11.1] - 2026-05-22
 
 ### Bug Fixes

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Summary

Patch version bump for the VS Code extension from 0.11.2 → 0.11.3.

Updates:
- \scode-extension/package.json\: version 0.11.2 → 0.11.3
- \scode-extension/CHANGELOG.md\: added entries for v0.11.2 and v0.11.3