### PR TITLE
refactor: reduce complexity in cacheManager, sessionDiscovery, syncService

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -36,7 +36,7 @@ type ModelUsageEntry = { inputTokens: number; outputTokens: number; interactions
  * The caller is responsible for any logging based on the result.
  */
 export function parseConsentTimestamp(raw: unknown): Date | Error {
-	const ts = raw == null ? '' : String(raw);
+	const ts = (raw === null || raw === undefined) ? '' : String(raw);
 	if (!ts) {
 		return new Error('no consent timestamp provided');
 	}
@@ -378,9 +378,7 @@ const req = request as ChatRequest;
 const reqId = (req as any).requestId as string | undefined;
 if (reqId && seenRequestIds.has(reqId)) { continue; }
 if (reqId) { seenRequestIds.add(reqId); }
-const normalizedTs = this.utility.normalizeTimestampToMs(
-typeof req.timestamp !== 'undefined' ? req.timestamp : undefined
-);
+const normalizedTs = this.utility.normalizeTimestampToMs(req.timestamp);
 const eventMs = Number.isFinite(normalizedTs) ? normalizedTs : fileMtimeMs;
 if (!eventMs || eventMs < startMs) { continue; }
 const dayKey = this.utility.toUtcDayKey(new Date(eventMs));
@@ -388,7 +386,7 @@ const rawModel = (req as any).modelId || (req as any).result?.metadata?.modelId;
 const model = rawModel ? (rawModel as string).replace(/^copilot\//, '') : defaultModel;
 if (!dayModelInteractions.has(dayKey)) { dayModelInteractions.set(dayKey, new Map()); }
 const dayMap = dayModelInteractions.get(dayKey)!;
-dayMap.set(model, (dayMap.get(model) || 0) + 1);
+dayMap.set(model, (dayMap.get(model) ?? 0) + 1);
 }
 }
 
@@ -432,6 +430,24 @@ return null;
 }
 }
 
