### PR TITLE
refactor(adapterPredicates): extract inline regex literals into named exported constants

### DIFF
--- a/vscode-extension/src/adapters/adapterPredicates.ts
+++ b/vscode-extension/src/adapters/adapterPredicates.ts
@@ -10,6 +10,31 @@ import * as path from 'path';
 import { normalizePath } from '../utils/pathUtils';
 
 // ---------------------------------------------------------------------------
+// Named regex constants — one per distinct path shape, exported for testability
+// ---------------------------------------------------------------------------
+
+/** Matches .json or .jsonl file extensions. */
+export const JSONL_FILE_EXTENSION_PATTERN = /\.jsonl?$/;
+
+/** Matches legacy workspaceStorage/<hash>/chatSessions/<file> layout. */
+export const LEGACY_WORKSPACE_CHAT_SESSIONS_PATTERN = /\/workspaceStorage\/[^/]+\/chatSessions\/[^/]+$/;
+
+/** Matches workspaceStorage/<hash>/{copilot-extension}/chatSessions/<file>. */
+export const WORKSPACE_EXTENSION_CHAT_SESSIONS_PATTERN = /\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/chatSessions\/[^/]+$/;
+
+/** Matches workspaceStorage/<hash>/{copilot-extension}/debug-logs/<file>. */
+export const WORKSPACE_EXTENSION_DEBUG_LOGS_PATTERN = /\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/debug-logs\/[^/]+$/;
+
+/** Matches globalStorage/emptyWindowChatSessions/<file>. */
+export const GLOBAL_EMPTY_WINDOW_CHAT_SESSIONS_PATTERN = /\/globalStorage\/emptyWindowChatSessions\/[^/]+$/;
+
+/** Matches any file under globalStorage/{GitHub,github}.copilot or .copilot-chat. */
+export const GLOBAL_STORAGE_COPILOT_PATTERN = /\/globalStorage\/(?:GitHub|github)\.copilot(?:-chat)?\/.+$/;
+
+/** Matches JetBrains partition files: /.copilot/jb/…/partition-{n}.jsonl. */
+export const JETBRAINS_PARTITION_FILE_PATTERN = /\/partition-\d+\.jsonl$/;
+
+// ---------------------------------------------------------------------------
 // Copilot Chat
 // ---------------------------------------------------------------------------
 
@@ -38,24 +63,18 @@ export function isCopilotChatNonSessionFile(filename: string): boolean {
  */
 export function isCopilotChatSessionPath(filePath: string): boolean {
 	const norm = normalizePath(filePath);
-	if (!/\.jsonl?$/.test(norm)) { return false; }
+	if (!JSONL_FILE_EXTENSION_PATTERN.test(norm)) { return false; }
 
 	// workspaceStorage/<hash>/chatSessions/<file>  (legacy)
-	if (/\/workspaceStorage\/[^/]+\/chatSessions\/[^/]+$/.test(norm)) {
-		return true;
-	}
+	if (LEGACY_WORKSPACE_CHAT_SESSIONS_PATTERN.test(norm)) { return true; }
 	// workspaceStorage/<hash>/{extension}/chatSessions/<file>
-	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/chatSessions\/[^/]+$/.test(norm)) {
-		return true;
-	}
+	if (WORKSPACE_EXTENSION_CHAT_SESSIONS_PATTERN.test(norm)) { return true; }
 	// workspaceStorage/<hash>/{extension}/debug-logs/<file>
-	if (/\/workspaceStorage\/[^/]+\/(?:GitHub\.copilot-chat|github\.copilot-chat|GitHub\.copilot|github\.copilot)\/debug-logs\/[^/]+$/.test(norm)) {
-		return true;
-	}
+	if (WORKSPACE_EXTENSION_DEBUG_LOGS_PATTERN.test(norm)) { return true; }
 	// globalStorage/emptyWindowChatSessions/<file>
-	if (/\/globalStorage\/emptyWindowChatSessions\/[^/]+$/.test(norm)) { return true; }
+	if (GLOBAL_EMPTY_WINDOW_CHAT_SESSIONS_PATTERN.test(norm)) { return true; }
 	// globalStorage/{GitHub,github}.copilot-chat/** and {GitHub,github}.copilot/**
-	if (/\/globalStorage\/(?:GitHub|github)\.copilot(?:-chat)?\/.+$/.test(norm)) {
+	if (GLOBAL_STORAGE_COPILOT_PATTERN.test(norm)) {
 		return !isCopilotChatNonSessionFile(path.basename(norm));
 	}
 	return false;
@@ -81,5 +100,5 @@ export function isCopilotCliSessionPath(filePath: string): boolean {
  */
 export function isJetBrainsSessionPath(filePath: string): boolean {
 	const norm = normalizePath(filePath);
-	return norm.includes('/.copilot/jb/') && /\/partition-\d+\.jsonl$/.test(norm);
+	return norm.includes('/.copilot/jb/') && JETBRAINS_PARTITION_FILE_PATTERN.test(norm);
 }


### PR DESCRIPTION
## Summary

Refactors \scode-extension/src/adapters/adapterPredicates.ts\ to replace 7 anonymous inline regex literals with named exported constants near the top of the file.

### Named constants added

| Constant | Pattern | Purpose |
|---|---|---|
| \JSONL_FILE_EXTENSION_PATTERN\ | \/\.jsonl?\$/\ | Matches .json/.jsonl extensions |
| \LEGACY_WORKSPACE_CHAT_SESSIONS_PATTERN\ | \/workspaceStorage/.../chatSessions/...\ | Legacy layout |
| \WORKSPACE_EXTENSION_CHAT_SESSIONS_PATTERN\ | \/workspaceStorage/.../copilot.../chatSessions/...\ | Extension-namespaced layout |
| \WORKSPACE_EXTENSION_DEBUG_LOGS_PATTERN\ | \/workspaceStorage/.../copilot.../debug-logs/...\ | Debug logs layout |
| \GLOBAL_EMPTY_WINDOW_CHAT_SESSIONS_PATTERN\ | \/globalStorage/emptyWindowChatSessions/...\ | Empty window global storage |
| \GLOBAL_STORAGE_COPILOT_PATTERN\ | \/globalStorage/{GitHub,github}.copilot.../\ | Global storage copilot |
| \JETBRAINS_PARTITION_FILE_PATTERN\ | \/partition-{n}.jsonl\ | JetBrains partition files |

### Changes
- **No behavioural changes** — regex values are identical
- Constants are \xport\d so they can be imported and unit-tested independently
- All existing tests in \copilotChatAdapter.test.ts\ continue to pass

Closes part of the adapter test coverage work.