### PR TITLE
feat: show loading steps in status bar tooltip flyout during analysis

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1663,6 +1663,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (silent) { return undefined; }
 		let parsingStepNotified = false;
 		let lastProgressSentMs = 0;
+		let lastTooltipPctBucket = -1;
 		return (completed: number, total: number) => {
 			const percentage = Math.round((completed / total) * 100);
 			this.setStatusBarText(`$(loading~spin) Analyzing Logs: ${percentage}%`);
@@ -1673,12 +1674,18 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const msg: Record<string, unknown> = { command: 'loadingStep', step: 'parsing', total, editors };
 				this.sendLoadingPanelMessage(msg);
 				// Update tooltip once when parsing starts (editors are now known).
-				// Do NOT update again on each 500ms tick — VS Code destroys and recreates the
-				// tooltip widget on every property change, causing continuous flickering.
 				// Skip entirely when the loading panel is already open — no need to double up.
 				if (!this._detailsPanelIsLoading) {
-					this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing');
+					this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing', percentage > 0 ? percentage : undefined);
 				}
+			}
+			// Update tooltip at each 10% boundary to show real progress.
+			// Using buckets (not raw %) prevents multiple updates at the same threshold.
+			// Skip when the loading panel is open — the panel already shows progress.
+			const pctBucket = Math.floor(percentage / 10);
+			if (!this._detailsPanelIsLoading && pctBucket > lastTooltipPctBucket && percentage > 0) {
+				lastTooltipPctBucket = pctBucket;
+				this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing', percentage);
 			}
 			const now = Date.now();
 			if (now - lastProgressSentMs >= 500 || completed === total) {
@@ -1716,8 +1723,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.statusBarItem.tooltip = this.buildTooltipMarkdown(detailedStats);
 	}
 
-	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing'): vscode.MarkdownString {
-		const svg = this.generateLoadingSvg(step, this._loadingEditors);
+	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing', percentage?: number): vscode.MarkdownString {
+		const svg = this.generateLoadingSvg(step, this._loadingEditors, percentage);
 		const tooltip = new vscode.MarkdownString(`![Loading](data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)})`);
 		tooltip.isTrusted = true;
 		tooltip.supportThemeIcons = false;
@@ -1727,7 +1734,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity
 	private generateLoadingSvg(
 		step: 'discovering' | 'parsing' | 'computing',
-		editors: { icon: string; name: string }[]
+		editors: { icon: string; name: string }[],
+		percentage?: number
 	): string {
 		const W = 440, P = 16;
 		const BG   = '#181825', CARD  = '#24273a', FG  = '#cdd6f4';
@@ -1742,8 +1750,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			'Discovering session files', 'Checking cache',
 			'Parsing session logs',      'Computing statistics', 'Ready!',
 		];
-		const pct     = step === 'computing' ? 96 : 2;
-		const pctTxt  = step === 'computing' ? '96%' : '–';
+		const pct     = step === 'computing' ? 96 : (percentage ?? 0);
+		const pctTxt  = step === 'computing' ? '96%' : (percentage !== undefined && percentage > 0 ? `${percentage}%` : '–');
 		const subtitle =
 			step === 'discovering' ? 'Discovering session files...' :
 			step === 'parsing'     ? 'Parsing session files...'     :
@@ -1788,8 +1796,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Progress track
 		o.push(`<rect x="${P}" y="${PRY}" width="${PW}" height="${PRH}" rx="2.5" fill="${BRD}"/>`);
 
