### PR TITLE
refactor: reduce complexity in GeminiCliAdapter.analyzeUsage

### DIFF
--- a/vscode-extension/src/adapters/geminiCliAdapter.ts
+++ b/vscode-extension/src/adapters/geminiCliAdapter.ts
@@ -94,38 +94,45 @@ export class GeminiCliAdapter implements IEcosystemAdapter, IDiscoverableEcosyst
 		analysis.modeUsage.cli += session.userRecords.length;
 
 		for (const assistant of session.assistantRecords) {
-			const model = normalizeGeminiModelId(assistant.model || 'unknown');
-			models.push(model);
-
-			for (const toolCall of Array.isArray(assistant.toolCalls) ? assistant.toolCalls : []) {
-				const toolName = typeof toolCall?.name === 'string' && toolCall.name.trim().length > 0
-					? toolCall.name.trim()
-					: typeof toolCall?.displayName === 'string' && toolCall.displayName.trim().length > 0
-						? toolCall.displayName.trim()
-						: '';
-				if (!toolName) {
-					continue;
-				}
-
-				analysis.toolCalls.total++;
-				analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
-			}
+			this.processGeminiAssistantRecord(assistant, analysis, models);
 		}
 
+		this.applyGeminiModelSwitchingStats(models, analysis);
+		applyModelTierClassification(ctx.modelPricing, analysis.modelSwitching.uniqueModels, models, analysis);
+
+		return analysis;
+	}
+
+	private processGeminiAssistantRecord(assistant: any, analysis: import('../types').SessionUsageAnalysis, models: string[]): void {
+		const model = normalizeGeminiModelId(assistant.model || 'unknown');
+		models.push(model);
+		for (const toolCall of (Array.isArray(assistant.toolCalls) ? assistant.toolCalls : [])) {
+			const toolName = this.resolveGeminiToolName(toolCall);
+			if (!toolName) { continue; }
+			analysis.toolCalls.total++;
+			analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+		}
+	}
+
+	private resolveGeminiToolName(toolCall: any): string {
+		if (typeof toolCall?.name === 'string' && toolCall.name.trim().length > 0) {
+			return toolCall.name.trim();
+		}
+		if (typeof toolCall?.displayName === 'string' && toolCall.displayName.trim().length > 0) {
+			return toolCall.displayName.trim();
+		}
+		return '';
+	}
+
+	private applyGeminiModelSwitchingStats(models: string[], analysis: import('../types').SessionUsageAnalysis): void {
 		const uniqueModels = [...new Set(models)];
 		analysis.modelSwitching.uniqueModels = uniqueModels;
 		analysis.modelSwitching.modelCount = uniqueModels.length;
 		analysis.modelSwitching.totalRequests = models.length;
-
 		let switchCount = 0;
-		for (let index = 1; index < models.length; index++) {
-			if (models[index] !== models[index - 1]) {
-				switchCount++;
-			}
+		for (let i = 1; i < models.length; i++) {
+			if (models[i] !== models[i - 1]) { switchCount++; }
 		}
 		analysis.modelSwitching.switchCount = switchCount;
-		applyModelTierClassification(ctx.modelPricing, uniqueModels, models, analysis);
-
-		return analysis;
 	}
 }


### PR DESCRIPTION
## Summary

Reduces cognitive complexity in \GeminiCliAdapter.analyzeUsage\ (cognitive complexity 20 > 15) by extracting helpers:

- \processGeminiAssistantRecord\ — model tracking + tool-call processing per assistant record
- \esolveGeminiToolName\ — resolves tool name from \
ame\ or \displayName\ field
- \pplyGeminiModelSwitchingStats\ — computes model switching stats

### Before
- Nested function at line 89: cognitive complexity 20 ❌

### After
- All methods below the 15-unit threshold ✅