### PR TITLE
Improve loading screen pending step text readability

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6011,7 +6011,7 @@ ${this.getLoadingHtmlBody(nonce)}
     --bg-secondary: var(--vscode-sideBar-background, #181825);
     --bg-card: var(--vscode-editorWidget-background, #24273a);
     --text-primary: var(--vscode-editor-foreground, #cdd6f4);
-    --text-muted: var(--vscode-disabledForeground, #6c7086);
+    --text-muted: var(--vscode-descriptionForeground, #9399b2);
     --accent: var(--vscode-textLink-foreground, #89b4fa);
     --success: var(--vscode-terminal-ansiGreen, #a6e3a1);
     --border: var(--vscode-panel-border, #313244);


### PR DESCRIPTION
The pending steps ('Computing statistics', 'Ready!') in the loading screen used \--vscode-disabledForeground\ (#6c7086) which is very dark and hard to read on a dark background.

Changed to \--vscode-descriptionForeground\ (#9399b2) which is the VS Code semantic token intended for secondary/descriptive text — noticeably lighter and much more readable while still visually distinct from active/completed steps.