### PR TITLE
refactor(formatUtils): export EDITOR_ICON_MAP with EditorName union type

### DIFF
--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -22,28 +22,54 @@ export function setCompactNumbers(enabled: boolean): void {
 	compactNumbersEnabled = enabled;
 }
 
+/** Union of all known editor display names that have explicit icon mappings. */
+export type EditorName =
+	| 'VS Code'
+	| 'VS Code Insiders'
+	| 'VS Code Exploration'
+	| 'VS Code Server'
+	| 'VS Code Server (Insiders)'
+	| 'VSCodium'
+	| 'Cursor'
+	| 'Copilot CLI'
+	| 'OpenCode'
+	| 'Visual Studio'
+	| 'Claude Code'
+	| 'Claude Desktop Cowork'
+	| 'Mistral Vibe'
+	| 'Gemini CLI'
+	| 'Unknown';
+
+/**
+ * Maps known editor display names to their representative emoji icons.
+ *
+ * Icon format: a single Unicode emoji character (e.g. '💙', '⚡').
+ * Editors not present in this map fall back to '📝' in {@link getEditorIcon}.
+ */
+export const EDITOR_ICON_MAP: Record<EditorName, string> = {
+	'VS Code': '💙',
+	'VS Code Insiders': '💚',
+	'VS Code Exploration': '🧪',
+	'VS Code Server': '☁️',
+	'VS Code Server (Insiders)': '☁️',
+	'VSCodium': '🔷',
+	'Cursor': '⚡',
+	'Copilot CLI': '🤖',
+	'OpenCode': '🟢',
+	'Visual Studio': '🪟',
+	'Claude Code': '🟠',
+	'Claude Desktop Cowork': '🟠',
+	'Mistral Vibe': '🔥',
+	'Gemini CLI': '💎',
+	'Unknown': '❓'
+};
+
 /**
  * Returns an icon for a given editor name.
+ * Falls back to '📝' for editors not present in {@link EDITOR_ICON_MAP}.
  */
 export function getEditorIcon(editor: string): string {
-	const icons: Record<string, string> = {
-		'VS Code': '💙',
-		'VS Code Insiders': '💚',
-		'VS Code Exploration': '🧪',
-		'VS Code Server': '☁️',
-		'VS Code Server (Insiders)': '☁️',
-		'VSCodium': '🔷',
-		'Cursor': '⚡',
-		'Copilot CLI': '🤖',
-		'OpenCode': '🟢',
-            'Visual Studio': '🪟',
-		'Claude Code': '🟠',
-		'Claude Desktop Cowork': '🟠',
-		'Mistral Vibe': '🔥',
-		'Gemini CLI': '💎',
-		'Unknown': '❓'
-	};
-	return icons[editor] || '📝';
+	return EDITOR_ICON_MAP[editor as EditorName] || '📝';
 }
 
 /**


### PR DESCRIPTION
## Summary

Extracts the hardcoded inline icon object from \getEditorIcon\ in \scode-extension/src/webview/shared/formatUtils.ts\ into a properly exported constant.

## Changes

- **New \EditorName\ union type** — lists all known editor display names as a TypeScript union, enabling type-safe key lookups.
- **New \EDITOR_ICON_MAP\ exported constant** — \Record<EditorName, string>\, replacing the local \icons\ variable inside \getEditorIcon\. Includes JSDoc explaining the icon format (single Unicode emoji character).
- **\getEditorIcon\ simplified** — now delegates to \EDITOR_ICON_MAP\, keeping the \'📝'\ fallback for unknown editors.

## Why

The map was previously unreachable from outside the function, making it impossible for callers (e.g. webview rendering code, tests) to enumerate or reference the icon set without duplicating data.

## Testing

All existing \getEditorIcon\ tests in \	est/unit/webview-utils.test.ts\ continue to pass. No behaviour changes.