### PR TITLE
refactor(cli): extract shared payload factory functions into payloads.ts

### DIFF
--- a/cli/src/commands/all.ts
+++ b/cli/src/commands/all.ts
@@ -14,6 +14,15 @@ import {
 } from '../helpers';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
 import { shouldOutputJson } from '../commandUtils';
+import {
+	createEmptyDetailsPayload,
+	createEmptyChartPayload,
+	createEmptyUsageAnalysisPayload,
+	createEmptyFluencyPayload,
+	createDetailsPayload,
+	createUsageAnalysisPayload,
+	createFluencyPayload,
+} from './payloads';
 
 export const allCommand = new Command('all')
 	.description('Output all view data in a single JSON response (for Visual Studio extension)')
@@ -29,23 +38,10 @@ export const allCommand = new Command('all')
 
 		if (files.length === 0) {
 			const empty = {
-				details: {
-					today: {}, month: {}, lastMonth: {}, last30Days: {},
-					lastUpdated: now.toISOString(), backendConfigured: false,
-				},
-				chart: {
-					labels: [], tokensData: [], sessionsData: [], modelDatasets: [],
-					editorDatasets: [], editorTotalsMap: {}, repositoryDatasets: [],
-					repositoryTotalsMap: {}, dailyCount: 0, totalTokens: 0,
-					avgTokensPerDay: 0, totalSessions: 0,
-					lastUpdated: now.toISOString(), backendConfigured: false,
-				},
-				usage: {
-					today: {}, last30Days: {}, month: {},
-					locale: Intl.DateTimeFormat().resolvedOptions().locale,
-					lastUpdated: now.toISOString(), backendConfigured: false,
-				},
-				fluency: {},
+				details: createEmptyDetailsPayload(now),
+				chart:   createEmptyChartPayload(now),
+				usage:   createEmptyUsageAnalysisPayload(now),
+				fluency: createEmptyFluencyPayload(),
 			};
 			process.stdout.write(JSON.stringify(empty));
 			return;
@@ -64,22 +60,10 @@ export const allCommand = new Command('all')
 		const chartPayload = buildChartPayload(labels, days, allDaysMap);
 
 		// Build details payload (mirrors the `usage --json` output)
-		const detailsPayload = {
-			today:      detailedStats.today,
-			month:      detailedStats.month,
-			lastMonth:  detailedStats.lastMonth,
-			last30Days: detailedStats.last30Days,
-			lastUpdated: detailedStats.lastUpdated.toISOString(),
-			backendConfigured: false,
-		};
+		const detailsPayload = createDetailsPayload(detailedStats);
 
 		// Build usage-analysis payload (mirrors the `usage-analysis --json` output)
-		const usagePayload = {
-			...usageStats,
-			locale: Intl.DateTimeFormat().resolvedOptions().locale,
-			lastUpdated: now.toISOString(),
-			backendConfigured: false,
-		};
+		const usagePayload = createUsageAnalysisPayload(usageStats, now);
 
 		// Build fluency/maturity payload (mirrors the `fluency --json` output)
 		const customizationMatrix = await buildCustomizationMatrix(files);
@@ -88,14 +72,7 @@ export const allCommand = new Command('all')
 			async () => usageStats,
 			false
 		);
