### PR TITLE
feat: session parent/child hierarchy visualization + validate-app-db-schema skill

### DIFF
--- a/.github/skills/validate-app-db-schema/SKILL.md
+++ b/.github/skills/validate-app-db-schema/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: validate-app-db-schema
+description: Validate that ~/.copilot/data.db has the required schema for session hierarchy (workspace_parent_links, workspaces, sessions tables and columns). Runs an actual today's-data query so schema regressions are caught early. Use when data.db schema changes may have broken hierarchy enrichment, or on a periodic schedule to detect breaking changes.
+---
+
+# Validate App DB Schema Skill
+
+Validates that the Copilot app's `~/.copilot/data.db` still exposes the tables and columns that the extension's **session hierarchy** feature depends on.
+
+## Background
+
+The session hierarchy feature reads parent/child workspace relationships from `data.db` — a private Copilot app database that is **not part of any public API**. Its schema can change without notice when the app is updated.
+
+This skill:
+1. Checks that the required tables and columns exist
+2. Runs an actual data query (today's parent/child links) to confirm reads work end-to-end
+3. Reports a clear PASS / FAIL with details so CI or a periodic workflow can surface regressions early
+
+## What We Depend On
+
+| Table | Required columns |
+|---|---|
+| `workspace_parent_links` | `child_workspace_id`, `parent_workspace_id`, `creator_session_id`, `created_at` |
+| `workspaces` | `id`, `session_id`, `name`, `updated_at` |
+| `sessions` | `id`, `title`, `created_at`, `updated_at` |
+
+The join that the extension uses (simplified):
+```sql
+SELECT cw.session_id, cw.name, pw.session_id, pw.name
+FROM workspace_parent_links l
+JOIN workspaces cw ON cw.id = l.child_workspace_id
+JOIN workspaces pw ON pw.id = l.parent_workspace_id
+WHERE cw.session_id IN (...)
+   OR pw.session_id IN (...)
+```
+
+## Usage
+
+```bash
+# Basic validation — exits 0 on pass, 1 on fail
+node .github/skills/validate-app-db-schema/validate-schema.js
+
+# Output as JSON (for automated processing)
+node .github/skills/validate-app-db-schema/validate-schema.js --json
+
+# Show help
+node .github/skills/validate-app-db-schema/validate-schema.js --help
+```
+
+## Integration
+
+Add to a periodic GitHub Actions workflow or run manually after a Copilot app update. Example:
+
+```yaml
+- name: Validate data.db schema
+  run: node .github/skills/validate-app-db-schema/validate-schema.js --json
+```
+
+## Implementation Details
+
+The script reads `data.db` using `sql.js` (pure WASM — no native SQLite binaries required).
+It performs three checks:
+
+1. **File exists**: `~/.copilot/data.db` is present
+2. **Schema check**: `PRAGMA table_info(table_name)` confirms all required columns exist
+3. **Live query**: Runs the actual JOIN query used by the extension against the last 24h of data
+
+## Related Code
+
+- `vscode-extension/src/copilotAppData.ts` — the module that reads data.db at runtime
+- `vscode-extension/src/types.ts` — `SessionHierarchyNode`, `SessionRelationRef`, `SessionFileDetails`
+- `vscode-extension/src/extension.ts` — `enrichSessionHierarchy()` method

--- a/.github/skills/validate-app-db-schema/validate-schema.js
+++ b/.github/skills/validate-app-db-schema/validate-schema.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * validate-schema.js — Validate ~/.copilot/data.db schema for the session
+ * hierarchy feature.
+ *
+ * Checks that workspace_parent_links, workspaces and sessions tables still
+ * have the columns the extension depends on, then runs the actual JOIN query
+ * against today's data to confirm end-to-end reads work.
+ *
+ * Usage:
+ *   node .github/skills/validate-app-db-schema/validate-schema.js [--json] [--help]
+ *
+ * Exit codes:
+ *   0 — all checks passed
+ *   1 — one or more checks failed (or data.db not found)
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+const args     = process.argv.slice(2);
+const jsonMode = args.includes('--json');
+const helpMode = args.includes('--help');
+
+if (helpMode) {
+  console.log(`
+validate-schema.js — Validate ~/.copilot/data.db schema for session hierarchy
+
+USAGE:
+  node validate-schema.js [--json] [--help]
+
+OPTIONS:
+  --json   Output results as JSON (default: human-readable)
+  --help   Show this help
+
+WHAT IT CHECKS:
+  1. data.db file exists at ~/.copilot/data.db
+  2. workspace_parent_links has: child_workspace_id, parent_workspace_id,
+     creator_session_id, created_at
+  3. workspaces has: id, session_id, name, updated_at
+  4. sessions has: id, title, created_at, updated_at
+  5. Live JOIN query runs without error and returns sensible results
+
+EXIT CODES:
+  0 — PASS (all checks succeeded)
+  1 — FAIL (data.db missing, schema mismatch, or query failed)
+`);
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Required schema definition
+// ---------------------------------------------------------------------------
+const REQUIRED = {
+  workspace_parent_links: ['child_workspace_id', 'parent_workspace_id', 'creator_session_id', 'created_at'],
+  workspaces:             ['id', 'session_id', 'name', 'updated_at'],
+  sessions:               ['id', 'title', 'created_at', 'updated_at'],
+};
+
+// ---------------------------------------------------------------------------
+// sql.js bootstrap (pure WASM — no native sqlite3 needed)
+// ---------------------------------------------------------------------------
+async function loadSqlJs() {
+  // Try to find sql.js in the vscode-extension node_modules first (already installed),
+  // then fall back to a local install if present.
+  const candidates = [
+    path.join(__dirname, '..', '..', '..', 'vscode-extension', 'node_modules', 'sql.js'),
+    path.join(__dirname, 'node_modules', 'sql.js'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(path.join(p, 'dist', 'sql-wasm.js'))) {
+      const initSqlJs = require(path.join(p, 'dist', 'sql-wasm.js'));
+      const wasmPath  = path.join(p, 'dist', 'sql-wasm.wasm');
+      const wasmBinary = fs.existsSync(wasmPath) ? fs.readFileSync(wasmPath) : undefined;
+      return initSqlJs(wasmBinary ? { wasmBinary } : undefined);
+    }
+  }
+  throw new Error(
+    'sql.js not found. Run `npm install sql.js` inside vscode-extension/ or ' +
+    path.join(__dirname, '') + ' first.'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main validation
+// ---------------------------------------------------------------------------
+async function validate() {
+  const results = {
+    dbPath:   path.join(os.homedir(), '.copilot', 'data.db'),
+    checks:   [],
+    passed:   0,
+    failed:   0,
+    liveQuery: null,
+    timestamp: new Date().toISOString(),
+  };
+
+  function addCheck(name, passed, detail) {
+    results.checks.push({ name, passed, detail: detail ?? '' });
+    if (passed) { results.passed++; } else { results.failed++; }
+  }
+
+  // ── Check 1: file exists ──────────────────────────────────────────────────
+  if (!fs.existsSync(results.dbPath)) {
+    addCheck('data.db exists', false, `Not found at ${results.dbPath}`);
+    return results;
+  }
+  addCheck('data.db exists', true, results.dbPath);
+
+  // ── Load sql.js ───────────────────────────────────────────────────────────
+  let SQL;
+  try {
+    SQL = await loadSqlJs();
+  } catch (e) {
+    addCheck('sql.js available', false, String(e));
+    return results;
+  }
+  addCheck('sql.js available', true, '');
+
+  // ── Open database ─────────────────────────────────────────────────────────
+  let db;
+  try {
+    const buf = fs.readFileSync(results.dbPath);
+    db = new SQL.Database(buf);
+  } catch (e) {
+    addCheck('open data.db', false, String(e));
+    return results;
+  }
+  addCheck('open data.db', true, `size: ${fs.statSync(results.dbPath).size.toLocaleString()} bytes`);
+
+  try {
+    // ── Check 2-4: required table columns ───────────────────────────────────
+    for (const [table, requiredCols] of Object.entries(REQUIRED)) {
+      let existingCols;
+      try {
+        const info = db.exec(`PRAGMA table_info(${table})`);
+        existingCols = info.length > 0
+          ? info[0].values.map(r => r[1])   // column [1] is the name
+          : [];
+      } catch (e) {
+        addCheck(`table: ${table}`, false, `PRAGMA failed: ${e}`);
+        continue;
+      }
+
+      if (existingCols.length === 0) {
+        addCheck(`table: ${table}`, false, 'Table does not exist');
+        continue;
+      }
+
+      const missing = requiredCols.filter(c => !existingCols.includes(c));
+      if (missing.length > 0) {
+        addCheck(`table: ${table}`, false,
+          `Missing columns: ${missing.join(', ')}. Present: ${existingCols.join(', ')}`);
+      } else {
+        addCheck(`table: ${table}`, true,
+          `All ${requiredCols.length} required columns present`);
+      }
+    }
+
+    // ── Check 5: live JOIN query (last 24 h) ─────────────────────────────────
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const liveQuery = `
+      SELECT
+        cw.session_id  AS child_uuid,
+        cw.name        AS child_name,
+        pw.session_id  AS parent_uuid,
+        pw.name        AS parent_name,
+        l.created_at
+      FROM workspace_parent_links l
+      JOIN workspaces cw ON cw.id = l.child_workspace_id
+      JOIN workspaces pw ON pw.id = l.parent_workspace_id
+      WHERE l.created_at >= '${since}'
+      ORDER BY l.created_at DESC
+      LIMIT 10
+    `;
+
+    try {
+      const liveResult = db.exec(liveQuery);
+      const rows = liveResult.length > 0 ? liveResult[0].values : [];
+      results.liveQuery = {
+        rowsReturned: rows.length,
+        since,
+        sampleRows: rows.slice(0, 3).map(r => ({
+          childName:  r[1],
+          parentName: r[3],
+          createdAt:  r[4],
+        })),
+      };
+      addCheck('live JOIN query', true,
+        `${rows.length} parent/child link(s) in last 24h`);
+    } catch (e) {
+      addCheck('live JOIN query', false, String(e));
+    }
+
+    // ── Check 6: total link count (regression canary) ────────────────────────
+    try {
+      const countResult = db.exec('SELECT COUNT(*) FROM workspace_parent_links');
+      const total = countResult.length > 0 ? countResult[0].values[0][0] : 0;
+      addCheck('workspace_parent_links row count', true,
+        `${total.toLocaleString()} total links in DB`);
+    } catch (e) {
+      addCheck('workspace_parent_links row count', false, String(e));
+    }
+
+  } finally {
+    db.close();
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+(async () => {
+  let results;
+  try {
+    results = await validate();
+  } catch (e) {
+    const err = { error: String(e), passed: 0, failed: 1, timestamp: new Date().toISOString() };
+    if (jsonMode) { console.log(JSON.stringify(err, null, 2)); }
+    else { console.error('Unexpected error:', e); }
+    process.exit(1);
+  }
+
+  const allPassed = results.failed === 0;
+
+  if (jsonMode) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    const line = '─'.repeat(60);
+    console.log(line);
+    console.log('Copilot data.db schema validation');
+    console.log(line);
+    for (const c of results.checks) {
+      const icon = c.passed ? '✅' : '❌';
+      console.log(`${icon}  ${c.name}`);
+      if (c.detail) { console.log(`     ${c.detail}`); }
+    }
+    console.log(line);
+    if (results.liveQuery) {
+      console.log(`Live query (last 24h): ${results.liveQuery.rowsReturned} link(s)`);
+      for (const r of results.liveQuery.sampleRows) {
+        console.log(`  ↑ ${r.parentName ?? '?'}  →  ${r.childName ?? '?'}  (${r.createdAt})`);
+      }
+      console.log(line);
+    }
+    console.log(`Result: ${allPassed ? '✅ PASS' : '❌ FAIL'} — ${results.passed} passed, ${results.failed} failed`);
+    console.log(line);
+  }
+
+  process.exit(allPassed ? 0 : 1);
+})();

--- a/docs/FLUENCY-LEVELS.md
+++ b/docs/FLUENCY-LEVELS.md
@@ -71,6 +71,9 @@ Measures adoption of autonomous, multi-step agent mode workflows.
 - Multi-file edit sessions detected → at least Stage 2
 - Average 3+ files per edit session → at least Stage 3
 - 20+ multi-file edits with average 3+ files per session → Stage 4
+- Sessions with 2+ child workspaces (multi-agent orchestration) → at least Stage 3; 3+ such sessions → at least Stage 4
+
+> **Note about multi-agent orchestration:** This signal is read from `~/.copilot/data.db` (Copilot app only). It counts sessions where you were the *parent* of 2 or more child workspaces — covering both sessions where you manually launched child sessions and sessions where an agent autonomously spawned a subagent fleet. It is absent (and does not affect scoring) when `data.db` is not available.
 
 > **Note:** Only *intentional* tools count toward the unique tool thresholds — tools that Copilot calls automatically (file reads, searches, error lookups, confirmations, memory, etc.) are excluded. See [Automatic vs. Intentional Tools](#automatic-vs-intentional-tools) below.
 

--- a/vscode-extension/src/copilotAppData.ts
+++ b/vscode-extension/src/copilotAppData.ts
@@ -1,0 +1,219 @@
+/**
+ * CopilotAppDataAccess — reads session hierarchy from ~/.copilot/data.db.
+ *
+ * The Copilot app stores parent/child workspace relationships in `data.db`,
+ * including both user-initiated child sessions and agent-spawned subagent
+ * fleets (where an agent calls `create_session` to spawn N child sessions).
+ *
+ * The bridge to our session files:
+ *   workspace_parent_links.child/parent_workspace_id
+ *     → workspaces.id
+ *     → workspaces.session_id   ← this equals the events.jsonl UUID directory
+ *     → ~/.copilot/session-state/{UUID}/events.jsonl
+ *
+ * This module is an optional enrichment layer. All methods return gracefully
+ * when data.db is absent or the schema differs from what we expect.
+ */
+/// <reference types="sql.js" />
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import initSqlJs from 'sql.js';
+
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+
+/**
+ * Hierarchy information for one session, keyed by its events.jsonl UUID.
+ * Names come from the `workspaces.name` column (the session display name).
+ */
+export interface SessionHierarchyNode {
+	uuid: string;
+	parentUuid: string | null;
+	/** Display name of the parent workspace (may be null when parent exists but name is not set). */
+	parentName: string | null;
+	/** UUIDs of all direct children (every workspace that lists this as parent). */
+	childUuids: string[];
+	/** Display names keyed by child UUID. */
+	childNames: Map<string, string>;
+	/**
+	 * Total child count across ALL children in data.db, not just those in our
+	 * current session window. Useful when showing "↓ N" badges for fleet parents.
+	 */
+	totalChildCount: number;
+}
+
+export class CopilotAppDataAccess {
+	private _sqlJsModule: SqlJsStatic | null = null;
+
+	/** Absolute path to ~/.copilot/data.db. */
+	getDbPath(): string {
+		return path.join(os.homedir(), '.copilot', 'data.db');
+	}
+
+	/** Lazily initialise and cache the sql.js WASM module. */
+	private async initSqlJs(): Promise<SqlJsStatic> {
+		if (this._sqlJsModule) { return this._sqlJsModule; }
+		// Re-use the same WASM file that CopilotCliStoreAccess uses.
+		const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+		let wasmBinary: Uint8Array | undefined;
+		if (fs.existsSync(wasmPath)) {
+			wasmBinary = fs.readFileSync(wasmPath);
+		}
+		const sqlJs = await initSqlJs(wasmBinary ? { wasmBinary } : undefined);
+		this._sqlJsModule = sqlJs;
+		return sqlJs;
+	}
+
+	/**
+	 * Build a hierarchy map for the given events.jsonl session UUIDs.
+	 *
+	 * For each UUID we return:
+	 *   - its parent UUID + name (null when it is a root session)
+	 *   - its direct child UUIDs + names (empty when it has no children)
+	 *   - a `totalChildCount` drawn from data.db (may be > childUuids.length when
+	 *     some children fall outside the caller's visible session set)
+	 *
+	 * Only UUIDs that appear in at least one side of a parent/child relationship
+	 * are included in the returned map.  Sessions with no hierarchy are omitted.
+	 *
+	 * Returns an empty map when data.db does not exist, the schema is unexpected,
+	 * or any error occurs — all errors are suppressed.
+	 */
+	async getSessionHierarchy(sessionUuids: string[]): Promise<Map<string, SessionHierarchyNode>> {
+		const result = new Map<string, SessionHierarchyNode>();
+		if (sessionUuids.length === 0) { return result; }
+
+		const dbPath = this.getDbPath();
+		if (!fs.existsSync(dbPath)) { return result; }
+
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			const db = new SQL.Database(buffer);
+			try {
+				return this._buildHierarchyFromDb(db, sessionUuids);
+			} finally {
+				db.close();
+			}
+		} catch {
+			return result;
+		}
+	}
+
+	private _buildHierarchyFromDb(
+		db: initSqlJs.Database,
+		sessionUuids: string[],
+	): Map<string, SessionHierarchyNode> {
+		const linkRows = this._queryLinkRows(db, sessionUuids);
+		if (linkRows.length === 0) { return new Map(); }
+
+		const parentUuids   = this._collectParentUuids(linkRows);
+		const totalCounts   = this._queryTotalChildCounts(db, parentUuids);
+		return this._buildResultMap(linkRows, totalCounts);
+	}
+
+	/** Query parent/child link rows for the given UUIDs (as child or parent). */
+	private _queryLinkRows(
+		db: initSqlJs.Database,
+		sessionUuids: string[],
+	): (string | null)[][] {
+		const ph = sessionUuids.map(() => '?').join(', ');
+		const sql = `
+			SELECT cw.session_id, cw.name, pw.session_id, pw.name
+			FROM workspace_parent_links l
+			JOIN workspaces cw ON cw.id = l.child_workspace_id
+			JOIN workspaces pw ON pw.id = l.parent_workspace_id
+			WHERE cw.session_id IN (${ph}) OR pw.session_id IN (${ph})
+		`;
+		try {
+			const res = db.exec(sql, [...sessionUuids, ...sessionUuids]);
+			return res.length > 0 ? (res[0].values as (string | null)[][]) : [];
+		} catch {
+			return [];
+		}
+	}
+
+	/** Collect the set of parent UUIDs from link rows. */
+	private _collectParentUuids(rows: (string | null)[][]): Set<string> {
+		const parents = new Set<string>();
+		for (const row of rows) {
+			const parentUuid = row[2] as string | null;
+			if (parentUuid) { parents.add(parentUuid); }
+		}
+		return parents;
+	}
+
+	/** Query total child counts for each parent UUID (counts ALL DB children). */
+	private _queryTotalChildCounts(
+		db: initSqlJs.Database,
+		parentUuids: Set<string>,
+	): Map<string, number> {
+		const counts = new Map<string, number>();
+		if (parentUuids.size === 0) { return counts; }
+
+		const ph  = Array.from(parentUuids).map(() => '?').join(', ');
+		const sql = `
+			SELECT pw.session_id, COUNT(*)
+			FROM workspace_parent_links l
+			JOIN workspaces pw ON pw.id = l.parent_workspace_id
+			WHERE pw.session_id IN (${ph})
+			GROUP BY pw.session_id
+		`;
+		try {
+			const res = db.exec(sql, Array.from(parentUuids));
+			if (res.length > 0) {
+				for (const row of res[0].values) {
+					counts.set(row[0] as string, row[1] as number);
+				}
+			}
+		} catch { /* ignore — totalChildCount will default to childUuids.length */ }
+		return counts;
+	}
+
+	/** Build the hierarchy map from link rows and precomputed total counts. */
+	private _buildResultMap(
+		rows: (string | null)[][],
+		totalCounts: Map<string, number>,
+	): Map<string, SessionHierarchyNode> {
+		const result = new Map<string, SessionHierarchyNode>();
+
+		const ensureNode = (uuid: string): SessionHierarchyNode => {
+			if (!result.has(uuid)) {
+				result.set(uuid, {
+					uuid, parentUuid: null, parentName: null,
+					childUuids: [], childNames: new Map(), totalChildCount: 0,
+				});
+			}
+			return result.get(uuid)!;
+		};
+
+		for (const row of rows) {
+			const [childUuid, childName, parentUuid, parentName] = row as (string | null)[];
+			if (!childUuid || !parentUuid) { continue; }
+
+			const childNode  = ensureNode(childUuid);
+			const parentNode = ensureNode(parentUuid);
+
+			childNode.parentUuid = parentUuid;
+			childNode.parentName = parentName ?? null;
+
+			if (!parentNode.childUuids.includes(childUuid)) {
+				parentNode.childUuids.push(childUuid);
+				parentNode.childNames.set(childUuid, childName ?? childUuid);
+			}
+
+			const total = totalCounts.get(parentUuid);
+			if (total !== undefined && total > parentNode.totalChildCount) {
+				parentNode.totalChildCount = total;
+			}
+		}
+
+		// Ensure totalChildCount is at least as large as the observed list.
+		for (const node of result.values()) {
+			if (node.totalChildCount < node.childUuids.length) {
+				node.totalChildCount = node.childUuids.length;
+			}
+		}
+		return result;
+	}
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -53,6 +53,7 @@ import type {
   WorkspaceCustomizationSummary,
   AgentSessionsResult,
   TokenEstimator,
+  SessionRelationRef,
 } from './types';
 
 // --- Ecosystem adapter types & helpers ---
@@ -67,6 +68,7 @@ import type { GeminiCliDataAccess } from './geminicli';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { getEcosystemDisplayName } from './ecosystemAdapter';
 import { buildAdapterRegistry, createDataAccessInstances } from './adapters';
+import { CopilotAppDataAccess } from './copilotAppData';
 import { getVSCodeUserPaths } from './adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from './adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from './jetbrains';
@@ -288,6 +290,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private geminiCli!: GeminiCliDataAccess;
 	private ecosystems!: IEcosystemAdapter[];
 	private cacheManager!: CacheManager;
+	private readonly copilotAppData = new CopilotAppDataAccess();
 
 	private get usageAnalysisDeps(): UsageAnalysisDeps {
 		return { warn: (m: string) => this.warn(m), tokenEstimators: this.tokenEstimators, modelPricing: this.modelPricing, toolNameMap: this.toolNameMap, ecosystems: this.ecosystems };
@@ -3811,6 +3814,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			editorName, size: details.size, modified: details.modified, interactions: details.interactions,
 			contextReferences: details.contextReferences, firstInteraction: details.firstInteraction,
 			lastInteraction: details.lastInteraction, turns, usageAnalysis, actualTokens,
+			...(details.parentInfo ? { parentInfo: details.parentInfo } : {}),
+			...(details.childInfo ? { childInfo: details.childInfo, totalChildCount: details.totalChildCount } : {}),
 			...this.buildLogDataCacheFields(sessionCache, subAgentsStarted),
 		};
 	}
@@ -6900,7 +6905,69 @@ ${this.getLoadingHtmlScript()}
         if (lastActivity >= fourteenDaysAgo) { detailedSessionFiles.push(details); }
       } catch { /* Skip inaccessible files */ }
     }
+    await this.enrichSessionHierarchy(detailedSessionFiles);
     await this.sendBgLoadResults(panel, detailedSessionFiles, initialCacheHits, initialCacheMisses);
+  }
+
+  /**
+   * Extract the Copilot CLI events.jsonl UUID from a session file path.
+   * Handles both:
+   *   - ~/.copilot/session-state/{uuid}/events.jsonl  → returns the uuid directory name
+   *   - ~/.copilot/session-store.db#{uuid}           → returns the uuid after '#'
+   * Returns null for all other session types.
+   */
+  private extractCopilotCliUuid(sessionFile: string): string | null {
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    // Virtual DB path: .../session-store.db#uuid
+    if (sessionFile.includes('session-store.db#')) {
+      const uuid = sessionFile.split('session-store.db#')[1] ?? '';
+      return UUID_RE.test(uuid) ? uuid : null;
+    }
+    // events.jsonl path: .../session-state/{uuid}/events.jsonl
+    if (sessionFile.includes('session-state')) {
+      const uuid = path.basename(path.dirname(sessionFile));
+      return UUID_RE.test(uuid) ? uuid : null;
+    }
+    return null;
+  }
+
+  /**
+   * Enrich Copilot CLI sessions in `files` with parent/child hierarchy data
+   * read from ~/.copilot/data.db.  All other session types are left untouched.
+   * Errors are suppressed — hierarchy is an optional enrichment.
+   */
+  private async enrichSessionHierarchy(files: SessionFileDetails[]): Promise<void> {
+    // Build uuid → SessionFileDetails map for Copilot CLI sessions only.
+    const uuidToDetails = new Map<string, SessionFileDetails>();
+    for (const details of files) {
+      const uuid = this.extractCopilotCliUuid(details.file);
+      if (uuid) { uuidToDetails.set(uuid, details); }
+    }
+    if (uuidToDetails.size === 0) { return; }
+
+    try {
+      const hierarchy = await this.copilotAppData.getSessionHierarchy([...uuidToDetails.keys()]);
+      for (const [uuid, node] of hierarchy) {
+        const details = uuidToDetails.get(uuid);
+        if (!details) { continue; }
+        if (node.parentUuid) {
+          const ref: SessionRelationRef = {
+            uuid: node.parentUuid,
+            name: node.parentName ?? node.parentUuid,
+            sessionFile: uuidToDetails.get(node.parentUuid)?.file,
+          };
+          details.parentInfo = ref;
+        }
+        if (node.childUuids.length > 0) {
+          details.childInfo = node.childUuids.map(cUuid => ({
+            uuid: cUuid,
+            name: node.childNames.get(cUuid) ?? cUuid,
+            sessionFile: uuidToDetails.get(cUuid)?.file,
+          } satisfies SessionRelationRef));
+          details.totalChildCount = node.totalChildCount;
+        }
+      }
+    } catch { /* hierarchy is optional — never surface errors */ }
   }
 
   private async sortSessionFilesByMtime(sessionFiles: string[]): Promise<string[]> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2482,6 +2482,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.aggregateUsageFileResults(usageResults, periods, wsMaps, todaySessionsList, totalFiles);
 			this.deduplicateWorkspacePaths(workspaceSessionCounts, workspaceInteractionCounts);
 			this.buildUsageCustomizationMatrix(workspaceSessionCounts, workspaceInteractionCounts, unresolvedWorkspaceIds, unresolvedWorkspaceInteractionCounts);
+			await this.enrichMultiAgentParentCount(usageResults, last30DaysStats, last30DaysUtcStartKey);
 		} catch (error) {
 			this.error('Error calculating usage analysis stats:', error);
 		}
@@ -2526,6 +2527,36 @@ class CopilotTokenTracker implements vscode.Disposable {
 			conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
 			agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 }
 		};
