### PR TITLE
Add validate-session-schemas skill

### DIFF
--- a/.github/skills/validate-session-schemas/SKILL.md
+++ b/.github/skills/validate-session-schemas/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: validate-session-schemas
+description: Loop over recent local AI-coding session log files for every supported file-based platform (Copilot Chat, Copilot CLI, JetBrains, Claude Code, Gemini CLI, Antigravity, OpenCode) and validate they still match the documented schema, while surfacing newly-discovered fields we could start using. Use after an editor/CLI update, when adding a parser, or on a schedule to catch schema drift early.
+---
+
+# Validate Session Schemas Skill
+
+Validates that **recent** session log files on the current machine still match
+the schema our parsers expect, **per supported platform**, and surfaces
+**new fields** that appeared on disk but aren't documented/used yet.
+
+It answers two questions in one pass:
+
+1. **Did anything break?** — Drift detection against a small set of fields our
+   parsers actually depend on ("contracts"). A missing required field on an
+   observed record type is a `DRIFT` failure.
+2. **Is there new information to use?** — Any field observed on disk that is not
+   in the known baseline ("knownFields") is reported as a new field. These are
+   candidates for new features or better token attribution (e.g. real token
+   counts, new model metadata, new event types).
+
+## Why this skill exists
+
+The pre-existing `copilot-log-analysis` skill (`analyze-session-schema.ps1`)
+only covered VS Code Copilot Chat JSON + Copilot CLI JSONL + OpenCode, with
+crude substring-based "new field" detection. It did **not** loop per supported
+platform, had no recency window, and didn't cover JetBrains, Claude Code,
+Gemini CLI, or Antigravity. This skill closes that gap.
+
+## Platforms covered
+
+The source of truth for supported platforms is
+`vscode-extension/src/adapters/adapterRegistry.ts`. This skill validates the
+**file-based JSON/JSONL** ecosystems that have schema docs under
+`docs/logFilesSchema/`:
+
+| Platform id    | Editor / tool        | Format | Discovery root |
+|----------------|----------------------|--------|----------------|
+| `copilot-chat` | VS Code Copilot Chat | json / jsonl | VS Code variants `workspaceStorage/*/chatSessions`, `globalStorage` |
+| `copilot-cli`  | Copilot CLI          | jsonl  | `~/.copilot/session-state/` |
+| `jetbrains`    | JetBrains Copilot    | jsonl  | `~/.copilot/jb/{uuid}/partition-*.jsonl` |
+| `claude-code`  | Claude Code          | jsonl  | `~/.claude/projects/{hash}/*.jsonl` |
+| `gemini-cli`   | Gemini CLI           | jsonl  | `~/.gemini/tmp/*/chats/session-*.jsonl` |
+| `antigravity`  | Antigravity          | jsonl  | `~/.gemini/antigravity/brain/*/.system_generated/logs/transcript.jsonl` |
+| `opencode`     | OpenCode             | json   | `<xdg-data>/opencode/storage/session/**/ses_*.json` |
+
+**Not validated by this skill** (DB / binary formats that need the adapters'
+own parsers, so a generic JSON walker can't read them): `crush` (SQLite),
+`visual-studio` (MessagePack), `continue`, `mistral-vibe`, `claude-desktop`.
+They are listed in the report under "Not validated" so coverage is never
+silently overstated. If you add a new file-based adapter, add a discovery
+function + a `schema-baselines.json` entry here too.
+
+## Usage
+
+```bash
+# Validate every platform's recent sessions (last 30 days, 5 files each)
+node .github/skills/validate-session-schemas/validate-session-schemas.js
+
+# Widen the window and look at more files
+node .github/skills/validate-session-schemas/validate-session-schemas.js --days 60 --max 10
+
+# One platform only
+node .github/skills/validate-session-schemas/validate-session-schemas.js --platform claude-code
+
+# Machine-readable output (for CI / further processing)
+node .github/skills/validate-session-schemas/validate-session-schemas.js --json
+
+# Refresh the "known fields" snapshot from what's on disk (does NOT touch contracts)
+node .github/skills/validate-session-schemas/validate-session-schemas.js --update-baseline
+
+# Include truncated example values (may contain user content — off by default)
+node .github/skills/validate-session-schemas/validate-session-schemas.js --include-examples
+```
+
+### Options
+
+| Flag | Meaning |
+|------|---------|
+| `--days N` | Only consider files modified within the last N days (default 30; `0` = no limit) |
+| `--max N` | Analyze at most N most-recent files per platform (default 5) |
+| `--platform <id>` | Validate a single platform |
+| `--update-baseline` | Rewrite `knownFields` from observed fields; never modifies `contracts` |
+| `--include-examples` | Capture truncated example values per field |
+| `--fail-on-new-fields` | Exit non-zero when new fields are discovered |
+| `--json` | Emit JSON only |
+| `--help` | Usage |
+
+### Exit codes
+
+- `0` — all observed contracts pass (new fields alone do not fail unless `--fail-on-new-fields`)
+- `1` — contract drift or an unparseable file
+- `2` — configuration / environment error (bad args, missing baseline)
+
+### Per-platform statuses
+
+`PASS`, `DRIFT`, `NO_FILES` (editor not installed / no sessions),
+`NO_RECENT_FILES` (sessions exist but none in the window), `INCONCLUSIVE`
+(recent files existed but no parseable records).
+
+## How drift and new-field detection work
+
+`schema-baselines.json` holds two independent things per platform:
+
+- **`contracts`** — hand-maintained list of the fields our parsers depend on,
+  optionally scoped by `format` (`json`/`jsonl`) and a `discriminator`
+  (the JSONL event `type` / `kind`). A contract is only evaluated when matching
+  records are actually observed, so a union format never produces false drift
+  for an event type that simply wasn't present. `--update-baseline` never
+  changes contracts — edit them by hand when the parser's real dependencies
+  change.
+- **`knownFields`** — the last-known set of observed field paths. New = observed
+  − known. Refresh with `--update-baseline` once you've reviewed and accepted
+  the new fields.
+
+Field-path notation: `a.b` nested, `arr[]` array items, `arr[].c` a field inside
+array items.
+
+## Acting on results
+
+- **DRIFT** → a required field disappeared. Open the platform's doc under
+  `docs/logFilesSchema/` and the matching adapter under
+  `vscode-extension/src/adapters/`, confirm the change, and update both the
+  parser and the contract.
+- **New fields** → review them. If useful (e.g. real token counts, new model
+  metadata, a new event type), document them in `docs/logFilesSchema/`, consider
+  wiring them into the adapter/parser, then run `--update-baseline` to clear them
+  from future reports.
+
+## Periodic run (optional)
+
+This script is dependency-free Node and CI-friendly via its exit codes:
+
+```yaml
+- name: Validate recent session schemas
+  run: node .github/skills/validate-session-schemas/validate-session-schemas.js --json
+```
+
+(On CI the runner usually has no local session files, so most platforms report
+`NO_FILES` and the job passes — it's most useful run on a developer machine or a
+self-hosted runner that has real session data.)
+
+## Related
+
+- `docs/logFilesSchema/` — per-platform schema documentation (the human source of truth)
+- `.github/skills/copilot-log-analysis/` — deeper Copilot-only schema field dump (`analyze-session-schema.ps1`)
+- `.github/skills/validate-app-db-schema/` — validates the unrelated `~/.copilot/data.db` hierarchy schema
+- `vscode-extension/src/adapters/adapterRegistry.ts` — canonical list of supported ecosystems

--- a/.github/skills/validate-session-schemas/schema-baselines.json
+++ b/.github/skills/validate-session-schemas/schema-baselines.json
@@ -1,0 +1,131 @@
+{
+  "_comment": "Baselines for the validate-session-schemas skill. Two independent concepts: 'contracts' = the small hand-maintained set of fields our parsers actually depend on (drift detection); never auto-updated. 'knownFields' = the last-known observed field set per platform; refreshed with --update-baseline. New observed fields = observed - knownFields, surfaced as 'NEW' (potential information we could start using). Field-path notation: a.b nested, arr[] array items, arr[].c field inside array items, kind/type are the JSONL event discriminators.",
+  "version": "1.0",
+  "lastUpdated": "2026-05-30",
+  "platforms": {
+    "copilot-chat": {
+      "displayName": "VS Code Copilot Chat",
+      "doc": "docs/logFilesSchema/session-file-schema.json",
+      "contracts": [
+        { "format": "json", "require": ["requests", "requests[].message"], "desc": "VS Code Copilot Chat .json sessions expose a requests[] array with per-turn message objects." }
+      ],
+      "knownFields": [
+        "requests",
+        "requests[].message",
+        "requests[].message.parts[].text",
+        "requests[].response[].value",
+        "requests[].result.metadata.modelId",
+        "requestCount",
+        "sessionId",
+        "creationDate",
+        "lastMessageDate"
+      ]
+    },
+    "copilot-cli": {
+      "displayName": "Copilot CLI",
+      "doc": "docs/logFilesSchema/session-file-schema.json",
+      "contracts": [
+        { "format": "jsonl", "require": ["type"], "desc": "Copilot CLI events are JSONL records discriminated by a string 'type'." }
+      ],
+      "knownFields": [
+        "type",
+        "timestamp",
+        "sessionId"
+      ]
+    },
+    "jetbrains": {
+      "displayName": "JetBrains Copilot",
+      "doc": "docs/logFilesSchema/jetbrains-session-schema.json",
+      "contracts": [
+        { "format": "jsonl", "require": ["type"], "desc": "JetBrains partition events are JSONL records discriminated by a string 'type'." },
+        { "format": "jsonl", "discriminator": { "field": "type", "value": "assistant.message" }, "require": ["data"], "desc": "assistant.message events carry a 'data' payload (text/thinking)." }
+      ],
+      "knownFields": [
+        "type",
+        "data",
+        "data.conversationId",
+        "data.renderedMessage",
+        "data.thinking.text",
+        "data.toolCallId"
+      ]
+    },
+    "claude-code": {
+      "displayName": "Claude Code",
+      "doc": "docs/logFilesSchema/claude-code-session-schema.json",
+      "contracts": [
+        { "format": "jsonl", "require": ["type"], "desc": "Claude Code events are JSONL records discriminated by a string 'type'." },
+        { "format": "jsonl", "discriminator": { "field": "type", "value": "assistant" }, "require": ["message.usage.input_tokens", "message.usage.output_tokens"], "desc": "assistant events carry real Anthropic API token counts in message.usage." }
+      ],
+      "knownFields": [
+        "type",
+        "uuid",
+        "timestamp",
+        "message.usage.input_tokens",
+        "message.usage.output_tokens",
+        "message.usage.cache_creation_input_tokens",
+        "message.usage.cache_read_input_tokens",
+        "message.model"
+      ]
+    },
+    "gemini-cli": {
+      "displayName": "Gemini CLI",
+      "doc": "docs/logFilesSchema/gemini-cli-session-format.md",
+      "contracts": [
+        { "format": "jsonl", "discriminator": { "field": "type", "value": "gemini" }, "require": ["tokens.input", "tokens.output", "tokens.total"], "desc": "gemini turns carry real token counts in a tokens{} object." },
+        { "format": "jsonl", "discriminator": { "field": "type", "value": "user" }, "require": ["content"], "desc": "user turns carry a content array." }
+      ],
+      "knownFields": [
+        "sessionId",
+        "projectHash",
+        "startTime",
+        "lastUpdated",
+        "kind",
+        "id",
+        "timestamp",
+        "type",
+        "content",
+        "content[].text",
+        "thoughts[]",
+        "tokens.input",
+        "tokens.output",
+        "tokens.cached",
+        "tokens.thoughts",
+        "tokens.tool",
+        "tokens.total",
+        "model",
+        "toolCalls[]"
+      ]
+    },
+    "antigravity": {
+      "displayName": "Antigravity",
+      "doc": "docs/logFilesSchema/antigravity-session-format.md",
+      "contracts": [
+        { "format": "jsonl", "require": ["type", "source", "created_at"], "desc": "Every Antigravity transcript entry carries common type/source/created_at fields." }
+      ],
+      "knownFields": [
+        "step_index",
+        "source",
+        "type",
+        "status",
+        "created_at",
+        "content",
+        "thinking",
+        "tool_calls[]"
+      ]
+    },
+    "opencode": {
+      "displayName": "OpenCode",
+      "doc": null,
+      "contracts": [
+        { "format": "json", "require": ["id"], "desc": "OpenCode ses_*.json metadata files carry an id." }
+      ],
+      "knownFields": [
+        "id",
+        "title",
+        "version",
+        "time.created",
+        "time.updated"
+      ]
+    }
+  }
+}

--- a/.github/skills/validate-session-schemas/validate-session-schemas.js
+++ b/.github/skills/validate-session-schemas/validate-session-schemas.js
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+/**
+ * validate-session-schemas.js
+ *
+ * Loops over RECENT local AI-coding session log files for every supported,
+ * file-based platform and validates that they still match the documented
+ * schema. Two outputs per platform:
+ *
+ *   1. Drift detection  — checks the small set of fields our parsers actually
+ *      depend on ("contracts" in schema-baselines.json). A missing required
+ *      field on an observed record type => DRIFT (fails CI).
+ *   2. New information   — fields observed on disk that are NOT in the known
+ *      baseline ("knownFields"). These are candidates for new features /
+ *      better token attribution. New fields WARN by default (do not fail).
+ *
+ * Source of truth for supported platforms: vscode-extension/src/adapters/
+ * adapterRegistry.ts. This skill covers the file-based JSON/JSONL ecosystems
+ * that have schema docs under docs/logFilesSchema/. DB / binary ecosystems
+ * (Crush sqlite, Visual Studio MessagePack, Continue, Mistral Vibe, Claude
+ * Desktop) are intentionally NOT validated here — they need the adapters'
+ * binary parsers. They are listed as "not validated" in the report.
+ *
+ * Privacy: raw field example values are NOT emitted by default because they
+ * can contain user prompts / file paths / secrets. Pass --include-examples to
+ * capture truncated samples.
+ *
+ * Exit codes:  0 = all observed contracts pass   1 = drift / parse failure
+ *              2 = configuration / environment error
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = {
+    json: false,
+    days: 30,
+    max: 5,
+    platform: null,
+    updateBaseline: false,
+    includeExamples: false,
+    failOnNewFields: false,
+    help: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--json': opts.json = true; break;
+      case '--update-baseline': opts.updateBaseline = true; break;
+      case '--include-examples': opts.includeExamples = true; break;
+      case '--fail-on-new-fields': opts.failOnNewFields = true; break;
+      case '-h': case '--help': opts.help = true; break;
+      case '--days': opts.days = parseInt(argv[++i], 10); break;
+      case '--max': opts.max = parseInt(argv[++i], 10); break;
+      case '--platform': opts.platform = argv[++i]; break;
+      default:
+        if (a.startsWith('--days=')) { opts.days = parseInt(a.split('=')[1], 10); }
+        else if (a.startsWith('--max=')) { opts.max = parseInt(a.split('=')[1], 10); }
+        else if (a.startsWith('--platform=')) { opts.platform = a.split('=')[1]; }
+        else { throw new Error(`Unknown argument: ${a}`); }
+    }
+  }
+  if (Number.isNaN(opts.days) || opts.days < 0) { throw new Error('--days must be a non-negative integer (0 = no recency limit)'); }
+  if (Number.isNaN(opts.max) || opts.max < 1) { throw new Error('--max must be a positive integer'); }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`validate-session-schemas — validate recent session logs against documented schema
+
+Usage:
+  node validate-session-schemas.js [options]
+
+Options:
+  --days N             Only consider files modified within the last N days (default 30; 0 = no limit)
+  --max N              Analyze at most N most-recent files per platform (default 5)
+  --platform <id>      Only validate one platform (copilot-chat, copilot-cli, jetbrains,
+                       claude-code, gemini-cli, antigravity, opencode)
+  --update-baseline    Rewrite knownFields in schema-baselines.json from what was observed
+                       (does NOT touch parser contracts)
+  --include-examples   Capture truncated example values (may contain user content)
+  --fail-on-new-fields Exit non-zero when previously-unseen fields are discovered
+  --json               Emit machine-readable JSON only
+  -h, --help           Show this help
+
+Exit codes: 0 ok | 1 drift / parse failure | 2 config error`);
+}
+
+// ---------------------------------------------------------------------------
+// Status constants
+// ---------------------------------------------------------------------------
+
+const STATUS = {
+  PASS: 'PASS',
+  DRIFT: 'DRIFT',
+  NO_FILES: 'NO_FILES',
+  NO_RECENT_FILES: 'NO_RECENT_FILES',
+  INCONCLUSIVE: 'INCONCLUSIVE',
+};
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+function existsDir(p) { try { return fs.statSync(p).isDirectory(); } catch { return false; } }
+
+function safeReaddir(p) {
+  try { return fs.readdirSync(p, { withFileTypes: true }); } catch { return []; }
+}
+
+/** Recursively collect files matching predicate(name) up to a depth limit. */
+function walkFiles(dir, predicate, out, depth) {
+  if (depth < 0 || !existsDir(dir)) { return; }
+  for (const entry of safeReaddir(dir)) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) { walkFiles(full, predicate, out, depth - 1); }
+    else if (predicate(entry.name)) { out.push(full); }
+  }
+}
+
+function statOrNull(p) { try { return fs.statSync(p); } catch { return null; } }
+
+// ---------------------------------------------------------------------------
+// VS Code user-data paths (mirrors getVSCodeUserPaths in the extension)
+// ---------------------------------------------------------------------------
+
+function getVSCodeUserPaths() {
+  const platform = os.platform();
+  const home = os.homedir();
+  const variants = ['Code', 'Code - Insiders', 'Code - Exploration', 'VSCodium', 'Cursor'];
+  const paths = [];
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    for (const v of variants) { paths.push(path.join(appData, v, 'User')); }
+  } else if (platform === 'darwin') {
+    for (const v of variants) { paths.push(path.join(home, 'Library', 'Application Support', v, 'User')); }
+  } else {
+    const xdg = process.env.XDG_CONFIG_HOME || path.join(home, '.config');
+    for (const v of variants) { paths.push(path.join(xdg, v, 'User')); }
+  }
+  paths.push(
+    path.join(home, '.vscode-server', 'data', 'User'),
+    path.join(home, '.vscode-server-insiders', 'data', 'User'),
+    path.join(home, '.vscode-remote', 'data', 'User'),
+  );
+  return paths;
+}
+
+function xdgDataHome() {
+  const home = os.homedir();
+  if (os.platform() === 'win32') { return path.join(home, '.local', 'share'); }
+  return process.env.XDG_DATA_HOME || path.join(home, '.local', 'share');
+}
+
+// ---------------------------------------------------------------------------
+// Per-platform discovery. Each returns an array of absolute file paths.
+// Paths mirror the adapters under vscode-extension/src/adapters/.
+// ---------------------------------------------------------------------------
+
+const HOME = os.homedir();
+
+function discoverCopilotChat() {
+  const files = [];
+  const isSession = (n) => n.endsWith('.json') || n.endsWith('.jsonl');
+  for (const userPath of getVSCodeUserPaths()) {
+    if (!existsDir(userPath)) { continue; }
+    const wsStorage = path.join(userPath, 'workspaceStorage');
+    for (const ws of safeReaddir(wsStorage)) {
+      if (!ws.isDirectory()) { continue; }
+      const chat = path.join(wsStorage, ws.name, 'chatSessions');
+      for (const f of safeReaddir(chat)) {
+        if (!f.isDirectory() && isSession(f.name)) { files.push(path.join(chat, f.name)); }
+      }
+    }
+    const legacy = path.join(userPath, 'globalStorage', 'emptyWindowChatSessions');
+    for (const f of safeReaddir(legacy)) {
+      if (!f.isDirectory() && isSession(f.name)) { files.push(path.join(legacy, f.name)); }
+    }
+    const copilotChat = path.join(userPath, 'globalStorage', 'github.copilot-chat');
+    walkFiles(copilotChat, isSession, files, 4);
+  }
+  return files;
+}
+
+function discoverCopilotCli() {
+  const root = path.join(HOME, '.copilot', 'session-state');
+  const files = [];
+  // Top-level *.json / *.jsonl plus per-session UUID dirs containing events.jsonl
+  walkFiles(root, (n) => n.endsWith('.json') || n.endsWith('.jsonl'), files, 2);
+  return files;
+}
+
+function discoverJetBrains() {
+  const root = path.join(HOME, '.copilot', 'jb');
+  const files = [];
+  walkFiles(root, (n) => n.startsWith('partition-') && n.endsWith('.jsonl'), files, 2);
+  return files;
+}
+
+function discoverClaudeCode() {
+  const root = path.join(HOME, '.claude', 'projects');
+  const files = [];
+  walkFiles(root, (n) => n.endsWith('.jsonl'), files, 3);
+  return files;
+}
+
+function discoverGeminiCli() {
+  const root = path.join(HOME, '.gemini', 'tmp');
+  const files = [];
+  // ~/.gemini/tmp/<project>/chats/session-*.jsonl
+  walkFiles(root, (n) => n.startsWith('session-') && n.endsWith('.jsonl'), files, 3);
+  return files;
+}
+
+function discoverAntigravity() {
+  const root = path.join(HOME, '.gemini', 'antigravity', 'brain');
+  const files = [];
+  // brain/<uuid>/.system_generated/logs/transcript.jsonl
+  walkFiles(root, (n) => n === 'transcript.jsonl', files, 4);
+  return files;
+}
+
+function discoverOpenCode() {
+  const root = path.join(xdgDataHome(), 'opencode', 'storage', 'session');
+  const files = [];
+  walkFiles(root, (n) => n.startsWith('ses_') && n.endsWith('.json'), files, 4);
+  return files;
+}
+
+const PLATFORM_DISCOVERY = {
+  'copilot-chat': discoverCopilotChat,
+  'copilot-cli': discoverCopilotCli,
+  'jetbrains': discoverJetBrains,
+  'claude-code': discoverClaudeCode,
+  'gemini-cli': discoverGeminiCli,
+  'antigravity': discoverAntigravity,
+  'opencode': discoverOpenCode,
+};
+
+// Ecosystems supported by the extension but NOT validated by this skill
+// (DB / binary formats requiring the adapters' parsers).
+const NOT_VALIDATED = ['crush', 'visual-studio', 'continue', 'mistral-vibe', 'claude-desktop'];
+
+// ---------------------------------------------------------------------------
+// Schema extraction
+// ---------------------------------------------------------------------------
+
+function typeName(v) {
+  if (v === null) { return 'null'; }
+  if (Array.isArray(v)) { return 'array'; }
+  switch (typeof v) {
+    case 'object': return 'object';
+    case 'boolean': return 'boolean';
+    case 'number': return 'number';
+    case 'string': return 'string';
+    default: return typeof v;
+  }
+}
+
+function truncate(s, n) { return s.length > n ? s.slice(0, n) + '\u2026' : s; }
+
+const ARRAY_SAMPLE = 5;
+
+/**
+ * Walk an object/array, recording every field path into `schemaMap`
+ * (path -> { types:Set, count, examples }) and into the per-record `fieldSet`.
+ */
+function walkValue(value, prefix, schemaMap, fieldSet, includeExamples) {
+  const t = typeName(value);
+  if (t === 'object') {
+    for (const key of Object.keys(value)) {
+      const p = prefix ? `${prefix}.${key}` : key;
+      recordField(schemaMap, fieldSet, p, value[key], includeExamples);
+      walkValue(value[key], p, schemaMap, fieldSet, includeExamples);
+    }
+  } else if (t === 'array') {
+    const p = `${prefix}[]`;
+    const n = Math.min(value.length, ARRAY_SAMPLE);
+    for (let i = 0; i < n; i++) {
+      recordField(schemaMap, fieldSet, p, value[i], includeExamples);
+      walkValue(value[i], p, schemaMap, fieldSet, includeExamples);
+    }
+  }
+}
+
+function recordField(schemaMap, fieldSet, p, value, includeExamples) {
+  const t = typeName(value);
+  let info = schemaMap.get(p);
+  if (!info) { info = { types: new Set(), count: 0, examples: [] }; schemaMap.set(p, info); }
+  info.types.add(t);
+  info.count++;
+  fieldSet.add(p);
+  if (includeExamples && info.examples.length < 2 && (t === 'string' || t === 'number' || t === 'boolean')) {
+    const ex = t === 'string' ? truncate(value, 40) : value;
+    if (!info.examples.includes(ex)) { info.examples.push(ex); }
+  }
+}
+
+/** Detect the discriminator for a JSONL record. */
+function discriminatorOf(rec) {
+  if (rec && typeof rec === 'object') {
+    if (typeof rec.kind === 'number') { return { field: 'kind', value: rec.kind }; }
+    if (typeof rec.type === 'string') { return { field: 'type', value: rec.type }; }
+  }
+  return { field: null, value: null };
+}
+
+const MAX_LINES = 5000;
+
+/**
+ * Analyze a single file. Mutates the shared platform aggregate.
+ */
+function analyzeFile(filePath, agg, includeExamples) {
+  let raw;
+  try { raw = fs.readFileSync(filePath, 'utf8'); }
+  catch { agg.unreadableFiles++; return; }
+
+  if (raw.trim().length === 0) { agg.emptyFiles++; return; }
+
+  const isJsonl = filePath.endsWith('.jsonl');
+  if (isJsonl) {
+    analyzeJsonl(raw, agg, includeExamples);
+  } else {
+    // Heuristic: a .json file that is really newline-delimited (CLI sometimes
+    // writes .json events) — if first non-ws char is '{' and there are many
+    // lines that each parse, treat as jsonl; else parse whole.
+    const trimmed = raw.trimStart();
+    let parsedWhole = null;
+    try { parsedWhole = JSON.parse(raw); } catch { parsedWhole = undefined; }
+    if (parsedWhole !== undefined) {
+      agg.formats.add('json');
+      const set = new Set();
+      walkValue(parsedWhole, '', agg.schemaMap, set, includeExamples);
+      addUnion(agg.jsonUnion, set);
+      agg.records++;
+      agg.analyzedFiles++;
+    } else if (trimmed.startsWith('{')) {
+      analyzeJsonl(raw, agg, includeExamples);
+    } else {
+      agg.parseFailedFiles++;
+    }
+  }
+}
+
+function analyzeJsonl(raw, agg, includeExamples) {
+  const lines = raw.split(/\r?\n/);
+  let parsedAny = false;
+  let lineCount = 0;
+  for (const line of lines) {
+    if (!line.trim()) { continue; }
+    lineCount++;
+    if (lineCount > MAX_LINES) { agg.truncatedFiles++; break; }
+    let rec;
+    try { rec = JSON.parse(line); } catch { agg.malformedLines++; continue; }
+    parsedAny = true;
+    agg.formats.add('jsonl');
+    const set = new Set();
+    walkValue(rec, '', agg.schemaMap, set, includeExamples);
+    addUnion(agg.jsonlUnion, set);
+    agg.records++;
+    const d = discriminatorOf(rec);
+    if (d.value !== null) {
+      const key = String(d.value);
+      let u = agg.byDiscriminator.get(key);
+      if (!u) { u = new Set(); agg.byDiscriminator.set(key, u); }
+      addUnion(u, set);
+      agg.discriminatorCounts.set(key, (agg.discriminatorCounts.get(key) || 0) + 1);
+    }
+  }
+  if (parsedAny) { agg.analyzedFiles++; }
+  else if (lineCount === 0) { agg.emptyFiles++; }
+  else { agg.parseFailedFiles++; }
+}
+
+function addUnion(target, src) { for (const v of src) { target.add(v); } }
+
+// ---------------------------------------------------------------------------
+// Contract evaluation
+// ---------------------------------------------------------------------------
+
+function evaluateContracts(contracts, agg) {
+  const results = [];
+  for (const rule of contracts) {
+    let observedSet = null;
+    let applies = false;
+    if (rule.discriminator) {
+      observedSet = agg.byDiscriminator.get(String(rule.discriminator.value)) || null;
+      applies = observedSet !== null;
+    } else if (rule.format === 'json') {
+      applies = agg.formats.has('json');
+      observedSet = agg.jsonUnion;
+    } else if (rule.format === 'jsonl') {
+      applies = agg.formats.has('jsonl');
+      observedSet = agg.jsonlUnion;
+    } else {
+      applies = agg.records > 0;
+      observedSet = new Set([...agg.jsonUnion, ...agg.jsonlUnion]);
+    }
+    if (!applies) {
+      results.push({ desc: rule.desc, applied: false, missing: [], require: rule.require });
+      continue;
+    }
+    const missing = rule.require.filter((p) => !observedSet.has(p));
+    results.push({ desc: rule.desc, applied: true, missing, require: rule.require });
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function newAggregate() {
+  return {
+    formats: new Set(),
+    schemaMap: new Map(),
+    jsonUnion: new Set(),
+    jsonlUnion: new Set(),
+    byDiscriminator: new Map(),
+    discriminatorCounts: new Map(),
+    records: 0,
+    analyzedFiles: 0,
+    emptyFiles: 0,
+    parseFailedFiles: 0,
+    unreadableFiles: 0,
+    truncatedFiles: 0,
+    malformedLines: 0,
+  };
+}
+
+function run(opts) {
+  const baselinePath = path.join(__dirname, 'schema-baselines.json');
+  let baseline;
+  try { baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8')); }
+  catch (e) { console.error(`Could not read baseline file ${baselinePath}: ${e.message}`); process.exitCode = 2; return; }
+
+  const now = Date.now();
+  const cutoff = opts.days > 0 ? now - opts.days * 24 * 60 * 60 * 1000 : 0;
+
+  const platformIds = opts.platform ? [opts.platform] : Object.keys(PLATFORM_DISCOVERY);
+  for (const id of platformIds) {
+    if (!PLATFORM_DISCOVERY[id]) { console.error(`Unknown platform: ${id}`); process.exitCode = 2; return; }
+  }
+
+  const report = { generatedAt: new Date().toISOString(), options: opts, platforms: {}, notValidated: NOT_VALIDATED };
+  let anyDrift = false;
+  let anyNewFields = false;
+  let anyParseFailure = false;
+
+  for (const id of platformIds) {
+    const cfg = baseline.platforms[id] || { displayName: id, contracts: [], knownFields: [] };
+    const allFiles = PLATFORM_DISCOVERY[id]();
+    const withStat = allFiles
+      .map((f) => ({ f, st: statOrNull(f) }))
+      .filter((x) => x.st && x.st.size > 0);
+    const recent = withStat
+      .filter((x) => x.st.mtimeMs >= cutoff)
+      .sort((a, b) => b.st.mtimeMs - a.st.mtimeMs)
+      .slice(0, opts.max);
+
+    const entry = {
+      displayName: cfg.displayName,
+      filesFound: allFiles.length,
+      filesRecent: withStat.filter((x) => x.st.mtimeMs >= cutoff).length,
+      filesAnalyzed: 0,
+      analyzedPaths: recent.map((x) => x.f),
+      newestMtime: withStat.length ? new Date(Math.max(...withStat.map((x) => x.st.mtimeMs))).toISOString() : null,
+      status: STATUS.NO_FILES,
+      contracts: [],
+      newFields: [],
+      observedDiscriminators: [],
+      notes: [],
+    };
+
+    if (allFiles.length === 0) {
+      entry.status = STATUS.NO_FILES;
+      report.platforms[id] = entry;
+      continue;
+    }
+    if (recent.length === 0) {
+      entry.status = STATUS.NO_RECENT_FILES;
+      entry.notes.push(`${withStat.length} file(s) exist but none modified within ${opts.days} day(s).`);
+      report.platforms[id] = entry;
+      continue;
+    }
+
+    const agg = newAggregate();
+    for (const x of recent) { analyzeFile(x.f, agg, opts.includeExamples); }
+    entry.filesAnalyzed = agg.analyzedFiles;
+    entry.observedDiscriminators = [...agg.discriminatorCounts.entries()]
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => b.count - a.count);
+
+    if (agg.malformedLines > 0) { entry.notes.push(`${agg.malformedLines} malformed JSONL line(s) skipped.`); }
+    if (agg.truncatedFiles > 0) { entry.notes.push(`${agg.truncatedFiles} file(s) truncated at ${MAX_LINES} lines.`); }
+    if (agg.parseFailedFiles > 0) { entry.notes.push(`${agg.parseFailedFiles} file(s) could not be parsed.`); anyParseFailure = true; }
+
+    // New-field detection.
+    const known = new Set(cfg.knownFields || []);
+    const observed = [...agg.schemaMap.keys()].sort();
+    entry.newFields = observed.filter((p) => !known.has(p));
+    if (entry.newFields.length > 0) { anyNewFields = true; }
+
+    if (opts.includeExamples) {
+      entry.fieldDetails = {};
+      for (const [p, info] of agg.schemaMap) {
+        entry.fieldDetails[p] = { types: [...info.types], count: info.count, examples: info.examples };
+      }
+    }
+
+    // Update baseline knownFields if requested (never touches contracts).
+    if (opts.updateBaseline && baseline.platforms[id]) {
+      const merged = new Set([...(cfg.knownFields || []), ...observed]);
+      baseline.platforms[id].knownFields = [...merged].sort();
+    }
+
+    // Contract evaluation.
+    const contractResults = evaluateContracts(cfg.contracts || [], agg);
+    entry.contracts = contractResults;
+    const drift = contractResults.some((r) => r.applied && r.missing.length > 0);
+
+    if (agg.analyzedFiles === 0) {
+      entry.status = STATUS.INCONCLUSIVE;
+      entry.notes.push('No parseable records found in recent files.');
+    } else if (drift) {
+      entry.status = STATUS.DRIFT;
+      anyDrift = true;
+    } else {
+      entry.status = STATUS.PASS;
+    }
+    report.platforms[id] = entry;
+  }
+
+  if (opts.updateBaseline) {
+    baseline.lastUpdated = new Date().toISOString().slice(0, 10);
+    fs.writeFileSync(baselinePath, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report, opts);
+  }
+
+  if (anyDrift || anyParseFailure) { process.exitCode = 1; }
+  else if (opts.failOnNewFields && anyNewFields) { process.exitCode = 1; }
+  else { process.exitCode = 0; }
+}
+
+function statusIcon(status) {
+  switch (status) {
+    case STATUS.PASS: return '\u2705';
+    case STATUS.DRIFT: return '\u274c';
+    case STATUS.INCONCLUSIVE: return '\u26a0\ufe0f';
+    case STATUS.NO_RECENT_FILES: return '\u23f3';
+    case STATUS.NO_FILES: return '\u2796';
+    default: return '\u2022';
+  }
+}
+
+function printHuman(report, opts) {
+  const line = '='.repeat(72);
+  console.log(line);
+  console.log('Session schema validation');
+  console.log(`  generated ${report.generatedAt}`);
+  console.log(`  window: last ${opts.days === 0 ? '\u221e' : opts.days} day(s), up to ${opts.max} file(s)/platform`);
+  console.log(line);
+
+  for (const [id, p] of Object.entries(report.platforms)) {
+    console.log('');
+    console.log(`${statusIcon(p.status)} ${p.displayName} [${id}] — ${p.status}`);
+    console.log(`   files: ${p.filesFound} found, ${p.filesRecent} recent, ${p.filesAnalyzed} analyzed` +
+      (p.newestMtime ? `  (newest ${p.newestMtime})` : ''));
+    if (p.observedDiscriminators && p.observedDiscriminators.length > 0) {
+      const top = p.observedDiscriminators.slice(0, 8).map((d) => `${d.value}(${d.count})`).join(', ');
+      console.log(`   record types: ${top}`);
+    }
+    for (const c of p.contracts) {
+      if (!c.applied) { console.log(`   \u2022 (not observed) ${c.desc}`); }
+      else if (c.missing.length === 0) { console.log(`   \u2713 ${c.desc}`); }
+      else { console.log(`   \u2717 DRIFT: ${c.desc} — missing: ${c.missing.join(', ')}`); }
+    }
+    if (p.newFields.length > 0) {
+      console.log(`   \u2728 ${p.newFields.length} new field(s) not in baseline:`);
+      for (const f of p.newFields.slice(0, 40)) { console.log(`        + ${f}`); }
+      if (p.newFields.length > 40) { console.log(`        \u2026 and ${p.newFields.length - 40} more`); }
+    }
+    for (const n of p.notes) { console.log(`   note: ${n}`); }
+  }
+
+  console.log('');
+  console.log(line);
+  console.log(`Not validated by this skill (DB/binary formats): ${report.notValidated.join(', ')}`);
+  console.log(line);
+}
+
+// ---------------------------------------------------------------------------
+
+function main() {
+  let opts;
+  try { opts = parseArgs(process.argv); }
+  catch (e) { console.error(e.message); console.error('Run with --help for usage.'); process.exitCode = 2; return; }
+  if (opts.help) { printHelp(); return; }
+  run(opts);
+}
+
+main();


### PR DESCRIPTION
## Why

We document session log schemas per editor under `docs/logFilesSchema/`, but those formats drift whenever an editor or CLI updates, and new fields (real token counts, new model metadata, new event types) show up on disk before we notice. The existing `copilot-log-analysis` skill only covered VS Code Copilot Chat JSON + Copilot CLI JSONL + OpenCode, with crude substring-based "new field" detection. There was no skill that loops over recent sessions and validates them per supported platform.

## What this adds

A new self-contained, dependency-free Node skill at `.github/skills/validate-session-schemas/` that loops over **recent** local session logs for all 7 file-based platforms (Copilot Chat, Copilot CLI, JetBrains, Claude Code, Gemini CLI, Antigravity, OpenCode) and produces two things in one pass:

- **Drift detection** against the small set of fields our parsers actually depend on ("contracts"). A required field missing from an observed record type is a `DRIFT` failure.
- **New information** - any field observed on disk that isn't in the known baseline, surfaced as a candidate for new features or better token attribution.

## Design notes

- `schema-baselines.json` deliberately separates hand-maintained `contracts` (never auto-updated) from `knownFields` (refreshed via `--update-baseline`), so reviewing/accepting new fields can't silently bless a breaking schema change.
- Contracts are **discriminator-aware** (scoped by JSONL `type`/`kind`) and only evaluated when matching records are actually observed, which avoids false drift on union formats.
- **Privacy:** raw field example values are off by default (they can contain user prompts/paths/secrets); `--include-examples` opts in with truncation.
- **CI-friendly exit codes:** `0` ok, `1` drift/parse failure, `2` config error. Explicit per-platform statuses (`PASS`, `DRIFT`, `NO_FILES`, `NO_RECENT_FILES`, `INCONCLUSIVE`).
- The 5 DB/binary ecosystems (Crush, Visual Studio, Continue, Mistral Vibe, Claude Desktop) are explicitly listed as "not validated" so coverage is never silently overstated. The source of truth for the supported set is `vscode-extension/src/adapters/adapterRegistry.ts`.

## Verification

Ran against real local session data: all 7 file-based platforms behave correctly (6 `PASS`, OpenCode `NO_RECENT_FILES`) and it surfaced genuine new fields per platform. Notably it correctly flagged that recent Copilot Chat files are now the incremental `kind`-based JSONL format (reported as "not observed" for the json contract rather than a false failure). Verified `--help`, `--json`, `--platform`, bad-arg exit code (2), and that `--update-baseline` refreshes `knownFields` without touching contracts.

Design was reviewed via a rubber-duck critique before implementation; privacy handling, contract/baseline separation, discriminator-aware checks, and exit codes all came out of that pass.