### PR TITLE
docs(adapterPredicates): add JSDoc to COPILOT_CHAT_NON_SESSION_PATTERNS and predicate functions

### DIFF
--- a/vscode-extension/src/adapters/adapterPredicates.ts
+++ b/vscode-extension/src/adapters/adapterPredicates.ts
@@ -13,8 +13,26 @@ import { normalizePath } from '../utils/pathUtils';
 // Copilot Chat
 // ---------------------------------------------------------------------------
 
-/** Filenames we explicitly skip when recursively scanning Copilot Chat globalStorage. */
-const COPILOT_CHAT_NON_SESSION_PATTERNS = [
+/**
+ * Filename substrings that identify non-session files inside the Copilot Chat
+ * globalStorage directory. When scanning that directory recursively we must
+ * ignore these to avoid treating auxiliary storage as chat-session data.
+ *
+ * Rationale for each entry:
+ * - `'embeddings'`        — vector-embedding stores used for semantic search; not conversation sessions.
+ * - `'index'`             — storage index / search-index files; structural metadata, not session content.
+ * - `'cache'`             — transient cached responses or asset caches; not persistent session records.
+ * - `'preferences'`       — per-user preference blobs written by the extension; not session logs.
+ * - `'settings'`          — extension or workspace settings snapshots; not session logs.
+ * - `'config'`            — general configuration files (e.g. feature flags); not session logs.
+ * - `'workspacesessions'` — workspace-scoped session *containers* (directory names); individual session
+ *                           files inside are matched by more specific path predicates, so the container
+ *                           name itself must be excluded to avoid double-counting.
+ * - `'globalsessions'`    — global session *containers* equivalent; same reasoning as workspacesessions.
+ * - `'api.json'`          — API metadata / endpoint configuration emitted by the extension host; not a
+ *                           chat-session file.
+ */
+export const COPILOT_CHAT_NON_SESSION_PATTERNS = [
 	'embeddings',
 	'index',
 	'cache',
@@ -26,7 +44,15 @@ const COPILOT_CHAT_NON_SESSION_PATTERNS = [
 	'api.json',
 ];
 
-/** Returns true for filenames that are not Copilot Chat session files. */
+/**
+ * Returns `true` when the given filename matches one of the
+ * {@link COPILOT_CHAT_NON_SESSION_PATTERNS}, indicating that the file should
+ * be skipped during session discovery.
+ *
+ * The check is case-insensitive and uses substring matching so it catches both
+ * exact filenames (e.g. `api.json`) and directory/file names that contain the
+ * pattern as a fragment (e.g. `embeddings-v2`).
+ */
 export function isCopilotChatNonSessionFile(filename: string): boolean {
 	const lower = filename.toLowerCase();
 	return COPILOT_CHAT_NON_SESSION_PATTERNS.some(p => lower.includes(p));
@@ -35,6 +61,14 @@ export function isCopilotChatNonSessionFile(filename: string): boolean {
 /**
  * Path predicate that recognises Copilot Chat session storage shapes. Kept
  * narrow so it never accidentally claims unrelated VS Code files.
+ *
+ * Recognised layouts (all must end in `.json` or `.jsonl`):
+ * - `workspaceStorage/<hash>/chatSessions/<file>` — legacy per-workspace sessions.
+ * - `workspaceStorage/<hash>/{extension}/chatSessions/<file>` — extension-namespaced workspace sessions.
+ * - `workspaceStorage/<hash>/{extension}/debug-logs/<file>` — debug-log session files.
+ * - `globalStorage/emptyWindowChatSessions/<file>` — sessions from editor windows with no open workspace.
+ * - `globalStorage/{GitHub,github}.copilot[-chat]/**` — all global Copilot / Copilot-Chat storage,
+ *   minus files matched by {@link isCopilotChatNonSessionFile}.
  */
 export function isCopilotChatSessionPath(filePath: string): boolean {
 	const norm = normalizePath(filePath);


### PR DESCRIPTION
## Summary

Adds comprehensive JSDoc documentation to scode-extension/src/adapters/adapterPredicates.ts:

- **Exports** COPILOT_CHAT_NON_SESSION_PATTERNS so callers outside the module can reference the list directly.
- **Per-entry rationale** in the constant's JSDoc: explains why each of the 9 patterns (mbeddings, index, cache, preferences, settings, config, workspacesessions, globalsessions, pi.json) is excluded from session detection.
- **Expanded JSDoc** on isCopilotChatNonSessionFile(): clarifies the case-insensitive substring matching strategy.
- **Expanded JSDoc** on isCopilotChatSessionPath(): enumerates all 5 recognised Copilot Chat storage layouts.

No behavioural changes. All existing adapter tests pass.