+	}
+
+	/**
+	 * Query data.db for multi-agent parent count and set it on the period.
+	 * A session counts as a "multi-agent parent" when it has 2+ direct child workspaces.
+	 * Errors are swallowed — this is optional enrichment only.
+	 */
+	private async enrichMultiAgentParentCount(
+		usageResults: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
+		last30DaysStats: UsageAnalysisPeriod,
+		last30DaysUtcStartKey: string,
+	): Promise<void> {
+		const uuids: string[] = [];
+		for (const r of usageResults) {
+			if (!r) { continue; }
+			const lastActivityKey = this.computeLastActivityKey(r.sessionData, r.mtime);
+			if (lastActivityKey < last30DaysUtcStartKey) { continue; }
+			const uuid = this.extractCopilotCliUuid(r.sessionFile);
+			if (uuid) { uuids.push(uuid); }
+		}
+		if (uuids.length === 0) { return; }
+		try {
+			const hierarchy = await this.copilotAppData.getSessionHierarchy(uuids);
+			let count = 0;
+			for (const uuid of uuids) {
+				const node = hierarchy.get(uuid);
+				if (node && node.totalChildCount >= 2) { count++; }
+			}
+			if (count > 0) { last30DaysStats.multiAgentParentSessions = count; }
+		} catch { /* optional enrichment — suppress */ }
 	}
 
 	private buildDefaultSessionAnalysis(): SessionUsageAnalysis {

--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -85,6 +85,12 @@ export const STAGE_THRESHOLDS = {
 		stage4MinNonAutoTools: 5,
 		/** Minimum multi-file edit sessions (alongside avgFilesPerSession) to promote to Stage 4. */
 		stage4MinMultiFileEdits: 20,
+		/** Minimum sessions with 2+ child workspaces (multi-agent orchestration) to reach at least Stage 3. */
+		stage3MinMultiAgentParents: 1,
+		/** Minimum sessions with 2+ child workspaces (multi-agent orchestration) to reach at least Stage 4. */
+		stage4MinMultiAgentParents: 3,
+		/** Minimum number of child workspaces per session to count as multi-agent orchestration. */
+		multiAgentMinChildren: 2,
 	},
 	toolUsage: {
 		/** Minimum number of distinct advanced built-in tools used to promote to Stage 3. */
@@ -552,11 +558,25 @@ function _agQualifiesMultiFileStage4(editScope: UsageAnalysisPeriod['editScope']
 	return !!editScope && editScope.multiFileEdits >= T.stage4MinMultiFileEdits && editScope.avgFilesPerSession >= T.stage3MinAvgFilesPerSession;
 }
 
+function _agApplyMultiAgentBooster(
+	multiAgentParents: number,
+	T: typeof STAGE_THRESHOLDS.agentic,
+	stage: Stage,
+	evidence: string[],
+): Stage {
+	if (multiAgentParents < T.stage3MinMultiAgentParents) { return stage; }
+	const label = multiAgentParents === 1 ? '1 session' : `${fmt(multiAgentParents)} sessions`;
+	evidence.push(`${label} with child workspaces (multi-agent orchestration)`);
+	stage = promoteStage(stage, 3);
+	if (multiAgentParents >= T.stage4MinMultiAgentParents) { stage = promoteStage(stage, 4); }
+	return stage;
+}
+
 function _agBuildTips(stage: Stage): string[] {
 	const tips: string[] = [];
 	if (stage < 2) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) — it can run terminal commands, edit files, and explore your codebase autonomously'); }
 	if (stage < 3) { tips.push('Use [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-step tasks; let it chain tools like file search, terminal, and code edits'); }
-	if (stage < 4) { tips.push('Tackle complex refactoring or debugging tasks in [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for deeper autonomous workflows'); }
+	if (stage < 4) { tips.push('Try [multi-agent orchestration](https://code.visualstudio.com/docs/copilot/agents/overview): start child sessions from a parent session to run multiple agents in parallel on independent sub-tasks'); }
 	return tips;
 }
 
@@ -584,6 +604,7 @@ function _scoreAgentic(p: UsageAnalysisPeriod): CategoryScore {
 	if (_agQualifiesForStage3(agentInteractions, nonAutoToolCount, T)) { stage = 3; }
 	if (_agQualifiesForStage4(agentInteractions, nonAutoToolCount, T)) { stage = 4; }
 	if (_agQualifiesMultiFileStage4(p.editScope, T)) { stage = promoteStage(stage, 4); }
+	stage = _agApplyMultiAgentBooster(p.multiAgentParentSessions ?? 0, T, stage, evidence);
 
 	return { stage, evidence, tips: _agBuildTips(stage) };
 }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -442,6 +442,14 @@ export interface UsageAnalysisPeriod {
   };
 }
 
