### PR TITLE
feat: log Copilot token endpoint metadata on startup

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -168,6 +168,8 @@ import {
 	fetchRepoPrs,
 	fetchCopilotPlanInfo,
 	fetchCopilotTokenEndpointInfo,
+	fetchUserEnterprises,
+	fetchEnterprisePremiumBudgets,
 	type CopilotPlanInfo,
 	type RepoPrDetail,
 	type RepoPrInfo,
@@ -1549,6 +1551,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	/**
 	 * Fetch and log Copilot plan information and token endpoint metadata for the authenticated user.
 	 * Both API calls run in parallel so all Copilot info is logged together as a single grouped block.
+	 * For enterprise plans, also discovers the enterprise slug and checks the premium request budget.
 	 * Best-effort: each call is independent — a failure in one does not suppress the other.
 	 */
 	private async loadAndLogCopilotPlanInfo(): Promise<void> {
@@ -1561,10 +1564,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		// Log plan info
 		const { planInfo, statusCode: planStatus, error: planError } = planResult;
+		let isEnterprisePlan = false;
 		if (planError || !planInfo) {
 			this.warn(`Copilot plan info unavailable (HTTP ${planStatus ?? 'n/a'}): ${planError ?? 'no data'}`);
 		} else {
 			const planId = planInfo.copilot_plan as string | undefined;
+			isEnterprisePlan = (planId ?? '').toLowerCase().includes('enterprise');
 			const plans = copilotPlansData.plans as Record<string, { name: string; monthlyPremiumRequests: number | null; monthlyPricePerUser: number; monthlyAiCreditsUsd: number }>;
 			const knownPlan = planId ? plans[planId] : undefined;
 			const planLabel = knownPlan ? `${knownPlan.name} (${planId})` : (planId ?? 'unknown');
@@ -1580,6 +1585,61 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (info.endpoints?.api) { this.log(`  Copilot API endpoint: ${info.endpoints.api}`); }
 			if (info.expires_at !== undefined) { this.log(`  Copilot token valid until: ${new Date(info.expires_at * 1000).toISOString()}`); }
 			if (info.sku) { this.log(`  Copilot SKU: ${info.sku}`); }
+		}
+
+		// For enterprise plans: discover enterprise and check premium request budget
+		if (isEnterprisePlan) {
+			await this.loadAndLogEnterpriseInfo();
+		}
+	}
+
+	/**
+	 * Discover which enterprise the user belongs to and fetch the premium request budget.
+	 * Uses GraphQL viewer.enterprises and the enterprise billing/budgets endpoint.
+	 * Best-effort: requires enterprise admin or billing manager for budget data.
+	 */
+	private async loadAndLogEnterpriseInfo(): Promise<void> {
+		if (!this.githubSession) { return; }
+
+		const { enterprises, error: entError } = await fetchUserEnterprises(this.githubSession.accessToken);
+		if (entError || !enterprises?.length) {
+			this.warn(`Enterprise discovery unavailable: ${entError ?? 'no enterprises found'}`);
+			return;
+		}
+
+		const username = this.githubSession.account.label;
+		this.log(`  Enterprise(s): ${enterprises.map((e) => `${e.name} (${e.slug})`).join(', ')}`);
+
+		// Fetch budget for each enterprise in parallel
+		const budgetResults = await Promise.all(
+			enterprises.map((e) =>
+				fetchEnterprisePremiumBudgets(e.slug, username, this.githubSession!.accessToken)
+					.then((r) => ({ enterprise: e, ...r }))
+					.catch((err) => ({ enterprise: e, error: String(err) }))
+			)
+		);
+
+		for (const result of budgetResults) {
+			const { enterprise, budgets, statusCode, error } = result as { enterprise: { slug: string; name: string }; budgets?: any[]; statusCode?: number; error?: string };
+			if (error) {
+				// 403 means the user isn't an admin/billing manager — log quietly
+				const isForbidden = statusCode === 403 || error.includes('403');
+				if (isForbidden) {
+					this.log(`  Budget (${enterprise.slug}): not accessible (requires enterprise admin or billing manager)`);
+				} else {
+					this.warn(`  Budget fetch failed for ${enterprise.slug} (HTTP ${statusCode ?? 'n/a'}): ${error}`);
+				}
+				continue;
+			}
+			if (!budgets?.length) {
+				this.log(`  Budget (${enterprise.slug}): no premium request budgets configured`);
+				continue;
+			}
+			for (const budget of budgets) {
+				const amount = budget.budget_amount !== undefined ? `$${budget.budget_amount}` : 'n/a';
+				const block = budget.prevent_further_usage ? ', blocks usage' : '';
+				this.log(`  Budget (${enterprise.slug}): ${amount}/month${block} [${budget.budget_scope ?? 'unknown scope'}]`);
+			}
 		}
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1661,10 +1661,50 @@ class CopilotTokenTracker implements vscode.Disposable {
 		} else if (planId) {
 			this._copilotPlanResolved = { planId, planName: planId, monthlyAiCreditsUsd: 0, monthlyPremiumRequests: null };
 		}
-		if (planInfo.ide_chat !== undefined)          { this.log(`  IDE chat: ${planInfo.ide_chat}`); }
-		if (planInfo.copilot_ide_agent !== undefined) { this.log(`  Agent mode: ${planInfo.copilot_ide_agent}`); }
-		if (planInfo.public_code_suggestions !== undefined) { this.log(`  Public code suggestions: ${planInfo.public_code_suggestions}`); }
-		if (planInfo.unlimited_pr_summaries !== undefined)  { this.log(`  Unlimited PR summaries: ${planInfo.unlimited_pr_summaries}`); }
+
+		// Log user info from copilot_internal/user response
+		if (planInfo.login != null)                              { this.log(`  Login: ${planInfo.login}`); }
+		if (planInfo.chat_enabled != null)                      { this.log(`  Chat enabled: ${planInfo.chat_enabled}`); }
+		if (planInfo.cli_enabled != null)                       { this.log(`  CLI enabled: ${planInfo.cli_enabled}`); }
+		if (planInfo.is_mcp_enabled != null)                    { this.log(`  MCP enabled: ${planInfo.is_mcp_enabled}`); }
+		if (planInfo.editor_preview_features_enabled != null)   { this.log(`  Editor preview features: ${planInfo.editor_preview_features_enabled}`); }
+		if (planInfo.copilotignore_enabled != null)             { this.log(`  Copilotignore enabled: ${planInfo.copilotignore_enabled}`); }
+		if (planInfo.restricted_telemetry != null)              { this.log(`  Restricted telemetry: ${planInfo.restricted_telemetry}`); }
+		if (planInfo.access_type_sku != null)                   { this.log(`  Access type SKU: ${planInfo.access_type_sku}`); }
+		if (planInfo.assigned_date != null)                     { this.log(`  Assigned date: ${planInfo.assigned_date}`); }
+		if (planInfo.organization_list != null && Array.isArray(planInfo.organization_list)) {
+			this.log(`  Organizations: ${planInfo.organization_list.join(', ')}`);
+		}
+		if (planInfo.quota_reset_date_utc != null)              { this.log(`  Quota reset date (UTC): ${planInfo.quota_reset_date_utc}`); }
+		if (planInfo.quota_reset_date != null)                  { this.log(`  Quota reset date: ${planInfo.quota_reset_date}`); }
+		if (planInfo.token_based_billing != null)               { this.log(`  Token-based billing: ${planInfo.token_based_billing}`); }
+		if (planInfo.analytics_tracking_id != null)             { this.log(`  Analytics tracking ID: ${planInfo.analytics_tracking_id}`); }
+
+		// Log quota snapshots if present
+		if (planInfo.quota_snapshots && typeof planInfo.quota_snapshots === 'object') {
+			for (const [key, snapshot] of Object.entries(planInfo.quota_snapshots)) {
+				const qs = snapshot as any;
+				if (typeof qs === 'object' && qs !== null) {
+					const parts: string[] = [];
+					if (qs.quota_id != null)              parts.push(`id=${qs.quota_id}`);
+					if (qs.entitlement != null)          parts.push(`entitlement=${qs.entitlement}`);
+					if (qs.unlimited != null)            parts.push(`unlimited=${qs.unlimited}`);
+					if (qs.quota_remaining != null)      parts.push(`remaining=${qs.quota_remaining}`);
+					if (qs.percent_remaining != null)    parts.push(`${qs.percent_remaining}%`);
+					if (qs.overage_count != null)        parts.push(`overage=${qs.overage_count}`);
+					if (qs.quota_reset_at != null)       parts.push(`reset=${qs.quota_reset_at}`);
+					if (parts.length > 0) {
+						this.log(`  Quota (${key}): ${parts.join(', ')}`);
+					}
+				}
+			}
+		}
+
+		// Log legacy fields if present (for backwards compatibility)
+		if (planInfo.ide_chat != null)          { this.log(`  IDE chat: ${planInfo.ide_chat}`); }
+		if (planInfo.copilot_ide_agent != null) { this.log(`  Agent mode: ${planInfo.copilot_ide_agent}`); }
+		if (planInfo.public_code_suggestions != null) { this.log(`  Public code suggestions: ${planInfo.public_code_suggestions}`); }
+		if (planInfo.unlimited_pr_summaries != null)  { this.log(`  Unlimited PR summaries: ${planInfo.unlimited_pr_summaries}`); }
 	}
 
 	public async updateTokenStats(silent: boolean = false, skipIfBusy = false): Promise<DetailedStats | undefined> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1551,7 +1551,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	/**
 	 * Fetch and log Copilot plan information and token endpoint metadata for the authenticated user.
 	 * Both API calls run in parallel so all Copilot info is logged together as a single grouped block.
-	 * For enterprise plans, also discovers the enterprise slug and checks the premium request budget.
+	 * For enterprise or business plans, also discovers the enterprise/org and checks the premium request budget.
 	 * Best-effort: each call is independent — a failure in one does not suppress the other.
 	 */
 	private async loadAndLogCopilotPlanInfo(): Promise<void> {
@@ -1564,12 +1564,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		// Log plan info
 		const { planInfo, statusCode: planStatus, error: planError } = planResult;
-		let isEnterprisePlan = false;
+		let isOrgPlan = false;
 		if (planError || !planInfo) {
 			this.warn(`Copilot plan info unavailable (HTTP ${planStatus ?? 'n/a'}): ${planError ?? 'no data'}`);
 		} else {
 			const planId = planInfo.copilot_plan as string | undefined;
-			isEnterprisePlan = (planId ?? '').toLowerCase().includes('enterprise');
+			const planIdLower = (planId ?? '').toLowerCase();
+			// Business and Enterprise plans are both backed by a GitHub Enterprise — show enterprise/budget info for both
+			isOrgPlan = planIdLower.includes('enterprise') || planIdLower.includes('business');
 			const plans = copilotPlansData.plans as Record<string, { name: string; monthlyPremiumRequests: number | null; monthlyPricePerUser: number; monthlyAiCreditsUsd: number }>;
 			const knownPlan = planId ? plans[planId] : undefined;
 			const planLabel = knownPlan ? `${knownPlan.name} (${planId})` : (planId ?? 'unknown');
@@ -1587,14 +1589,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (info.sku) { this.log(`  Copilot SKU: ${info.sku}`); }
 		}
 
-		// For enterprise plans: discover enterprise and check premium request budget
-		if (isEnterprisePlan) {
+		// For business/enterprise plans: discover enterprise and check premium request budget
+		if (isOrgPlan) {
 			await this.loadAndLogEnterpriseInfo();
 		}
 	}
 
 	/**
-	 * Discover which enterprise the user belongs to and fetch the premium request budget.
+	 * Discover which GitHub Enterprise(s) the user belongs to and fetch the premium request budget.
+	 * Fires for both Copilot Business and Copilot Enterprise plans (both are backed by a GitHub Enterprise).
 	 * Uses GraphQL viewer.enterprises and the enterprise billing/budgets endpoint.
 	 * Best-effort: requires enterprise admin or billing manager for budget data.
 	 */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1547,54 +1547,39 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	/**
-	 * Fetch and log Copilot plan information for the authenticated user.
-	 * Best-effort: silently skips if not authenticated or if the endpoint is unavailable.
+	 * Fetch and log Copilot plan information and token endpoint metadata for the authenticated user.
+	 * Both API calls run in parallel so all Copilot info is logged together as a single grouped block.
+	 * Best-effort: each call is independent — a failure in one does not suppress the other.
 	 */
 	private async loadAndLogCopilotPlanInfo(): Promise<void> {
 		if (!this.githubSession) { return; }
-		try {
-			const { planInfo, statusCode, error } = await fetchCopilotPlanInfo(this.githubSession.accessToken);
-			if (error || !planInfo) {
-				this.warn(`Copilot plan info unavailable (HTTP ${statusCode ?? 'n/a'}): ${error ?? 'no data'}`);
-				return;
-			}
+
+		const [planResult, tokenResult] = await Promise.all([
+			fetchCopilotPlanInfo(this.githubSession.accessToken).catch((err): ReturnType<typeof fetchCopilotPlanInfo> => Promise.resolve({ error: String(err) })),
+			fetchCopilotTokenEndpointInfo(this.githubSession.accessToken).catch((err): ReturnType<typeof fetchCopilotTokenEndpointInfo> => Promise.resolve({ error: String(err) })),
+		]);
+
+		// Log plan info
+		const { planInfo, statusCode: planStatus, error: planError } = planResult;
+		if (planError || !planInfo) {
+			this.warn(`Copilot plan info unavailable (HTTP ${planStatus ?? 'n/a'}): ${planError ?? 'no data'}`);
+		} else {
 			const planId = planInfo.copilot_plan as string | undefined;
 			const plans = copilotPlansData.plans as Record<string, { name: string; monthlyPremiumRequests: number | null; monthlyPricePerUser: number; monthlyAiCreditsUsd: number }>;
 			const knownPlan = planId ? plans[planId] : undefined;
 			const planLabel = knownPlan ? `${knownPlan.name} (${planId})` : (planId ?? 'unknown');
 			this.log(`Copilot plan: ${planLabel}`);
 			this.logCopilotPlanDetails(planId, knownPlan, planInfo);
-		} catch (err) {
-			this.warn('Failed to load Copilot plan info: ' + String(err));
 		}
-		await this.loadAndLogCopilotTokenEndpointInfo();
-	}
 
-	/**
-	 * Fetch and log Copilot token endpoint metadata from copilot_internal/v2/token.
-	 * Logs the API endpoint URL (shows individual/business/enterprise tier) and token expiry.
-	 * Best-effort: silently skips on any failure.
-	 */
-	private async loadAndLogCopilotTokenEndpointInfo(): Promise<void> {
-		if (!this.githubSession) { return; }
-		try {
-			const { info, statusCode, error } = await fetchCopilotTokenEndpointInfo(this.githubSession.accessToken);
-			if (error || !info) {
-				this.warn(`Copilot token endpoint info unavailable (HTTP ${statusCode ?? 'n/a'}): ${error ?? 'no data'}`);
-				return;
-			}
-			if (info.endpoints?.api) {
-				this.log(`  Copilot API endpoint: ${info.endpoints.api}`);
-			}
-			if (info.expires_at !== undefined) {
-				const expiresDate = new Date(info.expires_at * 1000);
-				this.log(`  Copilot token valid until: ${expiresDate.toISOString()}`);
-			}
-			if (info.sku) {
-				this.log(`  Copilot SKU: ${info.sku}`);
-			}
-		} catch (err) {
-			this.warn('Failed to load Copilot token endpoint info: ' + String(err));
+		// Log token endpoint info
+		const { info, statusCode: tokenStatus, error: tokenError } = tokenResult;
+		if (tokenError || !info) {
+			this.warn(`Copilot token endpoint info unavailable (HTTP ${tokenStatus ?? 'n/a'}): ${tokenError ?? 'no data'}`);
+		} else {
+			if (info.endpoints?.api) { this.log(`  Copilot API endpoint: ${info.endpoints.api}`); }
+			if (info.expires_at !== undefined) { this.log(`  Copilot token valid until: ${new Date(info.expires_at * 1000).toISOString()}`); }
+			if (info.sku) { this.log(`  Copilot SKU: ${info.sku}`); }
 		}
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1687,16 +1687,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 			for (const [key, snapshot] of Object.entries(planInfo.quota_snapshots)) {
 				const qs = snapshot as any;
 				if (typeof qs === 'object' && qs !== null) {
-					// Capture entitlements for use in budget fallback
+					// Capture entitlements (in cents) for use in budget fallback, convert to dollars
 					if (key === 'premium_interactions' && qs.entitlement != null) {
-						this._copilotQuotaEntitlements.premium_interactions = qs.entitlement;
+						this._copilotQuotaEntitlements.premium_interactions = qs.entitlement / 100;
 					} else if (key === 'completions' && qs.entitlement != null) {
-						this._copilotQuotaEntitlements.completions = qs.entitlement;
+						this._copilotQuotaEntitlements.completions = qs.entitlement / 100;
 					}
 
 					const parts: string[] = [];
 					if (qs.quota_id != null)              parts.push(`id=${qs.quota_id}`);
-					if (qs.entitlement != null)          parts.push(`entitlement=${qs.entitlement}`);
+					if (qs.entitlement != null)          parts.push(`entitlement=${qs.entitlement} cents ($${(qs.entitlement / 100).toFixed(2)})`);
 					if (qs.unlimited != null)            parts.push(`unlimited=${qs.unlimited}`);
 					if (qs.quota_remaining != null)      parts.push(`remaining=${qs.quota_remaining}`);
 					if (qs.percent_remaining != null)    parts.push(`${qs.percent_remaining}%`);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -452,6 +452,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private _githubSignedOutByUser: boolean = false;
 	/** Resolved Copilot plan details fetched from copilot_internal/user after sign-in. */
 	private _copilotPlanResolved: { planId: string; planName: string; monthlyAiCreditsUsd: number; monthlyPremiumRequests: number | null } | undefined;
+	/** Quota entitlements from copilot_internal/user response (e.g., premium_interactions entitlement). */
+	private _copilotQuotaEntitlements: { premium_interactions?: number; completions?: number } = {};
 
 	// Cached PR stats result for the repos tab
 	private _lastRepoPrStats?: RepoPrStatsResult;
@@ -1685,6 +1687,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 			for (const [key, snapshot] of Object.entries(planInfo.quota_snapshots)) {
 				const qs = snapshot as any;
 				if (typeof qs === 'object' && qs !== null) {
+					// Capture entitlements for use in budget fallback
+					if (key === 'premium_interactions' && qs.entitlement != null) {
+						this._copilotQuotaEntitlements.premium_interactions = qs.entitlement;
+					} else if (key === 'completions' && qs.entitlement != null) {
+						this._copilotQuotaEntitlements.completions = qs.entitlement;
+					}
+
 					const parts: string[] = [];
 					if (qs.quota_id != null)              parts.push(`id=${qs.quota_id}`);
 					if (qs.entitlement != null)          parts.push(`entitlement=${qs.entitlement}`);
@@ -2648,10 +2657,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	/** Returns the effective monthly budget: the explicitly configured value if set, otherwise falls back
-	 *  to the monthly AI credits included with the user's Copilot plan (derived from license info). */
+	 *  to the monthly AI credits included with the user's Copilot plan, or the premium_interactions
+	 *  quota entitlement from the API if available. */
 	private getEffectiveMonthlyBudget(): number {
 		const configured = this.getMonthlyBudgetSetting();
 		if (configured > 0) { return configured; }
+		// Fall back to quota entitlement (premium_interactions) if available, then to plan credits
+		if (this._copilotQuotaEntitlements.premium_interactions) {
+			return this._copilotQuotaEntitlements.premium_interactions;
+		}
 		return this._copilotPlanResolved?.monthlyAiCreditsUsd ?? 0;
 	}
 
@@ -7823,6 +7837,7 @@ ${this.getLoadingHtmlScript()}
       cacheInfo, backendStorageInfo,
       backendConfigured: this.isBackendConfigured(), isDebugMode, globalStateCounters,
       displaySettings: { showTokens: this.getStatusBarShowTokensSetting(), showCost: this.getStatusBarShowCostSetting(), monthlyBudget: this.getMonthlyBudgetSetting() },
+      quotaEntitlements: this._copilotQuotaEntitlements,
       toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
       toolFamilies: getToolFamilies(),
     }).replace(/</g, "\\u003c");

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -167,6 +167,7 @@ import {
 	discoverGitHubRepos,
 	fetchRepoPrs,
 	fetchCopilotPlanInfo,
+	fetchCopilotTokenEndpointInfo,
 	type CopilotPlanInfo,
 	type RepoPrDetail,
 	type RepoPrInfo,
@@ -1565,6 +1566,35 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.logCopilotPlanDetails(planId, knownPlan, planInfo);
 		} catch (err) {
 			this.warn('Failed to load Copilot plan info: ' + String(err));
+		}
+		await this.loadAndLogCopilotTokenEndpointInfo();
+	}
+
+	/**
+	 * Fetch and log Copilot token endpoint metadata from copilot_internal/v2/token.
+	 * Logs the API endpoint URL (shows individual/business/enterprise tier) and token expiry.
+	 * Best-effort: silently skips on any failure.
+	 */
+	private async loadAndLogCopilotTokenEndpointInfo(): Promise<void> {
+		if (!this.githubSession) { return; }
+		try {
+			const { info, statusCode, error } = await fetchCopilotTokenEndpointInfo(this.githubSession.accessToken);
+			if (error || !info) {
+				this.warn(`Copilot token endpoint info unavailable (HTTP ${statusCode ?? 'n/a'}): ${error ?? 'no data'}`);
+				return;
+			}
+			if (info.endpoints?.api) {
+				this.log(`  Copilot API endpoint: ${info.endpoints.api}`);
+			}
+			if (info.expires_at !== undefined) {
+				const expiresDate = new Date(info.expires_at * 1000);
+				this.log(`  Copilot token valid until: ${expiresDate.toISOString()}`);
+			}
+			if (info.sku) {
+				this.log(`  Copilot SKU: ${info.sku}`);
+			}
+		} catch (err) {
+			this.warn('Failed to load Copilot token endpoint info: ' + String(err));
 		}
 	}
 

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -31,8 +31,39 @@ export type RepoPrStatsResult = {
 // Copilot plan info
 // ---------------------------------------------------------------------------
 
+export type QuotaSnapshot = {
+	quota_id?: string;
+	timestamp_utc?: string;
+	entitlement?: string;
+	quota_remaining?: number;
+	remaining?: number;
+	percent_remaining?: number;
+	unlimited?: boolean;
+	overage_permitted?: boolean;
+	overage_count?: number;
+	has_quota?: boolean;
+	quota_reset_at?: string;
+	token_based_billing?: boolean;
+};
+
 export type CopilotPlanInfo = {
+	login?: string;
 	copilot_plan?: string;             // e.g. "copilot_individual" | "copilot_business" | "copilot_enterprise" | "copilot_free"
+	chat_enabled?: boolean;
+	cli_enabled?: boolean;
+	is_mcp_enabled?: boolean;
+	editor_preview_features_enabled?: boolean;
+	copilotignore_enabled?: boolean;
+	restricted_telemetry?: boolean;
+	access_type_sku?: string;
+	assigned_date?: string;
+	organization_list?: string[];
+	quota_snapshots?: Record<string, QuotaSnapshot>;
+	quota_reset_date_utc?: string;
+	quota_reset_date?: string;
+	token_based_billing?: boolean;
+	analytics_tracking_id?: string;
+	// Legacy fields (may still be present)
 	public_code_suggestions?: string;  // "block" | "allow"
 	ide_chat?: string;                 // "enabled" | "disabled"
 	copilot_ide_agent?: string;        // "enabled" | "disabled"

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -1,6 +1,6 @@
 import * as https from 'https';
 import * as childProcess from 'child_process';
-import { GITHUB_API_HOSTNAME, GITHUB_API_USER_AGENT, GITHUB_API_ACCEPT_V3 } from './githubApiConfig';
+import { GITHUB_API_HOSTNAME, GITHUB_API_USER_AGENT, GITHUB_API_ACCEPT_V3, GITHUB_API_VERSION } from './githubApiConfig';
 
 export type RepoPrDetail = {
 	number: number;
@@ -183,6 +183,144 @@ export function fetchCopilotTokenEndpointInfo(
 	fetcher: (token: string) => Promise<CopilotTokenEndpointResult> = fetchCopilotTokenEndpointInfoPage,
 ): Promise<CopilotTokenEndpointResult> {
 	return fetcher(token);
+}
+
+// ---------------------------------------------------------------------------
+// Enterprise membership discovery (GraphQL)
+// ---------------------------------------------------------------------------
+
+export type EnterpriseInfo = { slug: string; name: string };
+export type UserEnterprisesResult = { enterprises?: EnterpriseInfo[]; error?: string };
+
+/** Discover enterprises the authenticated user belongs to via the GitHub GraphQL API. */
+export function fetchUserEnterprises(
+	token: string,
+	fetcher: (token: string) => Promise<UserEnterprisesResult> = fetchUserEnterprisesPage,
+): Promise<UserEnterprisesResult> {
+	return fetcher(token);
+}
+
+function fetchUserEnterprisesPage(token: string): Promise<UserEnterprisesResult> {
+	const query = JSON.stringify({
+		query: '{ viewer { enterprises(first: 10, membershipType: ALL) { nodes { slug name } } } }',
+	});
+	return new Promise((resolve) => {
+		const req = https.request(
+			{
+				hostname: GITHUB_API_HOSTNAME,
+				path: '/graphql',
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'User-Agent': GITHUB_API_USER_AGENT,
+					'Content-Type': 'application/json',
+					'Content-Length': Buffer.byteLength(query),
+				},
+			},
+			(res) => {
+				let data = '';
+				res.on('data', (chunk) => (data += chunk));
+				res.on('end', () => {
+					const statusCode = res.statusCode ?? 0;
+					if (statusCode < 200 || statusCode >= 300) {
+						resolve({ error: `HTTP ${statusCode}` });
+						return;
+					}
+					try {
+						const parsed = JSON.parse(data);
+						const nodes = parsed?.data?.viewer?.enterprises?.nodes;
+						if (!Array.isArray(nodes)) {
+							const gqlError = parsed?.errors?.[0]?.message;
+							resolve({ error: gqlError ?? 'Unexpected response format' });
+							return;
+						}
+						resolve({ enterprises: nodes as EnterpriseInfo[] });
+					} catch (e) {
+						resolve({ error: String(e) });
+					}
+				});
+			},
+		);
+		req.on('error', (e) => resolve({ error: e.message }));
+		req.setTimeout(15000, () => {
+			req.destroy(new Error('Request timed out after 15 s'));
+		});
+		req.write(query);
+		req.end();
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Enterprise premium request budget
+// ---------------------------------------------------------------------------
+
+export type EnterpriseBudgetEntry = {
+	id?: string;
+	budget_amount?: number;
+	prevent_further_usage?: boolean;
+	budget_scope?: string;
+	budget_product_skus?: string[];
+	[key: string]: unknown;
+};
+export type EnterpriseBudgetResult = { budgets?: EnterpriseBudgetEntry[]; statusCode?: number; error?: string };
+
+/**
+ * Fetch enterprise billing budgets filtered for premium requests for a specific user.
+ * Requires the authenticated user to be an enterprise admin or billing manager.
+ * Best-effort — returns an error on 403/404 for non-admin users.
+ */
+export function fetchEnterprisePremiumBudgets(
+	enterpriseSlug: string,
+	username: string,
+	token: string,
+	fetcher: (slug: string, username: string, token: string) => Promise<EnterpriseBudgetResult> = fetchEnterprisePremiumBudgetsPage,
+): Promise<EnterpriseBudgetResult> {
+	return fetcher(enterpriseSlug, username, token);
+}
+
+function fetchEnterprisePremiumBudgetsPage(enterpriseSlug: string, username: string, token: string): Promise<EnterpriseBudgetResult> {
+	const params = new URLSearchParams({ user: username, budgetTarget: 'premium_req' });
+	return new Promise((resolve) => {
+		const req = https.request(
+			{
+				hostname: GITHUB_API_HOSTNAME,
+				path: `/enterprises/${encodeURIComponent(enterpriseSlug)}/settings/billing/budgets?${params}`,
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'User-Agent': GITHUB_API_USER_AGENT,
+					Accept: GITHUB_API_ACCEPT_V3,
+					'X-GitHub-Api-Version': GITHUB_API_VERSION,
+				},
+			},
+			(res) => {
+				let data = '';
+				res.on('data', (chunk) => (data += chunk));
+				res.on('end', () => {
+					const statusCode = res.statusCode ?? 0;
+					if (statusCode < 200 || statusCode >= 300) {
+						resolve({ statusCode, error: `HTTP ${statusCode}` });
+						return;
+					}
+					try {
+						const parsed = JSON.parse(data);
+						const budgets = parsed?.budgets ?? (Array.isArray(parsed) ? parsed : undefined);
+						if (budgets === undefined) {
+							resolve({ statusCode, error: 'Unexpected response format' });
+							return;
+						}
+						resolve({ budgets, statusCode });
+					} catch (e) {
+						resolve({ statusCode, error: String(e) });
+					}
+				});
+			},
+		);
+		req.on('error', (e) => resolve({ error: e.message }));
+		req.setTimeout(15000, () => {
+			req.destroy(new Error('Request timed out after 15 s'));
+		});
+		req.end();
+	});
 }
 
 /** Detect which AI system a GitHub login belongs to, or null if not an AI bot. */

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -99,6 +99,92 @@ export function fetchCopilotPlanInfo(
 	return fetcher(token);
 }
 
+// ---------------------------------------------------------------------------
+// Copilot v2 token endpoint info
+// ---------------------------------------------------------------------------
+
+/** Endpoint URLs returned by the copilot_internal/v2/token endpoint. */
+export type CopilotTokenEndpoints = {
+	api?: string;
+	'origin-tracker'?: string;
+	telemetry?: string;
+	proxy?: string;
+	[key: string]: string | undefined;
+};
+
+/** Non-sensitive metadata from the copilot_internal/v2/token response (token string excluded). */
+export type CopilotTokenEndpointInfo = {
+	endpoints?: CopilotTokenEndpoints;
+	/** Unix timestamp (seconds) when the token expires. */
+	expires_at?: number;
+	/** How many seconds until the token should be refreshed. */
+	refresh_in?: number;
+	/** Subscription SKU embedded in the token header (e.g. "copilot_individual"). */
+	sku?: string;
+	[key: string]: unknown;
+};
+
+export type CopilotTokenEndpointResult = { info?: CopilotTokenEndpointInfo; statusCode?: number; error?: string };
+
+/** Internal low-level fetcher for the copilot_internal/v2/token endpoint. */
+function fetchCopilotTokenEndpointInfoPage(token: string): Promise<CopilotTokenEndpointResult> {
+	return new Promise((resolve) => {
+		const req = https.request(
+			{
+				hostname: GITHUB_API_HOSTNAME,
+				path: '/copilot_internal/v2/token',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'User-Agent': GITHUB_API_USER_AGENT,
+					Accept: 'application/json',
+				},
+			},
+			(res) => {
+				let data = '';
+				res.on('data', (chunk) => (data += chunk));
+				res.on('end', () => {
+					const statusCode = res.statusCode ?? 0;
+					if (statusCode < 200 || statusCode >= 300) {
+						resolve({ statusCode, error: `HTTP ${statusCode}` });
+						return;
+					}
+					try {
+						const parsed = JSON.parse(data);
+						if (typeof parsed !== 'object' || parsed === null) {
+							resolve({ statusCode, error: 'Unexpected response format' });
+							return;
+						}
+						// Exclude the short-lived token string — we only care about the metadata.
+						const { token: _token, ...rest } = parsed as { token?: string } & CopilotTokenEndpointInfo;
+						resolve({ info: rest as CopilotTokenEndpointInfo, statusCode });
+					} catch (e) {
+						resolve({ statusCode, error: String(e) });
+					}
+				});
+			},
+		);
+		req.on('error', (e) => resolve({ error: e.message }));
+		req.setTimeout(15000, () => {
+			req.destroy(new Error('Request timed out after 15 s'));
+		});
+		req.end();
+	});
+}
+
+/**
+ * Fetch Copilot token endpoint metadata for the authenticated user.
+ * Uses the VS Code-only internal endpoint `https://api.github.com/copilot_internal/v2/token`.
+ * Returns metadata (endpoints, expiry) but never the token string itself.
+ * Treat as best-effort — this endpoint may not be available for all accounts.
+ * @param fetcher Injectable fetcher for testing; defaults to the real HTTPS implementation.
+ */
+export function fetchCopilotTokenEndpointInfo(
+	token: string,
+	fetcher: (token: string) => Promise<CopilotTokenEndpointResult> = fetchCopilotTokenEndpointInfoPage,
+): Promise<CopilotTokenEndpointResult> {
+	return fetcher(token);
+}
+
 /** Detect which AI system a GitHub login belongs to, or null if not an AI bot. */
 export function detectAiType(login: string): RepoPrDetail['aiType'] | null {
 	const l = login.toLowerCase();

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -106,6 +106,11 @@ type DisplaySettings = {
   monthlyBudget?: number;
 };
 
+type QuotaEntitlements = {
+  premium_interactions?: number;
+  completions?: number;
+};
+
 type DiagnosticsData = {
   report: string;
   sessionFiles: { file: string; size: number; modified: string }[];
@@ -118,6 +123,7 @@ type DiagnosticsData = {
   githubAuth?: GitHubAuthStatus;
   sessionFolders?: SessionFolder[];
   displaySettings?: DisplaySettings;
+  quotaEntitlements?: QuotaEntitlements;
   toolCallStats?: { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } } | null;
   toolFamilies?: ToolFamilyConfig[];
 };
@@ -1893,6 +1899,29 @@ Set a monthly AI spend budget in USD to get visual alerts on the status bar. The
   <input id="input-monthly-budget" type="number" min="0" max="99999" step="0.01" value="${monthlyBudget}" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px; width: 100px;" />
 </div>
 <p class="hint">Budget coloring uses the current calendar month's estimated cost. Set to 0 to disable.</p>
+${
+  data.quotaEntitlements && data.quotaEntitlements.premium_interactions
+    ? `<p class="hint" style="color: #90ee90;"><strong>ℹ️ API-driven budget:</strong> Your premium_interactions quota entitlement is <strong>$${data.quotaEntitlements.premium_interactions}</strong>/month. If the budget above is 0 or empty, this API value will be used as your effective budget.</p>`
+    : ''
+}
+</div>
+<div class="backend-card">
+<h4>📊 API Quota Information</h4>
+${
+  data.quotaEntitlements
+    ? `<p>
+${
+      data.quotaEntitlements.premium_interactions
+        ? `<strong>Premium Interactions:</strong> $${data.quotaEntitlements.premium_interactions}/month<br/>`
+        : ''
+}${
+      data.quotaEntitlements.completions
+        ? `<strong>Completions:</strong> $${data.quotaEntitlements.completions}/month<br/>`
+        : ''
+}
+    </p>`
+    : `<p class="hint">No quota information available from the API yet. Sign out and back in to refresh.</p>`
+}
 </div>
 <div class="backend-card">
 <h4>🔢 Number Formatting</h4>

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1901,7 +1901,7 @@ Set a monthly AI spend budget in USD to get visual alerts on the status bar. The
 <p class="hint">Budget coloring uses the current calendar month's estimated cost. Set to 0 to disable.</p>
 ${
   data.quotaEntitlements && data.quotaEntitlements.premium_interactions
-    ? `<p class="hint" style="color: #90ee90;"><strong>ℹ️ API-driven budget:</strong> Your premium_interactions quota entitlement is <strong>$${data.quotaEntitlements.premium_interactions}</strong>/month. If the budget above is 0 or empty, this API value will be used as your effective budget.</p>`
+    ? `<p class="hint" style="color: #90ee90;"><strong>ℹ️ API-driven budget:</strong> Your premium_interactions quota entitlement is <strong>$${data.quotaEntitlements.premium_interactions.toFixed(2)}</strong>/month. If the budget above is 0 or empty, this API value will be used as your effective budget.</p>`
     : ''
 }
 </div>
@@ -1912,11 +1912,11 @@ ${
     ? `<p>
 ${
       data.quotaEntitlements.premium_interactions
-        ? `<strong>Premium Interactions:</strong> $${data.quotaEntitlements.premium_interactions}/month<br/>`
+        ? `<strong>Premium Interactions:</strong> $${data.quotaEntitlements.premium_interactions.toFixed(2)}/month<br/>`
         : ''
 }${
       data.quotaEntitlements.completions
-        ? `<strong>Completions:</strong> $${data.quotaEntitlements.completions}/month<br/>`
+        ? `<strong>Completions:</strong> $${data.quotaEntitlements.completions.toFixed(2)}/month<br/>`
         : ''
 }
     </p>`

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, fetchCopilotTokenEndpointInfo, type CopilotPlanInfo, type CopilotTokenEndpointInfo } from '../../src/githubPrService';
+import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, fetchCopilotTokenEndpointInfo, fetchUserEnterprises, fetchEnterprisePremiumBudgets, type CopilotPlanInfo, type CopilotTokenEndpointInfo, type EnterpriseInfo, type EnterpriseBudgetEntry } from '../../src/githubPrService';
 
 // ---------------------------------------------------------------------------
 // detectAiType — pure function, no I/O
@@ -250,4 +250,76 @@ test('fetchCopilotTokenEndpointInfo: handles empty info object gracefully', asyn
 	const { info, error } = await fetchCopilotTokenEndpointInfo('token', mockFetcher);
 	assert.equal(error, undefined);
 	assert.deepEqual(info, {});
+});
+
+// ---------------------------------------------------------------------------
+// fetchUserEnterprises — uses injectable fetcher
+// ---------------------------------------------------------------------------
+
+test('fetchUserEnterprises: returns enterprises on success', async () => {
+	const enterprises: EnterpriseInfo[] = [
+		{ slug: 'acme-corp', name: 'Acme Corporation' },
+		{ slug: 'widgets-inc', name: 'Widgets Inc' },
+	];
+	const mockFetcher = async () => ({ enterprises });
+	const { enterprises: result, error } = await fetchUserEnterprises('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.deepEqual(result, enterprises);
+});
+
+test('fetchUserEnterprises: returns empty array when user has no enterprises', async () => {
+	const mockFetcher = async () => ({ enterprises: [] });
+	const { enterprises, error } = await fetchUserEnterprises('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.deepEqual(enterprises, []);
+});
+
+test('fetchUserEnterprises: returns error on network failure', async () => {
+	const mockFetcher = async () => ({ error: 'socket hang up' });
+	const { enterprises, error } = await fetchUserEnterprises('token', mockFetcher);
+	assert.equal(enterprises, undefined);
+	assert.equal(error, 'socket hang up');
+});
+
+test('fetchUserEnterprises: returns error on GraphQL error', async () => {
+	const mockFetcher = async () => ({ error: 'Must be logged in.' });
+	const { enterprises, error } = await fetchUserEnterprises('token', mockFetcher);
+	assert.equal(enterprises, undefined);
+	assert.ok(error?.includes('Must be logged in'));
+});
+
+// ---------------------------------------------------------------------------
+// fetchEnterprisePremiumBudgets — uses injectable fetcher
+// ---------------------------------------------------------------------------
+
+test('fetchEnterprisePremiumBudgets: returns budgets on success', async () => {
+	const budgets: EnterpriseBudgetEntry[] = [
+		{ id: 'budget-1', budget_amount: 500, prevent_further_usage: true, budget_scope: 'enterprise', budget_product_skus: ['copilot_premium_requests'] },
+	];
+	const mockFetcher = async () => ({ budgets, statusCode: 200 });
+	const { budgets: result, error } = await fetchEnterprisePremiumBudgets('acme-corp', 'rajbos', 'token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.deepEqual(result, budgets);
+});
+
+test('fetchEnterprisePremiumBudgets: returns error on 403 (not an admin)', async () => {
+	const mockFetcher = async () => ({ statusCode: 403, error: 'HTTP 403' });
+	const { budgets, statusCode, error } = await fetchEnterprisePremiumBudgets('acme-corp', 'rajbos', 'token', mockFetcher);
+	assert.equal(budgets, undefined);
+	assert.equal(statusCode, 403);
+	assert.equal(error, 'HTTP 403');
+});
+
+test('fetchEnterprisePremiumBudgets: returns error on network failure', async () => {
+	const mockFetcher = async () => ({ error: 'ECONNREFUSED' });
+	const { budgets, error } = await fetchEnterprisePremiumBudgets('acme-corp', 'rajbos', 'token', mockFetcher);
+	assert.equal(budgets, undefined);
+	assert.equal(error, 'ECONNREFUSED');
+});
+
+test('fetchEnterprisePremiumBudgets: returns empty array when no budgets configured', async () => {
+	const mockFetcher = async () => ({ budgets: [], statusCode: 200 });
+	const { budgets, error } = await fetchEnterprisePremiumBudgets('acme-corp', 'rajbos', 'token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.deepEqual(budgets, []);
 });

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, type CopilotPlanInfo } from '../../src/githubPrService';
+import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, fetchCopilotTokenEndpointInfo, type CopilotPlanInfo, type CopilotTokenEndpointInfo } from '../../src/githubPrService';
 
 // ---------------------------------------------------------------------------
 // detectAiType — pure function, no I/O
@@ -201,4 +201,53 @@ test('fetchCopilotPlanInfo: handles partial plan data gracefully', async () => {
 	assert.equal(error, undefined);
 	assert.equal(planInfo?.copilot_plan, 'copilot_free');
 	assert.equal(planInfo?.ide_chat, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// fetchCopilotTokenEndpointInfo — uses injectable fetcher
+// ---------------------------------------------------------------------------
+
+test('fetchCopilotTokenEndpointInfo: returns endpoint info on success', async () => {
+	const endpointData: CopilotTokenEndpointInfo = {
+		endpoints: { api: 'https://api.individual.githubcopilot.com' },
+		expires_at: 1730000000,
+		refresh_in: 1500,
+		sku: 'copilot_individual',
+	};
+	const mockFetcher = async () => ({ info: endpointData, statusCode: 200 });
+	const { info, statusCode, error } = await fetchCopilotTokenEndpointInfo('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.equal(statusCode, 200);
+	assert.deepEqual(info, endpointData);
+});
+
+test('fetchCopilotTokenEndpointInfo: returns error on non-2xx response', async () => {
+	const mockFetcher = async () => ({ statusCode: 401, error: 'HTTP 401' });
+	const { info, statusCode, error } = await fetchCopilotTokenEndpointInfo('token', mockFetcher);
+	assert.equal(info, undefined);
+	assert.equal(statusCode, 401);
+	assert.equal(error, 'HTTP 401');
+});
+
+test('fetchCopilotTokenEndpointInfo: returns error on network failure', async () => {
+	const mockFetcher = async () => ({ error: 'socket hang up' });
+	const { info, error } = await fetchCopilotTokenEndpointInfo('token', mockFetcher);
+	assert.equal(info, undefined);
+	assert.equal(error, 'socket hang up');
+});
+
+test('fetchCopilotTokenEndpointInfo: handles partial response gracefully', async () => {
+	// Only endpoints returned, no expiry info
+	const mockFetcher = async () => ({ info: { endpoints: { api: 'https://api.business.githubcopilot.com' } } as CopilotTokenEndpointInfo, statusCode: 200 });
+	const { info, error } = await fetchCopilotTokenEndpointInfo('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.equal(info?.endpoints?.api, 'https://api.business.githubcopilot.com');
+	assert.equal(info?.expires_at, undefined);
+});
+
+test('fetchCopilotTokenEndpointInfo: handles empty info object gracefully', async () => {
+	const mockFetcher = async () => ({ info: {} as CopilotTokenEndpointInfo, statusCode: 200 });
+	const { info, error } = await fetchCopilotTokenEndpointInfo('token', mockFetcher);
+	assert.equal(error, undefined);
+	assert.deepEqual(info, {});
 });


### PR DESCRIPTION
## Summary

Adds a second startup API call to \copilot_internal/v2/token\ alongside the existing \/copilot_internal/user\ plan-info call.

### What's logged

After the Copilot plan details, the extension now also logs:
- **Copilot API endpoint** — shows which tier is in use (e.g. \https://api.individual.githubcopilot.com\ vs \pi.business\ vs \pi.enterprise\)
- **Token valid-until** — ISO timestamp of when the current Copilot token expires
- **SKU** — subscription SKU embedded in the token header (when present)

### Implementation details

- New \etchCopilotTokenEndpointInfo\ in \githubPrService.ts\ — same injectable-fetcher pattern as \etchCopilotPlanInfo\ for testability
- The short-lived token string is explicitly stripped — only metadata is returned/logged
- Failures handled gracefully with a \warn\ log (never throws)
- 5 new unit tests: success, HTTP error, network failure, partial response, empty response