### PR TITLE
refactor: replace sharingLevel switch with Record lookup map

### DIFF
--- a/vscode-extension/src/backend/configurationFlow.ts
+++ b/vscode-extension/src/backend/configurationFlow.ts
@@ -81,21 +81,16 @@ export enum SharingLevel {
 	TeamIdentified = 30
 }
 
+const SHARING_LEVEL_MAP: Record<BackendSharingProfile, SharingLevel> = {
+	off: SharingLevel.Off,
+	teamAnonymized: SharingLevel.TeamAnonymized,
+	teamPseudonymous: SharingLevel.TeamPseudonymous,
+	soloFull: SharingLevel.SoloFull,
+	teamIdentified: SharingLevel.TeamIdentified,
+};
+
 export function sharingLevel(profile: BackendSharingProfile): SharingLevel {
-	switch (profile) {
-		case 'off':
-			return SharingLevel.Off;
-		case 'teamAnonymized':
-			return SharingLevel.TeamAnonymized;
-		case 'teamPseudonymous':
-			return SharingLevel.TeamPseudonymous;
-		case 'teamIdentified':
-			return SharingLevel.TeamIdentified;
-		case 'soloFull':
-			return SharingLevel.SoloFull;
-		default:
-			return SharingLevel.Off;
-	}
+	return SHARING_LEVEL_MAP[profile] ?? SharingLevel.Off;
 }
 
 export function needsConsent(previous: BackendConfigDraft, next: BackendConfigDraft): { required: boolean; reasons: string[] } {


### PR DESCRIPTION
## Summary

Replace the switch statement in \sharingLevel()\ (configurationFlow.ts lines 84-99) with a const \SHARING_LEVEL_MAP: Record<BackendSharingProfile, SharingLevel>\ lookup object.

## Changes

- **\scode-extension/src/backend/configurationFlow.ts\**: Replaced the \switch\ in \sharingLevel()\ with a \SHARING_LEVEL_MAP\ Record. Adding a new profile now only requires adding one entry to the map.

## Tests

All 47 existing unit tests pass.