### PR TITLE
fix: diagnostics - show Copilot CLI sessions correctly and auto-reveal hidden sessions

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -525,6 +525,11 @@ function renderSessionTable(
   // Count zero-interaction sessions (before hiding them) for the toggle label
   const zeroInteractionCount = filteredFiles.filter(sf => sf.interactions === 0).length;
 
+  // Auto-reveal hidden sessions when the current filter would leave nothing visible
+  if (hideEmptySessions && zeroInteractionCount === filteredFiles.length && filteredFiles.length > 0) {
+    hideEmptySessions = false;
+  }
+
   // Hide sessions with 0 interactions when filter is active
   if (hideEmptySessions) {
     filteredFiles = filteredFiles.filter(sf => sf.interactions > 0);

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -961,6 +961,7 @@ export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p:
 	const lowerPath = normalizePathForComparison(filePath);
 	if (lowerPath.includes('/.copilot/jb/')) { return 'JetBrains'; }
 	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
+	if (lowerPath.includes('/.copilot/session-store.db#')) { return 'Copilot CLI'; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
 	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
 	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -475,6 +475,14 @@ test('detectEditorSource: Copilot CLI takes priority over code path', () => {
         assert.equal(detectEditorSource('/home/user/.copilot/session-state/session123.json'), 'Copilot CLI');
 });
 
+test('detectEditorSource: detects Copilot CLI from session-store.db virtual path (Unix)', () => {
+        assert.equal(detectEditorSource('/home/user/.copilot/session-store.db#3ee22c56-uuid'), 'Copilot CLI');
+});
+
+test('detectEditorSource: detects Copilot CLI from session-store.db virtual path (Windows)', () => {
+        assert.equal(detectEditorSource('C:\\Users\\alice\\.copilot\\session-store.db#3ee22c56-uuid'), 'Copilot CLI');
+});
+
 test('detectEditorSource: JetBrains detected from .copilot/jb path', () => {
         assert.equal(detectEditorSource('/home/user/.copilot/jb/uuid-1234/partition-0.jsonl'), 'JetBrains');
 });


### PR DESCRIPTION
## Summary

Two fixes for the diagnostics report session files view:

### Fix 1: GitHub Copilot CLI sessions no longer appear under 'Unknown'
Sessions backed by the \session-store.db\ virtual path format (\<path>/session-store.db#<uuid>\) were not recognised by \detectEditorSource\, causing them to fall through to \'Unknown'\. Added pattern detection for \/.copilot/session-store.db#\ so these sessions correctly show under the **Copilot CLI** editor tile.

### Fix 2: Auto-reveal hidden sessions when a filter shows nothing
When clicking an editor tile that contains only 0-interaction sessions, the 'Hide sessions with 0 interactions' flag was still active, leaving the table empty with just a '(3 hidden)' hint. Now when all sessions for the active filter have 0 interactions, \hideEmptySessions\ is automatically toggled off so the sessions are visible.

## Tests
Added two new unit tests to \workspaceHelpers.test.ts\ covering the \session-store.db#uuid\ path detection on both Unix and Windows paths. All 30 test suites pass.