-		// Progress fill — shimmer (indeterminate) during discovering/parsing, solid fill for computing
-		if (step !== 'computing') {
+		// Progress fill — shimmer (indeterminate) during discovering/early parsing, solid fill when progress is known
+		if (step !== 'computing' && pct === 0) {
 			const sw = Math.round(PW * 0.25);
 			o.push(`<rect y="${PRY}" width="${sw}" height="${PRH}" rx="2.5" fill="url(#pg)" clip-path="url(#pclip)">
   <animate attributeName="x" from="${P - Math.round(PW * 0.35)}" to="${P + Math.round(PW * 1.1)}" dur="1.8s" repeatCount="indefinite" calcMode="ease-in-out"/>
@@ -4332,6 +4340,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (!stats) {
 			this.log('No cached stats — showing loading screen while calculating...');
 			this._detailsPanelIsLoading = true;
+			this.statusBarItem.tooltip = 'AI Engineering Fluency — loading in panel…';
 			this.detailsPanel.webview.html = this.getLoadingHtml(this.detailsPanel.webview);
 
 			stats = await this.updateTokenStats();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -371,6 +371,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// Flag to track if details panel is currently showing the loading screen
 	private _detailsPanelIsLoading = false;
 
+	// Editor list captured during the last (or current) log analysis, used to render the loading tooltip SVG
+	private _loadingEditors: { icon: string; name: string }[] = [];
+
 	// Cache mapping workspaceStorageId -> resolved workspace folder path (or undefined if not resolvable)
 	private _workspaceIdToFolderCache: Map<string, string | undefined> = new Map();
 
@@ -1608,6 +1611,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const { last30DaysStartMs, lastMonthStartMs } = computeUtcDateRanges(new Date());
 			const fileLoadCutoffMs = Math.min(last30DaysStartMs, lastMonthStartMs);
 
+			this._loadingEditors = [];
 			this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'discovering' });
 			if (!silent) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('discovering'); }
 
@@ -1665,6 +1669,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (!parsingStepNotified) {
 				parsingStepNotified = true;
 				const editors = getEditors?.() ?? [];
+				this._loadingEditors = editors;
 				const msg: Record<string, unknown> = { command: 'loadingStep', step: 'parsing', total, editors };
 				this.sendLoadingPanelMessage(msg);
 			}
@@ -1706,35 +1711,132 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing', percentage?: number): vscode.MarkdownString {
-		const tooltip = new vscode.MarkdownString();
-		tooltip.isTrusted = false;
-		tooltip.supportThemeIcons = true;
-		tooltip.appendMarkdown('#### $(loading~spin) AI Engineering Fluency — Loading…\n');
-		tooltip.appendMarkdown('\n---\n');
-		const steps: { id: 'discovering' | 'parsing' | 'computing'; label: string }[] = [
-			{ id: 'discovering', label: 'Discovering session files' },
-			{ id: 'parsing', label: 'Parsing session logs' },
-			{ id: 'computing', label: 'Computing statistics' },
-		];
-		const order = ['discovering', 'parsing', 'computing'] as const;
-		const currentIdx = order.indexOf(step);
-		for (let i = 0; i < steps.length; i++) {
-			const s = steps[i];
-			let icon: string;
-			let label = s.label;
-			if (i < currentIdx) {
-				icon = '$(check)';
-			} else if (i === currentIdx) {
-				icon = '$(loading~spin)';
-				if (step === 'parsing' && percentage !== undefined) {
-					label += ` — ${percentage}%`;
-				}
-			} else {
-				icon = '$(circle-outline)';
-			}
-			tooltip.appendMarkdown(`${icon} ${label}  \n`);
-		}
+		const svg = this.generateLoadingSvg(step, percentage, this._loadingEditors);
+		const tooltip = new vscode.MarkdownString(`![Loading](data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)})`);
+		tooltip.isTrusted = true;
+		tooltip.supportThemeIcons = false;
 		return tooltip;
+	}
+
+	// eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity
+	private generateLoadingSvg(
+		step: 'discovering' | 'parsing' | 'computing',
+		percentage: number | undefined,
+		editors: { icon: string; name: string }[]
+	): string {
+		const W = 440, P = 16;
+		const BG   = '#181825', CARD  = '#24273a', FG  = '#cdd6f4';
+		const MUT  = '#9399b2', ACC   = '#89b4fa', OK  = '#a6e3a1';
+		const BRD  = '#313244';
+		const FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif";
+		const esc  = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+		const doneUntil  = step === 'discovering' ? 0 : step === 'parsing' ? 2 : 3;
+		const activeStep = step === 'discovering' ? 0 : step === 'parsing' ? 2 : 3;
+		const STEPS = [
+			'Discovering session files', 'Checking cache',
+			'Parsing session logs',      'Computing statistics', 'Ready!',
+		];
+		const pct     = step === 'computing' ? 96 : Math.max(2, percentage ?? 0);
+		const pctTxt  = step === 'discovering' ? '–' : `${pct}%`;
+		const subtitle =
+			step === 'discovering'                    ? 'Discovering session files...' :
+			step === 'parsing' && percentage !== undefined  ? `Parsing session files… ${pct}%` :
+			step === 'parsing'                        ? 'Parsing session files...' :
+			                                            'Computing statistics...';
+		const pills   = editors.slice(0, 6);
+		const hasPills = pills.length > 0;
+
+		// Layout
+		const BY    = P + 13;
+		const TY    = BY + 20;
+		const SBY   = TY + 16;
+		const PRY   = SBY + 16;
+		const PRH   = 5;
+		const PIL_Y = PRY + PRH + 8;
+		const SBX_Y = PIL_Y + (hasPills ? 28 : 0) + 6;
+		const SBX_H = P + STEPS.length * 22 + 8;
+		const H     = SBX_Y + SBX_H + P;
+		const PW    = W - P * 2;
+
+		const o: string[] = [];
+		o.push(`<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">`);
+		o.push(`<defs>
+  <linearGradient id="pg" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="${ACC}"/>
+    <stop offset="100%" stop-color="${OK}"/>
+  </linearGradient>
+  <clipPath id="pclip"><rect x="${P}" y="${PRY}" width="${PW}" height="${PRH}" rx="2.5"/></clipPath>
+</defs>`);
+
+		// Card background
+		o.push(`<rect width="${W}" height="${H}" rx="10" fill="${BG}" stroke="${BRD}"/>`);
+
+		// Badge
+		o.push(`<text x="${P}" y="${BY}" font-family="${FONT}" font-size="10" font-weight="700" letter-spacing="1.5" fill="${ACC}">🤖 ANALYZING YOUR AI ACTIVITY</text>`);
+
+		// Title + large pct display
+		o.push(`<text x="${P}" y="${TY}" font-family="${FONT}" font-size="17" font-weight="700" fill="${FG}">Building Activity Index</text>`);
+		o.push(`<text x="${W - P}" y="${TY}" text-anchor="end" font-family="${FONT}" font-size="26" font-weight="800" fill="${FG}">${esc(pctTxt)}</text>`);
+
+		// Subtitle
+		o.push(`<text x="${P}" y="${SBY}" font-family="${FONT}" font-size="11" fill="${MUT}">${esc(subtitle)}</text>`);
+
+		// Progress track
+		o.push(`<rect x="${P}" y="${PRY}" width="${PW}" height="${PRH}" rx="2.5" fill="${BRD}"/>`);
+
+		// Progress fill — shimmer when indeterminate, solid fill otherwise
+		if (step === 'discovering') {
+			const sw = Math.round(PW * 0.25);
+			o.push(`<rect y="${PRY}" width="${sw}" height="${PRH}" rx="2.5" fill="url(#pg)" clip-path="url(#pclip)">
+  <animate attributeName="x" from="${P - Math.round(PW * 0.35)}" to="${P + Math.round(PW * 1.1)}" dur="1.8s" repeatCount="indefinite" calcMode="ease-in-out"/>
+</rect>`);
+		} else {
+			const fw = Math.max(8, Math.round((pct / 100) * PW));
+			o.push(`<rect x="${P}" y="${PRY}" width="${fw}" height="${PRH}" rx="2.5" fill="url(#pg)"/>`);
+		}
+
+		// Editor pills
+		if (hasPills) {
+			let px = P;
+			for (const ed of pills) {
+				const rawLbl = `${ed.icon} ${ed.name}`;
+				const pw2    = Math.min(Math.max([...rawLbl].length * 7 + 16, 64), 130);
+				if (px + pw2 > W - P) { break; }
+				o.push(`<rect x="${px}" y="${PIL_Y}" width="${pw2}" height="22" rx="11" fill="${CARD}" stroke="${BRD}"/>`);
+				o.push(`<text x="${px + pw2 / 2}" y="${PIL_Y + 15}" text-anchor="middle" font-family="${FONT}" font-size="10.5" fill="${FG}">${esc(rawLbl)}</text>`);
+				px += Math.round(pw2) + 6;
+			}
+		}
+
+		// Steps box
+		o.push(`<rect x="${P}" y="${SBX_Y}" width="${PW}" height="${SBX_H}" rx="8" fill="${CARD}" stroke="${BRD}"/>`);
+
+		const ICX = P + P + 4;
+		const LBX = ICX + 18;
+		let sy = SBX_Y + P + 8;
+		for (let i = 0; i < STEPS.length; i++) {
+			const done   = i < doneUntil;
+			const active = i === activeStep;
+			const col    = done ? OK : active ? ACC : MUT;
+			const wt     = active ? '600' : '400';
+			const lbl    = i === 2 && active && percentage !== undefined ? `Parsing session logs — ${pct}%` : STEPS[i];
+
+			if (done) {
+				o.push(`<text x="${ICX}" y="${sy}" text-anchor="middle" font-family="monospace" font-size="13" fill="${OK}">✓</text>`);
+			} else if (active) {
+				// Spinning ↻ via SMIL animateTransform around the glyph centre
+				const cy = sy - 4;
+				o.push(`<text x="${ICX}" y="${sy}" text-anchor="middle" font-family="monospace" font-size="13" fill="${ACC}">↻<animateTransform attributeName="transform" type="rotate" values="0 ${ICX} ${cy};360 ${ICX} ${cy}" dur="0.75s" repeatCount="indefinite" additive="sum"/></text>`);
+			} else {
+				o.push(`<text x="${ICX}" y="${sy}" text-anchor="middle" font-size="13" fill="${MUT}">○</text>`);
+			}
+			o.push(`<text x="${LBX}" y="${sy}" font-family="${FONT}" font-size="12" font-weight="${wt}" fill="${col}">${esc(lbl)}</text>`);
+			sy += 22;
+		}
+
+		o.push('</svg>');
+		return o.join('');
 	}
 
 	private buildTooltipMarkdown(detailedStats: DetailedStats): vscode.MarkdownString {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1613,7 +1613,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 			this._loadingEditors = [];
 			this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'discovering' });