+/** Parent/child session reference used in hierarchy info (Copilot CLI sessions). */
+export interface SessionRelationRef {
+  uuid: string;
+  name: string;
+  /** Resolved path to the related session file (undefined when outside the loaded set). */
+  sessionFile?: string;
+}
+
 // Detailed session file information for diagnostics view
 export interface SessionFileDetails {
   file: string;
@@ -457,6 +465,15 @@ export interface SessionFileDetails {
   editorName?: string; // friendly editor name (e.g., 'VS Code')
   title?: string; // session title (customTitle from session file)
   repository?: string; // Git remote origin URL for the session's workspace
+  /** Parent session info (Copilot CLI sessions only, populated from ~/.copilot/data.db). */
+  parentInfo?: SessionRelationRef | null;
+  /** Direct child sessions (Copilot CLI sessions only, populated from ~/.copilot/data.db). */
+  childInfo?: SessionRelationRef[];
+  /**
+   * Total child count from data.db — may exceed childInfo.length when some
+   * children fall outside the loaded 14-day diagnostic window.
+   */
+  totalChildCount?: number;
 }
 
 // Prompt token detail from actual LLM usage data
@@ -513,6 +530,12 @@ export interface SessionLogData {
   cachedTokens?: number;
   /** Number of distinct subagent sessions started (CLI format only, from subagent.started events). */
   subAgentsStarted?: number;
+  /** Parent session info (Copilot CLI sessions only, from data.db hierarchy). */
+  parentInfo?: SessionRelationRef | null;
+  /** Direct child sessions (Copilot CLI sessions only, from data.db hierarchy). */
+  childInfo?: SessionRelationRef[];
+  /** Total child count from data.db (may exceed childInfo.length). */
+  totalChildCount?: number;
   /** Input token total from debug log (sum of all llm_request events). Present for VS Code Copilot Chat agent-mode sessions. */
   debugLogInputTokens?: number;
   /** Output token total from debug log (sum of all llm_request events). Present for VS Code Copilot Chat agent-mode sessions. */

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -440,6 +440,12 @@ export interface UsageAnalysisPeriod {
     sessionCount: number; // sessions with effort data
     switchCount: number;  // total effort switches across all sessions
   };
+  /**
+   * Number of sessions in this period that are parents of 2+ child workspaces,
+   * indicating multi-agent orchestration. Populated from ~/.copilot/data.db;
+   * absent (undefined) when data.db is not available.
+   */
+  multiAgentParentSessions?: number;
 }
 
 /** Parent/child session reference used in hierarchy info (Copilot CLI sessions). */

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -37,6 +37,9 @@ type SessionFileDetails = {
   editorName?: string;
   title?: string;
   repository?: string;
+  parentInfo?: { uuid: string; name: string; sessionFile?: string } | null;
+  childInfo?: Array<{ uuid: string; name: string; sessionFile?: string }>;
+  totalChildCount?: number;
 };
 
 type CacheInfo = {
@@ -469,14 +472,32 @@ function buildSessionSummaryCardsHtml(filteredFiles: SessionFileDetails[], total
   <div class="filter-options"><label class="empty-sessions-toggle"><input type="checkbox" id="hide-empty-sessions" ${hideEmptySessions ? 'checked' : ''}>Hide sessions with 0 interactions${zeroInteractionCount > 0 ? `<span class="hidden-count">(${zeroInteractionCount} hidden)</span>` : ''}</label></div>`;
 }
 
+function buildHierarchyBadgesHtml(sf: SessionFileDetails): string {
+  let html = '';
+  if (sf.parentInfo) {
+    const parentTitle = escapeHtml(sf.parentInfo.name.length > 30 ? sf.parentInfo.name.substring(0, 30) + '…' : sf.parentInfo.name);
+    const linkAttr = sf.parentInfo.sessionFile
+      ? ` href="#" class="session-hierarchy-badge hierarchy-parent session-file-link" data-file="${encodeURIComponent(sf.parentInfo.sessionFile)}"`
+      : ` class="session-hierarchy-badge hierarchy-parent"`;
+    html += `<a${linkAttr} title="Parent session: ${escapeHtml(sf.parentInfo.name)}">↑ ${parentTitle}</a>`;
+  }
+  if (sf.totalChildCount && sf.totalChildCount > 0) {
+    const count = sf.totalChildCount;
+    const label = count === 1 ? '1 child' : `${count} children`;
+    html += `<span class="session-hierarchy-badge hierarchy-children" title="${label}">↓ ${count}</span>`;
+  }
+  return html ? `<div class="session-hierarchy-badges">${html}</div>` : '';
+}
+
 function buildSessionTableHtml(sortedFiles: SessionFileDetails[]): string {
   const rows = sortedFiles.map((sf, idx) => {
     const editorLabel = sf.editorName || sf.editorSource;
     const titleHtml = sf.title ? `<a href="#" class="session-file-link" data-file="${encodeURIComponent(sf.file)}" title="${escapeHtml(sf.title)}">${escapeHtml(sf.title.length > 40 ? sf.title.substring(0, 40) + "..." : sf.title)}</a>` : `<a href="#" class="session-file-link empty-session-link" data-file="${encodeURIComponent(sf.file)}" title="Empty session">(Empty session)</a>`;
+    const hierarchyBadges = buildHierarchyBadgesHtml(sf);
     const repoLabel = sf.repository ? escapeHtml(getRepoDisplayName(sf.repository)) : (sf.file.includes('session-store.db') ? '<span style="color: #888; font-style: italic;">No workspace</span>' : '<span style="color: #666;">—</span>');
     const repoTitle = sf.repository ? escapeHtml(sf.repository) : (sf.file.includes('session-store.db') ? 'Chat session — no workspace connected' : 'No repository detected');
     const isUnknownEditor = (sf.editorName || sf.editorSource || "Unknown") === "Unknown";
-    return `<tr><td>${idx + 1}</td><td><span class="${getEditorBadgeClass(editorLabel)}" title="${escapeHtml(sf.editorSource)}">${getEditorIcon(editorLabel)} ${escapeHtml(editorLabel)}</span></td><td class="session-title" title="${sf.title ? escapeHtml(sf.title) : "Empty session"}">${titleHtml}</td><td class="repository-cell" title="${repoTitle}">${repoLabel}</td><td>${formatFileSize(sf.size)}</td><td title="${Number(sf.tokens || 0).toLocaleString()} tokens">${formatTokenCount(sf.tokens)}</td><td>${sanitizeNumber(sf.interactions)}</td><td title="${escapeHtml(getContextRefsSummary(sf.contextReferences))}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td><td>${formatDate(sf.lastInteraction)}</td><td><a href="#" class="view-formatted-link" data-file="${encodeURIComponent(sf.file)}" title="View formatted JSONL file">📄 View</a>${isUnknownEditor ? ` <a href="#" class="report-editor-link" data-path="${encodeURIComponent(sf.file)}" title="Report this unknown path so we can add editor support">📢 Report</a>` : ""}</td></tr>`;
+    return `<tr><td>${idx + 1}</td><td><span class="${getEditorBadgeClass(editorLabel)}" title="${escapeHtml(sf.editorSource)}">${getEditorIcon(editorLabel)} ${escapeHtml(editorLabel)}</span></td><td class="session-title" title="${sf.title ? escapeHtml(sf.title) : "Empty session"}">${hierarchyBadges}${titleHtml}</td><td class="repository-cell" title="${repoTitle}">${repoLabel}</td><td>${formatFileSize(sf.size)}</td><td title="${Number(sf.tokens || 0).toLocaleString()} tokens">${formatTokenCount(sf.tokens)}</td><td>${sanitizeNumber(sf.interactions)}</td><td title="${escapeHtml(getContextRefsSummary(sf.contextReferences))}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td><td>${formatDate(sf.lastInteraction)}</td><td><a href="#" class="view-formatted-link" data-file="${encodeURIComponent(sf.file)}" title="View formatted JSONL file">📄 View</a>${isUnknownEditor ? ` <a href="#" class="report-editor-link" data-path="${encodeURIComponent(sf.file)}" title="Report this unknown path so we can add editor support">📢 Report</a>` : ""}</td></tr>`;
   }).join("");
   return `<div class="table-container"><table class="session-table"><thead><tr><th>#</th><th>Editor</th><th>Title</th><th>Repository</th><th class="sortable" data-sort="size">Size${getSortIndicator("size")}</th><th class="sortable" data-sort="tokens">Tokens${getSortIndicator("tokens")}</th><th class="sortable" data-sort="interactions">Interactions${getSortIndicator("interactions")}</th><th class="sortable" data-sort="contextRefs">Context Refs${getSortIndicator("contextRefs")}</th><th class="sortable" data-sort="lastInteraction">Last Interaction${getSortIndicator("lastInteraction")}</th><th>Actions</th></tr></thead><tbody>${rows}</tbody></table></div>`;
 }

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -461,6 +461,41 @@ background-position: center;
 	color: var(--text-muted);
 }
 
