### PR TITLE
refactor(tokenEstimation): type-safe accessors replacing unsafe casts

### DIFF
--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -46,6 +46,52 @@ interface SubAgentToolSpecificData {
 	modelName?: unknown;
 }
 
+/** Shape of the `result.metadata` block containing per-request token counts (Insiders format). */
+interface RequestResultMetadata {
+	promptTokens?: number;
+	outputTokens?: number;
+}
+
+/** Shape of the `result.usage` block from the usage-based token format. */
+interface RequestResultUsage {
+	promptTokens?: number;
+	completionTokens?: number;
+}
+
+/** Shape of the `result` field on a reconstructed delta session request. */
+export interface RequestResult {
+	promptTokens?: number;
+	outputTokens?: number;
+	metadata?: RequestResultMetadata;
+	usage?: RequestResultUsage;
+}
+
+/**
+ * Type-safe accessor: extracts the `result` object from an unknown request value.
+ * Returns the typed `RequestResult` if the value is an object with an object `result`,
+ * or `undefined` if the shape does not match.
+ */
+export function getRequestResult(req: unknown): RequestResult | undefined {
+	if (typeof req !== 'object' || req === null) { return undefined; }
+	const obj = req as Record<string, unknown>;
+	const result = obj['result'];
+	if (typeof result !== 'object' || result === null) { return undefined; }
+	return result as RequestResult;
+}
+
+/**
+ * Type-safe accessor: extracts the `response` array from an unknown request value.
+ * Returns the array if the value is an object with an array `response`,
+ * or `undefined` if the shape does not match.
+ */
+export function getResponseArray(req: unknown): unknown[] | undefined {
+	if (typeof req !== 'object' || req === null) { return undefined; }
+	const obj = req as Record<string, unknown>;
+	const response = obj['response'];
+	if (!Array.isArray(response)) { return undefined; }
+	return response;
+}
+
 /** Type guard: narrows an unknown value to a ToolInvocationSerializedItem. */
 function isToolInvocationSerialized(obj: unknown): obj is ToolInvocationSerializedItem {
 	if (typeof obj !== 'object' || obj === null) { return false; }
@@ -237,10 +283,9 @@ export class DeltaTokenStrategy implements TokenEstimationStrategy {
 		}
 		let totalActualTokens = 0;
 		for (let i = 0; i < maxIndex; i++) {
-			const request = requests[i] as { result?: { promptTokens?: number; outputTokens?: number; metadata?: { promptTokens?: number; outputTokens?: number }; usage?: { promptTokens?: number; completionTokens?: number } } } | undefined;
+			const result = getRequestResult(requests[i]);
 			let found = false;
-			if (request?.result) {
-				const result = request.result;
+			if (result) {
 				if (typeof result.promptTokens === 'number' && typeof result.outputTokens === 'number') {
 					totalActualTokens += result.promptTokens + result.outputTokens;
 					found = true;
@@ -267,9 +312,9 @@ export class DeltaTokenStrategy implements TokenEstimationStrategy {
 		// Sub-agent results are built up char-by-char via delta events and are only
 		// complete in the fully reconstructed state — count them here.
 		for (const request of requests) {
-			const req = request as { response?: unknown[] } | undefined;
-			if (!req?.response || !Array.isArray(req.response)) { continue; }
-			for (const responseItem of req.response) {
+			const responseItems = getResponseArray(request);
+			if (!responseItems) { continue; }
+			for (const responseItem of responseItems) {
 				const subAgent = extractSubAgentData(responseItem);
 				if (subAgent) {
 					if (subAgent.prompt) { totalTokens += estimateTokensFromText(subAgent.prompt); }

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -923,3 +923,92 @@ test('EventJsonlTokenStrategy: returns empty result for empty input', () => {
         assert.equal(result.actualTokens, 0);
         assert.deepEqual(result.modelUsage, {});
 });
+
+// ── getRequestResult ────────────────────────────────────────────────────────
+
+import { getRequestResult, getResponseArray } from '../../src/tokenEstimation';
+
+test('getRequestResult: returns undefined for null', () => {
+        assert.equal(getRequestResult(null), undefined);
+});
+
+test('getRequestResult: returns undefined for non-object primitives', () => {
+        assert.equal(getRequestResult(42), undefined);
+        assert.equal(getRequestResult('string'), undefined);
+        assert.equal(getRequestResult(undefined), undefined);
+});
+
+test('getRequestResult: returns undefined when result is missing', () => {
+        assert.equal(getRequestResult({}), undefined);
+        assert.equal(getRequestResult({ message: { text: 'hi' } }), undefined);
+});
+
+test('getRequestResult: returns undefined when result is not an object', () => {
+        assert.equal(getRequestResult({ result: 'string' }), undefined);
+        assert.equal(getRequestResult({ result: 42 }), undefined);
+        assert.equal(getRequestResult({ result: null }), undefined);
+});
+
+test('getRequestResult: returns typed result for valid promptTokens/outputTokens shape', () => {
+        const req = { result: { promptTokens: 100, outputTokens: 50 } };
+        const result = getRequestResult(req);
+        assert.ok(result !== undefined);
+        assert.equal(result!.promptTokens, 100);
+        assert.equal(result!.outputTokens, 50);
+});
+
+test('getRequestResult: returns typed result for Insiders metadata shape', () => {
+        const req = { result: { metadata: { promptTokens: 200, outputTokens: 80 } } };
+        const result = getRequestResult(req);
+        assert.ok(result !== undefined);
+        assert.ok(result!.metadata !== undefined);
+        assert.equal(result!.metadata!.promptTokens, 200);
+        assert.equal(result!.metadata!.outputTokens, 80);
+});
+
+test('getRequestResult: returns typed result for usage shape', () => {
+        const req = { result: { usage: { promptTokens: 50, completionTokens: 30 } } };
+        const result = getRequestResult(req);
+        assert.ok(result !== undefined);
+        assert.ok(result!.usage !== undefined);
+        assert.equal(result!.usage!.promptTokens, 50);
+        assert.equal(result!.usage!.completionTokens, 30);
+});
+
+// ── getResponseArray ────────────────────────────────────────────────────────
+
+test('getResponseArray: returns undefined for null', () => {
+        assert.equal(getResponseArray(null), undefined);
+});
+
+test('getResponseArray: returns undefined for non-object primitives', () => {
+        assert.equal(getResponseArray(42), undefined);
+        assert.equal(getResponseArray('string'), undefined);
+        assert.equal(getResponseArray(undefined), undefined);
+});
+
+test('getResponseArray: returns undefined when response is missing', () => {
+        assert.equal(getResponseArray({}), undefined);
+        assert.equal(getResponseArray({ result: {} }), undefined);
+});
+
+test('getResponseArray: returns undefined when response is not an array', () => {
+        assert.equal(getResponseArray({ response: 'not-array' }), undefined);
+        assert.equal(getResponseArray({ response: 42 }), undefined);
+        assert.equal(getResponseArray({ response: null }), undefined);
+        assert.equal(getResponseArray({ response: {} }), undefined);
+});
+
+test('getResponseArray: returns the array when response is a valid array', () => {
+        const items = [{ kind: 'markdownContent', value: 'hello' }, { kind: 'thinking', value: 'think' }];
+        const result = getResponseArray({ response: items });
+        assert.ok(Array.isArray(result));
+        assert.equal(result!.length, 2);
+        assert.deepEqual(result, items);
+});
+
+test('getResponseArray: returns empty array when response is []', () => {
+        const result = getResponseArray({ response: [] });
+        assert.ok(Array.isArray(result));
+        assert.equal(result!.length, 0);
+});


### PR DESCRIPTION
Replaces two unsafe inline casts in DeltaTokenStrategy.estimate with runtime-validating accessor functions. Adds TypeScript interfaces and 13 new tests. All 116 tokenEstimation tests pass.