### PR TITLE
Show friendly model display names in today's session list

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -10,6 +10,7 @@ import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 import { getWindowData } from '../shared/dataLoader';
 import { registerMessageHandler } from '../shared/messageHandler';
+import { getModelDisplayName } from '../shared/modelUtils';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
@@ -638,7 +639,7 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 	const rows = sorted.map((s, idx) => {
 		const title = escapeHtml(s.title || 'Untitled session');
 		const filePath = escapeHtml(s.filePath || '');
-		const models = s.models.map(m => escapeHtml(m)).join(', ') || '—';
+		const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—';
 		const editor = escapeHtml(s.editor || 'unknown');
 		const cost = s.estimatedCost > 0 ? `$${s.estimatedCost.toFixed(4)}` : '—';
 		const time = s.lastActivity ? new Date(s.lastActivity).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime }) : '—';


### PR DESCRIPTION
The Models column in the today's sessions table was displaying raw model identifiers (e.g. `claude-sonnet-4.6`, `gpt-5.4`) instead of the human-friendly display names already defined in `modelPricing.json` (e.g. "Claude Sonnet 4.6", "GPT-5.4").

The fix imports `getModelDisplayName` from `modelUtils` into `usage/main.ts` and applies it when building the models string for each session row. The existing `getModelDisplayName` function already has full coverage via `modelPricing.json` and falls back to the raw ID for any unknown model, so no data is lost.