### PR TITLE
fix: reduce complexity in adapter inner loop methods

### DIFF
--- a/vscode-extension/src/adapters/claudeDesktopAdapter.ts
+++ b/vscode-extension/src/adapters/claudeDesktopAdapter.ts
@@ -161,22 +161,39 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 			if (reqId) { seenRequestIds.add(reqId); }
 			const usage = msg?.usage;
 			if (usage && isFirstOccurrence) {
-				actualInputTokens += (usage.input_tokens || 0) + (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0);
-				actualOutputTokens += usage.output_tokens || 0;
+				const tokens = this.extractUsageTokens(usage);
+				actualInputTokens += tokens.input;
+				actualOutputTokens += tokens.output;
 			}
 			for (const block of (Array.isArray(msg?.content) ? msg.content : [])) {
-				if (block.type === 'text') { assistantText += block.text || ''; }
-				else if (block.type === 'tool_use') {
-					const toolName: string = block.name || 'unknown';
-					if (this.isMcpToolFn(toolName)) {
-						mcpTools.push({ server: this.extractMcpServerNameFn(toolName), tool: toolName });
-					} else {
-						toolCalls.push({ toolName, arguments: block.input ? JSON.stringify(block.input) : undefined });
-					}
-				}
+				assistantText += this.processEventContentBlock(block, toolCalls, mcpTools);
 			}
 		}
 		return { assistantText, model, actualInputTokens, actualOutputTokens, toolCalls, mcpTools };
