### PR TITLE
feat: monthly budget setting with status bar color alerts

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -196,6 +196,12 @@
           "default": "none",
           "description": "Controls which estimated costs (in USD) are shown in the status bar. Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing)."
         },
+        "aiEngineeringFluency.display.statusBar.monthlyBudget": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Monthly AI spend budget in USD. When set above 0, the status bar will change color as you approach the limit: yellow at 75%, orange at 90%, red at 100% or over. Set to 0 to disable budget coloring. Cost is estimated using GitHub Copilot AI-Credit rates."
+        },
         "aiEngineeringFluency.backend.enabled": {
           "type": "boolean",
           "default": false,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6680,7 +6680,13 @@ ${this.getLoadingHtmlScript()}
       'display.statusBar.monthlyBudget': 'aiEngineeringFluency.display.statusBar.monthlyBudget',
     };
     const fullKey = fullKeyMap[key];
-    if (fullKey) { await vscode.workspace.getConfiguration().update(fullKey, value, vscode.ConfigurationTarget.Global); }
+    if (!fullKey) { return; }
+    let sanitised: any = value;
+    if (key === 'display.statusBar.monthlyBudget') {
+      const n = typeof value === 'number' ? value : parseFloat(value);
+      sanitised = isNaN(n) ? 0 : Math.min(99999, Math.max(0, Math.round(n * 100) / 100));
+    }
+    await vscode.workspace.getConfiguration().update(fullKey, sanitised, vscode.ConfigurationTarget.Global);
   }
 
   private async diagHandleResetDebugCounters(): Promise<void> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1906,7 +1906,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (!this.chartPanel || (!this.lastFullDailyStats && !this.lastDailyStats)) { return; }
 		const chartStats = this.lastFullDailyStats ?? this.lastDailyStats!;
 		if (silent) {
-			void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: { ...this.buildChartData(chartStats), compactNumbers: this.getCompactNumbersSetting() } });
+			void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: { ...this.buildChartData(chartStats), compactNumbers: this.getCompactNumbersSetting(), monthlyBudget: this.getMonthlyBudgetSetting() } });
 		} else {
 			this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, chartStats);
 		}
@@ -7135,7 +7135,7 @@ ${this.getLoadingHtmlScript()}
       vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "chart.js"),
     );
 
-    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit };
+    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit, monthlyBudget: this.getMonthlyBudgetSetting() };
 
     const initialData = JSON.stringify(chartData).replace(/</g, "\\u003c");
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1721,6 +1721,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.setStatusBarText(this.buildStatusBarText(detailedStats));
 		}
 		this.statusBarItem.tooltip = this.buildTooltipMarkdown(detailedStats);
+		this.updateStatusBarBackgroundColor(detailedStats);
 	}
 
 	private buildLoadingTooltipMarkdown(step: 'discovering' | 'parsing' | 'computing', percentage?: number): vscode.MarkdownString {
@@ -1877,6 +1878,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		tooltip.appendMarkdown('\n---\n');
 		tooltip.appendMarkdown('*(UBB) = Copilot AI Credit rates — what Copilot will bill you under Usage Based Billing.*  \n');
 		tooltip.appendMarkdown('*Updates automatically every 5 minutes.*');
+		const budget = this.getMonthlyBudgetSetting();
+		if (budget > 0) {
+			const monthCost = detailedStats.month.estimatedCostCopilot ?? detailedStats.month.estimatedCost ?? 0;
+			const pct = Math.round((monthCost / budget) * 100);
+			tooltip.appendMarkdown(`\n---\n💰 Monthly budget: $${budget.toFixed(2)} — this month: $${monthCost.toFixed(2)} (${pct}%)`);
+		}
 		return tooltip;
 	}
 
@@ -2195,6 +2202,30 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar').get<StatusBarDisplaySetting>('showCost', 'none');
 	}
 