-		const fluencyPayload = {
-			overallStage: scores.overallStage,
-			overallLabel: scores.overallLabel,
-			categories:   scores.categories,
-			period:       scores.period,
-			lastUpdated:  scores.lastUpdated,
-			backendConfigured: false,
-		};
+		const fluencyPayload = createFluencyPayload(scores);
 
 		const payload = {
 			details: detailsPayload,

--- a/cli/src/commands/chart.ts
+++ b/cli/src/commands/chart.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import { discoverSessionFiles, calculateDailyStats, buildChartPayload } from '../helpers';
 import { shouldOutputJson } from '../commandUtils';
+import { createEmptyChartPayload } from './payloads';
 
 export const chartCommand = new Command('chart')
 	.description('Output daily token usage data for the chart webview')
@@ -17,7 +18,7 @@ export const chartCommand = new Command('chart')
 
 		const files = await discoverSessionFiles();
 		if (files.length === 0) {
-			process.stdout.write(JSON.stringify({ labels: [], tokensData: [], sessionsData: [], modelDatasets: [], editorDatasets: [], editorTotalsMap: {}, repositoryDatasets: [], repositoryTotalsMap: {}, dailyCount: 0, totalTokens: 0, avgTokensPerDay: 0, totalSessions: 0, lastUpdated: new Date().toISOString(), backendConfigured: false }));
+			process.stdout.write(JSON.stringify(createEmptyChartPayload()));
 			return;
 		}
 

--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -7,6 +7,7 @@ import { discoverSessionFiles, calculateUsageAnalysisStats, fmt, buildCustomizat
 import { ProgressTracker } from '../progress';
 import { calculateMaturityScores } from '../../../vscode-extension/src/maturityScoring';
 import { shouldOutputJson } from '../commandUtils';
+import { createFluencyPayload } from './payloads';
 
 export const fluencyCommand = new Command('fluency')
 	.description('Show your Copilot Fluency Score and improvement tips')
@@ -51,15 +52,7 @@ export const fluencyCommand = new Command('fluency')
 
 		if (json) {
 			// Machine-readable output: emit pure JSON to stdout and exit
-			const payload = {
-				overallStage: scores.overallStage,
-				overallLabel: scores.overallLabel,
-				categories: scores.categories,
-				period: scores.period,
-				lastUpdated: scores.lastUpdated,
-				backendConfigured: false,
-			};
-			process.stdout.write(JSON.stringify(payload));
+			process.stdout.write(JSON.stringify(createFluencyPayload(scores)));
 			return;
 		}
 

--- a/cli/src/commands/payloads.ts
+++ b/cli/src/commands/payloads.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared payload factory functions for CLI command JSON output.
+ *
+ * Each command emits a specific JSON shape; these helpers centralise the
+ * construction so that the `all` command (which bundles every view into one
+ * response) and the individual commands stay in sync automatically.
+ */
+import type { DetailedStats, UsageAnalysisStats, UsageAnalysisPeriod } from '../../../vscode-extension/src/types';
+
+// ---------------------------------------------------------------------------
+// Empty-state payloads (returned when no session files are discovered)
+// ---------------------------------------------------------------------------
+
+/** Empty details/usage payload (no session files found). */
+export function createEmptyDetailsPayload(now = new Date()) {
+	return {
+		today: {}, month: {}, lastMonth: {}, last30Days: {},
+		lastUpdated: now.toISOString(), backendConfigured: false,
+	};
+}
+
+/** Empty chart payload (no session files found). */
+export function createEmptyChartPayload(now = new Date()) {
+	return {
+		labels: [], tokensData: [], sessionsData: [], modelDatasets: [],
+		editorDatasets: [], editorTotalsMap: {}, repositoryDatasets: [],
+		repositoryTotalsMap: {}, dailyCount: 0, totalTokens: 0,
+		avgTokensPerDay: 0, totalSessions: 0,
+		lastUpdated: now.toISOString(), backendConfigured: false,
+	};
+}
+
+/** Empty usage-analysis payload (no session files found). */
+export function createEmptyUsageAnalysisPayload(now = new Date()) {
+	return {
+		today: {}, last30Days: {}, month: {},
+		locale: Intl.DateTimeFormat().resolvedOptions().locale,
+		lastUpdated: now.toISOString(), backendConfigured: false,
+	};
+}
+
+/** Empty fluency/maturity payload (no session files found). */
+export function createEmptyFluencyPayload() {
+	return {};
+}
+
+// ---------------------------------------------------------------------------
+// Full payloads (returned when session files are present)
+// ---------------------------------------------------------------------------
+
+/** Full details/usage payload built from computed stats. */
+export function createDetailsPayload(stats: DetailedStats) {
+	return {
+		today:      stats.today,
+		month:      stats.month,
+		lastMonth:  stats.lastMonth,
+		last30Days: stats.last30Days,
+		lastUpdated: stats.lastUpdated.toISOString(),
+		backendConfigured: false,
+	};
+}
+
+/** Full usage-analysis payload built from computed stats. */
+export function createUsageAnalysisPayload(stats: UsageAnalysisStats, now = new Date()) {
+	return {
+		...stats,
+		locale: Intl.DateTimeFormat().resolvedOptions().locale,
+		lastUpdated: now.toISOString(),
+		backendConfigured: false,
+	};
+}
+
+/** Full fluency/maturity payload built from scored results. */
+export function createFluencyPayload(scores: {
+	overallStage: number;
+	overallLabel: string;
+	categories: { category: string; icon: string; stage: number; evidence: string[]; tips: string[] }[];
+	period: UsageAnalysisPeriod;
+	lastUpdated: string;
+}) {
+	return {
+		overallStage: scores.overallStage,
+		overallLabel: scores.overallLabel,
+		categories:   scores.categories,
+		period:       scores.period,
+		lastUpdated:  scores.lastUpdated,
+		backendConfigured: false,
+	};
+}

--- a/cli/src/commands/usage-analysis.ts
+++ b/cli/src/commands/usage-analysis.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import { discoverSessionFiles, calculateUsageAnalysisStats } from '../helpers';
 import { shouldOutputJson } from '../commandUtils';
+import { createEmptyUsageAnalysisPayload, createUsageAnalysisPayload } from './payloads';
 
 export const usageAnalysisCommand = new Command('usage-analysis')
 	.description('Output usage analysis stats for the usage analysis webview')
@@ -17,21 +18,11 @@ export const usageAnalysisCommand = new Command('usage-analysis')
 		const files = await discoverSessionFiles();
 		const now = new Date();
 		if (files.length === 0) {
-			process.stdout.write(JSON.stringify({
-				today: {}, last30Days: {}, month: {},
-				locale: Intl.DateTimeFormat().resolvedOptions().locale,
-				lastUpdated: now.toISOString(),
-				backendConfigured: false,
-			}));
+			process.stdout.write(JSON.stringify(createEmptyUsageAnalysisPayload(now)));
 			return;
 		}
 
 		const stats = await calculateUsageAnalysisStats(files);
-		const payload = {
-			...stats,
-			locale: Intl.DateTimeFormat().resolvedOptions().locale,
-			lastUpdated: now.toISOString(),
-			backendConfigured: false,
-		};
+		const payload = createUsageAnalysisPayload(stats, now);
 		process.stdout.write(JSON.stringify(payload));
 	});

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -8,6 +8,7 @@ import { ProgressTracker } from '../progress';
 import type { PeriodStats, ModelUsage } from '../../../vscode-extension/src/types';
 import { getModelTier } from '../../../vscode-extension/src/tokenEstimation';
 import { shouldOutputJson } from '../commandUtils';
+import { createDetailsPayload } from './payloads';
 
 export const usageCommand = new Command('usage')
 	.description('Show token usage for today, current month, last month, and last 30 days')
@@ -22,15 +23,7 @@ export const usageCommand = new Command('usage')
 
 		if (shouldOutputJson(options)) {
 			// Machine-readable output: emit pure JSON to stdout and exit
-			const payload = {
-				today: stats.today,
-				month: stats.month,
-				lastMonth: stats.lastMonth,
-				last30Days: stats.last30Days,
-				lastUpdated: stats.lastUpdated.toISOString(),
-				backendConfigured: false,
-			};
-			process.stdout.write(JSON.stringify(payload));
+			process.stdout.write(JSON.stringify(createDetailsPayload(stats)));
 			return;
 		}
 


### PR DESCRIPTION
Extract shared payload factory functions to avoid duplicated JSON shapes across CLI commands. See commit message for details.