+	}
+
+	private extractUsageTokens(usage: any): { input: number; output: number } {
+		return {
+			input: (usage.input_tokens || 0) + (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0),
+			output: usage.output_tokens || 0
+		};
+	}
+
+	private processEventContentBlock(
+		block: any,
+		toolCalls: { toolName: string; arguments?: string }[],
+		mcpTools: { server: string; tool: string }[]
+	): string {
+		if (block.type === 'text') { return block.text || ''; }
+		if (block.type === 'tool_use') {
+			const toolName: string = block.name || 'unknown';
+			if (this.isMcpToolFn(toolName)) {
+				mcpTools.push({ server: this.extractMcpServerNameFn(toolName), tool: toolName });
+			} else {
+				toolCalls.push({ toolName, arguments: block.input ? JSON.stringify(block.input) : undefined });
+			}
+		}
+		return '';
 	}
 
 	async analyzeUsage(sessionFile: string, ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {

--- a/vscode-extension/src/adapters/crushAdapter.ts
+++ b/vscode-extension/src/adapters/crushAdapter.ts
@@ -169,17 +169,24 @@ export class CrushAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, 
 		for (const assistantMsg of turnAssistantMsgs) {
 			if (!model) { model = assistantMsg.model || null; }
 			for (const part of (Array.isArray(assistantMsg.parts) ? assistantMsg.parts : [])) {
-				if (part?.type === 'text' && part?.text) {
-					assistantText += part.text;
-				} else if (part?.type === 'tool_call' && part?.data?.name) {
-					toolCalls.push({
-						toolName: part.data.name,
-						arguments: part.data.arguments ? JSON.stringify(part.data.arguments) : undefined
-					});
-				}
+				assistantText += this.processCrushMessagePart(part, toolCalls);
 			}
 		}
 		return { assistantText, toolCalls, model };
+	}
+
+	private processCrushMessagePart(
+		part: any,
+		toolCalls: { toolName: string; arguments?: string; result?: string }[]
+	): string {
+		if (part?.type === 'text' && part?.text) { return part.text as string; }
+		if (part?.type === 'tool_call' && part?.data?.name) {
+			toolCalls.push({
+				toolName: part.data.name,
+				arguments: part.data.arguments ? JSON.stringify(part.data.arguments) : undefined
+			});
+		}
+		return '';
 	}
 
 	async getSyncData(sessionFile: string): Promise<{ tokens: number; interactions: number; modelUsage: ModelUsage; timestamp: number }> {

--- a/vscode-extension/src/adapters/mistralVibeAdapter.ts
+++ b/vscode-extension/src/adapters/mistralVibeAdapter.ts
@@ -123,19 +123,28 @@ export class MistralVibeAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 		for (let j = userIdx + 1; j < nextUserIdx; j++) {
 			const msg = messages[j];
 			if (msg.role === 'assistant') {
-				if (typeof msg.content === 'string') { assistantText += msg.content; }
-				for (const tc of (Array.isArray(msg.tool_calls) ? msg.tool_calls : [])) {
-					toolCalls.push({
-						toolName: tc.function?.name || tc.name || 'unknown',
-						arguments: tc.function?.arguments ? JSON.stringify(tc.function.arguments) : undefined
-					});
-				}
+				assistantText += this.processMistralAssistantMsg(msg, toolCalls);
 			} else if (msg.role === 'tool') {
 				const last = toolCalls[toolCalls.length - 1];
 				if (last) { last.result = typeof msg.content === 'string' ? msg.content : undefined; }
 			}
 		}
 		return { assistantText, toolCalls };
+	}
+
+	private processMistralAssistantMsg(
+		msg: any,
+		toolCalls: { toolName: string; arguments?: string; result?: string }[]
+	): string {
+		let text = '';
+		if (typeof msg.content === 'string') { text = msg.content; }
+		for (const tc of (Array.isArray(msg.tool_calls) ? msg.tool_calls : [])) {
+			toolCalls.push({
+				toolName: tc.function?.name || tc.name || 'unknown',
+				arguments: tc.function?.arguments ? JSON.stringify(tc.function.arguments) : undefined
+			});
+		}
+		return text;
 	}
 
 	async analyzeUsage(sessionFile: string, ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {

--- a/vscode-extension/src/adapters/openCodeAdapter.ts
+++ b/vscode-extension/src/adapters/openCodeAdapter.ts
@@ -213,19 +213,26 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 			}
 			const assistantParts = await this.openCode.getOpenCodePartsForMessage(assistantMsg.id);
 			for (const part of assistantParts) {
-				if (part.type === 'text' && part.text) {
-					assistantText += part.text;
-				} else if (part.type === 'tool' && part.tool) {
-					toolCalls.push({
-						toolName: part.tool,
-						arguments: part.state?.input ? JSON.stringify(part.state.input) : undefined,
-						result: part.state?.output || undefined
-					});
-				}
+				assistantText += this.processOpenCodePart(part, toolCalls);
 			}
 		}
 		const turnOutputAndThinking = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.output || 0) + (m.tokens?.reasoning || 0), 0);
 		return { assistantText, toolCalls, model, thinkingTokens, turnCumulativeTotal, turnOutputAndThinking };
+	}
+
+	private processOpenCodePart(
+		part: any,
+		toolCalls: { toolName: string; arguments?: string; result?: string }[]
+	): string {
+		if (part.type === 'text' && part.text) { return part.text as string; }
+		if (part.type === 'tool' && part.tool) {
+			toolCalls.push({
+				toolName: part.tool,
+				arguments: part.state?.input ? JSON.stringify(part.state.input) : undefined,
+				result: part.state?.output || undefined
+			});
+		}
+		return '';
 	}
 
 	async getSyncData(sessionFile: string): Promise<{ tokens: number; interactions: number; modelUsage: ModelUsage; timestamp: number }> {


### PR DESCRIPTION
Extracts helper methods to reduce complexity in 4 adapter files:

- `claudeDesktopAdapter`: `processEventContentBlock` + `extractUsageTokens` (complexity 23→12)
- `crushAdapter`: `processCrushMessagePart` (complexity 16→8)
- `mistralVibeAdapter`: `processMistralAssistantMsg` (cognitive 24→12)
- `openCodeAdapter`: `processOpenCodePart` (complexity 17→9)