+	private getMonthlyBudgetSetting(): number {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar').get<number>('monthlyBudget', 0);
+	}
+
+	/** Updates the status bar background color based on current-month spend vs. the configured budget.
+	 *  Uses VS Code's built-in theme colors: warning (yellow) at ≥75%, error (red/orange) at ≥90%.
+	 *  Clears the background when no budget is configured or spend is below 75%. */
+	private updateStatusBarBackgroundColor(stats: DetailedStats): void {
+		const budget = this.getMonthlyBudgetSetting();
+		if (budget <= 0) {
+			this.statusBarItem.backgroundColor = undefined;
+			return;
+		}
+		const monthCost = stats.month.estimatedCostCopilot ?? stats.month.estimatedCost ?? 0;
+		const ratio = monthCost / budget;
+		if (ratio >= 0.90) {
+			this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+		} else if (ratio >= 0.75) {
+			this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+		} else {
+			this.statusBarItem.backgroundColor = undefined;
+		}
+	}
+
 	private buildTokenParts(show: StatusBarDisplaySetting, stats: DetailedStats): string[] {
 		const parts: string[] = [];
 		if (show === 'today' || show === 'both' || show === 'todayAndCurrentMonth') {
@@ -2242,8 +2273,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private refreshOpenPanelsForSettingChange(): void {
 		const stats = this.lastDetailedStats;
 		if (!stats) { return; }
-		// Refresh status bar text (respects new display settings)
+		// Refresh status bar text and background color (respects new display settings)
 		this.setStatusBarText(this.buildStatusBarText(stats));
+		this.updateStatusBarBackgroundColor(stats);
 		if (this.detailsPanel) {
 			this.detailsPanel.webview.html = this.getDetailsHtml(this.detailsPanel.webview, stats);
 		}
@@ -6645,6 +6677,7 @@ ${this.getLoadingHtmlScript()}
     const fullKeyMap: Record<string, string> = {
       'display.statusBar.showTokens': 'aiEngineeringFluency.display.statusBar.showTokens',
       'display.statusBar.showCost': 'aiEngineeringFluency.display.statusBar.showCost',
+      'display.statusBar.monthlyBudget': 'aiEngineeringFluency.display.statusBar.monthlyBudget',
     };
     const fullKey = fullKeyMap[key];
     if (fullKey) { await vscode.workspace.getConfiguration().update(fullKey, value, vscode.ConfigurationTarget.Global); }
@@ -7010,7 +7043,7 @@ ${this.getLoadingHtmlScript()}
       report, sessionFiles, detailedSessionFiles, sessionFolders,
       cacheInfo, backendStorageInfo,
       backendConfigured: this.isBackendConfigured(), isDebugMode, globalStateCounters,
-      displaySettings: { showTokens: this.getStatusBarShowTokensSetting(), showCost: this.getStatusBarShowCostSetting() },
+      displaySettings: { showTokens: this.getStatusBarShowTokensSetting(), showCost: this.getStatusBarShowCostSetting(), monthlyBudget: this.getMonthlyBudgetSetting() },
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1876,8 +1876,6 @@ class CopilotTokenTracker implements vscode.Disposable {
 		tooltip.appendMarkdown(`| Average interactions/session :      | ${detailedStats.last30Days.avgInteractionsPerSession} |\n`);
 		tooltip.appendMarkdown(`| Average tokens/session :            | ${detailedStats.last30Days.avgTokensPerSession.toLocaleString()} |\n`);
 		tooltip.appendMarkdown('\n---\n');
-		tooltip.appendMarkdown('*(UBB) = Copilot AI Credit rates — what Copilot will bill you under Usage Based Billing.*  \n');
-		tooltip.appendMarkdown('*Updates automatically every 5 minutes.*');
 		const budget = this.getMonthlyBudgetSetting();
 		if (budget > 0) {
 			const monthCost = detailedStats.month.estimatedCostCopilot ?? detailedStats.month.estimatedCost ?? 0;

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -699,21 +699,42 @@ function buildCostViewConfig(period: ChartPeriodData, baseOptions: ReturnType<ty
 	const lastIdx = period.costData.length - 1;
 	const projExtra = !isRolling && lastIdx >= 0 ? computeProjectionExtra(period.costData[lastIdx], getCurrentPeriodFraction(currentPeriod)) : null;
 	const projDs = projExtra !== null ? [{ label: PROJECTION_LABELS[currentPeriod], data: period.costData.map((_: number, i: number) => i === lastIdx ? projExtra : 0), backgroundColor: 'rgba(34, 197, 94, 0.2)', borderColor: 'rgba(34, 197, 94, 0.5)', borderWidth: 1, yAxisID: 'y' }] : [];
-	const budgetDs = currentPeriod === 'month' && monthlyBudget > 0
-		? [{ label: `Monthly Budget ($${monthlyBudget.toFixed(2)})`, data: period.labels.map(() => monthlyBudget), type: 'line' as const, borderColor: 'rgba(255, 80, 80, 0.9)', borderWidth: 2, borderDash: [6, 4], pointRadius: 0, fill: false, tension: 0, yAxisID: 'y' }]
-		: [];
 	const rollingLabel = getRollingLabel();
+	const showBudgetLine = currentPeriod === 'month' && monthlyBudget > 0;
+	const budgetLinePlugin = showBudgetLine ? {
+		id: 'budgetLine',
+		afterDraw(ch: any) {
+			const { ctx, chartArea, scales: { y } } = ch;
+			if (!y || !chartArea) { return; }
+			const yPos = y.getPixelForValue(monthlyBudget);
+			if (yPos < chartArea.top || yPos > chartArea.bottom) { return; }
+			ctx.save();
+			ctx.strokeStyle = 'rgba(255, 80, 80, 0.9)';
+			ctx.lineWidth = 2;
+			ctx.setLineDash([6, 4]);
+			ctx.beginPath();
+			ctx.moveTo(chartArea.left, yPos);
+			ctx.lineTo(chartArea.right, yPos);
+			ctx.stroke();
+			ctx.setLineDash([]);
+			ctx.fillStyle = 'rgba(255, 80, 80, 0.9)';
+			ctx.font = 'bold 11px sans-serif';
+			ctx.textAlign = 'left';
+			ctx.fillText(`Budget: $${monthlyBudget.toFixed(2)}`, chartArea.left + 6, yPos - 5);
+			ctx.restore();
+		},
+	} : null;
 	return {
 		type: 'bar' as const,
 		data: { labels: period.labels, datasets: [
 			{ label: isRolling ? `${rollingLabel} (UBB)` : 'Est. Cost (UBB)', data: costData, backgroundColor: isRolling ? 'rgba(34, 197, 94, 0.15)' : 'rgba(34, 197, 94, 0.6)', borderColor: 'rgba(34, 197, 94, 1)', borderWidth: isRolling ? 2 : 1, type: isRolling ? 'line' as const : undefined, tension: isRolling ? 0.4 : undefined, fill: isRolling ? false : undefined, yAxisID: 'y' },
-			...projDs,
-			...budgetDs
+			...projDs
 		] },
 		options: { ...baseOptions, plugins: { ...baseOptions.plugins, tooltip: { ...baseOptions.plugins.tooltip, callbacks: { label: (ctx: any) => ` $${Number(ctx.parsed.y).toFixed(4)}` } } },
 			scales: { x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } }, y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (UBB)', color: c.textColor, font: { size: 12, weight: 'bold' as const } } } }
-		}
-	};
+		},
+		...(budgetLinePlugin ? { plugins: [budgetLinePlugin] } : {}),
+	} as ChartConfig;
 }
 
 function buildOutputViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -69,6 +69,7 @@ type InitialChartData = {
 	initialView?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
 	initialMetric?: 'tokens' | 'output' | 'cost';
 	initialSplit?: 'total' | 'model' | 'editor' | 'repository' | 'language';
+	monthlyBudget?: number;
 	periods?: {
 		day: ChartPeriodData;
 		week: ChartPeriodData;
@@ -692,18 +693,22 @@ function buildTotalViewConfig(period: ChartPeriodData, baseOptions: ReturnType<t
 	};
 }
 
-function buildCostViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+function buildCostViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors, monthlyBudget = 0): ChartConfig {
 	const isRolling = currentDisplayMode === 'rolling';
 	const costData = isRolling ? computeRollingAverage(period.costData, ROLLING_WINDOW[currentPeriod]) : period.costData;
 	const lastIdx = period.costData.length - 1;
 	const projExtra = !isRolling && lastIdx >= 0 ? computeProjectionExtra(period.costData[lastIdx], getCurrentPeriodFraction(currentPeriod)) : null;
 	const projDs = projExtra !== null ? [{ label: PROJECTION_LABELS[currentPeriod], data: period.costData.map((_: number, i: number) => i === lastIdx ? projExtra : 0), backgroundColor: 'rgba(34, 197, 94, 0.2)', borderColor: 'rgba(34, 197, 94, 0.5)', borderWidth: 1, yAxisID: 'y' }] : [];
+	const budgetDs = currentPeriod === 'month' && monthlyBudget > 0
+		? [{ label: `Monthly Budget ($${monthlyBudget.toFixed(2)})`, data: period.labels.map(() => monthlyBudget), type: 'line' as const, borderColor: 'rgba(255, 80, 80, 0.9)', borderWidth: 2, borderDash: [6, 4], pointRadius: 0, fill: false, tension: 0, yAxisID: 'y' }]
+		: [];
 	const rollingLabel = getRollingLabel();
 	return {
 		type: 'bar' as const,
 		data: { labels: period.labels, datasets: [
 			{ label: isRolling ? `${rollingLabel} (UBB)` : 'Est. Cost (UBB)', data: costData, backgroundColor: isRolling ? 'rgba(34, 197, 94, 0.15)' : 'rgba(34, 197, 94, 0.6)', borderColor: 'rgba(34, 197, 94, 1)', borderWidth: isRolling ? 2 : 1, type: isRolling ? 'line' as const : undefined, tension: isRolling ? 0.4 : undefined, fill: isRolling ? false : undefined, yAxisID: 'y' },
-			...projDs
+			...projDs,
+			...budgetDs
 		] },
 		options: { ...baseOptions, plugins: { ...baseOptions.plugins, tooltip: { ...baseOptions.plugins.tooltip, callbacks: { label: (ctx: any) => ` $${Number(ctx.parsed.y).toFixed(4)}` } } },
 			scales: { x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } }, y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (UBB)', color: c.textColor, font: { size: 12, weight: 'bold' as const } } } }
@@ -752,7 +757,7 @@ function createConfig(data: InitialChartData): ChartConfig {
 	const c = getChartColors();
 	const baseOptions = buildBaseOptions(c);
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
-	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c); }
+	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }
 	if (view.startsWith('output-')) { return buildOutputViewConfig(view, period, baseOptions, c); }
 	return buildStackedViewConfig(view, period, baseOptions, c);
 }

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -731,7 +731,7 @@ function buildCostViewConfig(period: ChartPeriodData, baseOptions: ReturnType<ty
 			...projDs
 		] },
 		options: { ...baseOptions, plugins: { ...baseOptions.plugins, tooltip: { ...baseOptions.plugins.tooltip, callbacks: { label: (ctx: any) => ` $${Number(ctx.parsed.y).toFixed(4)}` } } },
-			scales: { x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } }, y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (UBB)', color: c.textColor, font: { size: 12, weight: 'bold' as const } } } }
+			scales: { x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } }, y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (UBB)', color: c.textColor, font: { size: 12, weight: 'bold' as const } }, ...(showBudgetLine ? { suggestedMax: monthlyBudget * 1.05 } : {}) } }
 		},
 		...(budgetLinePlugin ? { plugins: [budgetLinePlugin] } : {}),
 	} as ChartConfig;

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -100,6 +100,7 @@ type StatusBarShowOption = 'none' | 'today' | 'last30days' | 'currentMonth' | 'b
 type DisplaySettings = {
   showTokens: StatusBarShowOption;
   showCost: StatusBarShowOption;
+  monthlyBudget?: number;
 };
 
 type DiagnosticsData = {
@@ -1156,6 +1157,14 @@ function setupDisplaySettingHandlers(): void {
       const value = (e.target as HTMLSelectElement).value;
       vscode.postMessage({ command: "updateDisplaySetting", key: "display.statusBar.showCost", value });
     });
