### PR TITLE
fix: decode URI-encoded model names for unify-chat-provider

### DIFF
--- a/vscode-extension/src/webview/shared/modelUtils.ts
+++ b/vscode-extension/src/webview/shared/modelUtils.ts
@@ -14,7 +14,14 @@ for (const [modelId, pricing] of Object.entries(modelPricingJson.pricing as Reco
 
 /**
  * Returns a human-friendly display name for a given model identifier.
+ * If the model ID is not in the pricing JSON, it falls back to URI-decoding
+ * the raw ID (e.g. unify-chat-provider names contain %20-encoded segments).
  */
 export function getModelDisplayName(model: string): string {
-    return _modelNames[model] || model;
+    if (_modelNames[model]) { return _modelNames[model]; }
+    try {
+        return decodeURIComponent(model);
+    } catch {
+        return model;
+    }
 }

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -30,6 +30,18 @@ test('getModelDisplayName: returns raw model ID for unknown models', () => {
 	assert.equal(getModelDisplayName(''), '');
 });
 
+test('getModelDisplayName: decodes URI-encoded segments in unknown model IDs', () => {
+	assert.equal(
+		getModelDisplayName('unify-chat-provider/OpenCode%20Go%20(Anthropic%20Messages)/qwen3.7-max'),
+		'unify-chat-provider/OpenCode Go (Anthropic Messages)/qwen3.7-max'
+	);
+	assert.equal(getModelDisplayName('provider/Model%20Name'), 'provider/Model Name');
+});
+
+test('getModelDisplayName: returns raw ID when URI decoding fails (malformed percent)', () => {
+	assert.equal(getModelDisplayName('bad%2model'), 'bad%2model');
+});
+
 // ── getEditorIcon ───────────────────────────────────────────────────────
 
 test('getEditorIcon: returns correct icons for known editors', () => {


### PR DESCRIPTION
## Summary

Fixes #1246

Model names from `unify-chat-provider` arrive URL-encoded (e.g. `OpenCode%20Go%20(Anthropic%20Messages)`). When no display name entry exists in the pricing JSON, `getModelDisplayName` previously fell back to returning the raw model ID verbatim — showing the `%20` sequences to the user.

## Change

In `getModelDisplayName` (`modelUtils.ts`), the fallback now calls `decodeURIComponent()` before returning, so encoded names render as human-readable text:

```
before: unify-chat-provider/OpenCode%20Go%20(Anthropic%20Messages)/qwen3.7-max
after:  unify-chat-provider/OpenCode Go (Anthropic Messages)/qwen3.7-max
```

A `try/catch` guards against malformed percent sequences, falling back to the raw string in that case.

## Tests

Added 2 new test cases to `webview-utils.test.ts`:
- Decodes `%20` and other encoded chars in unknown model IDs
- Returns the raw ID when URI decoding fails (malformed `%2` sequence)

All 22 tests in that file pass ✅