+/* Session hierarchy badges (parent ↑ / children ↓) */
+.session-hierarchy-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 3px;
+	margin-bottom: 3px;
+}
+
+.session-hierarchy-badge {
+	display: inline-block;
+	font-size: 10px;
+	padding: 1px 5px;
+	border-radius: 3px;
+	white-space: nowrap;
+	text-decoration: none;
+}
+
+.hierarchy-parent {
+	background: rgba(100, 60, 180, 0.2);
+	color: #b89dff;
+	border: 1px solid rgba(100, 60, 180, 0.4);
+	cursor: pointer;
+}
+
+.hierarchy-parent:hover {
+	background: rgba(100, 60, 180, 0.35);
+	color: #d0b8ff;
+}
+
+.hierarchy-children {
+	background: rgba(30, 120, 80, 0.2);
+	color: #7adbb0;
+	border: 1px solid rgba(30, 120, 80, 0.4);
+}
+
 .empty-session-link:hover {
 	color: var(--text-secondary);
 }

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -78,6 +78,12 @@ actualTokens?: number;
 cachedTokens?: number;
 /** Number of subagent sessions started (CLI format only). */
 subAgentsStarted?: number;
+/** Parent session info (Copilot CLI sessions only, from data.db hierarchy). */
+parentInfo?: { uuid: string; name: string; sessionFile?: string } | null;
+/** Direct child sessions (Copilot CLI sessions only, from data.db hierarchy). */
+childInfo?: Array<{ uuid: string; name: string; sessionFile?: string }>;
+/** Total child count from data.db (may exceed childInfo.length). */
+totalChildCount?: number;
 /** Input token total from debug log (sum of all llm_request events). Present for VS Code Copilot Chat agent-mode sessions. */
 debugLogInputTokens?: number;
 /** Output token total from debug log (sum of all llm_request events). Present for VS Code Copilot Chat agent-mode sessions. */
