### PR TITLE
fix: upgrade qs transitive dep to >=6.15.2 (CVE-2026-8723)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -10361,9 +10361,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -439,6 +439,7 @@
   "overrides": {
     "diff": ">=8.0.3",
     "fast-uri": ">=3.1.2",
+    "qs": ">=6.15.2",
     "serialize-javascript": ">=7.0.3",
     "uuid": "^14.0.0"
   }


### PR DESCRIPTION
Fixes Dependabot alert #85 (GHSA-q8mj-m7cp-5q26 / CVE-2026-8723). Adds qs>=6.15.2 to npm overrides in vscode-extension/package.json to force the patched version of this transitive dependency.