### PR TITLE
Improve settings tab card layout and headings

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1767,13 +1767,13 @@ function renderDiagDisplayTabHtml(data: DiagnosticsData): string {
 <div>Configure what is shown in the status bar at the bottom of VS Code. Changes take effect immediately — no data refresh needed.</div>
 </div>
 <div class="backend-card">
-<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">📊 Status Bar Display</h4>
-<p style="color: #ccc; margin-bottom: 16px;">
+<h4>📊 Status Bar Display</h4>
+<p>
 Choose what to show in the VS Code status bar toolbar. You can show token counts, estimated costs, both, or neither for each period.
 </p>
 <div style="display: grid; gap: 16px;">
 <div style="display: flex; align-items: center; gap: 12px;">
-  <label style="color: #ccc; min-width: 160px; font-size: 13px;">🔢 Token counts:</label>
+  <label style="min-width: 175px; font-size: 13px;">🔢 Token counts:</label>
   <select id="select-show-tokens" class="settings-select" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px;">
     <option value="none" ${sel(showTokens, 'none')}>None</option>
     <option value="today" ${sel(showTokens, 'today')}>Today only</option>
@@ -1784,7 +1784,7 @@ Choose what to show in the VS Code status bar toolbar. You can show token counts
   </select>
 </div>
 <div style="display: flex; align-items: center; gap: 12px;">
-  <label style="color: #ccc; min-width: 160px; font-size: 13px;">💰 Estimated cost (USD):</label>
+  <label style="min-width: 175px; font-size: 13px;">💰 Estimated cost (USD):</label>
   <select id="select-show-cost" class="settings-select" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px;">
     <option value="none" ${sel(showCost, 'none')}>None (hidden)</option>
     <option value="today" ${sel(showCost, 'today')}>Today only</option>
@@ -1795,22 +1795,22 @@ Choose what to show in the VS Code status bar toolbar. You can show token counts
   </select>
 </div>
 </div>
-<p style="color: #888; font-size: 11px; margin-top: 12px;">Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing). Changes apply to the status bar immediately.</p>
+<p class="hint">Cost is estimated using GitHub Copilot AI-Credit rates (Usage Based Billing). Changes apply to the status bar immediately.</p>
 </div>
 <div class="backend-card">
-<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">💰 Monthly Budget</h4>
-<p style="color: #ccc; margin-bottom: 16px;">
+<h4>💰 Monthly Budget</h4>
+<p>
 Set a monthly AI spend budget in USD to get visual alerts on the status bar. The bar turns yellow at 75%, orange at 90%, and red at 100% of your budget. Set to 0 to disable.
 </p>
 <div style="display: flex; align-items: center; gap: 12px;">
-  <label style="color: #ccc; min-width: 160px; font-size: 13px;">💵 Monthly budget (USD):</label>
+  <label style="min-width: 175px; font-size: 13px;">💵 Monthly budget (USD):</label>
   <input id="input-monthly-budget" type="number" min="0" max="99999" step="0.01" value="${monthlyBudget}" style="background: #2d2d2d; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 8px; font-size: 13px; width: 100px;" />
 </div>
-<p style="color: #888; font-size: 11px; margin-top: 12px;">Budget coloring uses the current calendar month's estimated cost. Set to 0 to disable.</p>
+<p class="hint">Budget coloring uses the current calendar month's estimated cost. Set to 0 to disable.</p>
 </div>
 <div class="backend-card">
-<h4 style="color: #fff; font-size: 14px; margin-bottom: 12px;">🔢 Number Formatting</h4>
-<p style="color: #ccc; margin-bottom: 12px;">
+<h4>🔢 Number Formatting</h4>
+<p>
 Token counts can be shown in compact format using K/M suffixes (e.g. <strong>1.5K</strong>, <strong>1.2M</strong>)
 for quick scanning, or as full numbers (e.g. <strong>1,500</strong>, <strong>1,200,000</strong>) for precision.
 </p>

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -510,6 +510,42 @@ background-position: center;
 	background: var(--list-hover-bg);
 }
 
+.backend-card {
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	padding: 16px 20px;
+	margin-bottom: 16px;
+}
+
+.backend-card h4 {
+	color: var(--text-primary);
+	font-size: 15px;
+	font-weight: 600;
+	margin-top: 0;
+	margin-bottom: 10px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--border-subtle);
+}
+
+.backend-card p {
+	color: var(--text-secondary);
+	font-size: 13px;
+	line-height: 1.5;
+	margin-bottom: 14px;
+}
+
+.backend-card p:last-child {
+	margin-bottom: 0;
+}
+
+.backend-card p.hint {
+	color: var(--text-muted, #888);
+	font-size: 11px;
+	margin-top: 10px;
+	margin-bottom: 0;
+}
+
 .info-box {
 	background: var(--list-active-bg);
 	border: 1px solid var(--border-color);


### PR DESCRIPTION
The settings tab ("⚙️ Settings") showed three sections (Status Bar Display, Monthly Budget, Number Formatting) as unstyled divs that flowed together with no visual separation. The `backend-card` CSS class was referenced in the HTML but never defined, and the headings used hardcoded `color: #fff` inline styles that ignored the VS Code theme.

**What changed:**

- Added a `.backend-card` CSS rule in `styles.css` with a themed background, border, border-radius, and margin so each section is visually distinct.
- Added `.backend-card h4` with a subtle bottom border separator and `font-size: 15px` bold heading, using `var(--text-primary)` instead of a hardcoded color.
- Added `.backend-card p` and `.backend-card p.hint` rules using `var(--text-secondary)` / `var(--text-muted)` so text colors follow the active VS Code theme.
- Removed all inline `color:` and `font-size:` overrides from the h4 and p elements in the HTML template; they now inherit from the CSS classes.

The result is three clearly separated cards with proper breathing room, consistent heading style, and full theme compatibility.