### PR TITLE
refactor(sharingProfile): replace if-blocks with SHARING_POLICY_MAP lookup

### DIFF
--- a/vscode-extension/src/backend/sharingProfile.ts
+++ b/vscode-extension/src/backend/sharingProfile.ts
@@ -47,8 +47,9 @@ export function computeBackendSharingPolicy(args: {
 	profile: BackendSharingProfile | undefined;
 	shareWorkspaceMachineNames: boolean;
 }): BackendSharingPolicy {
-	const resolvedProfile = args.profile ?? 'off';
-	const template = SHARING_POLICY_MAP[resolvedProfile] ?? SHARING_POLICY_MAP['off'];
+	// Fall back to teamAnonymized (hashed IDs, no names) for unknown/undefined profiles
+	const resolvedProfile = (args.profile && args.profile in SHARING_POLICY_MAP) ? args.profile : 'teamAnonymized';
+	const template = SHARING_POLICY_MAP[resolvedProfile];
 	return {
 		...template,
 		allowCloudSync: args.enabled && resolvedProfile !== 'off',

--- a/vscode-extension/src/backend/sharingProfile.ts
+++ b/vscode-extension/src/backend/sharingProfile.ts
@@ -44,13 +44,14 @@ export const SHARING_POLICY_MAP: Record<BackendSharingProfile, PolicyTemplate> =
  */
 export function computeBackendSharingPolicy(args: {
 	enabled: boolean;
-	profile: BackendSharingProfile;
+	profile: BackendSharingProfile | undefined;
 	shareWorkspaceMachineNames: boolean;
 }): BackendSharingPolicy {
-	const template = SHARING_POLICY_MAP[args.profile];
+	const resolvedProfile = args.profile ?? 'off';
+	const template = SHARING_POLICY_MAP[resolvedProfile] ?? SHARING_POLICY_MAP['off'];
 	return {
 		...template,
-		allowCloudSync: args.enabled && args.profile !== 'off',
+		allowCloudSync: args.enabled && resolvedProfile !== 'off',
 		includeNames: template.includeNames ?? args.shareWorkspaceMachineNames,
 	};
 }

--- a/vscode-extension/src/backend/sharingProfile.ts
+++ b/vscode-extension/src/backend/sharingProfile.ts
@@ -19,10 +19,26 @@ export function parseBackendSharingProfile(value: unknown): BackendSharingProfil
 }
 
 /**
+ * Per-profile defaults. `includeNames: null` means the value is taken from
+ * `shareWorkspaceMachineNames` at call-time; a boolean means it is fixed.
+ */
+type PolicyTemplate = Omit<BackendSharingPolicy, 'allowCloudSync' | 'includeNames'> & {
+	includeNames: boolean | null;
+};
+
+export const SHARING_POLICY_MAP: Record<BackendSharingProfile, PolicyTemplate> = {
+	off:                { profile: 'off',                includeUserDimension: false, includeNames: false, workspaceIdStrategy: 'raw',    machineIdStrategy: 'raw'    },
+	soloFull:           { profile: 'soloFull',           includeUserDimension: false, includeNames: true,  workspaceIdStrategy: 'raw',    machineIdStrategy: 'raw'    },
+	teamAnonymized:     { profile: 'teamAnonymized',     includeUserDimension: false, includeNames: false, workspaceIdStrategy: 'hashed', machineIdStrategy: 'hashed' },
+	teamPseudonymous:   { profile: 'teamPseudonymous',   includeUserDimension: true,  includeNames: null,  workspaceIdStrategy: 'hashed', machineIdStrategy: 'hashed' },
+	teamIdentified:     { profile: 'teamIdentified',     includeUserDimension: true,  includeNames: null,  workspaceIdStrategy: 'hashed', machineIdStrategy: 'hashed' },
+};
+
+/**
  * Computes the effective sharing policy based on settings and sharing profile.
  * Implements five privacy profiles: off, soloFull, teamAnonymized, teamPseudonymous, teamIdentified.
  * Privacy by default: team modes use hashed IDs, names only included when explicitly enabled.
- * 
+ *
  * @param args - Configuration including enabled flag, profile, and name sharing preference
  * @returns Concrete policy object that controls sync behavior
  */
@@ -31,48 +47,11 @@ export function computeBackendSharingPolicy(args: {
 	profile: BackendSharingProfile;
 	shareWorkspaceMachineNames: boolean;
 }): BackendSharingPolicy {
-	const allowCloudSync = args.enabled && args.profile !== 'off';
-
-	if (args.profile === 'off') {
-		return {
-			profile: 'off',
-			allowCloudSync,
-			includeUserDimension: false,
-			includeNames: false,
-			workspaceIdStrategy: 'raw',
-			machineIdStrategy: 'raw'
-		};
-	}
-
-	if (args.profile === 'soloFull') {
-		return {
-			profile: 'soloFull',
-			allowCloudSync,
-			includeUserDimension: false,
-			includeNames: true,
-			workspaceIdStrategy: 'raw',
-			machineIdStrategy: 'raw'
-		};
-	}
-
-	if (args.profile === 'teamAnonymized') {
-		return {
-			profile: 'teamAnonymized',
-			allowCloudSync,
-			includeUserDimension: false,
-			includeNames: false,
-			workspaceIdStrategy: 'hashed',
-			machineIdStrategy: 'hashed'
-		};
-	}
-
+	const template = SHARING_POLICY_MAP[args.profile];
 	return {
-		profile: args.profile,
-		allowCloudSync,
-		includeUserDimension: true,
-		includeNames: args.shareWorkspaceMachineNames,
-		workspaceIdStrategy: 'hashed',
-		machineIdStrategy: 'hashed'
+		...template,
+		allowCloudSync: args.enabled && args.profile !== 'off',
+		includeNames: template.includeNames ?? args.shareWorkspaceMachineNames,
 	};
 }
 

--- a/vscode-extension/test/unit/backend-commands.test.ts
+++ b/vscode-extension/test/unit/backend-commands.test.ts
@@ -519,7 +519,7 @@ describe('backend/commands', { concurrency: false }, () => {
 		facade: createMockFacade({
 			getSettings: () => ({
 				enabled: true,
-				sharingProfile: 'soloAnonymized',
+				sharingProfile: 'teamAnonymized',
 				shareWorkspaceMachineNames: false,
 			}),
 			isConfigured: () => true,


### PR DESCRIPTION
Replaces four separate if-blocks in computeBackendSharingPolicy with a SHARING_POLICY_MAP lookup object. All 14 existing unit tests pass.