### PR TITLE
refactor: replace FetchTaskPageFn positional params with FetchTaskPageOptions object

### DIFF
--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -65,10 +65,16 @@ export interface TaskDetailResult {
 	error?: string;
 }
 
-export type FetchTaskPageFn = (
-	owner: string, repo: string, token: string,
-	page: number, archived: boolean, since?: string,
-) => Promise<TaskPageResult>;
+export interface FetchTaskPageOptions {
+	owner: string;
+	repo: string;
+	token: string;
+	page: number;
+	archived: boolean;
+	since?: string;
+}
+
+export type FetchTaskPageFn = (options: FetchTaskPageOptions) => Promise<TaskPageResult>;
 
 export type FetchTaskDetailFn = (
 	owner: string, repo: string, taskId: string, token: string,
@@ -76,12 +82,7 @@ export type FetchTaskDetailFn = (
 
 /** Fetch one page of agent tasks from the GitHub API. */
 export function fetchAgentTasksPage(
-	owner: string,
-	repo: string,
-	token: string,
-	page: number,
-	archived: boolean,
-	since?: string,
+	{ owner, repo, token, page, archived, since }: FetchTaskPageOptions,
 ): Promise<TaskPageResult> {
 	return new Promise((resolve) => {
 		let queryParams = `per_page=100&page=${page}`;
@@ -190,7 +191,7 @@ export async function fetchAgentSessionsForRepo(
 	// Fetch active and archived task lists
 	for (const archived of [false, true]) {
 		for (let page = 1; page <= 5; page++) {
-			const { tasks, statusCode, error } = await fetchTaskPage(owner, repo, token, page, archived, sinceStr);
+			const { tasks, statusCode, error } = await fetchTaskPage({ owner, repo, token, page, archived, since: sinceStr });
 			if (tasks.length === 0 || error) {
 				if (page === 1 && !archived && error) {
 					const msg = statusCode === 404

--- a/vscode-extension/test/unit/agentSessionsService.test.ts
+++ b/vscode-extension/test/unit/agentSessionsService.test.ts
@@ -61,7 +61,7 @@ test('fetchAgentSessionsForRepo: returns empty result when task list is empty', 
 
 test('fetchAgentSessionsForRepo: counts only cloud-agent sessions', async () => {
 	const tasks = [makeTask('t1')];
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page) =>
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
 		page === 1 ? { tasks } : { tasks: [] };
 	const fetchDetail: FetchTaskDetailFn = async () => ({
 		sessions: [
@@ -79,7 +79,7 @@ test('fetchAgentSessionsForRepo: counts only cloud-agent sessions', async () => 
 
 test('fetchAgentSessionsForRepo: task with no cloud-agent sessions does not count toward totalTasks', async () => {
 	const tasks = [makeTask('t1')];
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page) =>
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
 		page === 1 ? { tasks } : { tasks: [] };
 	const fetchDetail: FetchTaskDetailFn = async () => ({
 		sessions: [makeSession('', undefined)],  // cli-remote only
@@ -91,7 +91,7 @@ test('fetchAgentSessionsForRepo: task with no cloud-agent sessions does not coun
 
 test('fetchAgentSessionsForRepo: handles missing usage.credits gracefully', async () => {
 	const tasks = [makeTask('t1')];
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page) =>
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
 		page === 1 ? { tasks } : { tasks: [] };
 	const fetchDetail: FetchTaskDetailFn = async () => ({
 		sessions: [makeSession('cloud-model')],  // no usage field
@@ -121,7 +121,7 @@ test('fetchAgentSessionsForRepo: returns error result when API returns 403', asy
 test('fetchAgentSessionsForRepo: deduplicates tasks that appear in both active and archived lists', async () => {
 	const task = makeTask('shared-id');
 	let activePageCalled = false;
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page, archived) => {
+	const fetchPage: FetchTaskPageFn = async ({ page, archived }) => {
 		if (!archived && page === 1) { activePageCalled = true; return { tasks: [task] }; }
 		if (archived && page === 1) { return { tasks: [task] }; } // same task in archived
 		return { tasks: [] };
@@ -142,7 +142,7 @@ test('fetchAgentSessionsForRepo: deduplicates tasks that appear in both active a
 test('fetchAgentSessionsForRepo: marks partial=true when tasksTotal > cap', async () => {
 	// Create 51 tasks (one over the MAX_TASKS_DETAIL_PER_REPO cap of 50)
 	const tasks = Array.from({ length: 51 }, (_, i) => makeTask(`t${i}`));
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page) =>
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
 		page === 1 ? { tasks } : { tasks: [] };
 	const fetchDetail: FetchTaskDetailFn = async () => ({
 		sessions: [makeSession('cloud-model', 1)],
@@ -156,7 +156,7 @@ test('fetchAgentSessionsForRepo: marks partial=true when tasksTotal > cap', asyn
 
 test('fetchAgentSessionsForRepo: partial=false when tasksTotal <= cap', async () => {
 	const tasks = [makeTask('t1'), makeTask('t2')];
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page) =>
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
 		page === 1 ? { tasks } : { tasks: [] };
 	const fetchDetail: FetchTaskDetailFn = async () => ({
 		sessions: [makeSession('cloud-model', 1)],
@@ -168,7 +168,7 @@ test('fetchAgentSessionsForRepo: partial=false when tasksTotal <= cap', async ()
 
 test('fetchAgentSessionsForRepo: handles detail fetch failure gracefully (skips task)', async () => {
 	const tasks = [makeTask('t1'), makeTask('t2')];
-	const fetchPage: FetchTaskPageFn = async (_o, _r, _t, page) =>
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
 		page === 1 ? { tasks } : { tasks: [] };
 	let callNum = 0;
 	const fetchDetail: FetchTaskDetailFn = async () => {


### PR DESCRIPTION
## Summary

Replaces the 6 positional parameters of FetchTaskPageFn with a single FetchTaskPageOptions options object interface for improved readability and extensibility.

### Changes
- Added FetchTaskPageOptions interface with fields: owner, epo, 	oken, page, rchived, since?
- Updated FetchTaskPageFn type signature to (options: FetchTaskPageOptions) => Promise<TaskPageResult>
- Updated etchAgentTasksPage implementation to use destructured options object
- Updated call site in etchAgentSessionsForRepo to pass options object
- Updated all test lambdas to use { page } / { page, archived } destructuring

### Tests
All 14 unit tests pass.