### PR TITLE
fix: replace extensionUri: any with UriLike in createDataAccessInstances

### DIFF
--- a/vscode-extension/src/adapters/adapterRegistry.ts
+++ b/vscode-extension/src/adapters/adapterRegistry.ts
@@ -14,6 +14,7 @@
  */
 import type { IEcosystemAdapter } from '../ecosystemAdapter';
 import { OpenCodeDataAccess } from '../opencode';
+import type { UriLike } from '../opencode';
 import { CrushDataAccess } from '../crush';
 import { ContinueDataAccess } from '../continue';
 import { VisualStudioDataAccess } from '../visualstudio';
@@ -68,7 +69,7 @@ export type DataAccessInstances = Omit<AdapterRegistryDeps, 'estimateTokens' | '
  * @param extensionUri - VS Code extension URI (or equivalent fake URI in the CLI)
  *   passed to data-access constructors that require it for WASM loading.
  */
-export function createDataAccessInstances(extensionUri: any): DataAccessInstances {
+export function createDataAccessInstances(extensionUri: UriLike): DataAccessInstances {
 	return {
 		openCode: new OpenCodeDataAccess(extensionUri),
 		crush: new CrushDataAccess(extensionUri),


### PR DESCRIPTION
## Summary

Removes the \ny\ type from the \xtensionUri\ parameter of \createDataAccessInstances\ in \dapterRegistry.ts\.

## Change

- Import the existing \UriLike\ structural interface from \../opencode\
- Change \xtensionUri: any\ → \xtensionUri: UriLike\

\UriLike\ is defined as \{ fsPath: string; path: string; scheme: string }\, which is a subset of \scode.Uri\. Both \OpenCodeDataAccess\ and \CrushDataAccess\ (the only constructors receiving this argument) already type their parameter as \UriLike\, so this change is fully backwards compatible.

## Tests

All 43 ecosystem adapter unit tests pass.