### PR TITLE
feat: add Lines-of-Code output charts with restructured chart controls

### DIFF
--- a/vscode-extension/src/chartDataBuilder.ts
+++ b/vscode-extension/src/chartDataBuilder.ts
@@ -1,4 +1,4 @@
-import type { DailyTokenStats, ChartDataPayload, ModelUsage } from './types';
+import type { DailyTokenStats, ChartDataPayload, ModelUsage, LanguageUsage } from './types';
 import { addModelUsage } from './statsHelpers';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 
@@ -57,11 +57,29 @@ export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDat
 			if (!target.editorUsage[e]) { target.editorUsage[e] = { tokens: 0, sessions: 0 }; }
 			target.editorUsage[e].tokens += u.tokens;
 			target.editorUsage[e].sessions += u.sessions;
+			if (u.linesAdded !== undefined) { target.editorUsage[e].linesAdded = (target.editorUsage[e].linesAdded ?? 0) + u.linesAdded; }
+			if (u.linesRemoved !== undefined) { target.editorUsage[e].linesRemoved = (target.editorUsage[e].linesRemoved ?? 0) + u.linesRemoved; }
 		}
 		for (const [r, u] of Object.entries(src.repositoryUsage)) {
 			if (!target.repositoryUsage[r]) { target.repositoryUsage[r] = { tokens: 0, sessions: 0 }; }
 			target.repositoryUsage[r].tokens += u.tokens;
 			target.repositoryUsage[r].sessions += u.sessions;
+			if (u.linesAdded !== undefined) { target.repositoryUsage[r].linesAdded = (target.repositoryUsage[r].linesAdded ?? 0) + u.linesAdded; }
+			if (u.linesRemoved !== undefined) { target.repositoryUsage[r].linesRemoved = (target.repositoryUsage[r].linesRemoved ?? 0) + u.linesRemoved; }
+		}
+		if (src.linesAdded !== undefined) {
+			target.linesAdded = (target.linesAdded ?? 0) + src.linesAdded;
+		}
+		if (src.linesRemoved !== undefined) {
+			target.linesRemoved = (target.linesRemoved ?? 0) + src.linesRemoved;
+		}
+		if (src.languageUsage) {
+			if (!target.languageUsage) { target.languageUsage = {}; }
+			for (const [ext, usage] of Object.entries(src.languageUsage)) {
+				if (!target.languageUsage[ext]) { target.languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+				target.languageUsage[ext].linesAdded += usage.linesAdded;
+				target.languageUsage[ext].linesRemoved += usage.linesRemoved;
+			}
 		}
 	};
 
@@ -142,6 +160,44 @@ export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDat
 		const costData = entries.map(e => deps.calculateEstimatedCost(e.modelUsage, 'copilot'));
 		const totalCost = costData.reduce((a, b) => a + b, 0);
 
+		const locData = entries.map(e => (e.linesAdded ?? 0) + (e.linesRemoved ?? 0));
+		const linesAddedData = entries.map(e => e.linesAdded ?? 0);
+		const linesRemovedData = entries.map(e => e.linesRemoved ?? 0);
+		const totalLinesAdded = entries.reduce((s, e) => s + (e.linesAdded ?? 0), 0);
+		const totalLinesRemoved = entries.reduce((s, e) => s + (e.linesRemoved ?? 0), 0);
+		const totalLoc = totalLinesAdded + totalLinesRemoved;
+		const avgLocPerPeriod = entries.length > 0 ? totalLoc / entries.length : 0;
+
+		const allLanguages = new Set<string>();
+		entries.forEach(e => { if (e.languageUsage) { Object.keys(e.languageUsage).forEach(l => allLanguages.add(l)); } });
+		const languageDatasets = Array.from(allLanguages).map((lang, idx) => {
+			const color = getModelColor(idx);
+			return {
+				label: lang,
+				data: entries.map(e => (e.languageUsage?.[lang]?.linesAdded ?? 0) + (e.languageUsage?.[lang]?.linesRemoved ?? 0)),
+				backgroundColor: color.bg, borderColor: color.border, borderWidth: 1,
+			};
+		});
+
+		const locEditorDatasets = Array.from(allEditors).map((editor, idx) => {
+			const color = getModelColor(idx);
+			return {
+				label: editor,
+				data: entries.map(e => (e.editorUsage[editor]?.linesAdded ?? 0) + (e.editorUsage[editor]?.linesRemoved ?? 0)),
+				backgroundColor: color.bg, borderColor: color.border, borderWidth: 1,
+			};
+		});
+
+		const locRepositoryDatasets = Array.from(allRepos).map((repo, idx) => {
+			const color = getModelColor(idx);
+			return {
+				label: deps.getRepoDisplayName(repo),
+				fullRepo: repo,
+				data: entries.map(e => (e.repositoryUsage[repo]?.linesAdded ?? 0) + (e.repositoryUsage[repo]?.linesRemoved ?? 0)),
+				backgroundColor: color.bg, borderColor: color.border, borderWidth: 1,
+			};
+		});
+
 		return {
 			labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets,
 			periodCount, totalTokens, totalSessions,
@@ -149,6 +205,15 @@ export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDat
 			costData,
 			totalCost,
 			avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0,
+			locData,
+			linesAddedData,
+			linesRemovedData,
+			languageDatasets,
+			locEditorDatasets,
+			locRepositoryDatasets,
+			totalLinesAdded,
+			totalLinesRemoved,
+			avgLocPerPeriod,
 		};
 	};
 
@@ -215,6 +280,9 @@ export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDat
 	const monthlyBuckets = Array.from(monthBucketMap.values()).sort((a, b) => a.key.localeCompare(b.key));
 	const monthlyPeriod = buildPeriodData(monthlyBuckets);
 
+	const hasLocData = Array.from(dailyBucketMap.values()).some(b => (b.stats.linesAdded ?? 0) + (b.stats.linesRemoved ?? 0) > 0)
+		|| fullDailyStats.some(d => (d.linesAdded ?? 0) + (d.linesRemoved ?? 0) > 0);
+
 	// ── Summary totals from the daily period (last 30 days) ──────────
 	const editorTotalsMap: Record<string, number> = {};
 	dailyBuckets.forEach(b => {
@@ -254,5 +322,6 @@ export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDat
 			week: weeklyPeriod,
 			month: monthlyPeriod,
 		},
+		hasLocData,
 	};
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -216,7 +216,7 @@ type StatusBarDisplaySetting = 'none' | 'today' | 'last30days' | 'currentMonth' 
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 51; // Tokens (input+output) excludes cached tokens
+	private static readonly CACHE_VERSION = 52; // Added LOC (linesAdded/linesRemoved/languageUsage)
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -299,6 +299,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private lastChartPeriod: 'day' | 'week' | 'month' = 'day';
 	/** Last view selected by the user in the chart view; restored on next open. */
 	private lastChartView: 'total' | 'model' | 'editor' | 'repository' | 'cost' = 'total';
+	private lastChartMetric: string = 'tokens';
+	private lastChartSplit: string = 'total';
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private lastDashboardData: any | undefined;
 	private tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsData.estimators;
@@ -3352,6 +3354,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 				debugLogOutputTokens: debugLogTokens.outputTokens,
 			} : {}),
 			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