+
+  document
+    .getElementById("input-monthly-budget")
+    ?.addEventListener("change", (e) => {
+      const raw = (e.target as HTMLInputElement).value;
+      const value = Math.max(0, parseFloat(raw) || 0);
+      vscode.postMessage({ command: "updateDisplaySetting", key: "display.statusBar.monthlyBudget", value });
+    });
 }
 
 function setupSubtabHandlers(): void {
@@ -1748,6 +1757,7 @@ function sel(current: string, value: string): string {
 function renderDiagDisplayTabHtml(data: DiagnosticsData): string {
   const showTokens = data.displaySettings?.showTokens ?? 'both';
   const showCost = data.displaySettings?.showCost ?? 'none';
+  const monthlyBudget = data.displaySettings?.monthlyBudget ?? 0;
   return `
 <div id="tab-display" class="tab-content">
 <div class="info-box">
@@ -1784,6 +1794,17 @@ Choose what to show in the VS Code status bar toolbar. You can show token counts
 </div>
 </div>
 <p style="color: #888; font-size: 11px; margin-top: 12px;">Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing). Changes apply to the status bar immediately.</p>
+</div>
+<div class="backend-card">
+<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">💰 Monthly Budget</h4>
+<p style="color: #ccc; margin-bottom: 16px;">
+Set a monthly AI spend budget in USD to get visual alerts on the status bar. The bar turns yellow at 75%, orange at 90%, and red at 100% of your budget. Set to 0 to disable.
+</p>
+<div style="display: flex; align-items: center; gap: 12px;">
+  <label style="color: #ccc; min-width: 160px; font-size: 13px;">💵 Monthly budget (USD):</label>
+  <input id="input-monthly-budget" type="number" min="0" step="1" value="${monthlyBudget}" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px; width: 100px;" />
+</div>
+<p style="color: #888; font-size: 11px; margin-top: 12px;">Budget coloring uses the current calendar month's estimated cost. Set to 0 to disable.</p>
 </div>
 <div class="backend-card">
 <h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">🔢 Number Formatting</h4>

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1161,8 +1161,10 @@ function setupDisplaySettingHandlers(): void {
   document
     .getElementById("input-monthly-budget")
     ?.addEventListener("change", (e) => {
-      const raw = (e.target as HTMLInputElement).value;
-      const value = Math.max(0, parseFloat(raw) || 0);
+      const input = e.target as HTMLInputElement;
+      const raw = parseFloat(input.value);
+      const value = isNaN(raw) ? 0 : Math.min(99999, Math.max(0, Math.round(raw * 100) / 100));
+      input.value = value.toString();
       vscode.postMessage({ command: "updateDisplaySetting", key: "display.statusBar.monthlyBudget", value });
     });
 }
@@ -1757,7 +1759,7 @@ function sel(current: string, value: string): string {
 function renderDiagDisplayTabHtml(data: DiagnosticsData): string {
   const showTokens = data.displaySettings?.showTokens ?? 'both';
   const showCost = data.displaySettings?.showCost ?? 'none';
-  const monthlyBudget = data.displaySettings?.monthlyBudget ?? 0;
+  const monthlyBudget = Math.round((data.displaySettings?.monthlyBudget ?? 0) * 100) / 100;
   return `
 <div id="tab-display" class="tab-content">
 <div class="info-box">
@@ -1802,7 +1804,7 @@ Set a monthly AI spend budget in USD to get visual alerts on the status bar. The
 </p>
 <div style="display: flex; align-items: center; gap: 12px;">
   <label style="color: #ccc; min-width: 160px; font-size: 13px;">💵 Monthly budget (USD):</label>
-  <input id="input-monthly-budget" type="number" min="0" step="1" value="${monthlyBudget}" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px; width: 100px;" />
+  <input id="input-monthly-budget" type="number" min="0" max="99999" step="0.01" value="${monthlyBudget}" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px; width: 100px;" />
 </div>
 <p style="color: #888; font-size: 11px; margin-top: 12px;">Budget coloring uses the current calendar month's estimated cost. Set to 0 to disable.</p>
 </div>


### PR DESCRIPTION
Adds a configurable monthly AI spend budget that colors the VS Code status bar based on current month spend. Yellow at 75%, orange/red at 90%, red at 100%+.