### PR TITLE
fix: optimistic UI for tool suppress — hide item immediately on click

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4585,13 +4585,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 			case 'suppressUnknownTool': {
 				const toolName = message.toolName as string;
 				if (toolName) {
+					// Acknowledge immediately so the webview can remove the item without waiting for the disk write.
+					this.analysisPanel?.webview.postMessage({ command: 'toolSuppressed', toolName });
 					const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
 					const current = config.get<string[]>('suppressedUnknownTools', []);
 					if (!current.includes(toolName)) {
 						await config.update('suppressedUnknownTools', [...current, toolName], vscode.ConfigurationTarget.Global);
 						this.log(`🔇 Suppressed unknown tool: ${toolName}`);
 					}
-					this.analysisPanel?.webview.postMessage({ command: 'toolSuppressed', toolName });
 				}
 				break;
 			}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -2464,6 +2464,9 @@ async function bootstrap(): Promise<void> {
 		const target = event.target as HTMLElement;
 		const toolName = target.getAttribute('data-suppress-tool');
 		if (toolName) {
+			// Optimistic UI: remove the item immediately so the user sees instant feedback,
+			// rather than waiting for the async config.update round-trip in the extension host.
+			handleToolSuppressed(toolName);
 			vscode.postMessage({ command: 'suppressUnknownTool', toolName });
 		}
 	});


### PR DESCRIPTION
## Problem

Dismissing an unknown tool call had a noticeable lag: the item stayed visible until the full async round-trip completed:

1. User clicks 🔇 suppress button  
2. Webview posts message to extension  
3. Extension reads config, awaits \config.update(...)\ (Global settings write — slow disk I/O)  
4. Extension posts \	oolSuppressed\ back  
5. Webview removes the DOM item  

This made the UI feel unresponsive and confused users who thought the click hadn't registered.

## Fix

Two complementary changes:

**Webview (optimistic UI):**  
Call \handleToolSuppressed(toolName)\ *immediately* in the click handler, before sending \postMessage\. The item disappears at click speed. The extension's delayed \	oolSuppressed\ reply is a safe no-op (the section guard already handles the already-removed case).

**Extension (early acknowledgement):**  
Send \	oolSuppressed\ *before* \config.update\ so that in edge cases where the optimistic removal didn't fire (e.g. panel reload mid-flight), the webview still gets a prompt response rather than waiting for the settings disk write.

## Result

- Item hides instantly on click
- Settings persist correctly in the background
- No regressions: \handleToolSuppressed\ is idempotent (guards on element existence)