### PR TITLE
feat: fall back to license-based budget when none is configured

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,18 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
     - name: Setup Node.js ${{ matrix.node-version }}
+      if: matrix.os != 'windows-latest'
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
         cache-dependency-path: vscode-extension/package-lock.json
+
+    - name: Setup Node.js ${{ matrix.node-version }} (Windows)
+      if: matrix.os == 'windows-latest'
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ matrix.node-version }}
         
     - name: Install dependencies
       working-directory: vscode-extension

--- a/vscode-extension/src/copilotPlans.json
+++ b/vscode-extension/src/copilotPlans.json
@@ -18,7 +18,7 @@
     "individual": {
       "name": "Copilot Pro",
       "monthlyPricePerUser": 10,
-      "monthlyAiCreditsUsd": 10,
+      "monthlyAiCreditsUsd": 15,
       "monthlyPremiumRequests": 300,
       "codeCompletionsPerMonth": null,
       "description": "For individual developers (legacy plan ID, same as 'pro')"
@@ -26,18 +26,26 @@
     "pro": {
       "name": "Copilot Pro",
       "monthlyPricePerUser": 10,
-      "monthlyAiCreditsUsd": 10,
+      "monthlyAiCreditsUsd": 15,
       "monthlyPremiumRequests": 300,
       "codeCompletionsPerMonth": null,
-      "description": "For individual developers"
+      "description": "For individual developers. Includes 1,000 base + 500 flex = 1,500 total monthly AI credits ($15)."
     },
     "pro_plus": {
       "name": "Copilot Pro+",
       "monthlyPricePerUser": 39,
-      "monthlyAiCreditsUsd": 39,
+      "monthlyAiCreditsUsd": 70,
       "monthlyPremiumRequests": 1500,
       "codeCompletionsPerMonth": null,
-      "description": "For power users needing more premium requests and the broadest model selection"
+      "description": "For power users needing more premium requests and the broadest model selection. Includes 3,900 base + 3,100 flex = 7,000 total monthly AI credits ($70)."
+    },
+    "max": {
+      "name": "Copilot Max",
+      "monthlyPricePerUser": 100,
+      "monthlyAiCreditsUsd": 200,
+      "monthlyPremiumRequests": null,
+      "codeCompletionsPerMonth": null,
+      "description": "For users who need the highest limits. Includes 10,000 base + 10,000 flex = 20,000 total monthly AI credits ($200)."
     },
     "business": {
       "name": "Copilot Business",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1876,7 +1876,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		tooltip.appendMarkdown(`| Average interactions/session :      | ${detailedStats.last30Days.avgInteractionsPerSession} |\n`);
 		tooltip.appendMarkdown(`| Average tokens/session :            | ${detailedStats.last30Days.avgTokensPerSession.toLocaleString()} |\n`);
 		tooltip.appendMarkdown('\n---\n');
-		const budget = this.getMonthlyBudgetSetting();
+		const budget = this.getEffectiveMonthlyBudget();
 		if (budget > 0) {
 			const monthCost = detailedStats.month.estimatedCostCopilot ?? detailedStats.month.estimatedCost ?? 0;
 			const pct = Math.round((monthCost / budget) * 100);
@@ -1906,7 +1906,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (!this.chartPanel || (!this.lastFullDailyStats && !this.lastDailyStats)) { return; }
 		const chartStats = this.lastFullDailyStats ?? this.lastDailyStats!;
 		if (silent) {
-			void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: { ...this.buildChartData(chartStats), compactNumbers: this.getCompactNumbersSetting(), monthlyBudget: this.getMonthlyBudgetSetting() } });
+			void this.chartPanel.webview.postMessage({ command: 'updateChartData', data: { ...this.buildChartData(chartStats), compactNumbers: this.getCompactNumbersSetting(), monthlyBudget: this.getEffectiveMonthlyBudget() } });
 		} else {
 			this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, chartStats);
 		}
@@ -2204,11 +2204,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar').get<number>('monthlyBudget', 0);
 	}
 
+	/** Returns the effective monthly budget: the explicitly configured value if set, otherwise falls back
+	 *  to the monthly AI credits included with the user's Copilot plan (derived from license info). */
+	private getEffectiveMonthlyBudget(): number {
+		const configured = this.getMonthlyBudgetSetting();
+		if (configured > 0) { return configured; }
+		return this._copilotPlanResolved?.monthlyAiCreditsUsd ?? 0;
+	}
+
 	/** Updates the status bar background color based on current-month spend vs. the configured budget.
 	 *  Uses VS Code's built-in theme colors: warning (yellow) at ≥75%, error (red/orange) at ≥90%.
 	 *  Clears the background when no budget is configured or spend is below 75%. */
 	private updateStatusBarBackgroundColor(stats: DetailedStats): void {
-		const budget = this.getMonthlyBudgetSetting();
+		const budget = this.getEffectiveMonthlyBudget();
 		if (budget <= 0) {
 			this.statusBarItem.backgroundColor = undefined;
 			return;
@@ -7136,7 +7144,7 @@ ${this.getLoadingHtmlScript()}
       vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "chart.js"),
     );
 
-    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit, monthlyBudget: this.getMonthlyBudgetSetting() };
+    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit, monthlyBudget: this.getEffectiveMonthlyBudget() };
 
     const initialData = JSON.stringify(chartData).replace(/</g, "\\u003c");
 


### PR DESCRIPTION
## What

When no monthly budget is explicitly configured, the chart budget line, status-bar colour thresholds, and tooltip now automatically use the monthly AI credits included with the user's Copilot plan instead of showing nothing.

## How

- Added `getEffectiveMonthlyBudget()`: returns the explicitly-configured budget if set (`> 0`), otherwise falls back to `_copilotPlanResolved.monthlyAiCreditsUsd` (populated from the Copilot license API at sign-in).
- Replaced `getMonthlyBudgetSetting()` with `getEffectiveMonthlyBudget()` in the four budget-display call sites: tooltip, chart HTML, chart live-update, and status-bar background colour. The diagnostics input field still uses the raw setting so the user sees what they've explicitly configured.
- Updated `copilotPlans.json` with **total** monthly AI credit values (base + flex allotment) per current GitHub Copilot pricing, and added the new `max` plan:

| Plan | `monthlyAiCreditsUsd` |
|---|---|
| Copilot Pro (`pro` / `individual`) | $15 (1,500 credits) |
| Copilot Pro+ (`pro_plus`) | $70 (7,000 credits) |
| **Copilot Max** (`max`) — new | $200 (20,000 credits) |
| Copilot Business | $19 |
| Copilot Enterprise | $39 |

## Tests

All 20 unit-test suites pass unchanged.