### PR TITLE
refactor: extract pathExistsWithLogging helper in getDiagnosticCandidatePaths

### DIFF
--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -69,6 +69,19 @@ export class SessionDiscovery {
 		}
 	}
 
+	/** Checks whether a path exists and logs a debug message when it does not. */
+	private pathExistsWithLogging(p: string, context: string): boolean {
+		try {
+			const exists = fs.existsSync(p);
+			if (!exists) {
+				this.deps.log(`🔍 Path not found [${context}]: ${p}`);
+			}
+			return exists;
+		} catch {
+			return false;
+		}
+	}
+
 	/**
 	 * Returns the candidate filesystem paths the extension considers when
 	 * scanning for session files, along with whether each path exists on
@@ -84,8 +97,7 @@ export class SessionDiscovery {
 			try {
 				const ecoPaths = eco.getCandidatePaths();
 				for (const cp of ecoPaths) {
-					let exists = false;
-					try { exists = fs.existsSync(cp.path); } catch { /* ignore */ }
+					const exists = this.pathExistsWithLogging(cp.path, cp.source);
 					candidates.push({ path: cp.path, exists, source: cp.source });
 				}
 			} catch { /* ignore individual adapter errors */ }


### PR DESCRIPTION
## Summary

Extracts a dedicated \pathExistsWithLogging(path, context)\ private helper method in \SessionDiscovery\, replacing the bare \s.existsSync\ calls with silent failure in \getDiagnosticCandidatePaths\.

### Changes
- **\scode-extension/src/sessionDiscovery.ts\**: Added \pathExistsWithLogging(p: string, context: string): boolean\ helper that logs a debug message (via \	his.deps.log\) when a candidate path does not exist, then returns the boolean result. The \getDiagnosticCandidatePaths\ method now delegates to this helper instead of using an inline try/catch with a silent \s.existsSync\.

### Behavior
No functional change — paths that don't exist still return \xists: false\. The only addition is a log line to aid debugging when a candidate path is missing from disk.

All unit tests pass.