### PR TITLE
refactor: reduce complexity in CrushAdapter buildTurns and analyzeUsage

### DIFF
--- a/vscode-extension/src/adapters/crushAdapter.ts
+++ b/vscode-extension/src/adapters/crushAdapter.ts
@@ -115,8 +115,7 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 		const turns: ChatTurn[] = [];
 		const messages = await this.crush.getCrushMessages(sessionFile);
 		const session = await this.crush.readCrushSession(sessionFile);
-		const userMessages = messages.filter(m => m.role === 'user');
-		const numTurns = userMessages.length;
+		const numTurns = messages.filter(m => m.role === 'user').length;
 		let turnNumber = 0;
 		for (let i = 0; i < messages.length; i++) {
 			const msg = messages[i];
@@ -127,46 +126,56 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 				if (messages[j].role === 'user') { break; }
 				if (messages[j].role === 'assistant') { turnAssistantMsgs.push(messages[j]); }
 			}
-			const userParts: any[] = Array.isArray(msg.parts) ? msg.parts : [];
-			const userText = userParts
-				.filter(p => p?.type === 'text' && p?.text)
-				.map(p => p.text as string)
-				.join('\n');
-			let assistantText = '';
-			const toolCalls: { toolName: string; arguments?: string; result?: string }[] = [];
-			let model: string | null = null;
-			for (const assistantMsg of turnAssistantMsgs) {
-				if (!model) { model = assistantMsg.model || null; }
-				const parts: any[] = Array.isArray(assistantMsg.parts) ? assistantMsg.parts : [];
-				for (const part of parts) {
-					if (part?.type === 'text' && part?.text) {
-						assistantText += part.text;
-					} else if (part?.type === 'tool_call' && part?.data?.name) {
-						toolCalls.push({
-							toolName: part.data.name,
-							arguments: part.data.arguments ? JSON.stringify(part.data.arguments) : undefined
-						});
-					}
-				}
-			}
-			const perTurnInput = session?.prompt_tokens && numTurns > 0 ? Math.round(session.prompt_tokens / numTurns) : 0;
-			const perTurnOutput = session?.completion_tokens && numTurns > 0 ? Math.round(session.completion_tokens / numTurns) : 0;
-			turns.push({
-				turnNumber,
-				timestamp: msg.created_at ? new Date(msg.created_at * 1000).toISOString() : null,
-				mode: 'cli',
-				userMessage: userText,
-				assistantResponse: assistantText,
-				model,
-				toolCalls,
-				contextReferences: createEmptyContextRefs(),
-				mcpTools: [],
-				inputTokensEstimate: perTurnInput,
-				outputTokensEstimate: perTurnOutput,
-				thinkingTokensEstimate: 0
-			});
+			turns.push(this.buildCrushTurn(msg, turnAssistantMsgs, session, numTurns, turnNumber));
 		}
 		return { turns };