-			if (!silent) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('discovering'); }
+			if (!silent && !this._detailsPanelIsLoading) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('discovering'); }
 
 			// Streaming pipeline: discovery and parsing run concurrently.
 			// Workers start processing files as each adapter batch arrives.
@@ -1624,7 +1624,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const { sessionFiles, preloaded } = await this._preloadSessionFiles(fileLoadCutoffMs, progressCallback, discoveredEditorSet);
 
 			this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'computing' });
-			if (!silent) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('computing'); }
+			if (!silent && !this._detailsPanelIsLoading) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('computing'); }
 
 			const { stats: detailedStats, dailyStats } = await this.calculateDetailedStats(undefined, preloaded);
 			this.lastDailyStats = dailyStats;
@@ -1675,7 +1675,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 				// Update tooltip once when parsing starts (editors are now known).
 				// Do NOT update again on each 500ms tick — VS Code destroys and recreates the
 				// tooltip widget on every property change, causing continuous flickering.
-				this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing');
+				// Skip entirely when the loading panel is already open — no need to double up.
+				if (!this._detailsPanelIsLoading) {
+					this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing');
+				}
 			}
 			const now = Date.now();
 			if (now - lastProgressSentMs >= 500 || completed === total) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1609,6 +1609,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const fileLoadCutoffMs = Math.min(last30DaysStartMs, lastMonthStartMs);
 
 			this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'discovering' });
