### PR TITLE
feat: add Antigravity editor support

### DIFF
--- a/.github/agents/tool-names.agent.md
+++ b/.github/agents/tool-names.agent.md
@@ -149,6 +149,38 @@ After editing `src/toolNames.json`:
 
 The `sync-toolnames` workflow (`.github/workflows/sync-toolnames.yml`) automatically syncs tool IDs from `microsoft/vscode-copilot-chat` using the prompt at `.github/workflows/prompts/sync-toolnames-prompt.md`. This covers VS Code built-in and Copilot tools. MCP tool names from user sessions are **not** covered by this sync and must be added manually via issues.
 
+## Antigravity Tool Names
+
+Antigravity (Google's closed-source successor to Gemini CLI, released May 2026) surfaces tool names via the `tool_calls[].name` field in `PLANNER_RESPONSE` entries of its `transcript.jsonl` session files. These are **not** MCP tools — they are built-in Antigravity agent capabilities.
+
+### Prefix Pattern
+
+Antigravity tools have **no prefix** — they use plain snake_case identifiers.
+
+| Raw name | Friendly name | Notes |
+|---|---|---|
+| `search_web` | `Search Web` | Built-in web search; called automatically by the agent |
+
+### Where These Names Appear
+
+The Antigravity adapter (`src/adapters/antigravityAdapter.ts`) counts tool calls from `tool_calls[].name` in parsed transcript entries and stores them in `analysis.toolCalls.byTool[tc.name]`. Any `tool_calls[].name` value that is not in `toolNames.json` will display as **"Unknown"** in the tool usage panel.
+
+### Automatic vs. Intentional
+
+All Antigravity built-in tools are **automatic** — the agent invokes them without user configuration. Add them to `automaticTools.json`.
+
+### How to Discover New Antigravity Tools
+
+1. Open `~/.gemini/antigravity/brain/*/. system_generated/logs/transcript.jsonl` for any session.
+2. Search for `"tool_calls"` — each entry's `name` field is a new tool candidate.
+3. Add the raw name to `toolNames.json` and to `automaticTools.json`.
+
+### Session Path Pattern
+
+Antigravity session paths match: `/.gemini/antigravity/brain/{uuid}/.system_generated/logs/transcript.jsonl`
+
+This is already handled by `workspaceHelpers.ts` (`detectToolEditorFromPath`, `detectEditorSource`, `getEditorNameFromRoot`) which all check for `/.gemini/antigravity/brain/` **before** the generic `/.gemini/` check used for Gemini CLI.
+
 ## Checklist
 
 - [ ] Identify all unknown tool names from the issue

--- a/.github/skills/copilot-log-analysis/SKILL.md
+++ b/.github/skills/copilot-log-analysis/SKILL.md
@@ -11,7 +11,7 @@ This skill documents the methods and approaches used by the GitHub Copilot Token
 
 The extension analyzes two types of log files:
 - **`.json` files**: Standard VS Code Copilot Chat session files
-- **`.jsonl` files**: Copilot CLI/Agent mode sessions, JetBrains IDE Copilot Chat sessions, Claude Code sessions, and other ecosystem adapters (one JSON event per line)
+- **`.jsonl` files**: Copilot CLI/Agent mode sessions, JetBrains IDE Copilot Chat sessions, Claude Code sessions, Gemini CLI sessions, **Antigravity sessions**, and other ecosystem adapters (one JSON event per line)
 
 ## Session File Discovery
 
@@ -36,6 +36,8 @@ This method discovers session files across all VS Code variants and locations:
 3. **Copilot Chat Extension Storage**: `{VSCode User Path}/globalStorage/github.copilot-chat/**/*.json`
 4. **Copilot CLI Sessions**: `~/.copilot/session-state/*.jsonl`
 5. **JetBrains IDE Copilot Sessions**: `~/.copilot/jb/{conversationId}/partition-{n}.jsonl`
+6. **Gemini CLI Sessions**: `~/.gemini/tmp/{project}/chats/session-*.jsonl`
+7. **Antigravity Sessions**: `~/.gemini/antigravity/brain/{session-uuid}/.system_generated/logs/transcript.jsonl`
 
 **Platform-Specific Paths:**
 - **Windows**: `%APPDATA%/{Variant}/User`
@@ -225,7 +227,39 @@ See the **Executable Scripts** section for available utilities:
 - **Model**: not in the file. Best-effort heuristic from `toolCallId` prefix (`toolu_*` ⇒ Anthropic Claude, `call_*` ⇒ OpenAI), otherwise `unknown`
 - **First/last interaction**: timestamps of the first `user.message` and the last `assistant.turn_end` (or `assistant.message`) event
 
-## Pricing and Cost Calculation
+## JSONL File Structure (Antigravity)
+
+**What**: Google's closed-source successor to Gemini CLI, released May 2026. An Electron-based desktop IDE backed by `cloudcode-pa.googleapis.com`.
+
+**Location**: `%USERPROFILE%\.gemini\antigravity\brain\{session-uuid}\.system_generated\logs\transcript.jsonl`
+
+**Full schema documentation**: [`docs/logFilesSchema/antigravity-session-format.md`](../../../docs/logFilesSchema/antigravity-session-format.md)
+
+**Entry types** (each line is one entry):
+
+```jsonl
+{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-05-22T21:48:22Z","content":"<USER_REQUEST>\nuser message here\n</USER_REQUEST>\n<ADDITIONAL_METADATA>...</ADDITIONAL_METADATA>"}
+{"step_index":1,"source":"SYSTEM","type":"CONVERSATION_HISTORY","status":"DONE","created_at":"2026-05-22T21:48:22Z"}
+{"step_index":2,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-05-22T21:48:22Z","tool_calls":[{"name":"search_web","args":{"query":"..."}}]}
+{"step_index":3,"source":"MODEL","type":"SEARCH_WEB","status":"DONE","created_at":"2026-05-22T21:48:23Z","content":"Search result text..."}
+{"step_index":11,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-05-22T21:48:44Z","content":"Final answer text...","thinking":"Chain of thought..."}
+```
+
+**Key extraction rules** (implemented by `AntigravityDataAccess` in `src/antigravity.ts`):
+
+- **Interactions**: count of `USER_INPUT` entries (`source: "USER_EXPLICIT"`)
+- **Session title**: `content` of first `USER_INPUT`, strip `<USER_REQUEST>` XML wrapper
+- **User message**: strip the `<USER_REQUEST>...</USER_REQUEST>` wrapper; discard everything after `</USER_REQUEST>` (metadata blocks)
+- **Model response**: `content` field of the last `PLANNER_RESPONSE` with non-empty `content`
+- **Thinking**: `thinking` field of any `PLANNER_RESPONSE`
+- **Tool calls**: `tool_calls[].name` on `PLANNER_RESPONSE` entries (e.g. `search_web`)
+- **Tool results**: `content` of `SEARCH_WEB` entries (and future tool result entry types)
+- **Actual tokens**: always 0 — **no token counts in Antigravity transcripts**
+- **Model**: not available — not stored in the transcript format
+- **Session ID**: the UUID directory name under `brain/`
+- **Timestamps**: `created_at` of first and last entries
+
+
 
 ### Pricing Data
 **Location**: `src/modelPricing.json`

--- a/docs/logFilesSchema/antigravity-session-format.md
+++ b/docs/logFilesSchema/antigravity-session-format.md
@@ -1,0 +1,257 @@
+---
+title: Antigravity Session Format
+created: 2026-05-22
+updated: 2026-05-22
+status: research
+type: format-analysis
+tags: [antigravity, google, jsonl, session-logs, schema]
+---
+
+# Antigravity Session Format (Observed on Windows)
+
+## TL;DR
+
+Antigravity is Google's closed-source successor to Gemini CLI (released May 2026). It is an
+Electron-based desktop IDE that uses Google Gemini models via `cloudcode-pa.googleapis.com`.
+
+The session format is rich enough for the tracker to support:
+
+- session discovery and session list views
+- chat turn reconstruction
+- tool call timelines (SEARCH_WEB, etc.)
+- model reasoning / thinking content display
+
+The transcripts contain **no token counts** and **no model name**. Token tracking requires
+estimation from text length. Model attribution is unavailable without reverse-engineering
+the API calls.
+
+## Why this document exists
+
+Antigravity replaced the open-source Gemini CLI in June 2026. Its transcript format is
+structurally different from Gemini CLI's JSONL format and requires a separate parser.
+
+Key differences:
+- No per-turn `tokens` object (Gemini CLI had `tokens.input`, `tokens.output`, etc.)
+- No `model` field in any entry
+- User messages are XML-wrapped in `<USER_REQUEST>` tags with additional metadata
+- Session ID is the folder name, not embedded in the transcript
+- Tool calls are represented as `PLANNER_RESPONSE` entries with a `tool_calls` array
+
+## Session storage layout
+
+```
+%USERPROFILE%\.gemini\antigravity\
+  brain\
+    {session-uuid}\
+      .system_generated\
+        logs\
+          transcript.jsonl         ← primary data source
+  annotations\
+    {session-uuid}.pbtxt           ← has last_user_view_time (text proto)
+  conversations\
+    {session-uuid}.pb              ← protobuf (binary, skip)
+  agyhub_summaries_proto.pb        ← protobuf summary index (skip)
+```
+
+The tracker discovers sessions by scanning:
+```
+%USERPROFILE%\.gemini\antigravity\brain\*\.system_generated\logs\transcript.jsonl
+```
+
+## High-level transcript structure
+
+The transcript is newline-delimited JSON (JSONL). Every line is an `AntigravityEntry` object
+with the following common fields:
+
+| Field         | Type    | Description                                         |
+|---------------|---------|-----------------------------------------------------|
+| `step_index`  | number  | Sequential index within the session (may have gaps) |
+| `source`      | string  | Who generated this entry (see values below)         |
+| `type`        | string  | Entry type (see types below)                        |
+| `status`      | string  | Always `"DONE"` in observed data                    |
+| `created_at`  | string  | ISO 8601 UTC timestamp, e.g. `"2026-05-22T21:48:22Z"` |
+| `content`     | string? | Message body or tool output (optional)             |
+| `thinking`    | string? | Model chain-of-thought reasoning (optional)        |
+| `tool_calls`  | array?  | Tool call objects (optional)                       |
+
+### Source values
+
+| Source          | Meaning                        |
+|-----------------|--------------------------------|
+| `USER_EXPLICIT` | User-authored input            |
+| `MODEL`         | Gemini model response          |
+| `SYSTEM`        | System-generated entry (skip)  |
+
+### Entry types
+
+#### USER_INPUT (`source: "USER_EXPLICIT"`)
+
+```json
+{
+  "step_index": 0,
+  "source": "USER_EXPLICIT",
+  "type": "USER_INPUT",
+  "status": "DONE",
+  "created_at": "2026-05-22T21:48:22Z",
+  "content": "<USER_REQUEST>\ntell me more about the antigravity rug pull...\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-05-22T23:48:22+02:00.\n</ADDITIONAL_METADATA>\n<USER_SETTINGS_CHANGE>\n...\n</USER_SETTINGS_CHANGE>"
+}
+```
+
+The `content` field is XML-structured. The clean user message is inside `<USER_REQUEST>…</USER_REQUEST>`.
+Everything outside that tag (ADDITIONAL_METADATA, USER_SETTINGS_CHANGE, etc.) is system metadata
+and should be stripped when displaying the message.
+
+#### CONVERSATION_HISTORY (`source: "SYSTEM"`)
+
+```json
+{
+  "step_index": 1,
+  "source": "SYSTEM",
+  "type": "CONVERSATION_HISTORY",
+  "status": "DONE",
+  "created_at": "2026-05-22T21:48:22Z"
+}
+```
+
+No useful content. Skip entirely.
+
+#### PLANNER_RESPONSE — planning step with tool calls (`source: "MODEL"`)
+
+```json
+{
+  "step_index": 2,
+  "source": "MODEL",
+  "type": "PLANNER_RESPONSE",
+  "status": "DONE",
+  "created_at": "2026-05-22T21:48:22Z",
+  "tool_calls": [
+    {
+      "name": "search_web",
+      "args": {
+        "query": "\"google antigravity rug pull gemini cli\"",
+        "toolAction": "\"Searching the web\"",
+        "toolSummary": "\"Web search for Google Antigravity Gemini CLI rug pull\""
+      }
+    }
+  ]
+}
+```
+
+Intermediate planning steps that dispatch tool calls. The `content` field is absent or empty.
+
+#### PLANNER_RESPONSE — final answer (`source: "MODEL"`)
+
+```json
+{
+  "step_index": 11,
+  "source": "MODEL",
+  "type": "PLANNER_RESPONSE",
+  "status": "DONE",
+  "created_at": "2026-05-22T21:48:44Z",
+  "content": "The term **\"Antigravity rug pull\"** refers to...",
+  "thinking": "**Formulating Direct Explanation**\n\nOkay, I've got a firm grasp..."
+}
+```
+
+The final model response for a turn. Has `content` (the visible answer) and optionally `thinking`
+(chain-of-thought reasoning). No `tool_calls` on this variant.
+
+#### SEARCH_WEB (`source: "MODEL"`)
+
+```json
+{
+  "step_index": 3,
+  "source": "MODEL",
+  "type": "SEARCH_WEB",
+  "status": "DONE",
+  "created_at": "2026-05-22T21:48:23Z",
+  "content": "Created At: 2026-05-22T21:48:23Z\nCompleted At: 2026-05-22T21:48:27Z\nThe search for \"google antigravity rug pull gemini cli\" returned the following summary:\n..."
+}
+```
+
+Tool execution result. The `content` string contains timing metadata and the search summary.
+This is the result of the preceding `PLANNER_RESPONSE` tool call with `name: "search_web"`.
+
+## Observed session summary
+
+The following numbers were extracted from a real Antigravity session file:
+
+| Metric                | Observed value                           |
+|-----------------------|------------------------------------------|
+| Session ID            | `13e60289-9ba1-42c0-afa9-7c560b7cc201`  |
+| Total JSONL lines     | 11                                       |
+| USER_INPUT entries    | 1                                        |
+| MODEL entries         | 9 (4 PLANNER_RESPONSE + 4 SEARCH_WEB)   |
+| SYSTEM entries        | 1 (CONVERSATION_HISTORY)                |
+| Tool calls (total)    | 4 (all `search_web`)                    |
+| First timestamp       | `2026-05-22T21:48:22Z`                  |
+| Last timestamp        | `2026-05-22T21:48:44Z`                  |
+| Input tokens          | **Not available**                        |
+| Output tokens         | **Not available**                        |
+
+## Key limitations
+
+### No token counts
+
+Unlike Gemini CLI (which embeds `tokens.input`, `tokens.output`, etc. per assistant turn),
+Antigravity stores **no token data** in `transcript.jsonl`. The tracker cannot report
+actual token usage for Antigravity sessions. All token fields will show `0`.
+
+### No model name
+
+The model name (e.g. `gemini-3.5-flash`) is **not present** in the transcript. Model
+attribution and per-model cost rollups are unavailable. Sessions appear under `unknown`
+in model usage reports.
+
+### Session title derivation
+
+There is no explicit `title` field. The session title is derived from the first `USER_INPUT`
+entry's `content` with the `<USER_REQUEST>` wrapper stripped.
+
+## Can we show sessions and chat turns?
+
+Yes, with limited fidelity.
+
+### Session list
+
+- File path gives the session ID (UUID folder name)
+- First/last `created_at` timestamps give session time range
+- First `USER_INPUT` content gives session title
+- Turn count from number of `USER_INPUT` entries
+
+### Turn reconstruction
+
+1. Iterate JSONL lines in `step_index` order
+2. Each `USER_INPUT` starts a new turn
+3. Collect subsequent `MODEL` entries until the next `USER_INPUT`
+4. `PLANNER_RESPONSE` with `content` → assistant response text
+5. `PLANNER_RESPONSE` with `tool_calls` → tool call list for the turn
+6. `SEARCH_WEB` → tool call result (attach to preceding tool call)
+7. `PLANNER_RESPONSE.thinking` → chain-of-thought (display separately)
+
+### Content coverage
+
+| Feature                   | Available? |
+|---------------------------|-----------|
+| User message text         | ✅ (strip XML wrapper) |
+| Assistant response text   | ✅ (last PLANNER_RESPONSE.content) |
+| Tool call names           | ✅ (PLANNER_RESPONSE.tool_calls[].name) |
+| Tool call arguments       | ✅ (PLANNER_RESPONSE.tool_calls[].args) |
+| Tool call results         | ✅ (SEARCH_WEB.content) |
+| Chain-of-thought thinking | ✅ (PLANNER_RESPONSE.thinking) |
+| Token counts              | ❌ Not available |
+| Model name                | ❌ Not available |
+| Cost estimate             | ❌ Not available (no tokens, no model) |
+
+## Parsing guidance for the tracker
+
+1. Discover session files at `~/.gemini/antigravity/brain/*/..system_generated/logs/transcript.jsonl`
+2. Parse as JSONL, one JSON object per line
+3. Session ID = UUID folder name directly under `brain/`
+4. Session title = first `USER_INPUT` content with `<USER_REQUEST>` tag stripped
+5. Start time = `created_at` of first entry
+6. End time = `created_at` of last entry
+7. Turn count = number of `USER_INPUT` entries
+8. Tool call count = sum of `tool_calls[]` arrays across all `PLANNER_RESPONSE` entries
+9. Skip `CONVERSATION_HISTORY` entries entirely
+10. All token fields are `0` — no estimation fallback available without model info

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.11.1",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.11.1",
+      "version": "0.11.3",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/src/adapters/adapterRegistry.ts
+++ b/vscode-extension/src/adapters/adapterRegistry.ts
@@ -22,6 +22,7 @@ import { ClaudeCodeDataAccess } from '../claudecode';
 import { ClaudeDesktopCoworkDataAccess } from '../claudedesktop';
 import { MistralVibeDataAccess } from '../mistralvibe';
 import { GeminiCliDataAccess } from '../geminicli';
+import { AntigravityDataAccess } from '../antigravity';
 
 import { OpenCodeAdapter } from './openCodeAdapter';
 import { CrushAdapter } from './crushAdapter';
@@ -31,26 +32,28 @@ import { ClaudeDesktopAdapter } from './claudeDesktopAdapter';
 import { ClaudeCodeAdapter } from './claudeCodeAdapter';
 import { MistralVibeAdapter } from './mistralVibeAdapter';
 import { GeminiCliAdapter } from './geminiCliAdapter';
+import { AntigravityAdapter } from './antigravityAdapter';
 import { CopilotChatAdapter } from './copilotChatAdapter';
 import { CopilotCliAdapter } from './copilotCliAdapter';
 import { JetBrainsAdapter } from './jetbrainsAdapter';
 
 /** Data-access instances and callbacks required to build the adapter registry. */
 export interface AdapterRegistryDeps {
-	openCode: OpenCodeDataAccess;
-	crush: CrushDataAccess;
-	continue_: ContinueDataAccess;
-	visualStudio: VisualStudioDataAccess;
-	claudeCode: ClaudeCodeDataAccess;
-	claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
-	mistralVibe: MistralVibeDataAccess;
-	geminiCli: GeminiCliDataAccess;
-	/** Estimates token count from raw text for a given model. */
-	estimateTokens: (text: string, model?: string) => number;
-	/** Returns true when the tool name identifies an MCP server tool. */
-	isMcpTool: (toolName: string) => boolean;
-	/** Extracts the MCP server name from a namespaced tool name. */
-	extractMcpServerName: (toolName: string) => string;
+openCode: OpenCodeDataAccess;
+crush: CrushDataAccess;
+continue_: ContinueDataAccess;
+visualStudio: VisualStudioDataAccess;
+claudeCode: ClaudeCodeDataAccess;
+claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
+mistralVibe: MistralVibeDataAccess;
+geminiCli: GeminiCliDataAccess;
+antigravity: AntigravityDataAccess;
+/** Estimates token count from raw text for a given model. */
+estimateTokens: (text: string, model?: string) => number;
+/** Returns true when the tool name identifies an MCP server tool. */
+isMcpTool: (toolName: string) => boolean;
+/** Extracts the MCP server name from a namespaced tool name. */
+extractMcpServerName: (toolName: string) => string;
 }
 
 /**
@@ -70,16 +73,17 @@ export type DataAccessInstances = Omit<AdapterRegistryDeps, 'estimateTokens' | '
  *   passed to data-access constructors that require it for WASM loading.
  */
 export function createDataAccessInstances(extensionUri: UriLike): DataAccessInstances {
-	return {
-		openCode: new OpenCodeDataAccess(extensionUri),
-		crush: new CrushDataAccess(extensionUri),
-		continue_: new ContinueDataAccess(),
-		visualStudio: new VisualStudioDataAccess(),
-		claudeCode: new ClaudeCodeDataAccess(),
-		claudeDesktopCowork: new ClaudeDesktopCoworkDataAccess(),
-		mistralVibe: new MistralVibeDataAccess(),
-		geminiCli: new GeminiCliDataAccess(),
-	};
+return {
+openCode: new OpenCodeDataAccess(extensionUri),
+crush: new CrushDataAccess(extensionUri),
+continue_: new ContinueDataAccess(),
+visualStudio: new VisualStudioDataAccess(),
+claudeCode: new ClaudeCodeDataAccess(),
+claudeDesktopCowork: new ClaudeDesktopCoworkDataAccess(),
+mistralVibe: new MistralVibeDataAccess(),
+geminiCli: new GeminiCliDataAccess(),
+antigravity: new AntigravityDataAccess(),
+};
 }
 
 /**
@@ -89,25 +93,29 @@ export function createDataAccessInstances(extensionUri: UriLike): DataAccessInst
  * use identical registration order and constructor wiring.
  */
 export function buildAdapterRegistry(deps: AdapterRegistryDeps): IEcosystemAdapter[] {
-	return [
-		new OpenCodeAdapter(deps.openCode),
-		new CrushAdapter(deps.crush),
-		new VisualStudioAdapter(deps.visualStudio, deps.estimateTokens),
-		new ContinueAdapter(deps.continue_),
-		new ClaudeDesktopAdapter(
-			deps.claudeDesktopCowork,
-			deps.isMcpTool,
-			deps.extractMcpServerName,
-			deps.estimateTokens
-		),
-		new ClaudeCodeAdapter(deps.claudeCode),
-		new MistralVibeAdapter(deps.mistralVibe),
-		new GeminiCliAdapter(deps.geminiCli),
-		// Copilot Chat / CLI adapters: discovery-only. Their handles() returns
-		// false so processSessionFile() falls through to the shared parser path
-		// for VS Code Copilot Chat and CLI files. See issue #654.
-		new CopilotChatAdapter(),
-		new CopilotCliAdapter(),
-		new JetBrainsAdapter(),
-	];
+return [
+new OpenCodeAdapter(deps.openCode),
+new CrushAdapter(deps.crush),
+new VisualStudioAdapter(deps.visualStudio, deps.estimateTokens),
+new ContinueAdapter(deps.continue_),
+new ClaudeDesktopAdapter(
+deps.claudeDesktopCowork,
+deps.isMcpTool,
+deps.extractMcpServerName,
+deps.estimateTokens
+),
+new ClaudeCodeAdapter(deps.claudeCode),
+new MistralVibeAdapter(deps.mistralVibe),
+// Antigravity must come before GeminiCliAdapter because both live under ~/.gemini/
+// and the Gemini CLI path check would not match Antigravity paths, but we place
+// it here explicitly to make the ordering intention clear.
+new AntigravityAdapter(deps.antigravity),
+new GeminiCliAdapter(deps.geminiCli),
+// Copilot Chat / CLI adapters: discovery-only. Their handles() returns
+// false so processSessionFile() falls through to the shared parser path
+// for VS Code Copilot Chat and CLI files. See issue #654.
+new CopilotChatAdapter(),
+new CopilotCliAdapter(),
+new JetBrainsAdapter(),
+];
 }

--- a/vscode-extension/src/adapters/adapterRegistry.ts
+++ b/vscode-extension/src/adapters/adapterRegistry.ts
@@ -109,7 +109,7 @@ new MistralVibeAdapter(deps.mistralVibe),
 // Antigravity must come before GeminiCliAdapter because both live under ~/.gemini/
 // and the Gemini CLI path check would not match Antigravity paths, but we place
 // it here explicitly to make the ordering intention clear.
-new AntigravityAdapter(deps.antigravity),
+new AntigravityAdapter(deps.antigravity, deps.estimateTokens),
 new GeminiCliAdapter(deps.geminiCli),
 // Copilot Chat / CLI adapters: discovery-only. Their handles() returns
 // false so processSessionFile() falls through to the shared parser path

--- a/vscode-extension/src/adapters/antigravityAdapter.ts
+++ b/vscode-extension/src/adapters/antigravityAdapter.ts
@@ -18,7 +18,10 @@ export class AntigravityAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 readonly id = 'antigravity';
 readonly displayName = 'Antigravity';
 
-constructor(private readonly antigravity: AntigravityDataAccess) {}
+constructor(
+private readonly antigravity: AntigravityDataAccess,
+private readonly estimateTokens: (text: string, model?: string) => number = () => 0
+) {}
 
 handles(sessionFile: string): boolean {
 return this.antigravity.isAntigravitySessionFile(sessionFile);
@@ -32,9 +35,9 @@ async stat(sessionFile: string): Promise<fs.Stats> {
 return fs.promises.stat(sessionFile);
 }
 
-async getTokens(_sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
-// Antigravity transcripts contain no token data.
-return { tokens: 0, thinkingTokens: 0, actualTokens: 0 };
+async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+const result = this.antigravity.estimateTokensFromAntigravitySession(sessionFile, this.estimateTokens);
+return { ...result, actualTokens: 0 }; // actualTokens stays 0 — these are estimates, not API counts
 }
 
 async countInteractions(sessionFile: string): Promise<number> {

--- a/vscode-extension/src/adapters/antigravityAdapter.ts
+++ b/vscode-extension/src/adapters/antigravityAdapter.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as inspector from 'inspector';
 import type { ModelUsage, ChatTurn } from '../types';
 import type {
 IEcosystemAdapter,
@@ -66,10 +67,14 @@ const candidatePaths = this.getCandidatePaths();
 const sessionFiles: string[] = [];
 const brainDir = this.antigravity.getAntigravityBrainDir();
 
+if (inspector.url()) {
 log(`🔍 [Antigravity] Checking brain dir: ${brainDir}`);
+}
 try {
 const files = this.antigravity.getAntigravitySessionFiles();
+if (inspector.url()) {
 log(`🔍 [Antigravity] Found ${files.length} transcript(s)`);
+}
 if (files.length > 0) {
 log(`📄 Found ${files.length} session file(s) in Antigravity (~/.gemini/antigravity/brain/*/)`);
 sessionFiles.push(...files);

--- a/vscode-extension/src/adapters/antigravityAdapter.ts
+++ b/vscode-extension/src/adapters/antigravityAdapter.ts
@@ -64,9 +64,12 @@ return Promise.resolve(this.antigravity.buildAntigravityTurns(sessionFile));
 async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
 const candidatePaths = this.getCandidatePaths();
 const sessionFiles: string[] = [];
+const brainDir = this.antigravity.getAntigravityBrainDir();
 
+log(`🔍 [Antigravity] Checking brain dir: ${brainDir}`);
 try {
 const files = this.antigravity.getAntigravitySessionFiles();
+log(`🔍 [Antigravity] Found ${files.length} transcript(s)`);
 if (files.length > 0) {
 log(`📄 Found ${files.length} session file(s) in Antigravity (~/.gemini/antigravity/brain/*/)`);
 sessionFiles.push(...files);

--- a/vscode-extension/src/adapters/antigravityAdapter.ts
+++ b/vscode-extension/src/adapters/antigravityAdapter.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { ModelUsage, ChatTurn } from '../types';
+import type {
+IEcosystemAdapter,
+IDiscoverableEcosystem,
+IAnalyzableEcosystem,
+DiscoveryResult,
+CandidatePath,
+UsageAnalysisAdapterContext,
+} from '../ecosystemAdapter';
+import { AntigravityDataAccess } from '../antigravity';
+import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
+
+export class AntigravityAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
+readonly id = 'antigravity';
+readonly displayName = 'Antigravity';
+
+constructor(private readonly antigravity: AntigravityDataAccess) {}
+
+handles(sessionFile: string): boolean {
+return this.antigravity.isAntigravitySessionFile(sessionFile);
+}
+
+getBackingPath(sessionFile: string): string {
+return sessionFile;
+}
+
+async stat(sessionFile: string): Promise<fs.Stats> {
+return fs.promises.stat(sessionFile);
+}
+
+async getTokens(_sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+// Antigravity transcripts contain no token data.
+return { tokens: 0, thinkingTokens: 0, actualTokens: 0 };
+}
+
+async countInteractions(sessionFile: string): Promise<number> {
+return Promise.resolve(this.antigravity.countAntigravityInteractions(sessionFile));
+}
+
+async getModelUsage(_sessionFile: string): Promise<ModelUsage> {
+return Promise.resolve({});
+}
+
+async getMeta(sessionFile: string): Promise<{
+title: string | undefined;
+firstInteraction: string | null;
+lastInteraction: string | null;
+workspacePath?: string;
+}> {
+return Promise.resolve(this.antigravity.getAntigravitySessionMeta(sessionFile));
+}
+
+getEditorRoot(_sessionFile: string): string {
+return this.antigravity.getAntigravityBrainDir();
+}
+
+async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
+return Promise.resolve(this.antigravity.buildAntigravityTurns(sessionFile));
+}
+
+async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
+const candidatePaths = this.getCandidatePaths();
+const sessionFiles: string[] = [];
+
+try {
+const files = this.antigravity.getAntigravitySessionFiles();
+if (files.length > 0) {
+log(`📄 Found ${files.length} session file(s) in Antigravity (~/.gemini/antigravity/brain/*/)`);
+sessionFiles.push(...files);
+}
+} catch (error) {
+log(`Could not read Antigravity session files: ${error}`);
+}
+
+return { sessionFiles, candidatePaths };
+}
+
+getCandidatePaths(): CandidatePath[] {
+return [
+{
+path: this.antigravity.getAntigravityBrainDir(),
+source: 'Antigravity (brain/)',
+},
+];
+}
+
+async analyzeUsage(sessionFile: string, _ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {
+const analysis = createEmptySessionUsageAnalysis();
+const session = this.antigravity.readAntigravitySession(sessionFile);
+
+// Count each USER_INPUT as one CLI interaction.
+analysis.modeUsage.cli += session.userEntries.length;
+
+// Count tool calls from PLANNER_RESPONSE entries.
+for (const entry of session.modelEntries) {
+if (!Array.isArray(entry.tool_calls)) { continue; }
+for (const tc of entry.tool_calls) {
+if (!tc.name) { continue; }
+analysis.toolCalls.total++;
+analysis.toolCalls.byTool[tc.name] = (analysis.toolCalls.byTool[tc.name] || 0) + 1;
+}
+}
+
+// No model info available — model switching stats stay empty.
+analysis.modelSwitching.uniqueModels = [];
+analysis.modelSwitching.modelCount = 0;
+analysis.modelSwitching.totalRequests = 0;
+analysis.modelSwitching.switchCount = 0;
+
+return analysis;
+}
+}

--- a/vscode-extension/src/adapters/index.ts
+++ b/vscode-extension/src/adapters/index.ts
@@ -8,6 +8,7 @@ export { ClaudeCodeAdapter } from './claudeCodeAdapter';
 export { VisualStudioAdapter } from './visualStudioAdapter';
 export { MistralVibeAdapter } from './mistralVibeAdapter';
 export { GeminiCliAdapter } from './geminiCliAdapter';
+export { AntigravityAdapter } from './antigravityAdapter';
 export { CopilotChatAdapter } from './copilotChatAdapter';
 export { CopilotCliAdapter } from './copilotCliAdapter';
 export { JetBrainsAdapter } from './jetbrainsAdapter';

--- a/vscode-extension/src/antigravity.ts
+++ b/vscode-extension/src/antigravity.ts
@@ -1,0 +1,342 @@
+/**
+ * Antigravity data access layer.
+ *
+ * Antigravity is Google's closed-source successor to Gemini CLI (released May 2026).
+ * It is an Electron-based desktop IDE that uses Google Gemini models via cloudcode-pa.googleapis.com.
+ *
+ * Session transcripts are stored as JSONL files at:
+ *   %USERPROFILE%\.gemini\antigravity\brain\{session-uuid}\.system_generated\logs\transcript.jsonl
+ *
+ * There are no token counts in the transcript files.
+ * The model name is not included in the transcript.
+ * Session title is derived from the first USER_INPUT entry (stripping XML wrapper tags).
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { ChatTurn, ModelUsage } from './types';
+import { createEmptyContextRefs } from './tokenEstimation';
+import { normalizePathForComparison } from './workspaceHelpers';
+
+// ---------------------------------------------------------------------------
+// Transcript entry interfaces
+// ---------------------------------------------------------------------------
+
+export interface AntigravityEntry {
+step_index: number;
+source: 'USER_EXPLICIT' | 'MODEL' | 'SYSTEM' | string;
+type: 'USER_INPUT' | 'CONVERSATION_HISTORY' | 'PLANNER_RESPONSE' | 'SEARCH_WEB' | string;
+status?: string;
+created_at: string;
+content?: string;
+thinking?: string;
+tool_calls?: AntigravityToolCall[];
+}
+
+export interface AntigravityToolCall {
+name: string;
+args?: Record<string, unknown>;
+}
+
+export interface AntigravityParsedSession {
+sessionId: string;
+userEntries: AntigravityEntry[];
+modelEntries: AntigravityEntry[];
+allEntries: AntigravityEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract clean user text from a USER_INPUT content string.
+ * Strips the XML wrapper: <USER_REQUEST>...</USER_REQUEST>
+ * Falls back to the full content string when the wrapper is absent.
+ */
+export function extractUserRequestText(content: string): string {
+const match = content.match(/<USER_REQUEST>([\s\S]*?)<\/USER_REQUEST>/);
+if (match) {
+return match[1].trim();
+}
+// No XML wrapper — return everything up to any <ADDITIONAL_METADATA> block.
+const metaIdx = content.indexOf('<ADDITIONAL_METADATA>');
+if (metaIdx !== -1) {
+return content.substring(0, metaIdx).trim();
+}
+return content.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Data access class
+// ---------------------------------------------------------------------------
+
+export class AntigravityDataAccess {
+/**
+ * Root directory of Antigravity data.
+ * %USERPROFILE%\.gemini\antigravity
+ */
+getAntigravityDataDir(): string {
+return path.join(os.homedir(), '.gemini', 'antigravity');
+}
+
+/**
+ * The brain directory that contains per-session subdirectories.
+ * %USERPROFILE%\.gemini\antigravity\brain
+ */
+getAntigravityBrainDir(): string {
+return path.join(this.getAntigravityDataDir(), 'brain');
+}
+
+/**
+ * Returns true when the file path is an Antigravity transcript.
+ * Path pattern: .../.gemini/antigravity/brain/{uuid}/.system_generated/logs/transcript.jsonl
+ */
+isAntigravitySessionFile(filePath: string): boolean {
+const normalized = normalizePathForComparison(filePath);
+return (
+normalized.includes('/.gemini/antigravity/brain/') &&
+normalized.endsWith('/transcript.jsonl')
+);
+}
+
+/**
+ * Extract the session UUID from an Antigravity transcript path.
+ * The UUID is the directory immediately under `.../brain/`.
+ */
+getSessionIdFromPath(filePath: string): string {
+const normalized = filePath.replace(/\\/g, '/');
+const brainIdx = normalized.toLowerCase().indexOf('/.gemini/antigravity/brain/');
+if (brainIdx === -1) { return path.basename(path.dirname(path.dirname(path.dirname(filePath)))); }
+const afterBrain = normalized.substring(brainIdx + '/.gemini/antigravity/brain/'.length);
+const slashIdx = afterBrain.indexOf('/');
+return slashIdx !== -1 ? afterBrain.substring(0, slashIdx) : afterBrain;
+}
+
+/**
+ * Discover all Antigravity transcript files under the brain directory.
+ */
+getAntigravitySessionFiles(): string[] {
+const brainDir = this.getAntigravityBrainDir();
+if (!fs.existsSync(brainDir)) {
+return [];
+}
+const sessionFiles: string[] = [];
+try {
+const sessionDirs = fs.readdirSync(brainDir, { withFileTypes: true });
+for (const sessionDir of sessionDirs) {
+if (!sessionDir.isDirectory()) { continue; }
+const transcriptPath = path.join(
+brainDir,
+sessionDir.name,
+'.system_generated',
+'logs',
+'transcript.jsonl',
+);
+try {
+const stat = fs.statSync(transcriptPath);
+if (stat.size > 0) {
+sessionFiles.push(transcriptPath);
+}
+} catch {
+// transcript.jsonl does not exist for this session — skip.
+}
+}
+} catch {
+return [];
+}
+return sessionFiles;
+}
+
+/**
+ * Read and parse an Antigravity transcript.jsonl file.
+ * Returns a parsed session with user and model entries separated.
+ */
+readAntigravitySession(filePath: string): AntigravityParsedSession {
+const sessionId = this.getSessionIdFromPath(filePath);
+const userEntries: AntigravityEntry[] = [];
+const modelEntries: AntigravityEntry[] = [];
+const allEntries: AntigravityEntry[] = [];
+
+let rawContent: string;
+try {
+rawContent = fs.readFileSync(filePath, 'utf8');
+} catch {
+return { sessionId, userEntries, modelEntries, allEntries };
+}
+
+const lines = rawContent.split('\n').filter(l => l.trim().length > 0);
+for (const line of lines) {
+let entry: AntigravityEntry;
+try {
+entry = JSON.parse(line) as AntigravityEntry;
+} catch {
+continue;
+}
+if (!entry || typeof entry.type !== 'string') { continue; }
+
+allEntries.push(entry);
+
+if (entry.type === 'USER_INPUT' && entry.source === 'USER_EXPLICIT') {
+userEntries.push(entry);
+} else if (entry.source === 'MODEL') {
+modelEntries.push(entry);
+}
+}
+
+// Sort all arrays by step_index to ensure chronological order.
+const byStepIndex = (a: AntigravityEntry, b: AntigravityEntry) => a.step_index - b.step_index;
+allEntries.sort(byStepIndex);
+userEntries.sort(byStepIndex);
+modelEntries.sort(byStepIndex);
+
+return { sessionId, userEntries, modelEntries, allEntries };
+}
+
+/**
+ * Get token counts for an Antigravity session.
+ * Antigravity transcripts contain no token data — always returns zeros.
+ */
+getTokensFromAntigravitySession(_filePath: string): { tokens: number; thinkingTokens: number } {
+return { tokens: 0, thinkingTokens: 0 };
+}
+
+/**
+ * Count the number of user interactions (USER_INPUT entries) in a session.
+ */
+countAntigravityInteractions(filePath: string): number {
+const session = this.readAntigravitySession(filePath);
+return session.userEntries.length;
+}
+
+/**
+ * Return per-model token usage.
+ * Antigravity transcripts have no model name or token data — returns empty.
+ */
+getAntigravityModelUsage(_filePath: string): ModelUsage {
+return {};
+}
+
+/**
+ * Extract session metadata: title, first/last interaction timestamps.
+ *
+ * Title: derived from the first USER_INPUT content (XML wrapper stripped).
+ * First interaction: created_at of first entry.
+ * Last interaction: created_at of last entry.
+ */
+getAntigravitySessionMeta(filePath: string): {
+title: string | undefined;
+firstInteraction: string | null;
+lastInteraction: string | null;
+} {
+const session = this.readAntigravitySession(filePath);
+const all = session.allEntries;
+
+let title: string | undefined;
+if (session.userEntries.length > 0) {
+const firstUser = session.userEntries[0];
+const content = firstUser.content ?? '';
+const extracted = extractUserRequestText(content);
+// Truncate to 120 chars for display.
+title = extracted.length > 120 ? extracted.substring(0, 117) + '...' : extracted || undefined;
+}
+
+const firstInteraction = all.length > 0 ? (all[0].created_at ?? null) : null;
+const lastInteraction = all.length > 0 ? (all[all.length - 1].created_at ?? null) : null;
+
+return { title, firstInteraction, lastInteraction };
+}
+
+/**
+ * Build chat turns for the log viewer.
+ *
+ * Each USER_INPUT becomes a turn. The subsequent MODEL entries (PLANNER_RESPONSE
+ * with content, SEARCH_WEB tool results) are collected as the assistant response
+ * for that turn.
+ *
+ * Because there are no token counts, inputTokensEstimate and outputTokensEstimate
+ * are always 0.
+ */
+buildAntigravityTurns(filePath: string): { turns: ChatTurn[]; actualTokens?: number } {
+const session = this.readAntigravitySession(filePath);
+const allEntries = session.allEntries;
+const turns: ChatTurn[] = [];
+let turnNumber = 0;
+
+for (let i = 0; i < allEntries.length; i++) {
+const entry = allEntries[i];
+if (entry.type !== 'USER_INPUT' || entry.source !== 'USER_EXPLICIT') { continue; }
+turnNumber++;
+
+const userMessage = extractUserRequestText(entry.content ?? '');
+
+// Collect everything until the next USER_INPUT.
+let assistantResponse = '';
+const toolCalls: ChatTurn['toolCalls'] = [];
+let thinkingContent = '';
+
+for (let j = i + 1; j < allEntries.length; j++) {
+const next = allEntries[j];
+if (next.type === 'USER_INPUT' && next.source === 'USER_EXPLICIT') { break; }
+
+if (next.source === 'MODEL') {
+if (next.type === 'PLANNER_RESPONSE') {
+if (next.content && next.content.trim()) {
+assistantResponse += (assistantResponse ? '\n\n' : '') + next.content.trim();
+}
+if (next.thinking && next.thinking.trim()) {
+thinkingContent += (thinkingContent ? '\n\n' : '') + next.thinking.trim();
+}
+if (Array.isArray(next.tool_calls)) {
+for (const tc of next.tool_calls) {
+if (tc.name) {
+toolCalls.push({
+toolName: tc.name,
+arguments: tc.args ? JSON.stringify(tc.args) : undefined,
+});
+}
+}
+}
+} else if (next.type === 'SEARCH_WEB' && next.content) {
+// Treat SEARCH_WEB result as a tool call result.
+// The last tool call (if any) receives this as its result.
+if (toolCalls.length > 0 && !toolCalls[toolCalls.length - 1].result) {
+toolCalls[toolCalls.length - 1].result = next.content.trim();
+}
+}
+}
+}
+
+turns.push({
+turnNumber,
+timestamp: entry.created_at ?? null,
+mode: 'cli',
+userMessage,
+assistantResponse,
+model: null, // Model name not available in transcript
+toolCalls,
+contextReferences: createEmptyContextRefs(),
+mcpTools: [],
+inputTokensEstimate: 0,
+outputTokensEstimate: 0,
+thinkingTokensEstimate: 0,
+});
+}
+
+return { turns };
+}
+
+/**
+ * Count the total number of tool calls across all entries in a session.
+ */
+countToolCalls(filePath: string): number {
+const session = this.readAntigravitySession(filePath);
+let total = 0;
+for (const entry of session.allEntries) {
+if (Array.isArray(entry.tool_calls)) {
+total += entry.tool_calls.length;
+}
+}
+return total;
+}
+}

--- a/vscode-extension/src/antigravity.ts
+++ b/vscode-extension/src/antigravity.ts
@@ -194,11 +194,30 @@ return { sessionId, userEntries, modelEntries, allEntries };
 }
 
 /**
- * Get token counts for an Antigravity session.
- * Antigravity transcripts contain no token data — always returns zeros.
+ * Estimate token counts from transcript content.
+ * Uses user message text for input and model response text for output.
+ * Since Antigravity doesn't persist token counts, this is a best-effort estimate.
  */
-getTokensFromAntigravitySession(_filePath: string): { tokens: number; thinkingTokens: number } {
-return { tokens: 0, thinkingTokens: 0 };
+estimateTokensFromAntigravitySession(
+filePath: string,
+estimateTokens: (text: string, model?: string) => number
+): { tokens: number; thinkingTokens: number } {
+const session = this.readAntigravitySession(filePath);
+let inputTokens = 0;
+let outputTokens = 0;
+let thinkingTokens = 0;
+
+for (const entry of session.userEntries) {
+inputTokens += estimateTokens(extractUserRequestText(entry.content ?? ''));
+}
+for (const entry of session.modelEntries) {
+if (entry.type === 'PLANNER_RESPONSE') {
+if (entry.content) { outputTokens += estimateTokens(entry.content); }
+if (entry.thinking) { thinkingTokens += estimateTokens(entry.thinking); }
+}
+}
+
+return { tokens: inputTokens + outputTokens + thinkingTokens, thinkingTokens };
 }
 
 /**

--- a/vscode-extension/src/automaticTools.json
+++ b/vscode-extension/src/automaticTools.json
@@ -134,5 +134,7 @@
 
   "add_loaded_assembly",
   "analyze_symbol",
-  "search_decompiled_symbols"
+  "search_decompiled_symbols",
+
+  "search_web"
 ]

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -962,6 +962,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// CRITICAL: Add output channel to context.subscriptions so VS Code doesn't dispose it
 		context.subscriptions.push(this.outputChannel);
 		this.log('Constructor called');
+		const version = context.extension.packageJSON?.version ?? 'unknown';
+		const mode = context.extensionMode === vscode.ExtensionMode.Development ? 'Development'
+			: context.extensionMode === vscode.ExtensionMode.Test ? 'Test' : 'Production';
+		let startupInfo = `🚀 AI Engineering Fluency v${version} [${mode}] (cache v${CopilotTokenTracker.CACHE_VERSION})`;
+		if (context.extensionMode === vscode.ExtensionMode.Development) {
+			try {
+				const sha = childProcess.execSync('git rev-parse --short HEAD', {
+					cwd: context.extensionUri.fsPath, encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe']
+				}).trim();
+				startupInfo += ` branch=${this._devBranch ?? 'unknown'} sha=${sha}`;
+			} catch { /* git unavailable */ }
+		}
+		this.log(startupInfo);
 
 		// Load persisted cache from storage
 		this.cacheManager.loadCacheFromStorage();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -216,7 +216,7 @@ type StatusBarDisplaySetting = 'none' | 'today' | 'last30days' | 'currentMonth' 
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 49; // Debug-log modelUsage breakdown for accurate per-model cost calculation
+	private static readonly CACHE_VERSION = 50; // Add Antigravity ecosystem adapter
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 

--- a/vscode-extension/src/toolNames.json
+++ b/vscode-extension/src/toolNames.json
@@ -662,4 +662,5 @@
   ,"debugger_get_output_window_text": "Debugger Get Output Window Text"
   ,"get_symbols": "Get Symbols"
   ,"lookup_vs": "Lookup VS"
+  ,"search_web": "Search Web"
 }

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -307,6 +307,11 @@ function buildEditorCards(editorTotals: Record<string, number>): HTMLElement | n
 			const labelEl = card.querySelector('.card-label');
 			if (labelEl) { labelEl.textContent = `${editor} ⓘ`; }
 		}
+		if (editor === 'Antigravity') {
+			card.title = 'Antigravity: token counts are estimated from transcript content. Actual API counts are not stored locally.';
+			const labelEl = card.querySelector('.card-label');
+			if (labelEl) { labelEl.textContent = `${editor} ⓘ`; }
+		}
 		wrap.append(card);
 	});
 	return wrap;
@@ -750,9 +755,14 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 						footer: (items: any[]) => {
 							if (view !== 'editor') { return ''; }
 							const hasJetBrains = items.some(i => i?.dataset?.label === 'JetBrains');
-							return hasJetBrains
-								? 'JetBrains: estimates from user messages + assistant text only.\nActual API counts and thinking tokens are not available.'
-								: '';
+							const hasAntigravity = items.some(i => i?.dataset?.label === 'Antigravity');
+							if (hasJetBrains) {
+								return 'JetBrains: estimates from user messages + assistant text only.\nActual API counts and thinking tokens are not available.';
+							}
+							if (hasAntigravity) {
+								return 'Antigravity: estimates from transcript content.\nActual API counts are not stored locally.';
+							}
+							return '';
 						}
 					}
 				}

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -787,7 +787,8 @@ const toolsTexts = [
 '🖥️ Visual Studio 2022+ — GitHub Copilot Chat extension',
 '🟢 OpenCode, 🦀 Crush — terminal-based coding agents',
 '🤖 Claude Code — Anthropic\'s CLI coding agent',
-'💎 Gemini CLI — Google\'s CLI coding agent',
+'💎 Gemini CLI — Google\'s open-source CLI coding agent',
+'🚀 Antigravity — Google\'s Gemini-powered desktop IDE',
 '💻 Copilot CLI — GitHub Copilot in the terminal',
 ];
 toolsTexts.forEach(text => {
@@ -807,7 +808,7 @@ steps.className = 'empty-state-steps';
 const stepTexts = [
 'Use any of the supported tools or editors listed above to interact with an AI model.',
 'For GitHub Copilot in VS Code: open the Copilot Chat panel (Ctrl+Alt+I / Cmd+Alt+I) and start a conversation.',
-'For terminal agents (Claude Code, Gemini CLI, OpenCode, Copilot CLI): run a coding session in your terminal.',
+'For terminal agents (Claude Code, Gemini CLI, Antigravity, OpenCode, Copilot CLI): run a coding session in your terminal.',
 'Click the 🔄 Refresh button above to reload the stats after your first session.',
 ];
 stepTexts.forEach(text => {

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -456,11 +456,17 @@ const tr = document.createElement('tr');
 if (editor === 'JetBrains') {
 tr.title = 'JetBrains: only user messages + assistant text are persisted, so token counts here are estimates of those alone. Actual API counts and thinking tokens are not available.';
 }
+if (editor === 'Antigravity') {
+tr.title = 'Antigravity: token counts are estimated from transcript content. Actual API counts are not stored locally.';
+}
 const labelTd = document.createElement('td');
 const labelWrapper = document.createElement('span');
 labelWrapper.className = 'metric-label';
 labelWrapper.textContent = `${getEditorIcon(editor)} ${editor}`;
 if (editor === 'JetBrains') {
+labelWrapper.textContent = `${labelWrapper.textContent} ⓘ`;
+}
+if (editor === 'Antigravity') {
 labelWrapper.textContent = `${labelWrapper.textContent} ⓘ`;
 }
 labelTd.append(labelWrapper);

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1085,6 +1085,7 @@ function renderFolderAnalyzerTab(): string {
           <option value="copilot-cli">🤖 GitHub Copilot CLI</option>
           <option value="claude-code">🟣 Claude Code (.jsonl only)</option>
           <option value="gemini-cli">💎 Gemini CLI (.jsonl only)</option>
+          <option value="antigravity">🚀 Antigravity (.jsonl only)</option>
           <option value="continue">⚡ Continue</option>
           <option value="opencode">🟢 OpenCode (JSON format only — DB not supported)</option>
           <option value="mistral-vibe">🔥 Mistral Vibe</option>

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -376,6 +376,10 @@ function getEditorBadgeClass(editor: string): string {
   if (lower.includes("mistral")) {
     return "editor-badge editor-badge-mistral-vibe";
   }
+  // Antigravity must be checked before gemini (both contain 'gemini' in their path)
+  if (lower.includes("antigravity")) {
+    return "editor-badge editor-badge-antigravity";
+  }
   if (lower.includes("gemini")) {
     return "editor-badge editor-badge-gemini-cli";
   }
@@ -395,6 +399,10 @@ function getEditorIcon(editor: string): string {
   }
   if (lower.includes("mistral")) {
     return "🔥";
+  }
+  // Antigravity: rocket emoji — evokes the anti-gravity concept and space theme
+  if (lower.includes("antigravity")) {
+    return "🚀";
   }
   if (lower.includes("gemini")) {
     return "💎";
@@ -2250,3 +2258,4 @@ async function bootstrap(): Promise<void> {
 }
 
 void bootstrap();
+

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -403,6 +403,12 @@ background-repeat: no-repeat;
 background-position: center;
 }
 
+.editor-badge-antigravity {
+	background: #0a1628;
+	color: #4285f4;
+	border: 1px solid #1a73e8;
+}
+
 .editor-badge-gemini-cli {
 	background: #111827;
 	color: #8ec5ff;
@@ -603,3 +609,4 @@ background-position: center;
 @keyframes spin {
 	to { transform: rotate(360deg); }
 }
+

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -711,10 +711,10 @@ ${totalModeTurns > 0 ? `<div class="summary-card" title="${escapeHtml(modeEntrie
 <div class="summary-value" style="font-size: 1.1em;">${primaryModeLabel}</div>
 <div class="summary-sub">${escapeHtml(modeSubLabel)}${modeEntries.length > 1 ? ` · ${modeEntries.slice(1).map(([m, n]) => `${MODE_LABELS[m]} ${n}`).join(', ')}` : ''}</div>
 </div>` : ''}
-<div class="summary-card"${data.editorName === 'JetBrains' ? ` title="JetBrains: only user messages + assistant text are persisted in the session log, so this is an estimate of those alone. Actual API token counts and thinking tokens are not available."` : ''}>
-<div class="summary-label">📊 Estimated Tokens${data.editorName === 'JetBrains' ? ' ⓘ' : ''}</div>
+<div class="summary-card"${data.editorName === 'JetBrains' ? ` title="JetBrains: only user messages + assistant text are persisted in the session log, so this is an estimate of those alone. Actual API token counts and thinking tokens are not available."` : data.editorName === 'Antigravity' ? ` title="Antigravity: token counts are estimated from transcript content. Actual API counts are not stored locally."` : ''}>
+<div class="summary-label">📊 Estimated Tokens${(data.editorName === 'JetBrains' || data.editorName === 'Antigravity') ? ' ⓘ' : ''}</div>
 <div class="summary-value">${formatCompact(totalTokens)}</div>
-<div class="summary-sub">${data.editorName === 'JetBrains' ? 'User + assistant text only (no API counts, no thinking)' : 'Input + Output estimated from text'}</div>
+<div class="summary-sub">${data.editorName === 'JetBrains' ? 'User + assistant text only (no API counts, no thinking)' : data.editorName === 'Antigravity' ? 'Estimated from transcript content' : 'Input + Output estimated from text'}</div>
 </div>
 ${hasAnyActualUsage && !data.debugLogInputTokens ? `
 <div class="summary-card">
@@ -988,7 +988,7 @@ e.preventDefault();
 
 // ── Entry-point renderers (signatures preserved) ─────────────────────────────
 
-function renderTurnCard(turn: ChatTurn, isJetBrains = false): string {
+function renderTurnCard(turn: ChatTurn, isJetBrains = false, isAntigravity = false): string {
 const totalTokens    = turn.inputTokensEstimate + turn.outputTokensEstimate + turn.thinkingTokensEstimate;
 const hasThinking    = turn.thinkingTokensEstimate > 0;
 const hasActualUsage = !!turn.actualUsage;
@@ -1018,7 +1018,7 @@ return `
 <span class="turn-mode" style="background: ${getModeColor(turn.mode)};">${getModeIcon(turn.mode)} ${turn.mode}</span>
 ${turn.model ? renderTurnModelBadge(turn.model) : ''}
 ${turn.thinkingEffort ? `<span class="turn-effort">💡 ${escapeHtml(getEffortDisplayName(turn.thinkingEffort))}</span>` : ''}
-${totalTokens > 0 ? `<span class="turn-tokens"${isJetBrains ? ` title="JetBrains: estimated from user message + assistant text only. Actual API counts and thinking tokens are not available."` : ''}>📊 ${formatCompact(totalTokens)} tokens (↑${turn.inputTokensEstimate} ↓${turn.outputTokensEstimate})${isJetBrains ? ' ⓘ' : ''}</span>` : ''}
+${totalTokens > 0 ? `<span class="turn-tokens"${isJetBrains ? ` title="JetBrains: estimated from user message + assistant text only. Actual API counts and thinking tokens are not available."` : isAntigravity ? ` title="Antigravity: estimated from transcript content. Actual API counts are not stored locally."` : ''}>📊 ${formatCompact(totalTokens)} tokens (↑${turn.inputTokensEstimate} ↓${turn.outputTokensEstimate})${(isJetBrains || isAntigravity) ? ' ⓘ' : ''}</span>` : ''}
 ${hasThinking ? `<span class="turn-tokens" style="color: #a78bfa;">🧠 ${formatCompact(turn.thinkingTokensEstimate)} thinking</span>` : ''}
 ${hasActualUsage ? `<span class="turn-tokens" style="color: #22c55e;">✓ ${formatCompact(turn.actualUsage!.promptTokens + turn.actualUsage!.completionTokens)} actual</span>` : ''}
 ${contextHeaderHtml}
@@ -1155,7 +1155,7 @@ aggregatedBreakdown,
 
 <div class="turns-list">
 ${data.turns.length > 0 
-? data.turns.map(turn => renderTurnCard(turn, data.editorName === 'JetBrains')).join('')
+? data.turns.map(turn => renderTurnCard(turn, data.editorName === 'JetBrains', data.editorName === 'Antigravity')).join('')
 : '<div class="empty-state">No chat turns found in this session.</div>'
 }
 </div>

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -38,6 +38,7 @@ export type EditorName =
 	| 'Claude Desktop Cowork'
 	| 'Mistral Vibe'
 	| 'Gemini CLI'
+	| 'Antigravity'
 	| 'Unknown';
 
 /**
@@ -61,6 +62,7 @@ export const EDITOR_ICON_MAP: Record<EditorName, string> = {
 	'Claude Desktop Cowork': '🟠',
 	'Mistral Vibe': '🔥',
 	'Gemini CLI': '💎',
+	'Antigravity': '🚀',
 	'Unknown': '❓'
 };
 

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -496,6 +496,8 @@ export function getEditorNameFromRoot(rootPath: string): string {
 	if (lower.includes('opencode')) { return 'OpenCode'; }
 	if (lower.includes('.continue')) { return 'Continue'; }
 	if (lower.includes('.vibe')) { return 'Mistral Vibe'; }
+	// Antigravity must be checked before generic .gemini (both live under ~/.gemini/).
+	if (lower.includes('.gemini/antigravity')) { return 'Antigravity'; }
 	if (lower.includes('.gemini')) { return 'Gemini CLI'; }
 	if (isCodeInsidersRoot(lower)) { return 'VS Code Insiders'; }
 	if (isCodeExplorationRoot(lower)) { return 'VS Code Exploration'; }
@@ -902,6 +904,9 @@ function detectToolEditorFromPath(
 	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (lowerPath.includes('/.claude/projects/')) { return 'Claude Code'; }
 	if (lowerPath.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
+	// Antigravity must be checked before Gemini CLI: both live under ~/.gemini/
+	// but Antigravity sessions are under ~/.gemini/antigravity/brain/ which is more specific.
+	if (lowerPath.includes('/.gemini/antigravity/brain/')) { return 'Antigravity'; }
 	if (isGeminiCliPath(lowerPath)) { return 'Gemini CLI'; }
 	return undefined;
 }
@@ -967,6 +972,9 @@ export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p:
 	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (lowerPath.includes('/.claude/projects/')) { return 'Claude Code'; }
 	if (lowerPath.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
+	// Antigravity must be checked before Gemini CLI (both live under ~/.gemini/).
+	if (lowerPath.includes('/.gemini/antigravity/brain/')) { return 'Antigravity'; }
 	if (isGeminiCliPath(lowerPath)) { return 'Gemini CLI'; }
 	return detectIDEEditorSource(lowerPath) ?? 'Unknown';
 }
+

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -23,6 +23,7 @@ import { MistralVibeAdapter } from '../../src/adapters/mistralVibeAdapter';
 import { GeminiCliAdapter } from '../../src/adapters/geminiCliAdapter';
 import { CopilotChatAdapter } from '../../src/adapters/copilotChatAdapter';
 import { CopilotCliAdapter } from '../../src/adapters/copilotCliAdapter';
+import { AntigravityAdapter } from '../../src/adapters/antigravityAdapter';
 
 import { OpenCodeDataAccess } from '../../src/opencode';
 import { CrushDataAccess } from '../../src/crush';
@@ -32,6 +33,7 @@ import { ClaudeDesktopCoworkDataAccess } from '../../src/claudedesktop';
 import { VisualStudioDataAccess } from '../../src/visualstudio';
 import { MistralVibeDataAccess } from '../../src/mistralvibe';
 import { GeminiCliDataAccess } from '../../src/geminicli';
+import { AntigravityDataAccess } from '../../src/antigravity';
 
 // Stub functions for adapters requiring callbacks
 const noopEstimateTokens = (_text: string, _model?: string) => 0;
@@ -47,6 +49,7 @@ const claudeDesktopDA = new ClaudeDesktopCoworkDataAccess();
 const visualStudioDA = new VisualStudioDataAccess();
 const mistralVibeDA = new MistralVibeDataAccess();
 const geminiCliDA = new GeminiCliDataAccess();
+const antigravityDA = new AntigravityDataAccess();
 
 const openCodeAdapter = new OpenCodeAdapter(openCodeDA);
 const crushAdapter = new CrushAdapter(crushDA);
@@ -58,22 +61,23 @@ const mistralVibeAdapter = new MistralVibeAdapter(mistralVibeDA);
 const geminiCliAdapter = new GeminiCliAdapter(geminiCliDA);
 const copilotChatAdapter = new CopilotChatAdapter();
 const copilotCliAdapter = new CopilotCliAdapter();
+const antigravityAdapter = new AntigravityAdapter(antigravityDA);
 
 const allAdapters: IEcosystemAdapter[] = [
     openCodeAdapter, crushAdapter, continueAdapter,
     claudeCodeAdapter, claudeDesktopAdapter, visualStudioAdapter, mistralVibeAdapter, geminiCliAdapter,
-    copilotChatAdapter, copilotCliAdapter,
+    copilotChatAdapter, copilotCliAdapter, antigravityAdapter,
 ];
 
 // ---------------------------------------------------------------------------
 // isDiscoverable type guard
 // ---------------------------------------------------------------------------
 
-test('isDiscoverable: returns true for all 10 adapters', () => {
+test('isDiscoverable: returns true for all 11 adapters', () => {
     for (const adapter of allAdapters) {
         assert.ok(isDiscoverable(adapter), `Expected ${adapter.id} to be discoverable`);
     }
-    assert.equal(allAdapters.length, 10);
+    assert.equal(allAdapters.length, 11);
 });
 
 test('isDiscoverable: returns false for plain IEcosystemAdapter without discover()', () => {
@@ -103,6 +107,7 @@ test('adapter IDs are stable lowercase identifiers', () => {
     assert.equal(geminiCliAdapter.id, 'geminicli');
     assert.equal(copilotChatAdapter.id, 'copilotchat');
     assert.equal(copilotCliAdapter.id, 'copilotcli');
+    assert.equal(antigravityAdapter.id, 'antigravity');
 });
 
 // ---------------------------------------------------------------------------
@@ -158,6 +163,31 @@ test('GeminiCliAdapter.handles: recognises ~/.gemini session paths', () => {
 
 test('GeminiCliAdapter.handles: rejects unrelated paths', () => {
     assert.ok(!geminiCliAdapter.handles(path.join(os.homedir(), '.gemini', 'logs.json')));
+});
+
+test('GeminiCliAdapter.handles: rejects Antigravity brain paths (must not steal from AntigravityAdapter)', () => {
+    const antigravityPath = path.join(os.homedir(), '.gemini', 'antigravity', 'brain', '13e60289-abcd-1234-5678-000000000000', '.system_generated', 'logs', 'transcript.jsonl');
+    assert.ok(!geminiCliAdapter.handles(antigravityPath));
+});
+
+test('AntigravityAdapter.handles: recognises POSIX-style brain transcript paths', () => {
+    const p = path.posix.join(os.homedir().replace(/\\/g, '/'), '.gemini', 'antigravity', 'brain', '13e60289-abcd-1234-5678-000000000000', '.system_generated', 'logs', 'transcript.jsonl');
+    assert.ok(antigravityAdapter.handles(p));
+});
+
+test('AntigravityAdapter.handles: recognises Windows backslash brain transcript paths', () => {
+    const p = 'C:\\Users\\RobBos\\.gemini\\antigravity\\brain\\13e60289-abcd-1234-5678-000000000000\\.system_generated\\logs\\transcript.jsonl';
+    assert.ok(antigravityAdapter.handles(p));
+});
+
+test('AntigravityAdapter.handles: rejects generic Gemini CLI session paths', () => {
+    const p = path.join(os.homedir(), '.gemini', 'tmp', 'demo-project', 'chats', 'session-abc.jsonl');
+    assert.ok(!antigravityAdapter.handles(p));
+});
+
+test('AntigravityAdapter.handles: rejects paths that lack transcript.jsonl filename', () => {
+    const p = path.join(os.homedir(), '.gemini', 'antigravity', 'brain', 'some-uuid', '.system_generated', 'logs', 'other.jsonl');
+    assert.ok(!antigravityAdapter.handles(p));
 });
 
 test('VisualStudioAdapter.handles: recognises VS .vs session paths', () => {
@@ -285,6 +315,20 @@ test('ClaudeCodeAdapter.getEditorRoot: returns claude data directory', () => {
 test('GeminiCliAdapter.getEditorRoot: returns Gemini data directory', () => {
     const root = geminiCliAdapter.getEditorRoot('/any/path');
     assert.ok(root.includes('.gemini'));
+});
+
+test('AntigravityAdapter.getEditorRoot: returns antigravity brain directory', () => {
+    const root = antigravityAdapter.getEditorRoot('/any/path');
+    assert.ok(root.includes('.gemini'), 'Should include .gemini in path');
+    assert.ok(root.includes('antigravity'), 'Should include antigravity in path');
+    assert.ok(root.includes('brain'), 'Should include brain in path');
+});
+
+test('AntigravityAdapter.getCandidatePaths: returns brain directory path', () => {
+    const paths = antigravityAdapter.getCandidatePaths();
+    assert.equal(paths.length, 1);
+    assert.ok(paths[0].path.includes('antigravity'), 'Path should include antigravity');
+    assert.equal(paths[0].source, 'Antigravity (brain/)');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds full support for Google's **Antigravity** editor (the closed-source Electron-based replacement for Gemini CLI, v2.0.6, released May 2026).

### Session log location

\\\
~/.gemini/antigravity/brain/{session-id}/.system_generated/logs/transcript.jsonl
\\\

### What's included

- **Session discovery** — scans \~/.gemini/antigravity/brain/*/\ for transcript files
- **Session parser** (\src/antigravity.ts\) — extracts title, timestamps, turn count, tool calls, user messages, model responses, and chain-of-thought (thinking)
- **Ecosystem adapter** (\src/adapters/antigravityAdapter.ts\) — integrates into all extension views
- **Path detection** — Antigravity sessions (under \.gemini/antigravity/brain/\) are correctly distinguished from Gemini CLI sessions (under \.gemini/tmp/\)
- **UI** — 🚀 badge with Google-blue colors in the diagnostics view
- **Schema docs** — \docs/logFilesSchema/antigravity-session-format.md\

### Known limitation

Antigravity's transcript format does **not** include token counts. Token data is unavailable; all token values are reported as 0. This is documented.

### Tests

All 40 existing unit tests pass. Build compiles with 0 errors.