### PR TITLE
fix: extract LOC data from delta-based JSONL sessions (Feb 2026+)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -265,7 +265,7 @@ function _scdlDistributeToDays(
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 53; // Add Antigravity ecosystem adapter + LOC support
+	private static readonly CACHE_VERSION = 54; // Fix LOC extraction for delta-based JSONL sessions (Feb 2026+)
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -265,7 +265,7 @@ function _scdlDistributeToDays(
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 54; // Fix LOC extraction for delta-based JSONL sessions (Feb 2026+)
+	private static readonly CACHE_VERSION = 55; // Fix LOC extraction for Copilot CLI coding agent sessions (edit/create tools)
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1413,6 +1413,8 @@ type AsuCliState = {
 	defaultEffort: string | null;
 	requestCount: number;
 	effortByRequest: { [effort: string]: number };
+	pendingToolCalls: Map<string, { toolName: string; args: Record<string, string> }>;
+	editedFilePaths: Set<string>;
 };
 
 /** Check if the first JSONL line indicates a delta-based VS Code incremental format. */
@@ -1586,6 +1588,72 @@ function _asuHandleToolAndMcpEvents(event: any, analysis: SessionUsageAnalysis, 
 	_asuHandleMcpToolEvent(event, analysis);
 }
 
+/** Count non-empty lines in text, ignoring a trailing newline. */
+function _asuCountTextLines(text: string): number {
+	if (!text) { return 0; }
+	const lines = text.split('\n');
+	if (lines[lines.length - 1] === '') { lines.pop(); }
+	return lines.length;
+}
+
+/** Ensure editScope is initialized on the analysis object. */
+function _asuEnsureEditScope(analysis: SessionUsageAnalysis): void {
+	if (!analysis.editScope) {
+		analysis.editScope = { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0, linesAdded: 0, linesRemoved: 0 };
+	}
+}
+
+/** Handle tool.execution_start for CLI LOC tracking — stores pending tool call args. */
+function _asuHandleToolStart(event: any, cliState: AsuCliState): void {
+	const { toolCallId, toolName, arguments: args } = event.data ?? {};
+	if (toolCallId && (toolName === 'edit' || toolName === 'create') && args) {
+		cliState.pendingToolCalls.set(toolCallId, { toolName, args });
+	}
+}
+
+/** Extract LOC counts from a completed CLI tool call and update editScope. */
+function _asuApplyToolLoc(pending: { toolName: string; args: Record<string, string> }, cliState: AsuCliState, analysis: SessionUsageAnalysis): void {
+	const linesAdded = pending.toolName === 'edit'
+		? _asuCountTextLines(pending.args.new_str ?? '')
+		: _asuCountTextLines(pending.args.file_text ?? '');
+	const linesRemoved = pending.toolName === 'edit' ? _asuCountTextLines(pending.args.old_str ?? '') : 0;
+	_asuEnsureEditScope(analysis);
+	analysis.editScope!.linesAdded = (analysis.editScope!.linesAdded ?? 0) + linesAdded;
+	analysis.editScope!.linesRemoved = (analysis.editScope!.linesRemoved ?? 0) + linesRemoved;
+	const filePath = pending.args.path ?? '';
+	cliState.editedFilePaths.add(filePath);
+	const ext = normalizeExtension(filePath);
+	if (!analysis.editScope!.languageUsage) { analysis.editScope!.languageUsage = {}; }
+	if (!analysis.editScope!.languageUsage[ext]) { analysis.editScope!.languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+	analysis.editScope!.languageUsage[ext].linesAdded += linesAdded;
+	analysis.editScope!.languageUsage[ext].linesRemoved += linesRemoved;
+}
+
+/** Handle tool.execution_complete for CLI LOC tracking — applies LOC on success. */
+function _asuHandleToolComplete(event: any, cliState: AsuCliState, analysis: SessionUsageAnalysis): void {
+	const { toolCallId, success } = event.data ?? {};
+	const pending = toolCallId ? cliState.pendingToolCalls.get(toolCallId) : undefined;
+	if (toolCallId) { cliState.pendingToolCalls.delete(toolCallId); }
+	if (pending && success) { _asuApplyToolLoc(pending, cliState, analysis); }
+}
+
+/** Handle tool.execution_start / tool.execution_complete for CLI LOC tracking. */
+function _asuHandleCliLocEvent(event: any, cliState: AsuCliState, analysis: SessionUsageAnalysis): void {
+	if (event.type === 'tool.execution_start') { _asuHandleToolStart(event, cliState); }
+	else if (event.type === 'tool.execution_complete') { _asuHandleToolComplete(event, cliState, analysis); }
+}
+
+/** Finalize editScope file counts from accumulated CLI tool LOC state. */
+function _asuApplyCliLocToEditScope(cliState: AsuCliState, analysis: SessionUsageAnalysis): void {
+	if (cliState.editedFilePaths.size === 0) { return; }
+	_asuEnsureEditScope(analysis);
+	const fileCount = cliState.editedFilePaths.size;
+	analysis.editScope!.totalEditedFiles = fileCount;
+	analysis.editScope!.singleFileEdits = fileCount === 1 ? 1 : 0;
+	analysis.editScope!.multiFileEdits = fileCount > 1 ? 1 : 0;
+	analysis.editScope!.avgFilesPerSession = fileCount;
+}
+
 /** Dispatch a single JSONL event to the appropriate event handlers. */
  
 function _asuProcessJsonlEvent(event: any, analysis: SessionUsageAnalysis, modeState: AsuModeState, cliState: AsuCliState, jetBrainsMode: JetBrainsMode | null, toolNameMap: { [key: string]: string }): void {
@@ -1594,6 +1662,7 @@ function _asuProcessJsonlEvent(event: any, analysis: SessionUsageAnalysis, modeS
 	_asuHandleKind2Event(event, analysis, modeState, toolNameMap);
 	_asuProcessCliEvents(event, cliState, analysis, jetBrainsMode);
 	_asuHandleToolAndMcpEvents(event, analysis, toolNameMap);
+	_asuHandleCliLocEvent(event, cliState, analysis);
 }
 
 /** Store CLI thinking effort data from the accumulated CLI state. */
@@ -1614,7 +1683,10 @@ async function _asuProcessNonDeltaJsonl(
 	analysis: SessionUsageAnalysis
 ): Promise<void> {
 	const modeState: AsuModeState = { sessionMode: 'ask' };
-	const cliState: AsuCliState = { defaultModel: 'unknown', defaultEffort: null, requestCount: 0, effortByRequest: {} };
+	const cliState: AsuCliState = {
+		defaultModel: 'unknown', defaultEffort: null, requestCount: 0, effortByRequest: {},
+		pendingToolCalls: new Map(), editedFilePaths: new Set(),
+	};
 	const isJetBrains = isJetBrainsSessionPath(sessionFile);
 	const jetBrainsMode: JetBrainsMode | null = isJetBrains ? detectJetBrainsModeFromContent(fileContent) : null;
 
@@ -1626,6 +1698,7 @@ async function _asuProcessNonDeltaJsonl(
 		} catch { /* skip malformed lines */ }
 	}
 
+	_asuApplyCliLocToEditScope(cliState, analysis);
 	_asuApplyCliThinkingEffort(cliState, analysis);
 	await calculateModelSwitching(deps, sessionFile, analysis, fileContent);
 	deriveConversationPatterns(analysis);
@@ -1650,6 +1723,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 			const lines = fileContent.trim().split('\n').filter((l: string) => l.trim());
 			if (_asuIsDeltaBased(lines)) {
 				_asuReconstructAndProcessDeltaState(deps, lines, analysis);
+				await trackEnhancedMetrics(deps, sessionFile, analysis, fileContent);
 				return analysis;
 			}
 			await _asuProcessNonDeltaJsonl(deps, sessionFile, lines, fileContent, analysis);

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -994,6 +994,108 @@ test('analyzeSessionUsage: delta-based JSONL session extracts LOC data from text
     assert.equal(result.editScope?.totalEditedFiles, 1);
 });
 
+test('analyzeSessionUsage: CLI JSONL session extracts LOC from successful edit tool calls', async () => {
+    const toolCallId = 'call-edit-1';
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.6' }, timestamp: '2026-05-01T10:00:00Z' },
+        {
+            type: 'tool.execution_start',
+            data: {
+                toolCallId,
+                toolName: 'edit',
+                arguments: {
+                    path: '/repo/src/foo.ts',
+                    old_str: 'line1\nline2',
+                    new_str: 'line1\nline2\nline3\nline4',
+                },
+            },
+        },
+        { type: 'tool.execution_complete', data: { toolCallId, success: true } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+    // old_str has 2 lines, new_str has 4 lines (no trailing newline)
+    assert.equal(result.editScope?.linesAdded, 4, 'expected 4 lines added');
+    assert.equal(result.editScope?.linesRemoved, 2, 'expected 2 lines removed');
+    assert.equal(result.editScope?.totalEditedFiles, 1);
+    assert.ok(result.editScope?.languageUsage?.['ts'], 'expected ts language usage');
+    assert.equal(result.editScope?.languageUsage?.['ts']?.linesAdded, 4);
+});
+
+test('analyzeSessionUsage: CLI JSONL session extracts LOC from successful create tool calls', async () => {
+    const toolCallId = 'call-create-1';
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.6' }, timestamp: '2026-05-01T10:00:00Z' },
+        {
+            type: 'tool.execution_start',
+            data: {
+                toolCallId,
+                toolName: 'create',
+                arguments: {
+                    path: '/repo/src/bar.ts',
+                    file_text: 'const x = 1;\nconst y = 2;\nconst z = 3;\n',
+                },
+            },
+        },
+        { type: 'tool.execution_complete', data: { toolCallId, success: true } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+    // file_text has 3 lines + trailing newline → 3 lines counted (trailing \n not counted as extra line)
+    assert.equal(result.editScope?.linesAdded, 3, 'expected 3 lines added (trailing newline not counted)');
+    assert.equal(result.editScope?.linesRemoved, 0, 'create should have 0 lines removed');
+});
+
+test('analyzeSessionUsage: CLI JSONL session does NOT count LOC for failed edit tool calls', async () => {
+    const toolCallId = 'call-edit-fail';
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.6' } },
+        {
+            type: 'tool.execution_start',
+            data: {
+                toolCallId,
+                toolName: 'edit',
+                arguments: { path: '/repo/src/foo.ts', old_str: 'old', new_str: 'new\nlines\nhere' },
+            },
+        },
+        { type: 'tool.execution_complete', data: { toolCallId, success: false } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+    assert.equal(result.editScope?.linesAdded ?? 0, 0, 'failed edits should not contribute LOC');
+    assert.equal(result.editScope?.linesRemoved ?? 0, 0, 'failed edits should not contribute LOC');
+});
+
+test('analyzeSessionUsage: CLI JSONL LOC counts multiple files across edit and create', async () => {
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.6' } },
+        {
+            type: 'tool.execution_start',
+            data: { toolCallId: 'id1', toolName: 'edit', arguments: { path: '/repo/a.py', old_str: 'x', new_str: 'x\ny\nz' } },
+        },
+        { type: 'tool.execution_complete', data: { toolCallId: 'id1', success: true } },
+        {
+            type: 'tool.execution_start',
+            data: { toolCallId: 'id2', toolName: 'create', arguments: { path: '/repo/b.js', file_text: 'a\nb\n' } },
+        },
+        { type: 'tool.execution_complete', data: { toolCallId: 'id2', success: true } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+    // edit: new_str='x\ny\nz' → 3 lines; old_str='x' → 1 line
+    // create: file_text='a\nb\n' → 2 lines
+    assert.equal(result.editScope?.linesAdded, 5, 'expected 3+2=5 lines added');
+    assert.equal(result.editScope?.linesRemoved, 1, 'expected 1 line removed');
+    assert.equal(result.editScope?.totalEditedFiles, 2, 'expected 2 edited files');
+    assert.ok(result.editScope?.multiFileEdits, 'expected multi-file edit flag');
+    assert.ok(result.editScope?.languageUsage?.['py'], 'expected py language tracking');
+    assert.ok(result.editScope?.languageUsage?.['js'], 'expected js language tracking');
+});
+
 // ---------------------------------------------------------------------------
 // isParsedSessionJson
 // ---------------------------------------------------------------------------

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -967,6 +967,33 @@ test('analyzeSessionUsage: empty requests array returns empty analysis', async (
     assert.equal(result.toolCalls.total, 0);
 });
 
+test('analyzeSessionUsage: delta-based JSONL session extracts LOC data from textEditGroup', async () => {
+    // Delta-based JSONL format (VS Code Insiders / Feb 2026+):
+    // kind=0 sets initial state, kind=2 appends to arrays, kind=1 sets properties.
+    // The fix ensures trackEnhancedMetrics is called after processDeltaSessionAnalysis.
+    const request = {
+        requestId: 'req-1',
+        timestamp: 1700000000000,
+        response: [{
+            kind: 'textEditGroup',
+            uri: { path: '/src/foo.ts' },
+            edits: [[
+                { text: 'line1\nline2\n', range: { startLineNumber: 1, endLineNumber: 3 } }
+            ]]
+        }]
+    };
+    // Build delta-based JSONL: initial state with requests array, then append the request
+    const line0 = JSON.stringify({ kind: 0, v: { version: 3, creationDate: 1700000000000, requests: [] } });
+    const line1 = JSON.stringify({ kind: 2, k: ['requests'], v: request });
+    const content = [line0, line1].join('\n');
+    const FAKE_JSONL_PATH = '/tmp/test-session.jsonl';
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, FAKE_JSONL_PATH, content);
+    // linesAdded should be populated from the textEditGroup edits
+    assert.ok((result.editScope?.linesAdded ?? 0) > 0, 'expected linesAdded > 0 from delta JSONL textEditGroup');
+    assert.equal(result.editScope?.totalEditedFiles, 1);
+});
+
 // ---------------------------------------------------------------------------
 // isParsedSessionJson
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
VS Code chatSession format switched from .json to .jsonl (delta-based) around Feb 2026. The JSONL delta path in analyzeSessionUsage() returned early without calling trackEnhancedMetrics(), so LOC/edit-scope data was never extracted for Feb-May 2026 sessions. Fix: add trackEnhancedMetrics() call before the early return. Bump CACHE_VERSION 53 to 54 to force re-processing.