+			if (!silent) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('discovering'); }
 
 			// Streaming pipeline: discovery and parsing run concurrently.
 			// Workers start processing files as each adapter batch arrives.
@@ -1619,6 +1620,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const { sessionFiles, preloaded } = await this._preloadSessionFiles(fileLoadCutoffMs, progressCallback, discoveredEditorSet);
 
 			this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'computing' });
+			if (!silent) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('computing'); }
 
 			const { stats: detailedStats, dailyStats } = await this.calculateDetailedStats(undefined, preloaded);
 			this.lastDailyStats = dailyStats;
@@ -1670,6 +1672,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (now - lastProgressSentMs >= 500 || completed === total) {
 				lastProgressSentMs = now;
 				this.sendLoadingPanelMessage({ command: 'loadingProgress', completed, total, percentage });
+				this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing', percentage);
 			}
 		};
 	}
@@ -1700,6 +1703,38 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.setStatusBarText(this.buildStatusBarText(detailedStats));
 		}
 		this.statusBarItem.tooltip = this.buildTooltipMarkdown(detailedStats);
+	}
+
+	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing', percentage?: number): vscode.MarkdownString {
+		const tooltip = new vscode.MarkdownString();
+		tooltip.isTrusted = false;
+		tooltip.supportThemeIcons = true;
+		tooltip.appendMarkdown('#### $(loading~spin) AI Engineering Fluency — Loading…\n');
+		tooltip.appendMarkdown('\n---\n');
+		const steps: { id: 'discovering' | 'parsing' | 'computing'; label: string }[] = [
+			{ id: 'discovering', label: 'Discovering session files' },
+			{ id: 'parsing', label: 'Parsing session logs' },
+			{ id: 'computing', label: 'Computing statistics' },
+		];
+		const order = ['discovering', 'parsing', 'computing'] as const;
+		const currentIdx = order.indexOf(step);
+		for (let i = 0; i < steps.length; i++) {
+			const s = steps[i];
+			let icon: string;
+			let label = s.label;
+			if (i < currentIdx) {
+				icon = '$(check)';
+			} else if (i === currentIdx) {
+				icon = '$(loading~spin)';
+				if (step === 'parsing' && percentage !== undefined) {
+					label += ` — ${percentage}%`;
+				}
+			} else {
+				icon = '$(circle-outline)';
+			}
+			tooltip.appendMarkdown(`${icon} ${label}  \n`);
+		}
+		return tooltip;
 	}
 
 	private buildTooltipMarkdown(detailedStats: DetailedStats): vscode.MarkdownString {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1672,12 +1672,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this._loadingEditors = editors;
 				const msg: Record<string, unknown> = { command: 'loadingStep', step: 'parsing', total, editors };
 				this.sendLoadingPanelMessage(msg);
+				// Update tooltip once when parsing starts (editors are now known).
+				// Do NOT update again on each 500ms tick — VS Code destroys and recreates the
+				// tooltip widget on every property change, causing continuous flickering.
+				this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing');
 			}
 			const now = Date.now();
 			if (now - lastProgressSentMs >= 500 || completed === total) {
 				lastProgressSentMs = now;
 				this.sendLoadingPanelMessage({ command: 'loadingProgress', completed, total, percentage });
-				this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('parsing', percentage);
 			}
 		};
 	}