+			...(usageAnalysis?.editScope?.linesAdded !== undefined && usageAnalysis.editScope.linesAdded > 0 ? {
+				linesAdded: usageAnalysis.editScope.linesAdded,
+				linesRemoved: usageAnalysis.editScope.linesRemoved ?? 0,
+				...(usageAnalysis.editScope.languageUsage ? { languageUsage: usageAnalysis.editScope.languageUsage } : {}),
+			} : {}),
 		};
 
 		this.setCachedSessionData(sessionFilePath, sessionData, fileSize);
@@ -3533,6 +3540,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(existingCache?.modelTurns !== undefined ? { modelTurns: existingCache.modelTurns } : {}),
 			...(existingCache?.debugLogInputTokens !== undefined ? { debugLogInputTokens: existingCache.debugLogInputTokens } : {}),
 			...(existingCache?.debugLogOutputTokens !== undefined ? { debugLogOutputTokens: existingCache.debugLogOutputTokens } : {}),
+			// Preserve LOC fields from existing cache
+			...(existingCache?.linesAdded !== undefined ? { linesAdded: existingCache.linesAdded } : {}),
+			...(existingCache?.linesRemoved !== undefined ? { linesRemoved: existingCache.linesRemoved } : {}),
+			...(existingCache?.languageUsage !== undefined ? { languageUsage: existingCache.languageUsage } : {}),
 			usageAnalysis: existingCache?.usageAnalysis || {
 				toolCalls: { total: 0, byTool: {} },
 				modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
@@ -4825,6 +4836,8 @@ usageAnalysis: undefined
 				if (v === 'total' || v === 'model' || v === 'editor' || v === 'repository' || v === 'cost') {
 					this.lastChartView = v;
 				}
+				if (typeof message.metric === 'string') { this.lastChartMetric = message.metric; }
+				if (typeof message.split === 'string') { this.lastChartSplit = message.split; }
 			}
 		});
 
