### PR TITLE
fix(lint): b95 remove unused eslint-disable directives and fix getModeType complexity

### DIFF
--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1443,7 +1443,7 @@ function _asuReconstructAndProcessDeltaState(
 /** Check if a selection range represents an actual selection (not just cursor position). */
 function _asuCheckImplicitSelection(selections: unknown[], refs: ContextReferenceUsage): void {
 	for (const sel of selections) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		 
 		const s = sel as any;
 		if (s && (s.startLineNumber !== s.endLineNumber || s.startColumn !== s.endColumn)) {
 			refs.implicitSelection++;
@@ -1453,7 +1453,7 @@ function _asuCheckImplicitSelection(selections: unknown[], refs: ContextReferenc
 }
 
 /** Handle VS Code incremental format kind=0 (session header) events. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuHandleKind0Event(event: any, analysis: SessionUsageAnalysis, modeState: AsuModeState): void {
 	if (event.kind !== 0 || !event.v?.inputState?.mode) { return; }
 	modeState.sessionMode = getModeType(event.v.inputState.mode);
@@ -1462,7 +1462,7 @@ function _asuHandleKind0Event(event: any, analysis: SessionUsageAnalysis, modeSt
 }
 
 /** Handle VS Code incremental format kind=1 (incremental update) events. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuHandleKind1Event(event: any, analysis: SessionUsageAnalysis, modeState: AsuModeState): void {
 	if (event.kind !== 1) { return; }
 	if (event.k?.includes('mode') && event.v) { modeState.sessionMode = getModeType(event.v); }
@@ -1508,7 +1508,7 @@ function _asuProcessResponseUpdates(items: unknown[], analysis: SessionUsageAnal
 }
 
 /** Process a single request from a kind=2 requests array. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuProcessRequest(request: any, analysis: SessionUsageAnalysis, sessionMode: string): void {
 	if (request.requestId) { incrementModeUsage(sessionMode, analysis.modeUsage); }
 	if (request.agent?.id) {
@@ -1522,7 +1522,7 @@ function _asuProcessRequest(request: any, analysis: SessionUsageAnalysis, sessio
 }
 
 /** Handle VS Code incremental format kind=2 (batch add) events. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuHandleKind2Event(event: any, analysis: SessionUsageAnalysis, modeState: AsuModeState, toolNameMap: { [key: string]: string }): void {
 	if (event.kind !== 2) { return; }
 	if (event.k?.[0] === 'requests' && Array.isArray(event.v)) {
@@ -1547,7 +1547,7 @@ function _asuHandleUserMessageMode(jetBrainsMode: JetBrainsMode | null, analysis
 }
 
 /** Handle Copilot CLI events (session.start, session.model_change, user.message). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuProcessCliEvents(event: any, cliState: AsuCliState, analysis: SessionUsageAnalysis, jetBrainsMode: JetBrainsMode | null): void {
 	if (event.type === 'session.start' && event.data) { _asuHandleSessionStartEvent(event.data as Record<string, unknown>, cliState); }
 	if (event.type === 'session.model_change' && typeof event.data?.newModel === 'string') { cliState.defaultModel = event.data.newModel; }
@@ -1560,7 +1560,7 @@ function _asuProcessCliEvents(event: any, cliState: AsuCliState, analysis: Sessi
 }
 
 /** Handle tool.call / tool.result / tool.execution_start events. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuHandleToolCallEvent(event: any, analysis: SessionUsageAnalysis, toolNameMap: { [key: string]: string }): void {
 	if (event.type !== 'tool.call' && event.type !== 'tool.result' && event.type !== 'tool.execution_start') { return; }
 	const toolName = event.data?.toolName || event.toolName || 'unknown';
@@ -1568,7 +1568,7 @@ function _asuHandleToolCallEvent(event: any, analysis: SessionUsageAnalysis, too
 }
 
 /** Handle mcp.tool.call events and events with data.mcpServer set. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuHandleMcpToolEvent(event: any, analysis: SessionUsageAnalysis): void {
 	if (event.type !== 'mcp.tool.call' && !event.data?.mcpServer) { return; }
 	analysis.mcpTools.total++;
@@ -1580,14 +1580,14 @@ function _asuHandleMcpToolEvent(event: any, analysis: SessionUsageAnalysis): voi
 }
 
 /** Handle tool.call / tool.result / mcp.tool.call events. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuHandleToolAndMcpEvents(event: any, analysis: SessionUsageAnalysis, toolNameMap: { [key: string]: string }): void {
 	_asuHandleToolCallEvent(event, analysis, toolNameMap);
 	_asuHandleMcpToolEvent(event, analysis);
 }
 
 /** Dispatch a single JSONL event to the appropriate event handlers. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _asuProcessJsonlEvent(event: any, analysis: SessionUsageAnalysis, modeState: AsuModeState, cliState: AsuCliState, jetBrainsMode: JetBrainsMode | null, toolNameMap: { [key: string]: string }): void {
 	_asuHandleKind0Event(event, analysis, modeState);
 	_asuHandleKind1Event(event, analysis, modeState);
@@ -1758,7 +1758,7 @@ function _gmusProcessCliShutdownMetrics(
 }
 
 /** Handle an assistant.message event, recording real or estimated output tokens. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusHandleAssistantMessage(event: any, model: string, state: GmusJsonlState, modelUsage: ModelUsage, deps: GmusDeps): void {
 	const realOutput = typeof event.data?.outputTokens === 'number' ? event.data.outputTokens : 0;
 	if (realOutput > 0) {
@@ -1770,7 +1770,7 @@ function _gmusHandleAssistantMessage(event: any, model: string, state: GmusJsonl
 }
 
 /** Handle a session.shutdown event, accumulating CLI shutdown model metrics into state. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusHandleShutdownEvent(event: any, state: GmusJsonlState): void {
 	if (!event.data?.modelMetrics) { return; }
 	if (!state.cliShutdownModelUsage) { state.cliShutdownModelUsage = {}; }
@@ -1778,7 +1778,7 @@ function _gmusHandleShutdownEvent(event: any, state: GmusJsonlState): void {
 }
 
 /** Dispatch a CLI-format JSONL event to the appropriate token accumulation handler. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusProcessCliEventLine(event: any, model: string, state: GmusJsonlState, modelUsage: ModelUsage, deps: GmusDeps): void {
 	if (event.type === 'session.shutdown') {
 		_gmusHandleShutdownEvent(event, state);
@@ -1795,21 +1795,21 @@ function _gmusProcessCliEventLine(event: any, model: string, state: GmusJsonlSta
 }
 
 /** Extract the model identifier from a kind-0 (session header) delta event, or null if absent. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusExtractKind0Model(event: any): string | null {
 	if (event.kind !== 0) { return null; }
 	return event.v?.selectedModel?.identifier || event.v?.selectedModel?.metadata?.id || event.v?.inputState?.selectedModel?.metadata?.id || null;
 }
 
 /** Extract the model identifier from a kind-2 selectedModel update event, or null if absent. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusExtractKind2Model(event: any): string | null {
 	if (event.kind !== 2 || event.k?.[0] !== 'selectedModel') { return null; }
 	return event.v?.identifier || event.v?.metadata?.id || null;
 }
 
 /** Update the default model tracked in state based on model-selection events. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusUpdateDefaultModelFromEvent(event: any, state: GmusJsonlState): void {
 	if (event.type === 'session.start' && typeof event.data?.selectedModel === 'string') {
 		state.defaultModel = event.data.selectedModel;
@@ -1826,7 +1826,7 @@ function _gmusUpdateDefaultModelFromEvent(event: any, state: GmusJsonlState): vo
 }
 
 /** Process a single parsed JSONL event, updating state and model usage. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function _gmusProcessJsonlLine(event: any, state: GmusJsonlState, modelUsage: ModelUsage, deps: GmusDeps): void {
 	if (typeof event.kind === 'number') {
 		state.isDeltaBased = true;
@@ -1847,7 +1847,7 @@ function _gmusParseJsonlLines(lines: string[], modelUsage: ModelUsage, deps: Gmu
 	for (const line of lines) {
 		if (!line.trim()) { continue; }
 		try {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			 
 			const event: any = JSON.parse(line);
 			_gmusProcessJsonlLine(event, state, modelUsage, deps);
 		} catch { /* skip malformed lines */ }

--- a/vscode-extension/src/utils/errors.ts
+++ b/vscode-extension/src/utils/errors.ts
@@ -60,7 +60,7 @@ function _sseFromErrorInstance(error: Error, secretsToRedact?: string[]): string
 }
 
 function _sseFromObject(error: object): string {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	 
 	const errorObj = error as any;
 	try {
 		return errorObj.message || errorObj.error || JSON.stringify(error);

--- a/vscode-extension/src/visualstudio.ts
+++ b/vscode-extension/src/visualstudio.ts
@@ -323,7 +323,7 @@ parts.push(inner.Content);
 return parts.join('\n');
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 private _decodeVcRaw(vcRaw: any, parts: string[]): void {
 const keys = Object.keys(vcRaw);
 if (keys.length === 0) { return; }
@@ -331,7 +331,7 @@ if (!isNaN(Number(keys[0]))) {
 try {
 const numKeys = keys.map(Number).sort((a, b) => a - b);
 const bytes = Buffer.from(numKeys.map(k => (vcRaw as Record<number, number>)[k]));
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 const inner = decode(bytes) as any;
 const innerData = Array.isArray(inner) ? inner[1] : inner;
 if (innerData?.Content && typeof innerData.Content === 'string') { parts.push(innerData.Content); }
@@ -346,7 +346,7 @@ parts.push(vcRaw.Content);
  * Each context item carries a ValueContainer whose second element is a
  * nested MessagePack-encoded byte array; decoded inner object has a Content field.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 extractContextText(contextArr: any): string {
 if (!Array.isArray(contextArr)) { return ''; }
 const parts: string[] = [];

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -369,52 +369,28 @@ export function getRepositoryUrl(): string {
 	return repoUrl || 'https://github.com/rajbos/ai-engineering-fluency';
 }
 
+function getModeFromAgentKind(id: string | undefined): 'agent' | 'plan' | 'customAgent' {
+	if (!id || id === 'agent') { return 'agent'; }
+	if (id.includes('plan-agent/Plan.agent.md')) { return 'plan'; }
+	if (id.includes('.agent.md')) { return 'customAgent'; }
+	return 'agent';
+}
+
 /**
  * Detect the actual mode type from inputState.mode object.
  * Returns 'ask', 'edit', 'agent', 'plan', or 'customAgent'.
  */
 export function getModeType(mode: ModeObject | string | null | undefined): 'ask' | 'edit' | 'agent' | 'plan' | 'customAgent' {
-	if (!mode) {
-		return 'ask';
-	}
-
-	// When mode arrives as a raw string kind (e.g. incremental state-update events)
+	if (!mode) { return 'ask'; }
 	if (typeof mode === 'string') {
 		if (mode === 'edit') { return 'edit'; }
 		if (mode === 'agent') { return 'agent'; }
 		return 'ask';
 	}
-
-	if (!mode.kind) {
-		return 'ask';
-	}
-
-	// Check kind first - edit and ask are straightforward
+	if (!mode.kind) { return 'ask'; }
 	if (mode.kind === 'edit') { return 'edit'; }
 	if (mode.kind === 'ask') { return 'ask'; }
-
-	// For agent kind, check the mode.id to differentiate
-	if (mode.kind === 'agent') {
-		if (!mode.id || mode.id === 'agent') {
-			// Standard agent mode (no special id or id='agent')
-			return 'agent';
-		}
-
-		// Check for plan mode (vscode-userdata:/.../plan-agent/Plan.agent.md)
-		if (typeof mode.id === 'string' && mode.id.includes('plan-agent/Plan.agent.md')) {
-			return 'plan';
-		}
-
-		// Check for custom agent (file:// URI to .agent.md)
-		if (typeof mode.id === 'string' && mode.id.includes('.agent.md')) {
-			return 'customAgent';
-		}
-
-		// Fallback to standard agent for any other agent kind
-		return 'agent';
-	}
-
-	// Default to ask for unknown modes
+	if (mode.kind === 'agent') { return getModeFromAgentKind(mode.id as string | undefined); }
 	return 'ask';
 }
 


### PR DESCRIPTION
Auto-fixes 22 unused no-explicit-any suppress comments across usageAnalysis.ts, errors.ts, and visualstudio.ts. Also extracts getModeFromAgentKind from getModeType to reduce cognitive complexity from 18 to 9.