### PR TITLE
refactor(syncService): extract pure parseConsentTimestamp function

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -30,34 +30,45 @@ import { getEditorTypeFromPath } from '../../workspaceHelpers';
 type ModelUsageEntry = { inputTokens: number; outputTokens: number; interactions?: number };
 
 /**
+ * Pure consent-timestamp parser — no side effects.
+ * Returns a `Date` when `raw` represents a valid, non-future timestamp,
+ * or an `Error` describing why the value is invalid.
+ * The caller is responsible for any logging based on the result.
+ */
+export function parseConsentTimestamp(raw: unknown): Date | Error {
+	const ts = raw == null ? '' : String(raw);
+	if (!ts) {
+		return new Error('no consent timestamp provided');
+	}
+	try {
+		const parsed = new Date(ts);
+		if (isNaN(parsed.getTime())) {
+			return new Error(`Invalid consent timestamp (not a valid date): "${ts}"`);
+		}
+		if (parsed.getTime() > Date.now()) {
+			return new Error(`Invalid consent timestamp (future date): "${ts}" (parsed: ${parsed.toISOString()})`);
+		}
+		return parsed;
+	} catch (e) {
+		return new Error(`Failed to parse consent timestamp: "${ts}", error: ${e}`);
+	}
+}
+
+/**
  * Validate and normalize consent timestamp.
  * Returns ISO string if valid, undefined if invalid or in the future.
+ * Delegates parsing to {@link parseConsentTimestamp} and logs any error via the optional logger.
  */
 function validateConsentTimestamp(ts: string | undefined, logger?: (msg: string) => void): string | undefined {
 	if (!ts) {
 		return undefined;
 	}
-	try {
-		const parsed = new Date(ts);
-		if (isNaN(parsed.getTime())) {
-			if (logger) {
-				logger(`Invalid consent timestamp (not a valid date): "${ts}"`);
-			}
-			return undefined;
-		}
-		if (parsed.getTime() > Date.now()) {
-			if (logger) {
-				logger(`Invalid consent timestamp (future date): "${ts}" (parsed: ${parsed.toISOString()})`);
-			}
-			return undefined;
-		}
-		return parsed.toISOString();
-	} catch (e) {
-		if (logger) {
-			logger(`Failed to parse consent timestamp: "${ts}", error: ${e}`);
-		}
+	const result = parseConsentTimestamp(ts);
+	if (result instanceof Error) {
+		logger?.(result.message);
 		return undefined;
 	}
+	return result.toISOString();
 }
 
 /** Logger callbacks for the sync service. */

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 
 // We can test timer management and the syncQueue serialization.
 // Most sync methods require heavy I/O mocking.
-import { SyncService, type SyncServiceDeps } from '../../src/backend/services/syncService';
+import { SyncService, parseConsentTimestamp, type SyncServiceDeps } from '../../src/backend/services/syncService';
 import { CredentialService } from '../../src/backend/services/credentialService';
 import { DataPlaneService } from '../../src/backend/services/dataPlaneService';
 import { BackendUtility } from '../../src/backend/services/utilityService';
@@ -1378,4 +1378,55 @@ test(`syncToBackendStore does NOT sync to sharing server when sharingServerEnabl
 		!logs.some(m => m.includes('Sharing server')),
 		`Expected no sharing server logs but got: ${logs.join('\n')}`
 	);
+});
+
+// ── parseConsentTimestamp ─────────────────────────────────────────────────
+
+test('parseConsentTimestamp returns Error for undefined', () => {
+	const result = parseConsentTimestamp(undefined);
+	assert.ok(result instanceof Error);
+});
+
+test('parseConsentTimestamp returns Error for null', () => {
+	const result = parseConsentTimestamp(null);
+	assert.ok(result instanceof Error);
+});
+
+test('parseConsentTimestamp returns Error for empty string', () => {
+	const result = parseConsentTimestamp('');
+	assert.ok(result instanceof Error);
+});
+
+test('parseConsentTimestamp returns Error for invalid date string', () => {
+	const result = parseConsentTimestamp('not-a-date');
+	assert.ok(result instanceof Error);
+	assert.ok(result.message.includes('not a valid date'));
+});
+
+test('parseConsentTimestamp returns Error for future date', () => {
+	const future = new Date(Date.now() + 86_400_000).toISOString();
+	const result = parseConsentTimestamp(future);
+	assert.ok(result instanceof Error);
+	assert.ok(result.message.includes('future date'));
+});
+
+test('parseConsentTimestamp returns Date for valid past timestamp', () => {
+	const past = new Date(Date.now() - 86_400_000).toISOString();
+	const result = parseConsentTimestamp(past);
+	assert.ok(result instanceof Date);
+	assert.ok(!isNaN(result.getTime()));
+});
+
+test('parseConsentTimestamp coerces Date object to string before parsing', () => {
+	// A Date object stringifies to a locale date string that new Date() can re-parse
+	const pastDate = new Date(Date.now() - 86_400_000);
+	const result = parseConsentTimestamp(pastDate);
+	assert.ok(result instanceof Date);
+});
+
+test('parseConsentTimestamp returned Date matches input ISO string', () => {
+	const isoString = '2023-01-15T10:30:00.000Z';
+	const result = parseConsentTimestamp(isoString);
+	assert.ok(result instanceof Date);
+	assert.equal((result as Date).toISOString(), isoString);
 });


### PR DESCRIPTION
Separates concerns in validateConsentTimestamp: extract parseConsentTimestamp(raw: unknown): Date | Error as a pure exported function, simplify validateConsentTimestamp as a logging wrapper, add 8 unit tests.