@@ -8339,7 +8352,7 @@ ${hashtag}`;
       vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "chart.js"),
     );
 
-    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView };
+    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit };
 
     const initialData = JSON.stringify(chartData).replace(/</g, "\\u003c");
 

--- a/vscode-extension/src/statsHelpers.ts
+++ b/vscode-extension/src/statsHelpers.ts
@@ -5,7 +5,7 @@
  * imported by extension.ts and exercised in isolation by unit tests.
  */
 
-import type { ModelUsage, EditorUsage, DailyTokenStats, SessionFileCache } from './types';
+import type { ModelUsage, EditorUsage, DailyTokenStats, SessionFileCache, LanguageUsage } from './types';
 
 /**
  * Merges `source` model usage into `target` (in-place).
@@ -27,7 +27,48 @@ target[model].cacheCreationTokens = (target[model].cacheCreationTokens ?? 0) + u
 }
 
 /**
- * Adds editor usage (in-place) to a period's `editorUsage` map.
+ * Merges `source` language usage into `target` (in-place).
+ */
+export function addLanguageUsage(target: LanguageUsage, source: LanguageUsage): void {
+	for (const [ext, usage] of Object.entries(source)) {
+		if (!target[ext]) { target[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+		target[ext].linesAdded += usage.linesAdded;
+		target[ext].linesRemoved += usage.linesRemoved;
+	}
+}
+
+/**
+ * Attributes session-level LOC data to the given daily stats entry.
+ * Updates totals, editorUsage LOC fields, repositoryUsage LOC fields, and languageUsage.
+ */
+function attributeLocToDay(
+	dailyEntry: DailyTokenStats,
+	sessionData: SessionFileCache,
+	editorType: string,
+	repository: string,
+): void {
+	const linesAdded = sessionData.linesAdded ?? 0;
+	const linesRemoved = sessionData.linesRemoved ?? 0;
+	if (linesAdded === 0 && linesRemoved === 0) { return; }
+
+	dailyEntry.linesAdded = (dailyEntry.linesAdded ?? 0) + linesAdded;
+	dailyEntry.linesRemoved = (dailyEntry.linesRemoved ?? 0) + linesRemoved;
+
+	if (!dailyEntry.editorUsage[editorType]) { dailyEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
+	dailyEntry.editorUsage[editorType].linesAdded = (dailyEntry.editorUsage[editorType].linesAdded ?? 0) + linesAdded;
+	dailyEntry.editorUsage[editorType].linesRemoved = (dailyEntry.editorUsage[editorType].linesRemoved ?? 0) + linesRemoved;
+
+	if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
+	dailyEntry.repositoryUsage[repository].linesAdded = (dailyEntry.repositoryUsage[repository].linesAdded ?? 0) + linesAdded;
+	dailyEntry.repositoryUsage[repository].linesRemoved = (dailyEntry.repositoryUsage[repository].linesRemoved ?? 0) + linesRemoved;
+
+	if (sessionData.languageUsage && !dailyEntry.languageUsage) { dailyEntry.languageUsage = {}; }
+	if (sessionData.languageUsage && dailyEntry.languageUsage) {
+		addLanguageUsage(dailyEntry.languageUsage, sessionData.languageUsage);
+	}
+}
+
+/**
  * Each call increments `sessions` by 1 regardless of token count.
  */
 export function addEditorUsage(target: EditorUsage, editorType: string, tokens: number): void {
@@ -274,6 +315,33 @@ addModelUsage(lastMonthStats.modelUsage, dayRollup.modelUsage);
 
 // Only count as skipped if the session contributed to neither relevant window.
 if (!addedToLast30Days && !addedToLastMonth) { skippedCount++; }
+
+// Add LOC once per session to the latest day in the rollup window
+if (addedToLast30Days && sessionData.linesAdded !== undefined) {
+const dayKeys = Object.keys(sessionData.dailyRollups).sort();
+const locDay = dayKeys.filter(k => k >= last30DaysUtcStartKey).pop();
+if (locDay) {
+const locEntry = dailyStatsMap.get(locDay);
+if (locEntry) {
+locEntry.linesAdded = (locEntry.linesAdded ?? 0) + sessionData.linesAdded;
+locEntry.linesRemoved = (locEntry.linesRemoved ?? 0) + (sessionData.linesRemoved ?? 0);
+if (sessionData.languageUsage) {
+if (!locEntry.languageUsage) { locEntry.languageUsage = {}; }
+for (const [ext, usage] of Object.entries(sessionData.languageUsage)) {
+if (!locEntry.languageUsage[ext]) { locEntry.languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+locEntry.languageUsage[ext].linesAdded += usage.linesAdded;
+locEntry.languageUsage[ext].linesRemoved += usage.linesRemoved;
+}
+}
+if (!locEntry.editorUsage[editorType]) { locEntry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
+locEntry.editorUsage[editorType].linesAdded = (locEntry.editorUsage[editorType].linesAdded ?? 0) + sessionData.linesAdded;
+locEntry.editorUsage[editorType].linesRemoved = (locEntry.editorUsage[editorType].linesRemoved ?? 0) + (sessionData.linesRemoved ?? 0);
+if (!locEntry.repositoryUsage[repository]) { locEntry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
+locEntry.repositoryUsage[repository].linesAdded = (locEntry.repositoryUsage[repository].linesAdded ?? 0) + sessionData.linesAdded;
+locEntry.repositoryUsage[repository].linesRemoved = (locEntry.repositoryUsage[repository].linesRemoved ?? 0) + (sessionData.linesRemoved ?? 0);
+}
+}
+}
 } else {
 // ── Fallback: session-level attribution using UTC boundaries ─────
 // Used when the session cache has no per-day rollup data.
@@ -317,6 +385,22 @@ if (!dailyEntry.repositoryUsage[repository]) { dailyEntry.repositoryUsage[reposi
 dailyEntry.repositoryUsage[repository].tokens += tokens;
 dailyEntry.repositoryUsage[repository].sessions += 1;
 addModelUsage(dailyEntry.modelUsage, modelUsage);
+if (sessionData.linesAdded !== undefined) {
+dailyEntry.linesAdded = (dailyEntry.linesAdded ?? 0) + sessionData.linesAdded;
+dailyEntry.linesRemoved = (dailyEntry.linesRemoved ?? 0) + (sessionData.linesRemoved ?? 0);
+if (sessionData.languageUsage) {
+if (!dailyEntry.languageUsage) { dailyEntry.languageUsage = {}; }
+for (const [ext, usage] of Object.entries(sessionData.languageUsage)) {
+if (!dailyEntry.languageUsage[ext]) { dailyEntry.languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+dailyEntry.languageUsage[ext].linesAdded += usage.linesAdded;
+dailyEntry.languageUsage[ext].linesRemoved += usage.linesRemoved;
+}
+}
+dailyEntry.editorUsage[editorType].linesAdded = (dailyEntry.editorUsage[editorType].linesAdded ?? 0) + sessionData.linesAdded;
+dailyEntry.editorUsage[editorType].linesRemoved = (dailyEntry.editorUsage[editorType].linesRemoved ?? 0) + (sessionData.linesRemoved ?? 0);
+dailyEntry.repositoryUsage[repository].linesAdded = (dailyEntry.repositoryUsage[repository].linesAdded ?? 0) + sessionData.linesAdded;
+dailyEntry.repositoryUsage[repository].linesRemoved = (dailyEntry.repositoryUsage[repository].linesRemoved ?? 0) + (sessionData.linesRemoved ?? 0);
+}
 
 // Last-30-days accumulation
 last30DaysStats.tokens += tokens;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -55,6 +55,8 @@ export interface EditorUsage {
   [editorType: string]: {
     tokens: number;
     sessions: number;
+    linesAdded?: number;
+    linesRemoved?: number;
   };
 }
 
@@ -62,6 +64,15 @@ export interface RepositoryUsage {
   [repository: string]: {
     tokens: number;
     sessions: number;
+    linesAdded?: number;
+    linesRemoved?: number;
+  };
+}
+
+export interface LanguageUsage {
+  [extension: string]: {
+    linesAdded: number;
+    linesRemoved: number;
   };
 }
 
@@ -105,6 +116,9 @@ export interface DailyTokenStats {
   modelUsage: ModelUsage;
   editorUsage: EditorUsage;
   repositoryUsage: RepositoryUsage;
+  languageUsage?: LanguageUsage;
+  linesAdded?: number;
+  linesRemoved?: number;
 }
 
 /** Aggregated data for one time window (day/week/month) in the chart. */
@@ -127,6 +141,15 @@ export interface ChartPeriodData {
   totalCost: number;
   /** Average estimated cost per bar in USD (provider/API rates). Raw float, not rounded. */
   avgCostPerPeriod: number;
+  locData?: number[];
+  linesAddedData?: number[];
+  linesRemovedData?: number[];
+  languageDatasets?: object[];
+  locEditorDatasets?: object[];
+  locRepositoryDatasets?: object[];
+  totalLinesAdded?: number;
+  totalLinesRemoved?: number;
+  avgLocPerPeriod?: number;
 }
 
 /** Shape of the data payload sent to the chart webview (via window.__INITIAL_CHART__ or postMessage). */
@@ -157,6 +180,7 @@ export interface ChartDataPayload {
    * When false, the webview should indicate that those views are loading.
    */
   periodsReady?: boolean;
+  hasLocData?: boolean;
 }
 
 /** Per-UTC-day token/interaction breakdown for a single session. Used for accurate daily stats. */
@@ -189,6 +213,9 @@ export interface SessionFileCache {
   debugLogOutputTokens?: number; // Output token total from debug log (sum across all llm_request events)
   /** Per-UTC-day token/interaction breakdown (keyed by YYYY-MM-DD UTC). Used for consistent daily stats. */
   dailyRollups?: { [utcDayKey: string]: DailyRollupEntry };
+  linesAdded?: number;
+  linesRemoved?: number;
+  languageUsage?: LanguageUsage;
 }
 
 // Local copy of customization file entry type (mirrors webview/shared/contextRefUtils.ts)
@@ -287,6 +314,9 @@ export interface EditScopeUsage {
   multiFileEdits: number; // Edit sessions touching 2+ files
   totalEditedFiles: number; // Total unique files edited
   avgFilesPerSession: number; // Average files per edit session
+  linesAdded?: number;
+  linesRemoved?: number;
+  languageUsage?: LanguageUsage;
 }
 
 export interface ApplyButtonUsage {

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -19,6 +19,7 @@ import type {
 	UsageAnalysisPeriod,
 	ModelPricing,
 	TokenEstimator,
+	LanguageUsage,
 } from './types';
 import {
 	applyDelta,
@@ -279,6 +280,18 @@ interface EditMetrics {
 	editedFilePaths: string[];
 	codeBlocks: number;
 	applies: number;
+	linesAdded: number;
+	linesRemoved: number;
+	languageUsage: LanguageUsage;
+}
+
+function normalizeExtension(filePath: string): string {
+	const name = filePath.split('/').pop()?.split('\\').pop() ?? '';
+	const dotIdx = name.lastIndexOf('.');
+	if (dotIdx <= 0) {
+		return name.toLowerCase() || 'unknown';
+	}
+	return name.slice(dotIdx + 1).toLowerCase();
 }
 
 /**
@@ -318,12 +331,40 @@ function extractEditMetrics(req: SessionRequestRaw): EditMetrics {
 	const editedFilePaths: string[] = [];
 	let codeBlocks = 0;
 	let applies = 0;
+	let linesAdded = 0;
+	let linesRemoved = 0;
+	const languageUsage: LanguageUsage = {};
 
 	if (req.response && Array.isArray(req.response)) {
 		for (const respRaw of req.response as ResponseItemRaw[]) {
 			if (!respRaw) { continue; }
 			if (respRaw.kind === 'textEditGroup' && respRaw.uri) {
-				editedFilePaths.push(respRaw.uri.path || JSON.stringify(respRaw.uri));
+				const filePath = respRaw.uri.path || JSON.stringify(respRaw.uri);
+				editedFilePaths.push(filePath);
+
+				const ext = normalizeExtension(filePath);
+				const respRawAny = respRaw as unknown as { edits?: unknown };
+				if (Array.isArray(respRawAny.edits)) {
+					for (const editGroup of respRawAny.edits as unknown[]) {
+						if (!Array.isArray(editGroup)) { continue; }
+						for (const edit of editGroup as unknown[]) {
+							if (!edit || typeof edit !== 'object') { continue; }
+							const editObj = edit as { text?: unknown; range?: { startLineNumber?: number; endLineNumber?: number } };
+							if (typeof editObj.text === 'string' && editObj.text) {
+								const added = (editObj.text.match(/\n/g) ?? []).length + (editObj.text.endsWith('\n') ? 0 : 1);
+								linesAdded += added;
+								if (!languageUsage[ext]) { languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+								languageUsage[ext].linesAdded += added;
+							}
+							if (editObj.range && typeof editObj.range.startLineNumber === 'number' && typeof editObj.range.endLineNumber === 'number') {
+								const removed = Math.max(0, editObj.range.endLineNumber - editObj.range.startLineNumber);
+								linesRemoved += removed;
+								if (!languageUsage[ext]) { languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+								languageUsage[ext].linesRemoved += removed;
+							}
+						}
+					}
+				}
 			}
 			if (respRaw.kind === 'codeblockUri') {
 				codeBlocks++;
@@ -334,7 +375,7 @@ function extractEditMetrics(req: SessionRequestRaw): EditMetrics {
 		}
 	}
 
-	return { editedFilePaths, codeBlocks, applies };
+	return { editedFilePaths, codeBlocks, applies, linesAdded, linesRemoved, languageUsage };
 }
 
 /**
@@ -349,9 +390,12 @@ function processRequestsForEnhancedMetrics(
 	timestamps: number[],
 	timingsData: { firstProgress?: number; totalElapsed?: number }[],
 	waitTimes: number[]
-): { totalApplies: number; totalCodeBlocks: number } {
+): { totalApplies: number; totalCodeBlocks: number; totalLinesAdded: number; totalLinesRemoved: number; languageUsage: LanguageUsage } {
 	let totalApplies = 0;
 	let totalCodeBlocks = 0;
+	let totalLinesAdded = 0;
+	let totalLinesRemoved = 0;
+	const languageUsage: LanguageUsage = {};
 	for (const requestRaw of requests) {
 		if (!requestRaw) { continue; }
 
@@ -369,8 +413,15 @@ function processRequestsForEnhancedMetrics(
 		for (const filePath of edits.editedFilePaths) { editedFiles.add(filePath); }
 		totalCodeBlocks += edits.codeBlocks;
 		totalApplies += edits.applies;
+		totalLinesAdded += edits.linesAdded;
+		totalLinesRemoved += edits.linesRemoved;
+		for (const [ext, usage] of Object.entries(edits.languageUsage)) {
+			if (!languageUsage[ext]) { languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+			languageUsage[ext].linesAdded += usage.linesAdded;
+			languageUsage[ext].linesRemoved += usage.linesRemoved;
+		}
 	}
-	return { totalApplies, totalCodeBlocks };
+	return { totalApplies, totalCodeBlocks, totalLinesAdded, totalLinesRemoved, languageUsage };
 }
 
 /**
@@ -1317,6 +1368,9 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 		const editedFiles = new Set<string>();
 		let totalApplies = 0;
 		let totalCodeBlocks = 0;
+		let totalLinesAdded = 0;
+		let totalLinesRemoved = 0;
+		const allLanguageUsage: LanguageUsage = {};
 		const timestamps: number[] = [];
 		const timingsData: { firstProgress?: number; totalElapsed?: number; }[] = [];
 		const waitTimes: number[] = [];
@@ -1329,7 +1383,7 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 		
 		if (isJsonl) {
 			// Handle delta-based JSONL format
-			const lines = fileContent.trim().split('\n').filter(l => l.trim());
+			const lines = fileContent.trim().split('\n').filter((l: string) => l.trim());
 			let isDeltaBased = false;
 			if (lines.length > 0) {
 				try {
@@ -1358,7 +1412,13 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 				
 				// Process requests
 				const requests = (sessionState.requests || []) as SessionRequestRaw[];
-				({ totalApplies, totalCodeBlocks } = processRequestsForEnhancedMetrics(requests, agentCounts, editedFiles, timestamps, timingsData, waitTimes));
+				let processedLoc: LanguageUsage;
+				({ totalApplies, totalCodeBlocks, totalLinesAdded, totalLinesRemoved, languageUsage: processedLoc } = processRequestsForEnhancedMetrics(requests, agentCounts, editedFiles, timestamps, timingsData, waitTimes));
+				for (const [ext, usage] of Object.entries(processedLoc)) {
+					if (!allLanguageUsage[ext]) { allLanguageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+					allLanguageUsage[ext].linesAdded += usage.linesAdded;
+					allLanguageUsage[ext].linesRemoved += usage.linesRemoved;
+				}
 			}
 		} else {
 			// Handle regular JSON files
@@ -1375,7 +1435,13 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 			
 			// Process requests
 			const requests = (sessionContent.requests ?? []) as SessionRequestRaw[];
-			({ totalApplies, totalCodeBlocks } = processRequestsForEnhancedMetrics(requests, agentCounts, editedFiles, timestamps, timingsData, waitTimes));
+			let processedLoc2: LanguageUsage;
+			({ totalApplies, totalCodeBlocks, totalLinesAdded, totalLinesRemoved, languageUsage: processedLoc2 } = processRequestsForEnhancedMetrics(requests, agentCounts, editedFiles, timestamps, timingsData, waitTimes));
+			for (const [ext, usage] of Object.entries(processedLoc2)) {
+				if (!allLanguageUsage[ext]) { allLanguageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+				allLanguageUsage[ext].linesAdded += usage.linesAdded;
+				allLanguageUsage[ext].linesRemoved += usage.linesRemoved;
+			}
 		}
 		
 		// Store edit scope data
@@ -1384,7 +1450,10 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 			singleFileEdits: editedFiles.size === 1 ? 1 : 0,
 			multiFileEdits: editedFiles.size > 1 ? 1 : 0,
 			totalEditedFiles: editedFiles.size,
-			avgFilesPerSession: editSessionCount > 0 ? editedFiles.size / editSessionCount : 0
+			avgFilesPerSession: editSessionCount > 0 ? editedFiles.size / editSessionCount : 0,
+			linesAdded: totalLinesAdded,
+			linesRemoved: totalLinesRemoved,
+			...(Object.keys(allLanguageUsage).length > 0 ? { languageUsage: allLanguageUsage } : {}),
 		};
 		
 		// Store apply button usage
@@ -1468,7 +1537,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 		// Handle .jsonl files OR .json files with JSONL content (Copilot CLI format and VS Code incremental format)
 		const isJsonl = sessionFile.endsWith('.jsonl') || isJsonlContent(fileContent);
 		if (isJsonl) {
-			const lines = fileContent.trim().split('\n').filter(l => l.trim());
+			const lines = fileContent.trim().split('\n').filter((l: string) => l.trim());
 
 			// Detect if this is delta-based format (VS Code incremental)
 			let isDeltaBased = false;

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -34,6 +34,15 @@ type ChartPeriodData = {
 	costData: number[];
 	totalCost: number;
 	avgCostPerPeriod: number;
+	locData?: number[];
+	linesAddedData?: number[];
+	linesRemovedData?: number[];
+	languageDatasets?: ModelDataset[];
+	locEditorDatasets?: ModelDataset[];
+	locRepositoryDatasets?: RepositoryDataset[];
+	totalLinesAdded?: number;
+	totalLinesRemoved?: number;
+	avgLocPerPeriod?: number;
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
@@ -55,8 +64,11 @@ type InitialChartData = {
 	backendConfigured?: boolean;
 	compactNumbers?: boolean;
 	periodsReady?: boolean;
+	hasLocData?: boolean;
 	initialPeriod?: ChartPeriod;
 	initialView?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
+	initialMetric?: 'tokens' | 'output' | 'cost';
+	initialSplit?: 'total' | 'model' | 'editor' | 'repository' | 'language';
 	periods?: {
 		day: ChartPeriodData;
 		week: ChartPeriodData;
@@ -86,10 +98,12 @@ async function loadChartModule(): Promise<void> {
 	const mod = await import('chart.js/auto');
 	Chart = mod.default;
 }
-let currentView: 'total' | 'model' | 'editor' | 'repository' | 'cost' = 'total';
+let currentMetric: 'tokens' | 'output' | 'cost' = 'tokens';
+let currentSplit: 'total' | 'model' | 'editor' | 'repository' | 'language' = 'total';
 let currentPeriod: ChartPeriod = 'day';
 // Stores state to restore after a background data update re-initializes the chart
-let pendingView: typeof currentView | null = null;
+let pendingMetric: typeof currentMetric | null = null;
+let pendingSplit: typeof currentSplit | null = null;
 let pendingPeriod: ChartPeriod | null = null;
 
 type DisplayMode = 'actual' | 'rolling';
@@ -97,18 +111,22 @@ let currentDisplayMode: DisplayMode = 'actual';
 
 type ChartWebviewState = {
 	period: ChartPeriod;
-	view: 'total' | 'model' | 'editor' | 'repository' | 'cost';
+	metric: 'tokens' | 'output' | 'cost';
+	split: 'total' | 'model' | 'editor' | 'repository' | 'language';
 	displayMode: DisplayMode;
+	/** @deprecated Use metric + split instead. Kept for migration of old saved state. */
+	view?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
 };
 
 const chartState = createViewStateManager<ChartWebviewState>(vscode, {
 	period: 'day',
-	view: 'total',
+	metric: 'tokens',
+	split: 'total',
 	displayMode: 'actual',
 });
 
 function saveWebviewState(): void {
-	chartState.save({ period: currentPeriod, view: currentView, displayMode: currentDisplayMode });
+	chartState.save({ period: currentPeriod, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode });
 }
 const ROLLING_WINDOW: Record<ChartPeriod, number> = { day: 7, week: 4, month: 3 };
 
@@ -128,8 +146,18 @@ function getRollingLabel(): string {
 
 function getChartTitle(): string {
 	const periodMeta = PERIOD_LABELS[currentPeriod];
-	let titleText = currentView === 'cost' ? periodMeta.costTitle : periodMeta.title;
-	if (currentDisplayMode === 'rolling' && (currentView === 'total' || currentView === 'cost')) {
+	if (currentMetric === 'cost') {
+		let titleText = periodMeta.costTitle;
+		if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
+			titleText += ` (${getRollingLabel()})`;
+		}
+		return titleText;
+	}
+	if (currentMetric === 'output') {
+		return periodMeta.outputTitle;
+	}
+	let titleText = periodMeta.title;
+	if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 		titleText += ` (${getRollingLabel()})`;
 	}
 	return titleText;
@@ -158,10 +186,10 @@ function getActivePeriodData(data: InitialChartData): ChartPeriodData {
 	};
 }
 
-const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string; costTitle: string; avgCostLabel: string }> = {
-	day:   { title: 'Token Usage – Last 30 Days',  footer: 'Day-by-day token usage for the last 30 days',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day',   costTitle: 'Est. Cost – Last 30 Days',  avgCostLabel: 'Avg Cost / Day'   },
-	week:  { title: 'Token Usage – Last 6 Weeks',  footer: 'Week-by-week token usage for the last 6 weeks', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week',  costTitle: 'Est. Cost – Last 6 Weeks',  avgCostLabel: 'Avg Cost / Week'  },
-	month: { title: 'Token Usage – Last 12 Months', footer: 'Monthly token usage for the last 12 months',   countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month', costTitle: 'Est. Cost – Last 12 Months', avgCostLabel: 'Avg Cost / Month' },
+const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string; costTitle: string; avgCostLabel: string; outputTitle: string; avgLocLabel: string }> = {
+	day:   { title: 'Token Usage – Last 30 Days',  footer: 'Day-by-day token usage for the last 30 days',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day',   costTitle: 'Est. Cost – Last 30 Days',  avgCostLabel: 'Avg Cost / Day',   outputTitle: 'Lines of Code – Last 30 Days',  avgLocLabel: 'Avg Lines / Day'   },
+	week:  { title: 'Token Usage – Last 6 Weeks',  footer: 'Week-by-week token usage for the last 6 weeks', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week',  costTitle: 'Est. Cost – Last 6 Weeks',  avgCostLabel: 'Avg Cost / Week',  outputTitle: 'Lines of Code – Last 6 Weeks',  avgLocLabel: 'Avg Lines / Week'  },
+	month: { title: 'Token Usage – Last 12 Months', footer: 'Monthly token usage for the last 12 months',   countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month', costTitle: 'Est. Cost – Last 12 Months', avgCostLabel: 'Avg Cost / Month', outputTitle: 'Lines of Code – Last 12 Months', avgLocLabel: 'Avg Lines / Month' },
 };
 
 function renderLayout(data: InitialChartData): void {
@@ -208,8 +236,19 @@ function renderLayout(data: InitialChartData): void {
 	cards.id = 'summary-cards';
 	cards.append(
 		buildCard('card-period-count',  periodMeta.countLabel,   periodData.periodCount.toLocaleString()),
-		buildCard('card-total-tokens',  currentView === 'cost' ? 'Total Cost (est.)' : 'Total Tokens', currentView === 'cost' ? `$${periodData.totalCost.toFixed(2)}` : formatCompact(periodData.totalTokens)),
-		buildCard('card-avg-tokens',    currentView === 'cost' ? periodMeta.avgCostLabel : periodMeta.avgLabel, currentView === 'cost' ? `$${periodData.avgCostPerPeriod.toFixed(2)}` : formatCompact(periodData.avgPerPeriod)),
+		buildCard('card-total-tokens',
+			currentMetric === 'cost' ? 'Total Cost (est.)' :
+			currentMetric === 'output' ? 'Total Lines (AI)' : 'Total Tokens',
+			currentMetric === 'cost' ? `$${periodData.totalCost.toFixed(2)}` :
+			currentMetric === 'output' ? ((periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0)).toLocaleString() :
+			formatCompact(periodData.totalTokens)),
+		buildCard('card-avg-tokens',
+			currentMetric === 'cost' ? periodMeta.avgCostLabel :
+			currentMetric === 'output' ? periodMeta.avgLocLabel :
+			periodMeta.avgLabel,
+			currentMetric === 'cost' ? `$${periodData.avgCostPerPeriod.toFixed(2)}` :
+			currentMetric === 'output' ? Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString() :
+			formatCompact(periodData.avgPerPeriod)),
 		buildCard('card-total-sessions','Total Sessions',         periodData.totalSessions.toLocaleString())
 	);
 	summarySection.append(cards);
@@ -247,22 +286,60 @@ function renderLayout(data: InitialChartData): void {
 
 	const chartShell = el('div', 'chart-shell');
 
-	// Chart view toggle row
+	// Supported metric/split combos
+	const isComboSupported = (metric: string, split: string): boolean => {
+		if (metric === 'cost') { return split === 'total'; }
+		if (metric === 'output') { return split !== 'model'; }
+		return split !== 'language'; // tokens
+	};
+
+	// Chart controls: [Metric group] | [Split group] | [Rolling avg]
 	const toggles = el('div', 'chart-controls');
-	const totalBtn = el('button', `toggle${currentView === 'total' ? ' active' : ''}`, 'Total Tokens');
-	totalBtn.id = 'view-total';
-	const modelBtn = el('button', `toggle${currentView === 'model' ? ' active' : ''}`, 'By Model');
-	modelBtn.id = 'view-model';
-	const editorBtn = el('button', `toggle${currentView === 'editor' ? ' active' : ''}`, 'By Editor');
-	editorBtn.id = 'view-editor';
-	const repoBtn = el('button', `toggle${currentView === 'repository' ? ' active' : ''}`, 'By Repository');
-	repoBtn.id = 'view-repository';
-	const costBtn = el('button', `toggle${currentView === 'cost' ? ' active' : ''}`, '💰 Est. Cost');
-	costBtn.id = 'view-cost';
-	const rollingApplicableNow = currentView === 'total' || currentView === 'cost';
-	const rollingBtn = el('button', `toggle rolling-toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicableNow ? '' : ' hidden'}`, '📈 Rolling Avg');
+
+	// Metric group
+	const metricGroup = el('div', 'control-group');
+	const tokensBtn = el('button', `toggle${currentMetric === 'tokens' ? ' active' : ''}`, 'Tokens');
+	tokensBtn.id = 'metric-tokens';
+	const outputBtn = el('button', `toggle${currentMetric === 'output' ? ' active' : ''}${!data.hasLocData ? ' dim' : ''}`, '✏️ Output');
+	outputBtn.id = 'metric-output';
+	if (!data.hasLocData) {
+		outputBtn.title = 'No edit data available yet (VS Code edit/agent sessions only)';
+	}
+	const costBtn = el('button', `toggle${currentMetric === 'cost' ? ' active' : ''}`, '💰 Cost');
+	costBtn.id = 'metric-cost';
+	metricGroup.append(tokensBtn, outputBtn, costBtn);
+
+	const sep1 = el('div', 'control-group-separator');
+
+	// Split group
+	const splitGroup = el('div', 'control-group');
+	const makeSplitBtn = (id: string, split: string, label: string) => {
+		const supported = isComboSupported(currentMetric, split);
+		const btn = el('button', `toggle${currentSplit === split ? ' active' : ''}${!supported ? ' disabled' : ''}`, label);
+		btn.id = id;
+		if (!supported) {
+			(btn as HTMLButtonElement).disabled = true;
+			btn.title = `Not available for ${currentMetric} metric`;
+		}
+		return btn;
+	};
+	const totalSplitBtn = makeSplitBtn('split-total', 'total', 'Total');
+	const modelSplitBtn = makeSplitBtn('split-model', 'model', 'By Model');
+	const editorSplitBtn = makeSplitBtn('split-editor', 'editor', 'By Editor');
+	const repoSplitBtn = makeSplitBtn('split-repository', 'repository', 'By Repository');
+	const langSplitBtn = makeSplitBtn('split-language', 'language', 'By Language');
+	splitGroup.append(totalSplitBtn, modelSplitBtn, editorSplitBtn, repoSplitBtn, langSplitBtn);
+
+	const sep2 = el('div', 'control-group-separator');
+
+	// Rolling avg group (only visible for total split with tokens/cost)
+	const rollingGroup = el('div', 'control-group');
+	const rollingApplicableNow = currentSplit === 'total' && currentMetric !== 'output';
+	const rollingBtn = el('button', `toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicableNow ? '' : ' hidden'}`, '📈 Rolling Avg');
 	rollingBtn.id = 'view-rolling';
-	toggles.append(totalBtn, modelBtn, editorBtn, repoBtn, costBtn, rollingBtn);
+	rollingGroup.append(rollingBtn);
+
+	toggles.append(metricGroup, sep1, splitGroup, sep2, rollingGroup);
 
 	const canvasWrap = el('div', 'canvas-wrap');
 	const canvas = document.createElement('canvas');
@@ -329,9 +406,13 @@ function updateSummaryCards(data: InitialChartData): void {
 
 	updateCard('card-period-count', periodMeta.countLabel, periodData.periodCount.toLocaleString());
 
-	if (currentView === 'cost') {
+	if (currentMetric === 'cost') {
 		updateCard('card-total-tokens', 'Total Cost (est.)', `$${periodData.totalCost.toFixed(2)}`);
 		updateCard('card-avg-tokens', periodMeta.avgCostLabel, `$${periodData.avgCostPerPeriod.toFixed(2)}`);
+	} else if (currentMetric === 'output') {
+		const totalLines = (periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0);
+		updateCard('card-total-tokens', 'Total Lines (AI)', totalLines.toLocaleString());
+		updateCard('card-avg-tokens', periodMeta.avgLocLabel, Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString());
 	} else {
 		updateCard('card-total-tokens', 'Total Tokens', formatCompact(periodData.totalTokens));
 		updateCard('card-avg-tokens', periodMeta.avgLabel, formatCompact(periodData.avgPerPeriod));
@@ -383,17 +464,28 @@ function wireInteractions(data: InitialChartData): void {
 		btn?.addEventListener('click', () => { void switchPeriod(period, data); });
 	});
 
-	// Chart view toggle buttons
-	const viewButtons = [
-		{ id: 'view-total',      view: 'total'      as const },
-		{ id: 'view-model',      view: 'model'      as const },
-		{ id: 'view-editor',     view: 'editor'     as const },
-		{ id: 'view-repository', view: 'repository' as const },
-		{ id: 'view-cost',       view: 'cost'       as const },
+	// Chart metric toggle buttons
+	const metricButtons: Array<{ id: string; metric: typeof currentMetric }> = [
+		{ id: 'metric-tokens', metric: 'tokens' },
+		{ id: 'metric-output', metric: 'output' },
+		{ id: 'metric-cost',   metric: 'cost'   },
 	];
-	viewButtons.forEach(({ id, view }) => {
+	metricButtons.forEach(({ id, metric }) => {
 		const btn = document.getElementById(id);
-		btn?.addEventListener('click', () => { void switchView(view, data); });
+		btn?.addEventListener('click', () => { void switchMetric(metric, data); });
+	});
+
+	// Chart split toggle buttons
+	const splitButtons: Array<{ id: string; split: typeof currentSplit }> = [
+		{ id: 'split-total',      split: 'total'      },
+		{ id: 'split-model',      split: 'model'      },
+		{ id: 'split-editor',     split: 'editor'     },
+		{ id: 'split-repository', split: 'repository' },
+		{ id: 'split-language',   split: 'language'   },
+	];
+	splitButtons.forEach(({ id, split }) => {
+		const btn = document.getElementById(id);
+		btn?.addEventListener('click', () => { void switchSplit(split, data); });
 	});
 
 	const rollingToggle = document.getElementById('view-rolling');
@@ -409,18 +501,24 @@ async function setupChart(canvas: HTMLCanvasElement, data: InitialChartData): Pr
 	if (!Chart) {
 		return;
 	}
-	chart = new Chart(ctx, createConfig('total', data));
+	chart = new Chart(ctx, createConfig(data));
 	// Restore the previously active period and view if a background update triggered a re-render
 	if (pendingPeriod !== null && pendingPeriod !== 'day') {
 		const periodToRestore = pendingPeriod;
 		currentPeriod = 'day';
 		await switchPeriod(periodToRestore, data);
-	} else if (pendingView !== null && pendingView !== 'total') {
-		const viewToRestore = pendingView;
-		currentView = 'total';
-		await switchView(viewToRestore, data);
+	} else if (pendingMetric !== null || pendingSplit !== null) {
+		const metricToRestore = pendingMetric ?? currentMetric;
+		const splitToRestore = pendingSplit ?? currentSplit;
+		currentMetric = 'tokens';
+		currentSplit = 'total';
+		await switchMetric(metricToRestore, data);
+		if (splitToRestore !== 'total') {
+			await switchSplit(splitToRestore, data);
+		}
 	}
-	pendingView = null;
+	pendingMetric = null;
+	pendingSplit = null;
 	pendingPeriod = null;
 }
 
@@ -449,44 +547,70 @@ async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promis
 	if (!Chart) {
 		return;
 	}
-	chart = new Chart(ctx, createConfig(currentView, data));
+	chart = new Chart(ctx, createConfig(data));
 }
 
-async function switchView(view: 'total' | 'model' | 'editor' | 'repository' | 'cost', data: InitialChartData): Promise<void> {
-	if (currentView === view) {
-		return;
-	}
-	const rollingApplicable = view === 'total' || view === 'cost';
-	if (!rollingApplicable) {
-		currentDisplayMode = 'actual';
-	}
-	currentView = view;
-	vscode.postMessage({ command: 'setViewPreference', view });
+async function switchMetric(metric: typeof currentMetric, data: InitialChartData): Promise<void> {
+	if (currentMetric === metric) { return; }
+	// When switching to cost, force split to total (only supported combo)
+	if (metric === 'cost') { currentSplit = 'total'; }
+	// When switching to output, disable unsupported splits
+	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; }
+	// When switching to tokens, disable language split
+	if (metric === 'tokens' && currentSplit === 'language') { currentSplit = 'total'; }
+	currentMetric = metric;
+	const rollingApplicable = currentSplit === 'total' && metric !== 'output';
+	if (!rollingApplicable) { currentDisplayMode = 'actual'; }
+	vscode.postMessage({ command: 'setViewPreference', metric: currentMetric, split: currentSplit });
 	saveWebviewState();
-	setActiveView(view);
+	setActiveMetric(metric);
+	setActiveSplit(currentSplit);
+	updateSplitButtonStates();
 	const rollingBtnEl = document.getElementById('view-rolling');
 	if (rollingBtnEl) {
 		rollingBtnEl.classList.toggle('hidden', !rollingApplicable);
 		rollingBtnEl.classList.toggle('active', rollingApplicable && currentDisplayMode === 'rolling');
 	}
 	updateSummaryCards(data);
-	if (!chart) {
-		return;
-	}
+	if (!chart) { return; }
 	const canvas = chart.canvas as HTMLCanvasElement | null;
 	chart.destroy();
-	if (!canvas) {
-		return;
-	}
+	if (!canvas) { return; }
 	const ctx = canvas.getContext('2d');
-	if (!ctx) {
-		return;
-	}
+	if (!ctx) { return; }
 	await loadChartModule();
-	if (!Chart) {
-		return;
+	if (!Chart) { return; }
+	chart = new Chart(ctx, createConfig(data));
+}
+
+async function switchSplit(split: typeof currentSplit, data: InitialChartData): Promise<void> {
+	if (currentSplit === split) { return; }
+	// Check if this combo is supported
+	const supported = (currentMetric === 'cost' && split === 'total') ||
+		(currentMetric === 'output' && split !== 'model') ||
+		(currentMetric === 'tokens' && split !== 'language');
+	if (!supported) { return; }
+	currentSplit = split;
+	const rollingApplicable = split === 'total' && currentMetric !== 'output';
+	if (!rollingApplicable) { currentDisplayMode = 'actual'; }
+	vscode.postMessage({ command: 'setViewPreference', metric: currentMetric, split: currentSplit });
+	saveWebviewState();
+	setActiveSplit(split);
+	const rollingBtnEl = document.getElementById('view-rolling');
+	if (rollingBtnEl) {
+		rollingBtnEl.classList.toggle('hidden', !rollingApplicable);
+		rollingBtnEl.classList.toggle('active', rollingApplicable && currentDisplayMode === 'rolling');
 	}
-	chart = new Chart(ctx, createConfig(view, data));
+	updateSummaryCards(data);
+	if (!chart) { return; }
+	const canvas = chart.canvas as HTMLCanvasElement | null;
+	chart.destroy();
+	if (!canvas) { return; }
+	const ctx = canvas.getContext('2d');
+	if (!ctx) { return; }
+	await loadChartModule();
+	if (!Chart) { return; }
+	chart = new Chart(ctx, createConfig(data));
 }
 
 function setActivePeriod(period: ChartPeriod): void {
@@ -497,13 +621,39 @@ function setActivePeriod(period: ChartPeriod): void {
 	});
 }
 
-function setActiveView(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'): void {
-	['view-total', 'view-model', 'view-editor', 'view-repository', 'view-cost'].forEach(id => {
+function setActiveMetric(metric: typeof currentMetric): void {
+	(['metric-tokens', 'metric-output', 'metric-cost'] as const).forEach(id => {
 		const btn = document.getElementById(id);
-		if (!btn) {
-			return;
-		}
-		btn.classList.toggle('active', id === `view-${view}`);
+		if (!btn) { return; }
+		btn.classList.toggle('active', id === `metric-${metric}`);
+	});
+}
+
+function setActiveSplit(split: typeof currentSplit): void {
+	(['split-total', 'split-model', 'split-editor', 'split-repository', 'split-language'] as const).forEach(id => {
+		const btn = document.getElementById(id);
+		if (!btn) { return; }
+		btn.classList.toggle('active', id === `split-${split}`);
+	});
+}
+
+function updateSplitButtonStates(): void {
+	const splits: Array<{ id: string; split: string }> = [
+		{ id: 'split-total',      split: 'total'      },
+		{ id: 'split-model',      split: 'model'      },
+		{ id: 'split-editor',     split: 'editor'     },
+		{ id: 'split-repository', split: 'repository' },
+		{ id: 'split-language',   split: 'language'   },
+	];
+	splits.forEach(({ id, split }) => {
+		const btn = document.getElementById(id) as HTMLButtonElement | null;
+		if (!btn) { return; }
+		const supported = (currentMetric === 'cost' && split === 'total') ||
+			(currentMetric === 'output' && split !== 'model') ||
+			(currentMetric === 'tokens' && split !== 'language');
+		btn.disabled = !supported;
+		btn.classList.toggle('disabled', !supported);
+		btn.title = supported ? '' : `Not available for ${currentMetric} metric`;
 	});
 }
 
@@ -526,11 +676,14 @@ async function switchDisplayMode(data: InitialChartData): Promise<void> {
 	if (!ctx) { return; }
 	await loadChartModule();
 	if (!Chart) { return; }
-	chart = new Chart(ctx, createConfig(currentView, data));
+	chart = new Chart(ctx, createConfig(data));
 }
 
-function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost', data: InitialChartData): ChartConfig {
+function createConfig(data: InitialChartData): ChartConfig {
 	const period = getActivePeriodData(data);
+	const view = currentMetric === 'tokens' ? (currentSplit === 'model' ? 'model' : currentSplit === 'editor' ? 'editor' : currentSplit === 'repository' ? 'repository' : 'total')
+		: currentMetric === 'cost' ? 'cost'
+		: `output-${currentSplit}`;
 
 	// Get CSS variables for theme-aware colors
 	const styles = getComputedStyle(document.body);
@@ -708,7 +861,58 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 		};
 	}
 
-	// Stacked views: model / editor / repository
+	// Output metric (lines of code)
+	if (view.startsWith('output-')) {
+		const locDatasets = view === 'output-language' ? (period.languageDatasets ?? []) :
+			view === 'output-editor' ? (period.locEditorDatasets ?? []) :
+			view === 'output-repository' ? (period.locRepositoryDatasets ?? []) :
+			// output-total: stacked added/removed
+			[
+				{
+					label: 'Lines Added',
+					data: period.linesAddedData ?? [],
+					backgroundColor: 'rgba(75, 192, 192, 0.6)',
+					borderColor: 'rgba(75, 192, 192, 1)',
+					borderWidth: 1,
+				},
+				{
+					label: 'Lines Removed',
+					data: (period.linesRemovedData ?? []).map((v: number) => -v),
+					backgroundColor: 'rgba(255, 99, 132, 0.6)',
+					borderColor: 'rgba(255, 99, 132, 1)',
+					borderWidth: 1,
+				},
+			];
+
+		return {
+			type: 'bar' as const,
+			data: { labels: period.labels, datasets: locDatasets as any },
+			options: {
+				...baseOptions,
+				plugins: {
+					...baseOptions.plugins,
+					legend: { position: 'top' as const, labels: { color: textColor, font: { size: 11 } } },
+					tooltip: {
+						...baseOptions.plugins.tooltip,
+						callbacks: {
+							label: (ctx: any) => ` ${Math.abs(Number(ctx.parsed.y)).toLocaleString()} lines`
+						}
+					}
+				},
+				scales: {
+					x: { stacked: view === 'output-total', grid: { color: gridColor }, ticks: { color: textColor, font: { size: 11 } } },
+					y: {
+						stacked: view === 'output-total',
+						grid: { color: gridColor },
+						ticks: { color: textColor, font: { size: 11 }, callback: (value: any) => Math.abs(Number(value)).toLocaleString() },
+						title: { display: true, text: 'Lines of Code', color: textColor, font: { size: 12, weight: 'bold' } }
+					}
+				}
+			}
+		};
+	}
+
+	// Stacked views: model / editor / repository (tokens metric)
 	// Compute total-token projection for the last bar and add a single "Projected" segment on top.
 	const lastIdx = period.tokensData.length - 1;
 	const fraction = getCurrentPeriodFraction(currentPeriod);
@@ -748,7 +952,7 @@ function createConfig(view: 'total' | 'model' | 'editor' | 'repository' | 'cost'
 						// (no API counts, no thinking tokens). Flag this in the chart
 						// tooltip whenever a JetBrains dataset is present in the hover.
 						footer: (items: any[]) => {
-							if (view !== 'editor') { return ''; }
+							if (currentSplit !== 'editor') { return ''; }
 							const hasJetBrains = items.some(i => i?.dataset?.label === 'JetBrains');
 							return hasJetBrains
 								? 'JetBrains: estimates from user messages + assistant text only.\nActual API counts and thinking tokens are not available.'
@@ -798,12 +1002,39 @@ async function bootstrap(): Promise<void> {
 	const hasSaved = !!vscode.getState();
 	if (hasSaved) {
 		currentPeriod = saved.period;
-		currentView = saved.view;
 		currentDisplayMode = saved.displayMode;
+		// Migrate old saved state: 'view' → metric + split
+		if (saved.view && !saved.metric) {
+			const viewMigration: Record<string, { metric: typeof currentMetric; split: typeof currentSplit }> = {
+				total:      { metric: 'tokens', split: 'total'      },
+				model:      { metric: 'tokens', split: 'model'      },
+				editor:     { metric: 'tokens', split: 'editor'     },
+				repository: { metric: 'tokens', split: 'repository' },
+				cost:       { metric: 'cost',   split: 'total'      },
+			};
+			const migration = viewMigration[saved.view] ?? { metric: 'tokens', split: 'total' };
+			currentMetric = migration.metric;
+			currentSplit = migration.split;
+		} else {
+			currentMetric = saved.metric ?? 'tokens';
+			currentSplit = saved.split ?? 'total';
+		}
 	} else {
 		// Fall back to server-supplied initial values (e.g., panel closed and reopened)
 		if (initialData.initialPeriod) { currentPeriod = initialData.initialPeriod; }
-		if (initialData.initialView) { currentView = initialData.initialView; }
+		if (initialData.initialMetric) { currentMetric = initialData.initialMetric; }
+		if (initialData.initialSplit) { currentSplit = initialData.initialSplit; }
+		// Legacy fallback from old initialView
+		else if (initialData.initialView) {
+			const legacyMap: Record<string, { metric: typeof currentMetric; split: typeof currentSplit }> = {
+				total: { metric: 'tokens', split: 'total' }, model: { metric: 'tokens', split: 'model' },
+				editor: { metric: 'tokens', split: 'editor' }, repository: { metric: 'tokens', split: 'repository' },
+				cost: { metric: 'cost', split: 'total' },
+			};
+			const mapped = legacyMap[initialData.initialView] ?? { metric: 'tokens', split: 'total' };
+			currentMetric = mapped.metric;
+			currentSplit = mapped.split;
+		}
 	}
 
 	renderLayout(initialData);
@@ -815,7 +1046,8 @@ void bootstrap();
 registerMessageHandler((message) => {
 	if (message.command === 'updateChartData') {
 		// Save current toggles for restoration after chart re-initializes
-		pendingView = currentView;
+		pendingMetric = currentMetric;
+		pendingSplit = currentSplit;
 		pendingPeriod = currentPeriod;
 		renderLayout(message.data as InitialChartData);
 	}

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -125,9 +125,24 @@ body {
 .chart-controls {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	align-items: center;
+	gap: 12px;
 	margin-bottom: 8px;
 	justify-content: center;
+}
+
+.control-group {
+	display: flex;
+	gap: 4px;
+	align-items: center;
+}
+
+.control-group-separator {
+	width: 1px;
+	height: 20px;
+	background: var(--border-subtle);
+	margin: 0 4px;
+	flex-shrink: 0;
 }
 
 .period-controls {
@@ -195,6 +210,15 @@ body {
 	display: none !important;
 }
 
-.rolling-toggle {
-	margin-left: 12px;
+.toggle.dim {
+	opacity: 0.6;
+}
+
+.toggle.disabled {
+	opacity: 0.45;
+	cursor: not-allowed;
+}
+
+.toggle.disabled:hover {
+	background: var(--button-secondary-bg);
 }


### PR DESCRIPTION
Adds LOC tracking from textEditGroup edits in VS Code sessions. Restructures chart controls into 3 groups: [Tokens|Output|Cost] | [Total|By Model|By Editor|By Repository|By Language] | [Rolling Avg].