@@ -1710,8 +1713,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.statusBarItem.tooltip = this.buildTooltipMarkdown(detailedStats);
 	}
 
-	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing', percentage?: number): vscode.MarkdownString {
-		const svg = this.generateLoadingSvg(step, percentage, this._loadingEditors);
+	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing'): vscode.MarkdownString {
+		const svg = this.generateLoadingSvg(step, this._loadingEditors);
 		const tooltip = new vscode.MarkdownString(`![Loading](data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)})`);
 		tooltip.isTrusted = true;
 		tooltip.supportThemeIcons = false;
@@ -1721,7 +1724,6 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity
 	private generateLoadingSvg(
 		step: 'discovering' | 'parsing' | 'computing',
-		percentage: number | undefined,
 		editors: { icon: string; name: string }[]
 	): string {
 		const W = 440, P = 16;
@@ -1737,24 +1739,22 @@ class CopilotTokenTracker implements vscode.Disposable {
 			'Discovering session files', 'Checking cache',
 			'Parsing session logs',      'Computing statistics', 'Ready!',
 		];
-		const pct     = step === 'computing' ? 96 : Math.max(2, percentage ?? 0);
-		const pctTxt  = step === 'discovering' ? '–' : `${pct}%`;
+		const pct     = step === 'computing' ? 96 : 2;
+		const pctTxt  = step === 'computing' ? '96%' : '–';
 		const subtitle =
-			step === 'discovering'                    ? 'Discovering session files...' :
-			step === 'parsing' && percentage !== undefined  ? `Parsing session files… ${pct}%` :
-			step === 'parsing'                        ? 'Parsing session files...' :
-			                                            'Computing statistics...';
+			step === 'discovering' ? 'Discovering session files...' :
+			step === 'parsing'     ? 'Parsing session files...'     :
+			                         'Computing statistics...';
 		const pills   = editors.slice(0, 6);
-		const hasPills = pills.length > 0;
 
-		// Layout
+		// Layout — always reserve pills row so height never changes between phases
 		const BY    = P + 13;
 		const TY    = BY + 20;
 		const SBY   = TY + 16;
 		const PRY   = SBY + 16;
 		const PRH   = 5;
 		const PIL_Y = PRY + PRH + 8;
-		const SBX_Y = PIL_Y + (hasPills ? 28 : 0) + 6;
+		const SBX_Y = PIL_Y + 34;  // 28px pills height + 6px gap, always reserved
 		const SBX_H = P + STEPS.length * 22 + 8;
 		const H     = SBX_Y + SBX_H + P;
 		const PW    = W - P * 2;
@@ -1785,8 +1785,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Progress track
 		o.push(`<rect x="${P}" y="${PRY}" width="${PW}" height="${PRH}" rx="2.5" fill="${BRD}"/>`);
 
-		// Progress fill — shimmer when indeterminate, solid fill otherwise
-		if (step === 'discovering') {
+		// Progress fill — shimmer (indeterminate) during discovering/parsing, solid fill for computing
+		if (step !== 'computing') {
 			const sw = Math.round(PW * 0.25);
 			o.push(`<rect y="${PRY}" width="${sw}" height="${PRH}" rx="2.5" fill="url(#pg)" clip-path="url(#pclip)">
   <animate attributeName="x" from="${P - Math.round(PW * 0.35)}" to="${P + Math.round(PW * 1.1)}" dur="1.8s" repeatCount="indefinite" calcMode="ease-in-out"/>
@@ -1797,7 +1797,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 
 		// Editor pills
-		if (hasPills) {
+		if (pills.length > 0) {
 			let px = P;
 			for (const ed of pills) {
 				const rawLbl = `${ed.icon} ${ed.name}`;
@@ -1820,7 +1820,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const active = i === activeStep;
 			const col    = done ? OK : active ? ACC : MUT;
 			const wt     = active ? '600' : '400';
-			const lbl    = i === 2 && active && percentage !== undefined ? `Parsing session logs — ${pct}%` : STEPS[i];
+			const lbl    = STEPS[i];
 
 			if (done) {
 				o.push(`<text x="${ICX}" y="${sy}" text-anchor="middle" font-family="monospace" font-size="13" fill="${OK}">✓</text>`);


### PR DESCRIPTION
During log analysis, update the status bar tooltip to reflect the current loading step using the same steps as the loading screen panel.

## What changed
- Added uildLoadingTooltipMarkdown(step, percentage?) method that builds a MarkdownString with supportThemeIcons = true
- Shows 3 steps with codicon icons: \\\ for active, \\\ for done, \\\ for pending
- Steps: **Discovering session files** → **Parsing session logs** (with %) → **Computing statistics**
- Tooltip updated at the 'discovering' step, throttled during parsing (every 500ms), and at the 'computing' step
- Only updates when not in silent mode (matching existing status bar text behaviour)