### PR TITLE
refactor: export makePeriodAccumulator factory and use it in extension.ts

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -144,7 +144,7 @@ import {
 import { buildChartData as _buildChartData } from './chartDataBuilder';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, computeUtcDateRanges, aggregatePeriodStats, type SessionAggregateInput } from './statsHelpers';
+import { addModelUsage, addEditorUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, type SessionAggregateInput } from './statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -170,7 +170,6 @@ import {
   type ViewRegressionProbeConfig,
   type ViewRegressionProbeSnapshot,
 } from './viewRegression';
-
 // --- Backend & UI ---
 import type { AiFluencyExtensionApi, ExtensionPointButton } from './extensionPoints';
 import { REPO_HYGIENE_SKILL } from './backend/repoHygieneSkill';
@@ -1881,10 +1880,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// calendar month, so April 1–12 sessions are not skipped on May 13.
 		const fileLoadCutoffMs = Math.min(last30DaysStartMs, lastMonthStartMs);
 
-		let todayStats = { tokens: 0, thinkingTokens: 0, cachedTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
-		let monthStats = { tokens: 0, thinkingTokens: 0, cachedTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
-		let lastMonthStats = { tokens: 0, thinkingTokens: 0, cachedTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
-		let last30DaysStats = { tokens: 0, thinkingTokens: 0, cachedTokens: 0, estimatedTokens: 0, actualTokens: 0, sessions: 0, interactions: 0, modelUsage: {} as ModelUsage, editorUsage: {} as EditorUsage };
+		let todayStats = makePeriodAccumulator();
+		let monthStats = makePeriodAccumulator();
+		let lastMonthStats = makePeriodAccumulator();
+		let last30DaysStats = makePeriodAccumulator();
 
 		// Daily stats map for the chart (populated by aggregatePeriodStats, finalized below)
 		let dailyStatsMap = new Map<string, DailyTokenStats>();

--- a/vscode-extension/src/statsHelpers.ts
+++ b/vscode-extension/src/statsHelpers.ts
@@ -132,7 +132,7 @@ dailyStatsMap: Map<string, DailyTokenStats>;
 skippedCount: number;
 }
 
-function makePeriodAccumulator(): PeriodAccumulator {
+export function makePeriodAccumulator(): PeriodAccumulator {
 return {
 tokens: 0,
 thinkingTokens: 0,


### PR DESCRIPTION
## Summary

The \PeriodAccumulator\ initialization pattern was repeated four times in \xtension.ts\ as verbose inline object literals. The factory function \makePeriodAccumulator()\ already existed privately in \statsHelpers.ts\ and was used internally by \ggregatePeriodStats\.

## Changes

- **\statsHelpers.ts\**: Export \makePeriodAccumulator()\ (changed \unction\ to \xport function\)
- **\xtension.ts\**: Import \makePeriodAccumulator\ and replace the four manual object constructions with factory calls

## Tests

All 30 unit tests pass.