### PR TITLE
fix(loader): fix editor pills not appearing during loading

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1662,9 +1662,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.setStatusBarText(`$(loading~spin) Analyzing Logs: ${percentage}%`);
 			if (!parsingStepNotified) {
 				parsingStepNotified = true;
-				const editors = getEditors?.();
-				const msg: Record<string, unknown> = { command: 'loadingStep', step: 'parsing', total };
-				if (editors && editors.length > 0) { msg.editors = editors; }
+				const editors = getEditors?.() ?? [];
+				const msg: Record<string, unknown> = { command: 'loadingStep', step: 'parsing', total, editors };
 				this.sendLoadingPanelMessage(msg);
 			}
 			const now = Date.now();
@@ -6063,12 +6062,7 @@ ${this.getLoadingHtmlScript()}
   private getLoadingHtmlScript(): string {
     return `(function () {
     var t0 = Date.now();
-    var EDITORS = [
-        { icon: '💙', name: 'VS Code' }, { icon: '🤖', name: 'Copilot CLI' }, { icon: '⚡', name: 'Cursor' },
-        { icon: '🟠', name: 'Claude Code' }, { icon: '🟢', name: 'OpenCode' }, { icon: '🔥', name: 'Mistral Vibe' },
-        { icon: '💎', name: 'Gemini CLI' }, { icon: '🪟', name: 'Visual Studio' }, { icon: '🔷', name: 'VSCodium' },
-        { icon: '💚', name: 'VS Code Insiders' },
-    ];
+    var EDITORS = [];
     var editorsSeen = 0;
     setInterval(function () {
         var s = Math.floor((Date.now() - t0) / 1000);
@@ -6093,7 +6087,7 @@ ${this.getLoadingHtmlScript()}
             if (m.step === 'discovering') { setActive('s-discover');
             } else if (m.step === 'parsing') {
                 var total = m.total || 0; setDone('s-discover');
-                if (m.editors && m.editors.length > 0) { EDITORS = m.editors; editorsSeen = 0; }
+                if (m.editors !== undefined) { EDITORS = m.editors; editorsSeen = 0; }
                 var sc = document.getElementById('sc-discover'); if (sc) sc.textContent = '(' + total + ' found)';
                 setDone('s-cache'); setActive('s-parse');
                 var sub = document.getElementById('subtitle'); if (sub) sub.textContent = 'Parsing ' + total + ' session files...';

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1515,7 +1515,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 */
 	private async _preloadSessionFiles(
 		cutoffMs: number,
-		progressCallback?: (completed: number, total: number) => void
+		progressCallback?: (completed: number, total: number) => void,
+		editorSet?: Set<string>
 	): Promise<{ sessionFiles: string[]; preloaded: SessionFilePreload[] }> {
 		// --- Streaming pipeline: overlap discovery with parsing ---
 		// Discovery pushes file batches into a shared queue as each adapter completes.
@@ -1534,6 +1535,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const discoveryPromise = (async () => {
 			try {
 				return await this.sessionDiscovery.getCopilotSessionFilesStreaming((batch) => {
+					if (editorSet) {
+						for (const file of batch) {
+							const editor = this.detectEditorSource(file);
+							if (editor && editor !== 'Unknown') { editorSet.add(editor); }
+						}
+					}
 					queue.push(...batch);
 					totalDiscovered += batch.length;
 				});
@@ -1605,8 +1612,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 			// Streaming pipeline: discovery and parsing run concurrently.
 			// Workers start processing files as each adapter batch arrives.
-			const progressCallback = this.buildProgressCallback(silent);
-			const { sessionFiles, preloaded } = await this._preloadSessionFiles(fileLoadCutoffMs, progressCallback);
+			const discoveredEditorSet = new Set<string>();
+			const progressCallback = this.buildProgressCallback(silent, () =>
+				[...discoveredEditorSet].map(name => ({ icon: this.getEditorIconForLoader(name), name }))
+			);
+			const { sessionFiles, preloaded } = await this._preloadSessionFiles(fileLoadCutoffMs, progressCallback, discoveredEditorSet);
 
 			this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'computing' });
 
@@ -1643,7 +1653,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 	}
 
-	private buildProgressCallback(silent: boolean): ((completed: number, total: number) => void) | undefined {
+	private buildProgressCallback(silent: boolean, getEditors?: () => { icon: string; name: string }[]): ((completed: number, total: number) => void) | undefined {
 		if (silent) { return undefined; }
 		let parsingStepNotified = false;
 		let lastProgressSentMs = 0;
@@ -1652,7 +1662,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.setStatusBarText(`$(loading~spin) Analyzing Logs: ${percentage}%`);
 			if (!parsingStepNotified) {
 				parsingStepNotified = true;
-				this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'parsing', total });
+				const editors = getEditors?.();
+				const msg: Record<string, unknown> = { command: 'loadingStep', step: 'parsing', total };
+				if (editors && editors.length > 0) { msg.editors = editors; }
+				this.sendLoadingPanelMessage(msg);
 			}
 			const now = Date.now();
 			if (now - lastProgressSentMs >= 500 || completed === total) {
@@ -1660,6 +1673,18 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.sendLoadingPanelMessage({ command: 'loadingProgress', completed, total, percentage });
 			}
 		};
+	}
+
+	/** Maps known editor display names to emoji icons for the loader animation. */
+	private getEditorIconForLoader(editorName: string): string {
+		const map: Record<string, string> = {
+			'VS Code': '💙', 'VS Code Insiders': '💚', 'VS Code Exploration': '🧪',
+			'VS Code Server': '☁️', 'VS Code Server (Insiders)': '☁️', 'VSCodium': '🔷',
+			'Cursor': '⚡', 'Copilot CLI': '🤖', 'OpenCode': '🟢', 'Visual Studio': '🪟',
+			'Claude Code': '🟠', 'Claude Desktop Cowork': '🟠', 'Mistral Vibe': '🔥',
+			'Gemini CLI': '💎', 'Antigravity': '🚀',
+		};
+		return map[editorName] ?? '📝';
 	}
 
 	private mergeIntoFullDailyStats(dailyStats: DailyTokenStats[]): void {
@@ -6068,6 +6093,7 @@ ${this.getLoadingHtmlScript()}
             if (m.step === 'discovering') { setActive('s-discover');
             } else if (m.step === 'parsing') {
                 var total = m.total || 0; setDone('s-discover');
+                if (m.editors && m.editors.length > 0) { EDITORS = m.editors; editorsSeen = 0; }
                 var sc = document.getElementById('sc-discover'); if (sc) sc.textContent = '(' + total + ' found)';
                 setDone('s-cache'); setActive('s-parse');
                 var sub = document.getElementById('subtitle'); if (sub) sub.textContent = 'Parsing ' + total + ' session files...';

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6087,7 +6087,8 @@ ${this.getLoadingHtmlScript()}
             var bf2 = document.getElementById('badge-files'); if (bf2) bf2.textContent = m.completed + '\\u202f/\\u202f' + m.total + ' files';
             var sc2 = document.getElementById('sc-parse'); if (sc2) sc2.textContent = '(' + m.completed + '/' + m.total + ')';
             var sub3 = document.getElementById('subtitle'); if (sub3) sub3.textContent = 'Parsing session ' + m.completed + '\\u202f/\\u202f' + m.total + '\\u2026';
-            if (m.completed % Math.max(1, Math.floor(m.total / 10)) === 0 && editorsSeen < EDITORS.length) {
+            var expectedPills = Math.min(EDITORS.length, Math.floor((m.completed / Math.max(1, m.total)) * EDITORS.length));
+            while (editorsSeen < expectedPills) {
                 var editor = EDITORS[editorsSeen]; editorsSeen++;
                 var row = document.getElementById('editors-row');
                 if (row) { var pill = document.createElement('div'); pill.className = 'chip'; pill.style.animation = 'pop-in 0.35s ease both'; pill.innerHTML = '<span>' + editor.icon + '</span>\\u00a0<span class="chip-value">' + esc(editor.name) + '</span>'; row.appendChild(pill); }


### PR DESCRIPTION
## Problem

The loader screen was supposed to pop up editor pills (💙 VS Code, 🤖 Copilot CLI, etc.) as session files are being parsed, but they were no longer appearing.

## Root Cause

The pill condition checked for an exact modulo match:
\\\js
if (m.completed % Math.max(1, Math.floor(m.total / 10)) === 0 && editorsSeen < EDITORS.length)
\\\

However, progress messages are throttled to **one per 500ms** (see \uildProgressCallback\). With this throttling, the \completed\ counter jumps in large increments that rarely land exactly on multiples of the step — so the condition is almost never \	rue\ and no pills appear.

## Fix

Replace the modulo check with a **percentage-based threshold** using a \while\ loop:

\\\js
var expectedPills = Math.min(EDITORS.length, Math.floor((m.completed / Math.max(1, m.total)) * EDITORS.length));
while (editorsSeen < expectedPills) {
    // create and append pill
}
\\\

This computes how many pills _should_ be visible given the current progress, and the \while\ loop catches up if any progress steps were skipped due to throttling.