### PR TITLE
refactor(cli): replace any cast with ModelPricingEntry type in analysis.ts

### DIFF
--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -8,11 +8,14 @@
 import { calculateEstimatedCost } from '../../vscode-extension/src/tokenEstimation';
 import { normalizePathForComparison } from '../../vscode-extension/src/workspaceHelpers';
 import { createEmptyContextRefs } from '../../vscode-extension/src/tokenEstimation';
-import type { ModelUsage, PeriodStats, UsageAnalysisPeriod } from '../../vscode-extension/src/types';
+import type { ModelUsage, ModelPricing, PeriodStats, UsageAnalysisPeriod } from '../../vscode-extension/src/types';
+
+/** Type alias for a single model pricing entry from modelPricing.json. */
+export type ModelPricingEntry = ModelPricing;
 
 // Import JSON data file used by buildChartPayload
 import modelPricingData from '../../vscode-extension/src/modelPricing.json';
-const modelPricing = modelPricingData.pricing as { [key: string]: any };
+const modelPricing = modelPricingData.pricing as Record<string, ModelPricingEntry>;
 
 // ── Types ────────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Replace the \{ [key: string]: any }\ cast on the \modelPricing\ constant in \cli/src/analysis.ts\ with a proper TypeScript type.

## Changes

- **\cli/src/analysis.ts\**:
  - Added \ModelPricing\ to the import from \scode-extension/src/types\
  - Exported \ModelPricingEntry\ as a type alias for \ModelPricing\ (the existing interface that already models the JSON shape: \inputCostPerMillion\, \outputCostPerMillion\, \	ier\, \multiplier\, \displayNames\, \copilotPricing\, etc.)
  - Changed \const modelPricing = modelPricingData.pricing as { [key: string]: any }\ to \Record<string, ModelPricingEntry>\

## Notes

- \scode-extension/src/extension.ts\ already used \ModelPricing\ correctly — no change needed there.
- \scode-extension/src/webview/shared/modelUtils.ts\ uses a narrow local type (not \ny\) — no change needed there.
- All existing unit tests pass.