@@ -778,6 +784,30 @@ function buildEffortCard(stats: SummaryStats): string {
 </div>`;
 }
 
+function buildHierarchyCard(data: SessionLogData): string {
+	const hasParent = !!data.parentInfo;
+	const childCount = data.totalChildCount ?? data.childInfo?.length ?? 0;
+	if (!hasParent && childCount === 0) { return ''; }
+
+	let parts: string[] = [];
+	if (hasParent) {
+		const pName = escapeHtml(data.parentInfo!.name);
+		parts.push(`<div class="hierarchy-line hierarchy-parent-line">↑ Parent: <strong>${pName}</strong></div>`);
+	}
+	if (childCount > 0) {
+		const shown = data.childInfo?.slice(0, 5) ?? [];
+		const more = childCount - shown.length;
+		const childItems = shown.map(c => `<span class="hierarchy-child-name">${escapeHtml(c.name)}</span>`).join(', ');
+		const moreHtml = more > 0 ? ` <span style="color: var(--vscode-descriptionForeground);">+${more} more</span>` : '';
+		parts.push(`<div class="hierarchy-line hierarchy-children-line">↓ Children (${childCount}): ${childItems}${moreHtml}</div>`);
+	}
+
+	return `<div class="summary-card">
+<div class="summary-label">🔗 Session Hierarchy</div>
+<div class="summary-sub hierarchy-card-content">${parts.join('')}</div>
+</div>`;
+}
+
 function buildSubAgentsCard(data: SessionLogData, stats: SummaryStats): string {
 	if (stats.totalSubAgentCalls <= 0 && (data.subAgentsStarted ?? 0) <= 0) { return ''; }
 	const count = data.subAgentsStarted ?? stats.totalSubAgentCalls;
@@ -828,6 +858,7 @@ ${buildCachedTokensCard(data)}
 ${buildThinkingTokensCard(data, stats)}
 ${buildEffortCard(stats)}
 ${buildSubAgentsCard(data, stats)}
+${buildHierarchyCard(data)}
 <div class="summary-card">
 <div class="summary-label">🔧 Tool Calls</div>
 <div class="summary-value">${usageToolTotal}</div>

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -1094,3 +1094,27 @@ details[open] > summary .collapse-arrow {
 		grid-template-columns: 1fr;
 	}
 }
+
+/* Session hierarchy card */
+.hierarchy-card-content {
+text-align: left;
+padding-top: 4px;
+}
+
+.hierarchy-line {
+font-size: 12px;
+line-height: 1.6;
+padding: 2px 0;
+}
+
+.hierarchy-parent-line {
+color: #b89dff;
+}
+
+.hierarchy-children-line {
+color: #7adbb0;
+}
+
+.hierarchy-child-name {
+font-style: italic;
+}


### PR DESCRIPTION
## Summary

Adds discovery and visualization of parent/child session relationships from `~/.copilot/data.db`, and a periodic validation skill to catch schema regressions early.

## What changed

### `vscode-extension/src/copilotAppData.ts` (new)
Reads `workspace_parent_links`, `workspaces` from `~/.copilot/data.db` via sql.js. Returns a `Map<uuid, SessionHierarchyNode>` covering both user-initiated child sessions and agent-spawned subagent fleets.

### `vscode-extension/src/types.ts`
- Added `SessionRelationRef` interface (uuid, name, sessionFile?)
- Added `parentInfo?`, `childInfo?`, `totalChildCount?` to `SessionFileDetails` and `SessionLogData`

### `vscode-extension/src/extension.ts`
- `extractCopilotCliUuid()` — extracts UUID from events.jsonl paths and session-store.db virtual paths
- `enrichSessionHierarchy()` — called before `sendBgLoadResults()`, fills hierarchy fields on each Copilot CLI session

### Diagnostics panel (`diagnostics/main.ts`, `diagnostics/styles.css`)
- `buildHierarchyBadgesHtml()` — renders a `↑ Parent name` clickable chip and a `↓ N` children count badge inline in the session title cell

### Log viewer (`logviewer/main.ts`, `logviewer/styles.css`)
- `buildHierarchyCard()` — summary card showing parent session name and up to 5 child session names + overflow count

### `.github/skills/validate-app-db-schema/` (new skill)
- `SKILL.md` — frontmatter + documentation of what the skill validates and how to use it
- `validate-schema.js` — Node.js script using sql.js that:
  1. Confirms `data.db` exists
  2. Checks all required tables/columns via `PRAGMA table_info`
  3. Runs the actual JOIN query against last 24h of data
  4. Reports PASS/FAIL; exits 0 on pass, 1 on fail (`--json` flag for CI)

## Testing

- `npm run compile` — 0 errors, warnings only in pre-existing files
- `npm run test:node` — all 64 unit tests pass

## How to use the skill

```bash
node .github/skills/validate-app-db-schema/validate-schema.js
node .github/skills/validate-app-db-schema/validate-schema.js --json
```

Add to a scheduled workflow to detect Copilot app updates that break the hierarchy feature.