### PR TITLE
refactor(azureErrorClassifier): extract magic HTTP status codes and Azure error code strings into named constants

### DIFF
--- a/vscode-extension/src/utils/azureErrorClassifier.ts
+++ b/vscode-extension/src/utils/azureErrorClassifier.ts
@@ -4,6 +4,34 @@
  * Backward-compatible re-exports are provided in `errors.ts`.
  */
 
+/** Standard HTTP status codes used for Azure error classification. */
+export const HTTP_STATUS = {
+	/** Forbidden – caller lacks permission to perform the operation. */
+	FORBIDDEN: 403,
+	/** Not Found – the requested resource does not exist. */
+	NOT_FOUND: 404,
+	/** Conflict – the resource already exists or state conflicts with the request. */
+	CONFLICT: 409,
+	/** Too Many Requests – the caller has been rate-limited. */
+	TOO_MANY_REQUESTS: 429,
+	/** Service Unavailable – the service is temporarily unavailable; safe to retry. */
+	SERVICE_UNAVAILABLE: 503,
+} as const;
+
+/** Azure SDK and Node.js error code strings used for error classification. */
+export const AZURE_ERROR_CODES = {
+	/** Azure RBAC / storage authorisation mismatch (HTTP 403). */
+	AUTHORIZATION_PERMISSION_MISMATCH: 'AuthorizationPermissionMismatch',
+	/** Azure Table Storage conflict: table with this name already exists (HTTP 409). */
+	TABLE_ALREADY_EXISTS: 'TableAlreadyExists',
+	/** Node.js network error: DNS resolution failed. */
+	ENOTFOUND: 'ENOTFOUND',
+	/** Node.js network error: connection or operation timed out. */
+	ETIMEDOUT: 'ETIMEDOUT',
+	/** Node.js network error: connection refused by the remote host. */
+	ECONNREFUSED: 'ECONNREFUSED',
+} as const;
+
 function _sc(e: unknown): number | undefined {
 if (!e || typeof e !== 'object') { return undefined; }
 const v = (e as any)['statusCode'];
@@ -29,28 +57,28 @@ return m.includes('allowsharedkeyaccess') || m.includes('local authentication') 
 (m.includes('shared key') && m.includes('policy'));
 }
 export function isAuthError(error: unknown): boolean {
-if (_sc(error) === 403) { return true; }
-if (_code(error) === 'AuthorizationPermissionMismatch') { return true; }
+if (_sc(error) === HTTP_STATUS.FORBIDDEN) { return true; }
+if (_code(error) === AZURE_ERROR_CODES.AUTHORIZATION_PERMISSION_MISMATCH) { return true; }
 const m = (error as any)?.message ?? '';
 return m.includes('403') || m.includes('Forbidden');
 }
 export function isNotFoundError(error: unknown): boolean {
-if (_sc(error) === 404) { return true; }
+if (_sc(error) === HTTP_STATUS.NOT_FOUND) { return true; }
 const m = (error as any)?.message ?? '';
 return m.includes('404') || m.includes('NotFound');
 }
 export function isConflictError(error: unknown): boolean {
-if (_sc(error) === 409) { return true; }
+if (_sc(error) === HTTP_STATUS.CONFLICT) { return true; }
 const c = _code(error);
-return c === 'TableAlreadyExists' || c === 409;
+return c === AZURE_ERROR_CODES.TABLE_ALREADY_EXISTS || c === HTTP_STATUS.CONFLICT;
 }
 export function isRetryableError(error: unknown): boolean {
 const s = _sc(error) ?? _code(error);
-return s === 429 || s === 503 || s === 'ETIMEDOUT';
+return s === HTTP_STATUS.TOO_MANY_REQUESTS || s === HTTP_STATUS.SERVICE_UNAVAILABLE || s === AZURE_ERROR_CODES.ETIMEDOUT;
 }
 export function isNetworkError(error: unknown): boolean {
 const c = _code(error);
-if (c === 'ENOTFOUND' || c === 'ETIMEDOUT' || c === 'ECONNREFUSED') { return true; }
+if (c === AZURE_ERROR_CODES.ENOTFOUND || c === AZURE_ERROR_CODES.ETIMEDOUT || c === AZURE_ERROR_CODES.ECONNREFUSED) { return true; }
 const m = (error as any)?.message ?? '';
 return m.includes('ENOTFOUND') || m.includes('ETIMEDOUT') || m.includes('ECONNREFUSED');
 }


### PR DESCRIPTION
## Summary

Extracts hardcoded magic values from \scode-extension/src/utils/azureErrorClassifier.ts\ into two exported named constant objects with JSDoc comments:

### \HTTP_STATUS\
| Constant | Value | Description |
|---|---|---|
| \FORBIDDEN\ | 403 | Caller lacks permission |
| \NOT_FOUND\ | 404 | Resource does not exist |
| \CONFLICT\ | 409 | Resource already exists / state conflict |
| \TOO_MANY_REQUESTS\ | 429 | Rate-limited |
| \SERVICE_UNAVAILABLE\ | 503 | Temporarily unavailable, safe to retry |

### \AZURE_ERROR_CODES\
| Constant | Value | Description |
|---|---|---|
| \AUTHORIZATION_PERMISSION_MISMATCH\ | \'AuthorizationPermissionMismatch'\ | Azure RBAC / storage auth mismatch |
| \TABLE_ALREADY_EXISTS\ | \'TableAlreadyExists'\ | Azure Table Storage conflict |
| \ENOTFOUND\ | \'ENOTFOUND'\ | DNS resolution failed |
| \ETIMEDOUT\ | \'ETIMEDOUT'\ | Connection/operation timed out |
| \ECONNREFUSED\ | \'ECONNREFUSED'\ | Connection refused |

No logic was changed — this is a pure refactoring. All existing tests should pass.