### PR TITLE
fix: use test:node in build.ps1 to avoid spawning VS Code

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -54,7 +54,7 @@ function Build-VsCode {
         switch ($Target) {
             'build'   { npm ci; npm run compile }
             'package' { npm ci; npm run package; npx vsce package }
-            'test'    { npm ci; npm run compile-tests; npm test }
+            'test'    { npm ci; npm run test:node }
             'clean'   { Remove-Item -Recurse -Force dist, out -ErrorAction SilentlyContinue }
         }
         Write-Ok "vscode-extension done."


### PR DESCRIPTION
## Problem

Running `./build.ps1 -Target test` (or `./build.ps1 -Project vscode -Target test`) was spawning a real VS Code (Electron) window unexpectedly. This happened because the vscode test target called `npm test`, which invokes `vscode-test` (`@vscode/test-cli` + `@vscode/test-electron`) — that tool downloads VS Code and launches it to run integration tests.

## Root cause

In `build.ps1`:
```powershell
'test'    { npm ci; npm run compile-tests; npm test }  # ← spawns VS Code
```

`npm test` = `vscode-test` (configured in `.vscode-test.mjs`) = downloads + launches VS Code Electron window.

## Fix

Switch the build orchestrator to `npm run test:node`, which runs all 60+ unit tests purely in Node.js using a VS Code shim — no VS Code window needed:

```powershell
'test'    { npm ci; npm run test:node }  # ✅ no VS Code
```

The `test:node` script already includes its own compile steps, so the separate `npm run compile-tests` call is also removed (it was redundant).

Integration tests that genuinely require a VS Code host can still be run explicitly with `npm test` inside `vscode-extension/`.