+private redistributeToMappedModels(
+modelMap: Map<string, number>,
+unmappedModels: Set<string>,
+cachedModelNames: string[],
+cachedModelUsage: ModelUsage,
+totalCachedTokens: number
+): void {
+let unmappedCount = 0;
+for (const um of unmappedModels) { unmappedCount += modelMap.get(um) ?? 0; modelMap.delete(um); }
+if (unmappedCount === 0) { return; }
+for (const cm of cachedModelNames) {
+const ct = cachedModelUsage[cm].inputTokens + cachedModelUsage[cm].outputTokens;
+const share = totalCachedTokens > 0 ? ct / totalCachedTokens : 1 / cachedModelNames.length;
+const redistributed = Math.round(unmappedCount * share);
+if (redistributed > 0) { modelMap.set(cm, (modelMap.get(cm) ?? 0) + redistributed); }
+}
+}
+
 /**
  * Remap event model names to cached model names when there is a mismatch.
  * CLI sessions often omit the model in individual events while session.shutdown
@@ -448,28 +464,12 @@ for (const modelMap of dayModelInteractions.values()) {
 for (const m of modelMap.keys()) { allEventModels.add(m); }
 }
 const unmappedModels = new Set<string>();
-for (const m of allEventModels) {
-if (!cachedModelUsage[m]) { unmappedModels.add(m); }
-}
+for (const m of allEventModels) { if (!cachedModelUsage[m]) { unmappedModels.add(m); } }
 if (unmappedModels.size === 0) { return; }
 const totalCachedTokens = cachedModelNames.reduce((sum, m) =>
 sum + cachedModelUsage[m].inputTokens + cachedModelUsage[m].outputTokens, 0);
 for (const [, modelMap] of dayModelInteractions) {
-let unmappedCount = 0;
-for (const um of unmappedModels) {
-unmappedCount += modelMap.get(um) || 0;
-modelMap.delete(um);
-}
-if (unmappedCount > 0) {
-for (const cm of cachedModelNames) {
-const ct = cachedModelUsage[cm].inputTokens + cachedModelUsage[cm].outputTokens;
-const share = totalCachedTokens > 0 ? ct / totalCachedTokens : 1 / cachedModelNames.length;
-const redistributed = Math.round(unmappedCount * share);
-if (redistributed > 0) {
-modelMap.set(cm, (modelMap.get(cm) || 0) + redistributed);
-}
-}
-}
+this.redistributeToMappedModels(modelMap, unmappedModels, cachedModelNames, cachedModelUsage, totalCachedTokens);
 }
 }
 
@@ -1186,6 +1186,21 @@ return true;
 		return { rollups, workspaceNamesById, machineNamesById };
 	}
 
+	private async tryProcessSpecialSession(
+		sessionFile: string, fileMtimeMs: number,
+		sessionArgs: ReturnType<typeof this.makeSessionRollupArgs>,
+		isType: (f: string) => boolean,
+		process: (f: string, mtime: number, args: ReturnType<typeof this.makeSessionRollupArgs>) => Promise<boolean>,
+		filesSkipped: { count: number }
+	): Promise<boolean> {
+		if (!isType(sessionFile)) { return false; }
+		try {
+			const processed = await process(sessionFile, fileMtimeMs, sessionArgs);
+			if (!processed) { filesSkipped.count++; }
+		} catch (e) { this.deps.logger.warn(`Backend sync: failed to process session ${sessionFile}: ${e}`); }
+		return true;
+	}
+
 	private async processOneSessionForRollup(
 		sessionFile: string,
 		ctx: {
@@ -1199,37 +1214,20 @@ return true;
 	): Promise<void> {
 		const fileMtimeMs = await this.statSessionFileForRollup(sessionFile, ctx);
 		if (fileMtimeMs === undefined) { return; }
-
 		const editorForFile = this.getEditorForFile(sessionFile, ctx.includeEditorDimension);
-
 		if (this.isVSSessionFileType(sessionFile)) { ctx.progress.filesSkipped++; return; }
-
 		const sessionArgs = this.makeSessionRollupArgs(ctx.machineId, ctx.userId, editorForFile, ctx.workspaceNamesById, ctx.rollups, ctx.startMs);
-		if (this.isOpenCodeSessionType(sessionFile)) {
-			try {
-				const processed = await this.processOpenCodeSession(sessionFile, fileMtimeMs, sessionArgs);
-				if (!processed) { ctx.progress.filesSkipped++; }
-			} catch (e) { this.deps.logger.warn(`Backend sync: failed to process OpenCode session ${sessionFile}: ${e}`); }
-			return;
-		}
-		if (this.isCrushSessionType(sessionFile)) {
-			try {
-				const processed = await this.processCrushSession(sessionFile, fileMtimeMs, sessionArgs);
-				if (!processed) { ctx.progress.filesSkipped++; }
-			} catch (e) { this.deps.logger.warn(`Backend sync: failed to process Crush session ${sessionFile}: ${e}`); }
-			return;
-		}
-
+		const skipped = { count: 0 };
+		if (await this.tryProcessSpecialSession(sessionFile, fileMtimeMs, sessionArgs, this.isOpenCodeSessionType.bind(this), this.processOpenCodeSession.bind(this), skipped)) { ctx.progress.filesSkipped += skipped.count; return; }
+		if (await this.tryProcessSpecialSession(sessionFile, fileMtimeMs, sessionArgs, this.isCrushSessionType.bind(this), this.processCrushSession.bind(this), skipped)) { ctx.progress.filesSkipped += skipped.count; return; }
 		const workspaceId = this.utility.extractWorkspaceIdFromSessionPath(sessionFile);
 		await this.ensureWorkspaceNameResolved(workspaceId, sessionFile, ctx.workspaceNamesById);
-
 		if (ctx.useCachedData) {
 			const fileStat = await this.deps.sessionHandlers.statSessionFile(sessionFile);
 			const cacheSuccess = await this.processCachedSessionFile(sessionFile, fileMtimeMs, fileStat.size, workspaceId, ctx.machineId, ctx.userId, ctx.rollups, ctx.startMs, ctx.now, editorForFile);
 			if (cacheSuccess) { ctx.progress.cacheHits++; return; }
 			ctx.progress.cacheMisses++;
 		}
-
 		let content: string;
 		try {
 			content = await fs.promises.readFile(sessionFile, 'utf8');

--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -108,6 +108,42 @@ export class CacheManager {
 		return path.join(this.context.globalStorageUri.fsPath, `cache_${cacheId}.lock`);
 	}
 
+	private async writeLockFile(lockPath: string): Promise<boolean> {
+		try {
+			const fd = await fs.promises.open(lockPath, 'wx');
+			await fd.writeFile(JSON.stringify({ sessionId: vscode.env.sessionId, pid: process.pid, timestamp: Date.now() }));
+			await fd.close();
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	private isLockOwnerAlive(pid: number): boolean {
+		try {
+			process.kill(pid, 0);
+			return true;
+		} catch (killErr: unknown) {
+			if (killErr instanceof Error && (killErr as NodeJS.ErrnoException).code === 'ESRCH') { return false; }
+			return true; // EPERM means process exists but is owned by another user
+		}
+	}
+
+	private async handleExistingLock(lockPath: string, staleThreshold: number): Promise<boolean> {
+		try {
+			const content = await fs.promises.readFile(lockPath, 'utf-8');
+			const lock = JSON.parse(content);
+			const ownerAlive = typeof lock.pid === 'number' ? this.isLockOwnerAlive(lock.pid) : true;
+			const isTimestampStale = Date.now() - lock.timestamp > staleThreshold;
+			if (!ownerAlive || isTimestampStale) {
+				this.deps.log(ownerAlive ? 'Breaking stale cache lock' : 'Breaking stale cache lock (owner process no longer running)');
+				await fs.promises.unlink(lockPath);
+				return await this.writeLockFile(lockPath);
+			}
+		} catch { /* lock file deleted or unreadable */ }
+		return false;
+	}
+
 	/**
 	 * Acquire an exclusive file lock for cache writes.
 	 * Uses atomic file creation (O_EXCL / CREATE_NEW) to prevent concurrent writes
@@ -117,73 +153,18 @@ export class CacheManager {
 	async acquireCacheLock(): Promise<boolean> {
 		const lockPath = this.getCacheLockPath();
 		try {
-			// Ensure the directory exists
 			await fs.promises.mkdir(path.dirname(lockPath), { recursive: true });
-
-			// Atomic exclusive create — fails if lock file already exists
 			const fd = await fs.promises.open(lockPath, 'wx');
-			await fd.writeFile(JSON.stringify({
-				sessionId: vscode.env.sessionId,
-				pid: process.pid,
-				timestamp: Date.now()
-			}));
+			await fd.writeFile(JSON.stringify({ sessionId: vscode.env.sessionId, pid: process.pid, timestamp: Date.now() }));
 			await fd.close();
 			return true;
 		} catch (err: unknown) {
 			const errCode = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
 			if (errCode !== 'EEXIST') {
-				// Unexpected error (permissions, disk full, etc.)
-				const message = err instanceof Error ? err.message : String(err);
-				this.deps.warn(`Unexpected error acquiring cache lock: ${message}`);
+				this.deps.warn(`Unexpected error acquiring cache lock: ${err instanceof Error ? err.message : String(err)}`);
 				return false;
 			}
-
-			// Lock file exists — check if the owning process is still alive or if the lock is stale
-			try {
-				const content = await fs.promises.readFile(lockPath, 'utf-8');
-				const lock = JSON.parse(content);
-				const staleThreshold = 5 * 60 * 1000; // 5 minutes (matches update interval)
-
-				// PID-based liveness check: if the owning process is gone, break immediately
-				let ownerAlive = true;
-				if (typeof lock.pid === 'number') {
-					try {
-						process.kill(lock.pid, 0); // Signal 0 checks existence without signalling
-					} catch (killErr: unknown) {
-						if (killErr instanceof Error && (killErr as NodeJS.ErrnoException).code === 'ESRCH') {
-							ownerAlive = false; // Process no longer exists
-						}
-						// EPERM means process exists but is owned by another user — treat as alive
-					}
-				}
-
-				const isTimestampStale = Date.now() - lock.timestamp > staleThreshold;
-
-				if (!ownerAlive || isTimestampStale) {
-					// Lock owner is dead or lock is old — break it and retry once
-					this.deps.log(
-						ownerAlive
-							? 'Breaking stale cache lock'
-							: 'Breaking stale cache lock (owner process no longer running)'
-					);
-					await fs.promises.unlink(lockPath);
-					try {
-						const fd = await fs.promises.open(lockPath, 'wx');
-						await fd.writeFile(JSON.stringify({
-							sessionId: vscode.env.sessionId,
-							pid: process.pid,
-							timestamp: Date.now()
-						}));
-						await fd.close();
-						return true;
-					} catch {
-						return false; // Another instance beat us to it
-					}
-				}
-			} catch {
-				// Can't read lock file — might have been deleted by the owner already
-			}
-			return false;
+			return await this.handleExistingLock(lockPath, 5 * 60 * 1000);
 		}
 	}
 
@@ -237,6 +218,14 @@ export class CacheManager {
 		}
 	}
 
+	private removeScopedKeyIfOld(key: string, prefix: string, currentKey: string): boolean {
+		if (!key.startsWith(prefix) || key === currentKey) { return false; }
+		const suffix = key.replace(prefix, '');
+		if (suffix === 'dev' || suffix === 'prod') { return false; }
+		this.context.globalState.update(key, undefined);
+		return true;
+	}
+
 	/**
 	 * One-time migration: remove old per-session cache keys that were created by
 	 * earlier versions of the extension (keys containing sessionId or timestamp).
@@ -247,38 +236,20 @@ export class CacheManager {
 			const allKeys = this.context.globalState.keys();
 			const currentCacheKey = `sessionFileCache_${currentCacheId}`;
 			const currentVersionKey = `sessionFileCacheVersion_${currentCacheId}`;
-			
 			let removedCount = 0;
 			for (const key of allKeys) {
-				// Remove old timestamp keys (no longer used)
 				if (key.startsWith('sessionFileCacheTimestamp_')) {
 					this.context.globalState.update(key, undefined);
 					removedCount++;
 					continue;
 				}
-				// Remove old per-session cache keys that have session IDs embedded
-				// (they contain more than one underscore-separated segment after the prefix)
-				if (key.startsWith('sessionFileCache_') && key !== currentCacheKey) {
-					const suffix = key.replace('sessionFileCache_', '');
-					if (suffix !== 'dev' && suffix !== 'prod') {
-						this.context.globalState.update(key, undefined);
-						removedCount++;
-					}
-				}
-				if (key.startsWith('sessionFileCacheVersion_') && key !== currentVersionKey) {
-					const suffix = key.replace('sessionFileCacheVersion_', '');
-					if (suffix !== 'dev' && suffix !== 'prod') {
-						this.context.globalState.update(key, undefined);
-						removedCount++;
-					}
-				}
-				// Remove legacy unscoped keys from the original code
+				if (this.removeScopedKeyIfOld(key, 'sessionFileCache_', currentCacheKey)) { removedCount++; }
+				if (this.removeScopedKeyIfOld(key, 'sessionFileCacheVersion_', currentVersionKey)) { removedCount++; }
 				if (key === 'sessionFileCache' || key === 'sessionFileCacheVersion') {
 					this.context.globalState.update(key, undefined);
 					removedCount++;
 				}
 			}
-			
 			if (removedCount > 0) {
 				this.deps.log(`Migrated: removed ${removedCount} old cache keys from globalState`);
 			}

--- a/vscode-extension/src/sessionDiscovery.ts
+++ b/vscode-extension/src/sessionDiscovery.ts
@@ -137,6 +137,59 @@ export class SessionDiscovery {
 		return this.getCopilotSessionFilesStreaming();
 	}
 
+	private async tryGetSampleDataFiles(now: number): Promise<string[] | undefined> {
+		const sampleDir = this.deps.sampleDataDirectoryOverride?.()
+			?? vscode.workspace.getConfiguration('aiEngineeringFluency').get<string>('sampleDataDirectory');
+		if (!sampleDir || sampleDir.trim().length === 0) { return undefined; }
+		const resolvedSampleDir = sampleDir.trim();
+		try {
+			if (!await this.pathExists(resolvedSampleDir)) {
+				this.deps.warn(`Sample data directory not found: ${resolvedSampleDir}`);
+				return undefined;
+			}
+			const sampleFiles = (await fs.promises.readdir(resolvedSampleDir))
+				.filter(f => f.endsWith('.json') || f.endsWith('.jsonl'))
+				.map(f => path.join(resolvedSampleDir, f));
+			this.deps.log(`📸 Sample data mode: using ${sampleFiles.length} file(s) from ${resolvedSampleDir}`);
+			this._sessionFilesCache = sampleFiles;
+			this._sessionFilesCacheTime = now;
+			this._lastDiscoveryFilesCount = sampleFiles.length;
+			return sampleFiles;
+		} catch (err) {
+			this.deps.warn(`Error reading sample data directory: ${err}`);
+			return undefined;
+		}
+	}
+
+	private async discoverFromAdapters(onBatch?: (files: string[]) => void): Promise<string[]> {
+		const seen = new Set<string>();
+		const allDeduped: string[] = [];
+		const discoveryStartMs = Date.now();
+		const discoverableAdapters = this.deps.ecosystems.filter(isDiscoverable);
+		this.deps.log(`🔍 Searching for session files via ${discoverableAdapters.length} discoverable ecosystem adapter(s) (parallel)`);
+		const results = await Promise.allSettled(discoverableAdapters.map(eco => eco.discover(this.deps.log)));
+		for (let i = 0; i < results.length; i++) {
+			const result = results[i];
+			if (result.status === 'rejected') {
+				this.deps.warn(`Could not discover ${discoverableAdapters[i].displayName} sessions: ${result.reason}`);
+				this._lastDiscoveryHadError = true;
+				continue;
+			}
+			const batch: string[] = [];
+			for (const f of result.value.sessionFiles) {
+				const key = normalizePathForDedup(f);
+				if (seen.has(key)) { continue; }
+				seen.add(key); batch.push(f);
+			}
+			if (batch.length > 0) { allDeduped.push(...batch); if (onBatch) { onBatch(batch); } }
+		}
+		const dupCount = results.reduce((n, r) => n + (r.status === 'fulfilled' ? r.value.sessionFiles.length : 0), 0) - allDeduped.length;
+		if (dupCount > 0) { this.deps.log(`🧹 Deduplicated ${dupCount} duplicate session path(s)`); }
+		this.deps.log(`✨ Total: ${allDeduped.length} session file(s) discovered in ${((Date.now() - discoveryStartMs) / 1000).toFixed(1)}s`);
+		if (allDeduped.length === 0) { this.deps.warn('⚠️ No session files found - Have you used GitHub Copilot Chat yet?'); }
+		return allDeduped;
+	}
+
 	/**
 	 * Discover session files with optional streaming: calls `onBatch` with
 	 * deduplicated file paths as each adapter completes. Adapters run in
@@ -149,81 +202,14 @@ export class SessionDiscovery {
 			if (onBatch) { onBatch(this._sessionFilesCache); }
 			return this._sessionFilesCache;
 		}
-
-		// Reset discovery state for this run.
 		this._lastDiscoveryHadError = false;
 		this._lastDiscoveryFilesCount = 0;
-
-		// Screenshot/demo mode: sample data directory bypasses adapter discovery.
-		const sampleDir = this.deps.sampleDataDirectoryOverride?.()
-			?? vscode.workspace.getConfiguration('aiEngineeringFluency').get<string>('sampleDataDirectory');
-		if (sampleDir && sampleDir.trim().length > 0) {
-			const resolvedSampleDir = sampleDir.trim();
-			try {
-				if (await this.pathExists(resolvedSampleDir)) {
-					const sampleFiles = (await fs.promises.readdir(resolvedSampleDir))
-						.filter(f => f.endsWith('.json') || f.endsWith('.jsonl'))
-						.map(f => path.join(resolvedSampleDir, f));
-					this.deps.log(`📸 Sample data mode: using ${sampleFiles.length} file(s) from ${resolvedSampleDir}`);
-					this._sessionFilesCache = sampleFiles;
-					this._sessionFilesCacheTime = now;
-					this._lastDiscoveryFilesCount = sampleFiles.length;
-					if (onBatch) { onBatch(sampleFiles); }
-					return sampleFiles;
-				} else {
-					this.deps.warn(`Sample data directory not found: ${resolvedSampleDir}`);
-				}
-			} catch (err) {
-				this.deps.warn(`Error reading sample data directory: ${err}`);
-			}
-		}
-
-		// Incrementally deduplicate as each adapter completes.
-		const seen = new Set<string>();
+		const sampleFiles = await this.tryGetSampleDataFiles(now);
+		if (sampleFiles) { if (onBatch) { onBatch(sampleFiles); } return sampleFiles; }
 		const allDeduped: string[] = [];
-
 		try {
-			const discoveryStartMs = Date.now();
-			const discoverableAdapters = this.deps.ecosystems.filter(isDiscoverable);
-			this.deps.log(`🔍 Searching for session files via ${discoverableAdapters.length} discoverable ecosystem adapter(s) (parallel)`);
-
-			// Run all adapters in parallel
-			const results = await Promise.allSettled(
-				discoverableAdapters.map(eco => eco.discover(this.deps.log))
-			);
-
-			for (let i = 0; i < results.length; i++) {
-				const result = results[i];
-				if (result.status === 'rejected') {
-					this.deps.warn(`Could not discover ${discoverableAdapters[i].displayName} sessions: ${result.reason}`);
-					this._lastDiscoveryHadError = true;
-					continue;
-				}
-				// Deduplicate incrementally so onBatch only receives new paths
-				const batch: string[] = [];
-				for (const f of result.value.sessionFiles) {
-					const key = normalizePathForDedup(f);
-					if (seen.has(key)) { continue; }
-					seen.add(key);
-					batch.push(f);
-				}
-				if (batch.length > 0) {
-					allDeduped.push(...batch);
-					if (onBatch) { onBatch(batch); }
-				}
-			}
-
-			const totalRaw = results.reduce((n, r) => n + (r.status === 'fulfilled' ? r.value.sessionFiles.length : 0), 0);
-			const dupCount = totalRaw - allDeduped.length;
-			if (dupCount > 0) {
-				this.deps.log(`🧹 Deduplicated ${dupCount} duplicate session path(s)`);
-			}
-
-			this.deps.log(`✨ Total: ${allDeduped.length} session file(s) discovered in ${((Date.now() - discoveryStartMs) / 1000).toFixed(1)}s`);
-			if (allDeduped.length === 0) {
-				this.deps.warn('⚠️ No session files found - Have you used GitHub Copilot Chat yet?');
-			}
-
+			const files = await this.discoverFromAdapters(onBatch);
+			allDeduped.push(...files);
 			this._sessionFilesCache = allDeduped;
 			this._sessionFilesCacheTime = Date.now();
 			this._lastDiscoveryFilesCount = allDeduped.length;


### PR DESCRIPTION
## Summary

Batch 21 lint/complexity fixes across 3 source files.

### \cacheManager.ts\
- Extracted \writeLockFile()\ — atomic lock file creation
- Extracted \isLockOwnerAlive()\ — PID-based liveness check
- Extracted \handleExistingLock()\ — stale lock detection and takeover
- Extracted \emoveScopedKeyIfOld()\ — reusable key migration helper
- Reduced \cquireCacheLock\ from cognitive 28 to under 15; \migrateOldCacheKeys\ from cognitive 21 to under 15

### \sessionDiscovery.ts\
- Extracted \	ryGetSampleDataFiles()\ — handles sample/demo mode file loading
- Extracted \discoverFromAdapters()\ — runs all ecosystem adapters in parallel
- Reduced \getCopilotSessionFilesStreaming\ from 93 lines (cognitive 30) to ~35 lines

### \ackend/services/syncService.ts\
- Fixed \qeqeq\ violation: \aw == null\ → \aw === null || raw === undefined\
- Simplified \processDeltaRequests\: removed redundant \	ypeof\ check, replaced \|| 0\ with \?? 0\
- Extracted \edistributeToMappedModels()\ from \emapUnmappedModels\ (cognitive 24 → under 15)
- Extracted \	ryProcessSpecialSession()\ from \processOneSessionForRollup\ (cognitive 17 → under 15)