### PR TITLE
feat: show sessions/interactions as columns and merge worktrees in repo hygiene list

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2737,6 +2737,54 @@ class CopilotTokenTracker implements vscode.Disposable {
 						}
 					}
 				}
+
+				// Pass 3 — Copilot CLI worktree dedup.
+				// The Copilot CLI creates per-branch worktrees at:
+				//   <home>/.copilot/copilot-worktrees/<repo-name>/<branch-name>
+				// Each branch shows up as a separate workspace with the branch name as basename,
+				// skewing the repo list. Merge all worktrees for the same repo into one entry,
+				// preferring the main checkout at <home>/.copilot/repos/<repo-name> when it exists.
+				{
+					const worktreeToCanonical = new Map<string, string>();
+
+					for (const key of Array.from(workspaceSessionCounts.keys())) {
+						const segments = key.split(path.sep);
+						const lowerSegments = segments.map(s => s.toLowerCase());
+						const wtIdx = lowerSegments.lastIndexOf('copilot-worktrees');
+						// Need at least <repo> and <branch> after copilot-worktrees
+						if (wtIdx === -1 || wtIdx + 2 >= segments.length) { continue; }
+
+						const repoName = segments[wtIdx + 1];
+						const reposPath = path.normalize(
+							segments.slice(0, wtIdx).concat('repos', repoName).join(path.sep)
+						);
+						const canonical = fs.existsSync(reposPath)
+							? reposPath
+							: path.normalize(segments.slice(0, wtIdx + 2).join(path.sep));
+						worktreeToCanonical.set(key, canonical);
+					}
+
+					const canonicals = new Set(worktreeToCanonical.values());
+					for (const canonical of canonicals) {
+						if (!workspaceSessionCounts.has(canonical)) {
+							workspaceSessionCounts.set(canonical, 0);
+							workspaceInteractionCounts.set(canonical, 0);
+						}
+						for (const [worktree, canon] of worktreeToCanonical) {
+							if (canon === canonical && worktree !== canonical && workspaceSessionCounts.has(worktree)) {
+								mergeInto(canonical, worktree);
+							}
+						}
+						if (!this._customizationFilesCache.has(canonical)) {
+							try {
+								const files = _scanWorkspaceCustomizationFiles(canonical);
+								this._customizationFilesCache.set(canonical, files);
+							} catch (e) {
+								// ignore scan errors per workspace
+							}
+						}
+					}
+				}
 			}
 
 			// Build the customization matrix using scanned workspace data and session counts

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -2212,24 +2212,40 @@ function renderRepositoryHygienePanels(): void {
 	listContainer.classList.remove('repo-hygiene-pane-collapsed');
 	detailsContainer.classList.toggle('repo-hygiene-pane-collapsed', !hasSelectedRepository);
 
-	listPane.innerHTML = visibleWorkspaces.map((ws, idx) => {
+	const colStyles = {
+		sessions: 'width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-secondary);',
+		interactions: 'width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-secondary);',
+		score: 'width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-secondary);',
+	};
+	const headerHtml = `
+		<div style="padding: 4px 12px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid var(--border-color); background: var(--bg-secondary);">
+			<div style="flex: 1; min-width: 0; font-size: 10px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Repository</div>
+			<div style="${colStyles.sessions} font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Sessions</div>
+			<div style="${colStyles.interactions} font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Interactions</div>
+			<div style="${colStyles.score} font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em;">Score</div>
+			<div style="width: 80px; flex-shrink: 0;"></div>
+		</div>
+	`;
+	listPane.innerHTML = headerHtml + visibleWorkspaces.map((ws, idx) => {
 		const record = repoAnalysisState.get(ws.workspacePath);
 		const hasResult = !!record?.data?.summary;
 		const scoreLabel = getScoreLabel(ws.workspacePath);
 		const buttonLabel = hasResult ? 'Details' : 'Analyze';
 		const buttonAction = hasResult ? 'details' : 'analyze';
 		const isCurrentSelection = selectedRepoPath === ws.workspacePath && hasSelectedRepository;
+		const sessions = Number(ws.sessionCount) || 0;
+		const interactions = Number(ws.interactionCount) || 0;
 		return `
-			<div class="repo-item" style="padding: 8px 12px; border-bottom: ${idx < visibleWorkspaces.length - 1 ? '1px solid var(--border-subtle)' : 'none'}; display: flex; align-items: center; justify-content: space-between; gap: 10px;">
+			<div class="repo-item" style="padding: 6px 12px; border-bottom: ${idx < visibleWorkspaces.length - 1 ? '1px solid var(--border-subtle)' : 'none'}; display: flex; align-items: center; gap: 10px;">
 				<div style="flex: 1; min-width: 0;">
 					<div class="repo-name" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'Courier New', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeHtml(ws.workspacePath)}">
 						${escapeHtml(ws.workspaceName)}
 					</div>
-					<div style="font-size: 10px; color: var(--text-muted); margin-top: 2px;">
-						${Number(ws.sessionCount) || 0} ${ws.sessionCount === 1 ? 'session' : 'sessions'} · ${Number(ws.interactionCount) || 0} ${ws.interactionCount === 1 ? 'interaction' : 'interactions'} · Score: ${escapeHtml(scoreLabel)}
-					</div>
 				</div>
-				<vscode-button class="btn-repo-action" data-action="${buttonAction}" data-workspace-path="${escapeHtml(ws.workspacePath)}" ${isCurrentSelection ? 'disabled="true"' : ''} style="min-width: 80px;">
+				<div style="${colStyles.sessions}">${sessions}</div>
+				<div style="${colStyles.interactions}">${interactions}</div>
+				<div style="${colStyles.score}">${escapeHtml(scoreLabel)}</div>
+				<vscode-button class="btn-repo-action" data-action="${buttonAction}" data-workspace-path="${escapeHtml(ws.workspacePath)}" ${isCurrentSelection ? 'disabled="true"' : ''} style="min-width: 80px; flex-shrink: 0;">
 					${buttonLabel}
 				</vscode-button>
 			</div>


### PR DESCRIPTION
## Changes

### UI: Repo hygiene table columns
- Sessions, Interactions, and Score are now shown as explicit **columns** in the Repository Hygiene list with a column header row
- The previous small muted sub-text under each repo name is removed — the same data is now prominently visible in aligned columns

### Backend: Merge Copilot CLI worktrees
- Added Pass 3 to workspace dedup: paths matching \~/.copilot/copilot-worktrees/<repo>/<branch>\ are merged into a single canonical repo entry
- Prefers \~/.copilot/repos/<repo>\ as canonical when that path exists on disk, so customization file scanning uses the main checkout
- Falls back to the worktree parent dir (\copilot-worktrees/<repo>\) when the repos path doesn't exist
- Prevents multiple branches/worktrees of the same repo from inflating the list and skewing session/interaction counts

All existing tests pass.