### PR TITLE
perf(vscode): reduce timer-path CPU (memoization + event-driven preload workers)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -70,6 +70,7 @@ import { buildAdapterRegistry, createDataAccessInstances } from './adapters';
 import { getVSCodeUserPaths } from './adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from './adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from './jetbrains';
+import { createWakeupGate } from './utils/promises';
 
 // --- Session parsing & token estimation ---
 import {
@@ -1532,6 +1533,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		let processed = 0;
 		const CONCURRENCY = 20;
 
+		// Event-driven wakeups: workers that find the queue empty park on the gate
+		// instead of polling on a timer, avoiding pointless wake-ups while discovery runs.
+		const gate = createWakeupGate();
+
 		const analyzeStartMs = Date.now();
 
 		// Discovery fills the queue via onBatch callback
@@ -1546,9 +1551,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 					}
 					queue.push(...batch);
 					totalDiscovered += batch.length;
+					gate.signal();
 				});
 			} finally {
 				discoveryDone = true;
+				gate.signal();
 			}
 		})();
 
@@ -1557,8 +1564,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 			while (true) {
 				if (readIndex >= queue.length) {
 					if (discoveryDone) { break; }
-					// Briefly yield to allow discovery batches to arrive
-					await new Promise(r => setTimeout(r, 20));
+					// Park until discovery pushes more work or signals completion. The gate
+					// registers the waiter synchronously in this same tick, so no batch can
+					// slip in unobserved between the emptiness check and parking.
+					await gate.wait();
 					continue;
 				}
 				const sessionFile = queue[readIndex++];

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -153,13 +153,31 @@ const DEFAULT_TOKENS_PER_CHAR = 0.25;
  */
 const FORMAT_DETECTION_LINE_LIMIT = 10;
 
+/**
+ * Cache of pre-normalized estimator entries keyed by the estimators object reference.
+ * estimateTokensFromText is called for every message part, response item, and tool
+ * result across all sessions on the 5-minute refresh; precomputing the dash-stripped
+ * model key once per estimators object avoids allocating a temporary string on every
+ * iteration of every call.
+ */
+const _estimatorEntriesCache = new WeakMap<object, Array<[string, string, TokenEstimator]>>();
+
+function getEstimatorEntries(tokenEstimators: Record<string, TokenEstimator>): Array<[string, string, TokenEstimator]> {
+	let entries = _estimatorEntriesCache.get(tokenEstimators);
+	if (!entries) {
+		entries = Object.entries(tokenEstimators).map(([modelKey, ratio]) => [modelKey, modelKey.replace('-', ''), ratio] as [string, string, TokenEstimator]);
+		_estimatorEntriesCache.set(tokenEstimators, entries);
+	}
+	return entries;
+}
+
 export function estimateTokensFromText(text: string, model: string = 'gpt-4', tokenEstimators: Record<string, TokenEstimator> = {}): number {
 	// Token estimation based on character count and model
 	let tokensPerChar = DEFAULT_TOKENS_PER_CHAR;
 
 	// Find matching model
-	for (const [modelKey, ratio] of Object.entries(tokenEstimators)) {
-		if (model.includes(modelKey) || model.includes(modelKey.replace('-', ''))) {
+	for (const [modelKey, normalizedKey, ratio] of getEstimatorEntries(tokenEstimators)) {
+		if (model.includes(modelKey) || model.includes(normalizedKey)) {
 			tokensPerChar = ratio;
 			break;
 		}
@@ -840,53 +858,53 @@ export function extractPerRequestUsageFromRawLines(lines: string[]): Map<number,
 	return usage;
 }
 
-/** Build a reverse lookup map from display name → model ID using modelPricing entries. */
-function _gmfrBuildReverseMap(modelPricing: { [key: string]: ModelPricing }): { [displayName: string]: string } {
-	const reverseMap: { [displayName: string]: string } = {};
-	for (const [modelId, pricing] of Object.entries(modelPricing)) {
-		if (pricing.displayNames) {
-			for (const displayName of pricing.displayNames) {
-				reverseMap[displayName] = modelId;
+/**
+ * Cache of the display-name → modelId lookup (and its length-sorted key list) keyed by
+ * the modelPricing object reference. getModelFromRequest is called once per request across
+ * every session on the 5-minute refresh; without this cache the map was rebuilt and the
+ * key list re-sorted on every single call, which dominated CPU during large analysis runs.
+ */
+const _displayNameLookupCache = new WeakMap<object, { map: { [displayName: string]: string }; sortedNames: string[] }>();
+
+function getDisplayNameLookup(modelPricing: { [key: string]: ModelPricing }): { map: { [displayName: string]: string }; sortedNames: string[] } {
+	let cached = _displayNameLookupCache.get(modelPricing);
+	if (!cached) {
+		const map: { [displayName: string]: string } = {};
+		for (const [modelId, pricing] of Object.entries(modelPricing)) {
+			if (pricing.displayNames) {
+				for (const displayName of pricing.displayNames) { map[displayName] = modelId; }
 			}
 		}
+		// Sort by length descending to match longer names first (e.g., "Gemini 3 Pro (Preview)" before "Gemini 3 Pro")
+		const sortedNames = Object.keys(map).sort((a, b) => b.length - a.length);
+		cached = { map, sortedNames };
+		_displayNameLookupCache.set(modelPricing, cached);
 	}
-	return reverseMap;
+	return cached;
 }
 
 /** Find the model ID for a request by matching display names against its details string. Returns null if not found. */
 function _gmfrFindByDisplayName(details: string, modelPricing: { [key: string]: ModelPricing }): string | null {
-	const reverseMap = _gmfrBuildReverseMap(modelPricing);
-	// Sort by length descending to match longer names first (e.g., "Gemini 3 Pro (Preview)" before "Gemini 3 Pro")
-	const sortedNames = Object.keys(reverseMap).sort((a, b) => b.length - a.length);
+	const { map, sortedNames } = getDisplayNameLookup(modelPricing);
 	for (const displayName of sortedNames) {
-		if (details.includes(displayName)) { return reverseMap[displayName]; }
+		if (details.includes(displayName)) { return map[displayName]; }
 	}
 	return null;
 }
 
-function _gmrBuildDisplayNameLookup(modelPricing: { [key: string]: ModelPricing }): { [displayName: string]: string } {
-const map: { [displayName: string]: string } = {};
-for (const [modelId, pricing] of Object.entries(modelPricing)) {
-if (pricing.displayNames) {
-for (const displayName of pricing.displayNames) { map[displayName] = modelId; }
-}
-}
-return map;
-}
-
-function _gmrMatchDisplayName(details: string, displayNameMap: { [dn: string]: string }): string | null {
-const sorted = Object.keys(displayNameMap).sort((a, b) => b.length - a.length);
-for (const displayName of sorted) {
-if (details.includes(displayName)) { return displayNameMap[displayName]; }
-}
-return null;
+function _gmrMatchDisplayName(details: string, modelPricing: { [key: string]: ModelPricing }): string | null {
+	const { map, sortedNames } = getDisplayNameLookup(modelPricing);
+	for (const displayName of sortedNames) {
+		if (details.includes(displayName)) { return map[displayName]; }
+	}
+	return null;
 }
 
 export function getModelFromRequest(request: ModelRequestSource, modelPricing: { [key: string]: ModelPricing } = {}): string {
 	if (request.modelId) { return request.modelId.replace(/^copilot\//, ''); }
 	if (request.result?.metadata?.modelId) { return request.result.metadata.modelId.replace(/^copilot\//, ''); }
 	if (request.result?.details) {
-		const matched = _gmrMatchDisplayName(request.result.details, _gmrBuildDisplayNameLookup(modelPricing));
+		const matched = _gmrMatchDisplayName(request.result.details, modelPricing);
 		if (matched) { return matched; }
 	}
 

--- a/vscode-extension/src/utils/promises.ts
+++ b/vscode-extension/src/utils/promises.ts
@@ -32,3 +32,38 @@ export function withTimeout<T>(
     }),
   ]);
 }
+
+/** A one-shot, multi-waiter notification gate used to wake parked async workers. */
+export interface WakeupGate {
+  /** Resolves once the next `signal()` is called after this `wait()`. */
+  wait(): Promise<void>;
+  /** Wakes every currently parked waiter. No-op when nobody is waiting. */
+  signal(): void;
+}
+
+/**
+ * Creates an event-driven wakeup gate for producer/consumer pipelines.
+ *
+ * Consumers that find no work available call `await gate.wait()` to park until the
+ * producer calls `gate.signal()`. This replaces timer-based polling (e.g.
+ * `setTimeout(..., 20)` spin loops) so idle workers consume no CPU while waiting.
+ *
+ * The waiter is registered synchronously inside `wait()` (the Promise executor runs
+ * before the returned promise is awaited), so a consumer can safely check its
+ * condition and then `await gate.wait()` in the same synchronous tick without a
+ * `signal()` slipping in unobserved between the two.
+ */
+export function createWakeupGate(): WakeupGate {
+  let waiters: Array<() => void> = [];
+  return {
+    wait(): Promise<void> {
+      return new Promise<void>((resolve) => { waiters.push(resolve); });
+    },
+    signal(): void {
+      if (waiters.length === 0) { return; }
+      const pending = waiters;
+      waiters = [];
+      for (const wake of pending) { wake(); }
+    },
+  };
+}

--- a/vscode-extension/test/unit/utils-promises.test.ts
+++ b/vscode-extension/test/unit/utils-promises.test.ts
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { createWakeupGate, withTimeout } from '../../src/utils/promises';
+
+test('createWakeupGate: signal resolves all currently parked waiters', async () => {
+	const gate = createWakeupGate();
+	const order: number[] = [];
+	const a = gate.wait().then(() => order.push(1));
+	const b = gate.wait().then(() => order.push(2));
+	gate.signal();
+	await Promise.all([a, b]);
+	assert.deepEqual(order.sort(), [1, 2]);
+});
+
+test('createWakeupGate: signal with no waiters is a no-op and does not affect later waits', async () => {
+	const gate = createWakeupGate();
+	gate.signal(); // nobody waiting yet
+	let resolved = false;
+	const p = gate.wait().then(() => { resolved = true; });
+	// The earlier signal must NOT satisfy this later wait.
+	await new Promise(r => setTimeout(r, 5));
+	assert.equal(resolved, false);
+	gate.signal();
+	await p;
+	assert.equal(resolved, true);
+});
+
+test('createWakeupGate: a fresh wait after signal stays parked until the next signal', async () => {
+	const gate = createWakeupGate();
+	const first = gate.wait();
+	gate.signal();
+	await first;
+
+	let secondResolved = false;
+	const second = gate.wait().then(() => { secondResolved = true; });
+	await new Promise(r => setTimeout(r, 5));
+	assert.equal(secondResolved, false);
+	gate.signal();
+	await second;
+	assert.equal(secondResolved, true);
+});
+
+test('createWakeupGate: producer/consumer drains all items without polling', async () => {
+	const gate = createWakeupGate();
+	const queue: number[] = [];
+	let readIndex = 0;
+	let done = false;
+	const consumed: number[] = [];
+
+	const consumer = (async () => {
+		while (true) {
+			if (readIndex >= queue.length) {
+				if (done) { break; }
+				await gate.wait();
+				continue;
+			}
+			consumed.push(queue[readIndex++]);
+		}
+	})();
+
+	const producer = (async () => {
+		for (let i = 0; i < 5; i++) {
+			await new Promise(r => setTimeout(r, 1));
+			queue.push(i);
+			gate.signal();
+		}
+		done = true;
+		gate.signal();
+	})();
+
+	await Promise.all([consumer, producer]);
+	assert.deepEqual(consumed, [0, 1, 2, 3, 4]);
+});
+
+test('withTimeout: resolves when the promise settles in time', async () => {
+	const result = await withTimeout(Promise.resolve('ok'), 1000, 'op');
+	assert.equal(result, 'ok');
+});
+
+test('withTimeout: rejects with a descriptive error when it times out', async () => {
+	await assert.rejects(
+		withTimeout(new Promise(() => { /* never settles */ }), 10, 'slow op'),
+		/slow op timed out after 10ms/,
+	);
+});


### PR DESCRIPTION
## Summary

Audit of the VS Code extension focused on the 5-minute timer refresh that historically risked blocking the UI / spiking CPU. This PR lands the clear, safe, behavior-preserving wins found during the audit; the remaining findings are catalogued below as follow-ups.

## Changes (implemented)

1. **`tokenEstimation.ts` — memoize the display-name lookup used by `getModelFromRequest`** (HIGH, hot path). It previously rebuilt the display-name→modelId map **and** re-sorted its keys (length-desc) on *every request across every session*. Now cached in a `WeakMap` keyed on the immutable `modelPricing` object. Consolidated two duplicate map-builders into one cached helper.

2. **`tokenEstimation.ts` — precompute estimator entries for `estimateTokensFromText`** (frequent call). Avoids allocating a temporary string (`modelKey.replace('-','')`) on every loop iteration of every call by caching `[key, normalizedKey, ratio]` per estimators object.

3. **`extension.ts` — event-driven preload workers** (LOW severity, but directly the kind of CPU-spinning the audit targeted). Replaced the `while(true){ … await setTimeout(20) }` busy-poll in `_preloadSessionFiles` (20 workers ≈ 1000 no-op wakeups/sec while discovery runs) with a `createWakeupGate()` notification primitive added to `utils/promises.ts`, with unit tests.

All output is unchanged — these are pure performance refactors.

## Verification
- `npm run compile` — 0 errors (no new lint warnings; the 9 remaining are pre-existing).
- `npm run test:node` — all suites pass, including new `utils-promises.test.ts`.
- Independent review (rubber-duck) confirmed no deadlock/lost-wakeup races and behavior-equivalence under the (verified) immutability of the config objects.

## Notable findings NOT changed (recommended follow-ups)
The biggest *latency* risk is **synchronous filesystem I/O on the discovery hot path** — these block the extension-host event loop:
- `visualstudio.ts` `_scanForVsDirs()` — synchronous **recursive** `readdirSync` walk of the user home dir (depth 7) + dev roots on every tick (Windows). Highest freeze risk.
- `claudedesktop.ts` `walkForJsonlFiles()` — recursive sync walk up to depth 8.
- `copilotCliStore.ts` `readSession()/getTurns()/countTurns()` — re-read the entire SQLite DB per session with no mtime/size cache guard (unlike `crush.ts`/`opencode.ts`).
- Adapter `readFileSync` calls per session file across all adapters.
- Same JSONL file delta-reconstructed 3× independently per cycle (`DeltaTokenStrategy.estimate`, `_asuReconstructAndProcessDeltaState`, `_temProcessDeltaJsonl`).

These are larger, higher-risk changes (sync→async conversions / shared reconstruction cache) and are intentionally left out of this PR to keep it surgical.