+	}
+
+	private buildCrushTurn(msg: any, turnAssistantMsgs: any[], session: any, numTurns: number, turnNumber: number): ChatTurn {
+		const userParts: any[] = Array.isArray(msg.parts) ? msg.parts : [];
+		const userText = userParts
+			.filter(p => p?.type === 'text' && p?.text)
+			.map(p => p.text as string)
+			.join('\n');
+		const { assistantText, toolCalls, model } = this.processAssistantMessagesForTurn(turnAssistantMsgs);
+		const perTurnInput = session?.prompt_tokens && numTurns > 0 ? Math.round(session.prompt_tokens / numTurns) : 0;
+		const perTurnOutput = session?.completion_tokens && numTurns > 0 ? Math.round(session.completion_tokens / numTurns) : 0;
+		return {
+			turnNumber,
+			timestamp: msg.created_at ? new Date(msg.created_at * 1000).toISOString() : null,
+			mode: 'cli',
+			userMessage: userText,
+			assistantResponse: assistantText,
+			model,
+			toolCalls,
+			contextReferences: createEmptyContextRefs(),
+			mcpTools: [],
+			inputTokensEstimate: perTurnInput,
+			outputTokensEstimate: perTurnOutput,
+			thinkingTokensEstimate: 0
+		};
+	}
+
+	private processAssistantMessagesForTurn(turnAssistantMsgs: any[]): {
+		assistantText: string; toolCalls: { toolName: string; arguments?: string; result?: string }[]; model: string | null;
+	} {
+		let assistantText = '';
+		const toolCalls: { toolName: string; arguments?: string; result?: string }[] = [];
+		let model: string | null = null;
+		for (const assistantMsg of turnAssistantMsgs) {
+			if (!model) { model = assistantMsg.model || null; }
+			for (const part of (Array.isArray(assistantMsg.parts) ? assistantMsg.parts : [])) {
+				if (part?.type === 'text' && part?.text) {
+					assistantText += part.text;
+				} else if (part?.type === 'tool_call' && part?.data?.name) {
+					toolCalls.push({
+						toolName: part.data.name,
+						arguments: part.data.arguments ? JSON.stringify(part.data.arguments) : undefined
+					});
+				}
+			}
+		}
+		return { assistantText, toolCalls, model };
 	}
 
 	async getSyncData(sessionFile: string): Promise<{ tokens: number; interactions: number; modelUsage: ModelUsage; timestamp: number }> {
@@ -180,18 +189,25 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 		for (const msg of messages) {
 			if (msg.role === 'user') { analysis.modeUsage.cli++; }
 			if (msg.role === 'assistant') {
-				const model = msg.model || 'unknown';
-				models.push(model);
-				const parts: any[] = Array.isArray(msg.parts) ? msg.parts : [];
-				for (const part of parts) {
-					if (part?.type === 'tool_call' && part?.data?.name) {
-						analysis.toolCalls.total++;
-						const toolName = part.data.name as string;
-						analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
-					}
-				}
+				this.processCrushAssistantMessage(msg, analysis, models);
 			}
 		}
+		this.applyCrushModelSwitchingStats(models, analysis);
+		applyModelTierClassification(ctx.modelPricing, analysis.modelSwitching.uniqueModels, models, analysis);
+		return analysis;
+	}
+
+	private processCrushAssistantMessage(msg: any, analysis: import('../types').SessionUsageAnalysis, models: string[]): void {
+		models.push(msg.model || 'unknown');
+		for (const part of (Array.isArray(msg.parts) ? msg.parts : [])) {
+			if (part?.type !== 'tool_call' || !part?.data?.name) { continue; }
+			analysis.toolCalls.total++;
+			const toolName = part.data.name as string;
+			analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+		}
+	}
+
+	private applyCrushModelSwitchingStats(models: string[], analysis: import('../types').SessionUsageAnalysis): void {
 		const uniqueModels = [...new Set(models)];
 		analysis.modelSwitching.uniqueModels = uniqueModels;
 		analysis.modelSwitching.modelCount = uniqueModels.length;
@@ -201,7 +217,5 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 			if (models[i] !== models[i - 1]) { switchCount++; }
 		}
 		analysis.modelSwitching.switchCount = switchCount;
-		applyModelTierClassification(ctx.modelPricing, uniqueModels, models, analysis);
-		return analysis;
 	}
 }


### PR DESCRIPTION
## Summary

Extracts private helpers from \uildTurns\ (complexity 29, cognitive 44) and \nalyzeUsage\ in \CrushAdapter\.

- \uildCrushTurn\ — constructs a ChatTurn from a user message + collected assistant responses
- \processAssistantMessagesForTurn\ — accumulates text, tool calls, and model from assistant messages
- \processCrushAssistantMessage\ — handles tool-call tracking for analyzeUsage
- \pplyCrushModelSwitchingStats\ — computes model switching stats

### Before
- \uildTurns\: complexity 29, cognitive complexity 44 ❌
- \nalyzeUsage\ nested inner function: cognitive complexity 19 ❌

### After
- All methods below the 15-unit threshold ✅