### PR TITLE
Validate new VS Code Copilot Chat delta-JSONL session format

### DIFF
--- a/.github/skills/validate-session-schemas/schema-baselines.json
+++ b/.github/skills/validate-session-schemas/schema-baselines.json
@@ -7,25 +7,110 @@
       "displayName": "VS Code Copilot Chat",
       "doc": "docs/logFilesSchema/session-file-schema.json",
       "contracts": [
-        { "format": "json", "require": ["requests", "requests[].message"], "desc": "VS Code Copilot Chat .json sessions expose a requests[] array with per-turn message objects." }
+        {
+          "format": "json",
+          "require": [
+            "requests",
+            "requests[].message"
+          ],
+          "desc": "VS Code Copilot Chat .json sessions expose a requests[] array with per-turn message objects."
+        },
+        {
+          "format": "jsonl",
+          "discriminator": {
+            "field": "kind",
+            "value": 0
+          },
+          "require": [
+            "v.requests",
+            "v.sessionId"
+          ],
+          "desc": "VS Code Copilot Chat .jsonl sessions (incremental delta format) carry the session snapshot under v on the kind:0 record (v.requests[], v.sessionId)."
+        }
       ],
       "knownFields": [
+        "creationDate",
+        "k",
+        "k[]",
+        "kind",
+        "lastMessageDate",
+        "requestCount",
         "requests",
         "requests[].message",
         "requests[].message.parts[].text",
         "requests[].response[].value",
         "requests[].result.metadata.modelId",
-        "requestCount",
         "sessionId",
-        "creationDate",
-        "lastMessageDate"
+        "v",
+        "v.creationDate",
+        "v.hasPendingEdits",
+        "v.initialLocation",
+        "v.inputState",
+        "v.inputState.attachments",
+        "v.inputState.contrib",
+        "v.inputState.contrib.chatDynamicVariableModel",
+        "v.inputState.inputText",
+        "v.inputState.mode",
+        "v.inputState.mode.id",
+        "v.inputState.mode.kind",
+        "v.inputState.permissionLevel",
+        "v.inputState.selectedModel",
+        "v.inputState.selectedModel.identifier",
+        "v.inputState.selectedModel.metadata",
+        "v.inputState.selectedModel.metadata.auth",
+        "v.inputState.selectedModel.metadata.auth.accountLabel",
+        "v.inputState.selectedModel.metadata.auth.providerLabel",
+        "v.inputState.selectedModel.metadata.capabilities",
+        "v.inputState.selectedModel.metadata.capabilities.agentMode",
+        "v.inputState.selectedModel.metadata.capabilities.toolCalling",
+        "v.inputState.selectedModel.metadata.capabilities.vision",
+        "v.inputState.selectedModel.metadata.extension",
+        "v.inputState.selectedModel.metadata.extension._lower",
+        "v.inputState.selectedModel.metadata.extension.value",
+        "v.inputState.selectedModel.metadata.family",
+        "v.inputState.selectedModel.metadata.id",
+        "v.inputState.selectedModel.metadata.isDefaultForLocation",
+        "v.inputState.selectedModel.metadata.isDefaultForLocation.editor",
+        "v.inputState.selectedModel.metadata.isDefaultForLocation.notebook",
+        "v.inputState.selectedModel.metadata.isDefaultForLocation.panel",
+        "v.inputState.selectedModel.metadata.isDefaultForLocation.terminal",
+        "v.inputState.selectedModel.metadata.isUserSelectable",
+        "v.inputState.selectedModel.metadata.maxInputTokens",
+        "v.inputState.selectedModel.metadata.maxOutputTokens",
+        "v.inputState.selectedModel.metadata.multiplierNumeric",
+        "v.inputState.selectedModel.metadata.name",
+        "v.inputState.selectedModel.metadata.pricing",
+        "v.inputState.selectedModel.metadata.tooltip",
+        "v.inputState.selectedModel.metadata.vendor",
+        "v.inputState.selectedModel.metadata.version",
+        "v.inputState.selections",
+        "v.inputState.selections[]",
+        "v.inputState.selections[].endColumn",
+        "v.inputState.selections[].endLineNumber",
+        "v.inputState.selections[].positionColumn",
+        "v.inputState.selections[].positionLineNumber",
+        "v.inputState.selections[].selectionStartColumn",
+        "v.inputState.selections[].selectionStartLineNumber",
+        "v.inputState.selections[].startColumn",
+        "v.inputState.selections[].startLineNumber",
+        "v.pendingRequests",
+        "v.requests",
+        "v.responderUsername",
+        "v.sessionId",
+        "v.version"
       ]
     },
     "copilot-cli": {
       "displayName": "Copilot CLI",
       "doc": "docs/logFilesSchema/session-file-schema.json",
       "contracts": [
-        { "format": "jsonl", "require": ["type"], "desc": "Copilot CLI events are JSONL records discriminated by a string 'type'." }
+        {
+          "format": "jsonl",
+          "require": [
+            "type"
+          ],
+          "desc": "Copilot CLI events are JSONL records discriminated by a string 'type'."
+        }
       ],
       "knownFields": [
         "type",
@@ -37,8 +122,24 @@
       "displayName": "JetBrains Copilot",
       "doc": "docs/logFilesSchema/jetbrains-session-schema.json",
       "contracts": [
-        { "format": "jsonl", "require": ["type"], "desc": "JetBrains partition events are JSONL records discriminated by a string 'type'." },
-        { "format": "jsonl", "discriminator": { "field": "type", "value": "assistant.message" }, "require": ["data"], "desc": "assistant.message events carry a 'data' payload (text/thinking)." }
+        {
+          "format": "jsonl",
+          "require": [
+            "type"
+          ],
+          "desc": "JetBrains partition events are JSONL records discriminated by a string 'type'."
+        },
+        {
+          "format": "jsonl",
+          "discriminator": {
+            "field": "type",
+            "value": "assistant.message"
+          },
+          "require": [
+            "data"
+          ],
+          "desc": "assistant.message events carry a 'data' payload (text/thinking)."
+        }
       ],
       "knownFields": [
         "type",
@@ -53,8 +154,25 @@
       "displayName": "Claude Code",
       "doc": "docs/logFilesSchema/claude-code-session-schema.json",
       "contracts": [
-        { "format": "jsonl", "require": ["type"], "desc": "Claude Code events are JSONL records discriminated by a string 'type'." },
-        { "format": "jsonl", "discriminator": { "field": "type", "value": "assistant" }, "require": ["message.usage.input_tokens", "message.usage.output_tokens"], "desc": "assistant events carry real Anthropic API token counts in message.usage." }
+        {
+          "format": "jsonl",
+          "require": [
+            "type"
+          ],
+          "desc": "Claude Code events are JSONL records discriminated by a string 'type'."
+        },
+        {
+          "format": "jsonl",
+          "discriminator": {
+            "field": "type",
+            "value": "assistant"
+          },
+          "require": [
+            "message.usage.input_tokens",
+            "message.usage.output_tokens"
+          ],
+          "desc": "assistant events carry real Anthropic API token counts in message.usage."
+        }
       ],
       "knownFields": [
         "type",
@@ -71,8 +189,30 @@
       "displayName": "Gemini CLI",
       "doc": "docs/logFilesSchema/gemini-cli-session-format.md",
       "contracts": [
-        { "format": "jsonl", "discriminator": { "field": "type", "value": "gemini" }, "require": ["tokens.input", "tokens.output", "tokens.total"], "desc": "gemini turns carry real token counts in a tokens{} object." },
-        { "format": "jsonl", "discriminator": { "field": "type", "value": "user" }, "require": ["content"], "desc": "user turns carry a content array." }
+        {
+          "format": "jsonl",
+          "discriminator": {
+            "field": "type",
+            "value": "gemini"
+          },
+          "require": [
+            "tokens.input",
+            "tokens.output",
+            "tokens.total"
+          ],
+          "desc": "gemini turns carry real token counts in a tokens{} object."
+        },
+        {
+          "format": "jsonl",
+          "discriminator": {
+            "field": "type",
+            "value": "user"
+          },
+          "require": [
+            "content"
+          ],
+          "desc": "user turns carry a content array."
+        }
       ],
       "knownFields": [
         "sessionId",
@@ -100,7 +240,15 @@
       "displayName": "Antigravity",
       "doc": "docs/logFilesSchema/antigravity-session-format.md",
       "contracts": [
-        { "format": "jsonl", "require": ["type", "source", "created_at"], "desc": "Every Antigravity transcript entry carries common type/source/created_at fields." }
+        {
+          "format": "jsonl",
+          "require": [
+            "type",
+            "source",
+            "created_at"
+          ],
+          "desc": "Every Antigravity transcript entry carries common type/source/created_at fields."
+        }
       ],
       "knownFields": [
         "step_index",
@@ -117,7 +265,13 @@
       "displayName": "OpenCode",
       "doc": null,
       "contracts": [
-        { "format": "json", "require": ["id"], "desc": "OpenCode ses_*.json metadata files carry an id." }
+        {
+          "format": "json",
+          "require": [
+            "id"
+          ],
+          "desc": "OpenCode ses_*.json metadata files carry an id."
+        }
       ],
       "knownFields": [
         "id",

--- a/.github/skills/validate-session-schemas/validate-session-schemas.js
+++ b/.github/skills/validate-session-schemas/validate-session-schemas.js
@@ -169,6 +169,12 @@ const HOME = os.homedir();
 function discoverCopilotChat() {
   const files = [];
   const isSession = (n) => n.endsWith('.json') || n.endsWith('.jsonl');
+  // Real VS Code Copilot Chat sessions are UUID-named (e.g.
+  // bd774e5f-e027-....json). Used to filter the noisy github.copilot-chat
+  // globalStorage walk so embeddings/cache/CLI-metadata files don't crowd out
+  // genuine sessions in the recency window.
+  const isUuidSession = (n) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(json|jsonl)$/i.test(n);
   for (const userPath of getVSCodeUserPaths()) {
     if (!existsDir(userPath)) { continue; }
     const wsStorage = path.join(userPath, 'workspaceStorage');
@@ -183,8 +189,14 @@ function discoverCopilotChat() {
     for (const f of safeReaddir(legacy)) {
       if (!f.isDirectory() && isSession(f.name)) { files.push(path.join(legacy, f.name)); }
     }
+    // The github.copilot-chat globalStorage folder mixes real chat sessions
+    // with non-session artifacts (commandEmbeddings.json, settingEmbeddings.json,
+    // api.json, copilotCli/*.json). Those caches are rewritten constantly, so an
+    // unfiltered walk lets them dominate the most-recent window and silently
+    // crowd out the real requests[] sessions (which are UUID-named). Restrict
+    // this broad walk to UUID-named session files only.
     const copilotChat = path.join(userPath, 'globalStorage', 'github.copilot-chat');
-    walkFiles(copilotChat, isSession, files, 4);
+    walkFiles(copilotChat, isUuidSession, files, 4);
   }
   return files;
 }


### PR DESCRIPTION
## What

Ran the `validate-session-schemas` skill to check current session state and improve coverage. All platforms report **PASS** (no drift), but the run surfaced a **silent coverage gap** for VS Code Copilot Chat that this PR closes.

## Findings

1. **Discovery over-collected cache files.** `discoverCopilotChat()` walked `globalStorage/github.copilot-chat` for any `.json`/`.jsonl`, picking up `commandEmbeddings.json`, `settingEmbeddings.json`, `api.json`, and `copilotCli/*` metadata. These are rewritten constantly, so they can dominate the most-recent window and crowd out real sessions.

2. **The contract didn't model the format VS Code actually writes.** The copilot-chat contract only knew the legacy top-level `.json` `requests[]` shape. VS Code now writes sessions as **incremental delta JSONL** (`{kind, k, v}` records, with the full session snapshot under `v` on the `kind:0` record). That format is already handled by the extension and documented in `session-file-schema.json` v2.0 — but the skill never validated it, reporting `(not observed)` plus 60 noise "new fields". Token tracking is **not** broken; only the validator was blind to it.

## Changes

- Restrict the `github.copilot-chat` globalStorage walk to UUID-named session files (`isUuidSession`), so embeddings/cache/CLI-metadata no longer pollute the window.
- Add a `jsonl` / `kind:0` contract requiring `v.requests` + `v.sessionId`, and refresh `knownFields` for the delta format.

## Verification

- `node validate-session-schemas.js --platform copilot-chat`: new `.jsonl` contract now **applies and passes**, zero new fields.
- Full run: all platforms **PASS**, exit code **0**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>