### PR TITLE
fix: use local timezone for 'today' and period boundary day keys

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -14,6 +14,7 @@ import { resolveFileUri } from '../../vscode-extension/src/workspacePathResolver
 import { parseSessionFileContent } from '../../vscode-extension/src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost } from '../../vscode-extension/src/tokenEstimation';
 import { extractDailyFractions } from '../../vscode-extension/src/dailyAttribution';
+import { toLocalDayKey } from '../../vscode-extension/src/utils/dayKeys';
 import type { DetailedStats, ModelUsage, UsageAnalysisStats, WorkspaceCustomizationMatrix } from '../../vscode-extension/src/types';
 import { analyzeSessionUsage, mergeUsageAnalysis } from '../../vscode-extension/src/usageAnalysis';
 import { withErrorRecovery } from '../../vscode-extension/src/utils/errors';
@@ -239,7 +240,7 @@ export async function processSessionFile(filePath: string): Promise<SessionData 
 				eco.countInteractions(filePath),
 				eco.getModelUsage(filePath),
 			]);
-			const mtimeDateKey = stats.mtime.toISOString().slice(0, 10);
+			const mtimeDateKey = toLocalDayKey(stats.mtime);
 			const ecoResult: SessionData = {
 				file: filePath,
 				tokens: tokenResult.actualTokens > 0 ? tokenResult.actualTokens : tokenResult.tokens,
@@ -334,22 +335,22 @@ export async function calculateDetailedStats(
 ): Promise<DetailedStats> {
 	const now = new Date();
 
-	// All period boundaries are UTC date keys (YYYY-MM-DD) to match the VS Code extension's behaviour.
-	const todayUtcKey = now.toISOString().slice(0, 10);
+	// All period boundaries use local calendar dates so that "today" reflects
+	// the user's local clock rather than resetting at UTC midnight.
+	const todayKey = toLocalDayKey(now);
 
-	const y = now.getUTCFullYear();
-	const m = now.getUTCMonth(); // 0-indexed
-	const monthStartKey = `${y}-${String(m + 1).padStart(2, '0')}-01`;
+	const y = now.getFullYear();
+	const m = now.getMonth(); // 0-indexed
+	const monthStartKey = toLocalDayKey(new Date(y, m, 1));
 
-	// Last month: the month before the current UTC month
-	const lmYear = m === 0 ? y - 1 : y;
-	const lmMonth = m === 0 ? 12 : m; // 1-indexed last month number
-	const lastMonthStartKey = `${lmYear}-${String(lmMonth).padStart(2, '0')}-01`;
+	// Last month: the month before the current local month
+	const lastMonthLastDay = new Date(y, m, 0); // day 0 = last day of previous month
+	const lastMonthStartKey = toLocalDayKey(new Date(lastMonthLastDay.getFullYear(), lastMonthLastDay.getMonth(), 1));
 	// lastMonthEndKey is the day before monthStartKey — string comparison handles this naturally
 	// (any date >= lastMonthStartKey && < monthStartKey is in last month)
 
-	const last30DaysDate = new Date(Date.UTC(y, m, now.getUTCDate() - 30));
-	const last30DaysStartKey = last30DaysDate.toISOString().slice(0, 10);
+	const last30DaysDate = new Date(y, m, now.getDate() - 30);
+	const last30DaysStartKey = toLocalDayKey(last30DaysDate);
 
 	const periods: {
 		today: PeriodStats;
@@ -386,7 +387,7 @@ export async function calculateDetailedStats(
 		let last30DaysFrac = 0;
 
 		for (const [dateKey, fraction] of Object.entries(data.dailyFractions)) {
-			if (dateKey === todayUtcKey) { todayFrac += fraction; }
+			if (dateKey === todayKey) { todayFrac += fraction; }
 			if (dateKey >= monthStartKey) { monthFrac += fraction; }
 			if (dateKey >= lastMonthStartKey && dateKey < monthStartKey) { lastMonthFrac += fraction; }
 			if (dateKey >= last30DaysStartKey) { last30DaysFrac += fraction; }
@@ -485,17 +486,17 @@ export async function calculateDailyStats(sessionFiles: string[]): Promise<{
 	allDaysMap: Map<string, DailyEntry>;
 }> {
 	const now = new Date();
-	const last30DaysDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
-	const last30DaysStartKey = last30DaysDate.toISOString().slice(0, 10);
-	const todayKey = now.toISOString().slice(0, 10);
+	const last30DaysDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+	const last30DaysStartKey = toLocalDayKey(last30DaysDate);
+	const todayKey = toLocalDayKey(now);
 
 	// Fill in all 31 days (today inclusive) with zeroes so the chart has continuous labels
 	const dailyMap = new Map<string, DailyEntry>();
 	const cursor = new Date(last30DaysDate);
-	while (cursor.toISOString().slice(0, 10) <= todayKey) {
-		const key = cursor.toISOString().slice(0, 10);
+	while (toLocalDayKey(cursor) <= todayKey) {
+		const key = toLocalDayKey(cursor);
 		dailyMap.set(key, { tokens: 0, sessions: 0, modelUsage: {}, editorUsage: {} });
-		cursor.setUTCDate(cursor.getUTCDate() + 1);
+		cursor.setDate(cursor.getDate() + 1);
 	}
 
 	// Full historical map (all time, no age filter) for weekly/monthly chart periods

--- a/vscode-extension/src/copilotCliStore.ts
+++ b/vscode-extension/src/copilotCliStore.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import initSqlJs from 'sql.js';
+import { toLocalDayKey } from './utils/dayKeys';
 
 // Access SqlJsStatic and Database via the globally declared initSqlJs namespace
 // (made available by the /// <reference types="sql.js" /> directive above).
@@ -227,7 +228,7 @@ export class CopilotCliStoreAccess {
 	}
 
 	/**
-	 * Returns per-UTC-day fractions for accurate session attribution.
+	 * Returns per-local-day fractions for accurate session attribution.
 	 * Uses turn timestamps when available; falls back to a single entry at
 	 * the session's updated_at date.
 	 */
@@ -238,7 +239,7 @@ export class CopilotCliStoreAccess {
 		for (const turn of turns) {
 			if (!turn.timestamp) { continue; }
 			try {
-				const dateKey = new Date(turn.timestamp).toISOString().slice(0, 10);
+				const dateKey = toLocalDayKey(new Date(turn.timestamp));
 				counts[dateKey] = (counts[dateKey] || 0) + 1;
 				total++;
 			} catch { /* skip malformed timestamp */ }
@@ -247,8 +248,8 @@ export class CopilotCliStoreAccess {
 			// Fallback: use session updated_at
 			const session = await this.readSession(virtualPath);
 			const fallbackDate = session?.updated_at
-				? new Date(session.updated_at).toISOString().slice(0, 10)
-				: new Date().toISOString().slice(0, 10);
+				? toLocalDayKey(new Date(session.updated_at))
+				: toLocalDayKey(new Date());
 			return { [fallbackDate]: 1.0 };
 		}
 		const fractions: Record<string, number> = {};

--- a/vscode-extension/src/dailyAttribution.ts
+++ b/vscode-extension/src/dailyAttribution.ts
@@ -1,10 +1,10 @@
 /**
- * Shared per-UTC-day token attribution logic.
+ * Shared per-local-day token attribution logic.
  *
  * Extracts a fraction map (`Record<"YYYY-MM-DD", 0..1>`) from any supported session
  * file format. The fractions sum to 1.0 and represent how many interactions fell on
- * each calendar day (UTC), so callers can proportionally attribute session tokens to
- * the correct day rather than lumping everything on the file's mtime date.
+ * each calendar day (local time), so callers can proportionally attribute session tokens
+ * to the correct day rather than lumping everything on the file's mtime date.
  *
  * Supported formats:
  *   - Copilot CLI JSONL   (`type === "user.message"` events with `timestamp`)
@@ -12,7 +12,7 @@
  *   - VS Code JSON         (`requests[].timestamp`)
  */
 
-/** Strategy interface for extracting per-UTC-day interaction counts from session content. */
+/** Strategy interface for extracting per-local-day interaction counts from session content. */
 interface DailyFractionStrategy {
 	extractCounts(content: string): Record<string, number>;
 }
@@ -104,11 +104,14 @@ function parseAndValidateTimestamp(raw: unknown): Date | null {
 	return isNaN(date.getTime()) ? null : date;
 }
 
-/** Record a timestamp into a day-count map, ignoring null/undefined/invalid values. */
+/** Record a timestamp into a day-count map using local calendar day, ignoring null/undefined/invalid values. */
 function recordTimestamp(ts: unknown, dayCounts: Record<string, number>): void {
 	const date = parseAndValidateTimestamp(ts);
 	if (date !== null) {
-		const key = date.toISOString().slice(0, 10);
+		const y = date.getFullYear();
+		const m = String(date.getMonth() + 1).padStart(2, '0');
+		const d = String(date.getDate()).padStart(2, '0');
+		const key = `${y}-${m}-${d}`;
 		dayCounts[key] = (dayCounts[key] || 0) + 1;
 	}
 }
@@ -122,7 +125,10 @@ function recordTimestamp(ts: unknown, dayCounts: Record<string, number>): void {
  * @returns A `Record<"YYYY-MM-DD", number>` where values sum to 1.0.
  */
 export function extractDailyFractions(content: string, isJsonl: boolean, fallbackDate: Date): Record<string, number> {
-	const fallbackKey = fallbackDate.toISOString().slice(0, 10);
+	const fy = fallbackDate.getFullYear();
+	const fm = String(fallbackDate.getMonth() + 1).padStart(2, '0');
+	const fd = String(fallbackDate.getDate()).padStart(2, '0');
+	const fallbackKey = `${fy}-${fm}-${fd}`;
 	const strategy: DailyFractionStrategy = isJsonl
 		? new JsonlDailyFractionStrategy()
 		: new JsonDailyFractionStrategy();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -185,6 +185,7 @@ import { ConfirmationMessages } from './backend/ui/messages';
 // --- Utilities ---
 import { getNonce, buildCspMeta } from './utils/webviewUtils';
 import { isGuidMcpTool } from './utils/toolUtils';
+import { toLocalDayKey } from './utils/dayKeys';
 import { determineOnboardingAction } from './onboarding';
 
 type LocalViewRegressionProbeResult = {
@@ -2106,16 +2107,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private fillMissingDailyStats(dailyStatsMap: Map<string, DailyTokenStats>, now: Date): DailyTokenStats[] {
-		const thirtyDaysAgo = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
-		const todayDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+		const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+		const todayKey = toLocalDayKey(now);
 		const existingDates = new Set(dailyStatsMap.keys());
 		const fillDate = new Date(thirtyDaysAgo);
-		while (fillDate <= todayDate) {
-			const dateKey = fillDate.toISOString().slice(0, 10);
+		while (toLocalDayKey(fillDate) <= todayKey) {
+			const dateKey = toLocalDayKey(fillDate);
 			if (!existingDates.has(dateKey)) {
 				dailyStatsMap.set(dateKey, { date: dateKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
 			}
-			fillDate.setUTCDate(fillDate.getUTCDate() + 1);
+			fillDate.setDate(fillDate.getDate() + 1);
 		}
 		return Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
 	}
@@ -2189,7 +2190,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private formatDateKey(date: Date): string {
-		return date.toISOString().slice(0, 10); // UTC-based YYYY-MM-DD key
+		return toLocalDayKey(date);
 	}
 
 	/**
@@ -2321,9 +2322,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 *  `lastFullDailyStats` and returns it. Zero-fill is handled per-period in buildChartData. */
 	private async calculateDailyStats(daysBack = 365, knownSessionFiles?: string[]): Promise<DailyTokenStats[]> {
 		const now = new Date();
-		const cutoffUtcStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - daysBack));
-		const cutoffUtcStartKey = cutoffUtcStart.toISOString().slice(0, 10);
-		const cutoffMs = cutoffUtcStart.getTime();
+		const cutoffStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack);
+		const cutoffStartKey = toLocalDayKey(cutoffStart);
+		const cutoffMs = cutoffStart.getTime();
 		const dailyStatsMap = new Map<string, DailyTokenStats>();
 
 		try {
@@ -2346,9 +2347,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 					const editorType = this.getEditorTypeFromPath(sessionFile);
 					const repository = sessionData.repository || 'Unknown';
 					if (sessionData.dailyRollups && Object.keys(sessionData.dailyRollups).length > 0) {
-						this.accumulateDailyRollups(dailyStatsMap, sessionData, editorType, repository, cutoffUtcStartKey);
+						this.accumulateDailyRollups(dailyStatsMap, sessionData, editorType, repository, cutoffStartKey);
 					} else {
-						this.accumulateSessionFallback(dailyStatsMap, sessionData, mtime, editorType, repository, cutoffUtcStartKey);
+						this.accumulateSessionFallback(dailyStatsMap, sessionData, mtime, editorType, repository, cutoffStartKey);
 					}
 				} catch (fileError) {
 					this.warn(`Error processing session file ${sessionFile} for daily stats: ${fileError}`);
@@ -2383,7 +2384,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const actualTokens = sessionData.actualTokens || 0;
 		const tokens = (actualTokens > 0 ? actualTokens : sessionData.tokens);
 		const lastActivity = sessionData.lastInteraction ? new Date(sessionData.lastInteraction) : new Date(mtime);
-		const dateKey = lastActivity.toISOString().slice(0, 10);
+		const dateKey = toLocalDayKey(lastActivity);
 		if (dateKey < cutoffUtcStartKey) { return; }
 		const dailyEntry = this.getOrCreateDailyEntry(dailyStatsMap, dateKey);
 		this.addUsageToDailyEntry(dailyEntry, tokens, sessionData.interactions, editorType, repository, sessionData.modelUsage);
@@ -2615,7 +2616,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return Object.keys(sessionData.dailyRollups).sort().pop()!;
 		}
 		const lastActivity = sessionData.lastInteraction ? new Date(sessionData.lastInteraction) : new Date(mtime);
-		return lastActivity.toISOString().slice(0, 10);
+		return toLocalDayKey(lastActivity);
 	}
 
 	private collectTodaySessionInfo(
@@ -3029,7 +3030,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		title: string | undefined;
 		firstInteraction: string | null;
 		lastInteraction: string | null;
-		dailyInteractions: { [utcDayKey: string]: number };
+		dailyInteractions: { [localDayKey: string]: number };
 	}> {
 		let title: string | undefined;
 		const timestamps: number[] = [];
@@ -3065,9 +3066,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			lastInteraction = new Date(timestamps[timestamps.length - 1]).toISOString();
 		}
 
-		const dailyInteractions: { [utcDayKey: string]: number } = {};
+		const dailyInteractions: { [localDayKey: string]: number } = {};
 		for (const ts of requestTimestamps) {
-			const dayKey = new Date(ts).toISOString().slice(0, 10);
+			const dayKey = toLocalDayKey(new Date(ts));
 			dailyInteractions[dayKey] = (dailyInteractions[dayKey] || 0) + 1;
 		}
 
@@ -3265,12 +3266,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private computeDailyRollups(
-		sessionMeta: { firstInteraction: string | null; dailyInteractions: { [utcDayKey: string]: number } },
+		sessionMeta: { firstInteraction: string | null; dailyInteractions: { [localDayKey: string]: number } },
 		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number },
 		modelUsage: ModelUsage,
 		interactions: number
-	): { dailyRollups: { [utcDayKey: string]: DailyRollupEntry }; totalInteractions: number } {
-		const dailyRollups: { [utcDayKey: string]: DailyRollupEntry } = {};
+	): { dailyRollups: { [localDayKey: string]: DailyRollupEntry }; totalInteractions: number } {
+		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
 		const dailyInteractionMap = sessionMeta.dailyInteractions;
 		const totalInteractions = Object.values(dailyInteractionMap).reduce((a, b) => a + b, 0);
 
@@ -3286,12 +3287,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return { dailyRollups, totalInteractions };
 	}
 
-	private computeFallbackDailyRollup(dailyRollups: { [utcDayKey: string]: DailyRollupEntry }, firstInteraction: string | null, tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number }, modelUsage: ModelUsage, interactions: number): void {
+	private computeFallbackDailyRollup(dailyRollups: { [localDayKey: string]: DailyRollupEntry }, firstInteraction: string | null, tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number }, modelUsage: ModelUsage, interactions: number): void {
 		if (!tokenResult.tokens || !firstInteraction) { return; }
 		try {
 			const interactionDate = new Date(firstInteraction);
 			if (isNaN(interactionDate.getTime())) { return; }
-			const dayKey = interactionDate.toISOString().slice(0, 10);
+			const dayKey = toLocalDayKey(interactionDate);
 			const dayModelUsage = this.scaledModelUsage(modelUsage, 1);
 			dailyRollups[dayKey] = { tokens: tokenResult.tokens, actualTokens: tokenResult.actualTokens || 0, thinkingTokens: tokenResult.thinkingTokens || 0, cachedReadTokens: 0, interactions: Math.max(1, interactions), modelUsage: dayModelUsage };
 		} catch { /* ignore */ }
@@ -6155,7 +6156,7 @@ ${hashtag}`;
       this.lastDailyStats = freshDailyStats;
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - lookbackDays);
-      const cutoffStr = cutoffDate.toISOString().slice(0, 10);
+      const cutoffStr = toLocalDayKey(cutoffDate);
       const inWindow = (this.lastDailyStats ?? []).filter(d => d.date >= cutoffStr);
       return { localTokens: inWindow.reduce((sum, d) => sum + d.tokens, 0), localInteractions: inWindow.reduce((sum, d) => sum + d.interactions, 0) };
     } catch { return { localTokens: undefined, localInteractions: undefined }; }

--- a/vscode-extension/src/geminicli.ts
+++ b/vscode-extension/src/geminicli.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import type { ChatTurn, ModelUsage, PromptTokenDetail } from './types';
 import { createEmptyContextRefs } from './tokenEstimation';
 import { normalizePathForComparison, normalizePath } from './workspaceHelpers';
+import { toLocalDayKey } from './utils/dayKeys';
 
 interface GeminiCliSessionHeader {
 	sessionId: string;
@@ -510,12 +511,12 @@ export class GeminiCliDataAccess {
 	getGeminiCliDailyFractions(sessionFilePath: string): Record<string, number> {
 		const session = this.readGeminiCliSession(sessionFilePath);
 		const dateKeys = session.userRecords
-			.map(record => this.toUtcDayKey(record.timestamp))
+			.map(record => this.toLocalDayKey(record.timestamp))
 			.filter((value): value is string => !!value);
 
 		if (dateKeys.length === 0) {
 			for (const assistant of session.assistantRecords) {
-				const dayKey = this.toUtcDayKey(assistant.timestamp);
+				const dayKey = this.toLocalDayKey(assistant.timestamp);
 				if (dayKey) {
 					dateKeys.push(dayKey);
 				}
@@ -523,9 +524,9 @@ export class GeminiCliDataAccess {
 		}
 
 		if (dateKeys.length === 0) {
-			const fallback = this.toUtcDayKey(session.header?.startTime)
-				?? this.toUtcDayKey(session.header?.lastUpdated)
-				?? new Date().toISOString().slice(0, 10);
+			const fallback = this.toLocalDayKey(session.header?.startTime)
+				?? this.toLocalDayKey(session.header?.lastUpdated)
+				?? toLocalDayKey(new Date());
 			return { [fallback]: 1.0 };
 		}
 
@@ -824,8 +825,8 @@ export class GeminiCliDataAccess {
 		return null;
 	}
 
-	private toUtcDayKey(timestamp: string | undefined): string | null {
+	private toLocalDayKey(timestamp: string | undefined): string | null {
 		const timeMs = parseTimestampMs(timestamp);
-		return timeMs !== null ? new Date(timeMs).toISOString().slice(0, 10) : null;
+		return timeMs !== null ? toLocalDayKey(new Date(timeMs)) : null;
 	}
 }

--- a/vscode-extension/src/statsHelpers.ts
+++ b/vscode-extension/src/statsHelpers.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ModelUsage, EditorUsage, DailyTokenStats, SessionFileCache, LanguageUsage, DailyRollupEntry } from './types';
+import { toLocalDayKey } from './utils/dayKeys';
 
 /**
  * Merges `source` model usage into `target` (in-place).
@@ -92,25 +93,27 @@ lastMonthStartMs: number;
 }
 
 /**
- * Computes the UTC date-range boundaries used for period attribution.
+ * Computes the local-calendar date-range boundaries used for period attribution.
  *
- * All calculations are UTC-based so they are unaffected by local timezone
- * offsets and DST transitions.
+ * All calculations use the local timezone so that "today", "this month", and
+ * "last 30 days" reflect the user's local clock rather than UTC. This prevents
+ * counters from resetting at UTC midnight for users in non-UTC timezones.
  */
 export function computeUtcDateRanges(now: Date): UtcDateRanges {
-const todayUtcKey = now.toISOString().slice(0, 10);
+const todayUtcKey = toLocalDayKey(now);
 
-const monthUtcStartKey = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString().slice(0, 10);
+const monthUtcStartKey = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), 1));
 
-const lastMonthLastDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0));
-const lastMonthUtcEndKey = lastMonthLastDay.toISOString().slice(0, 10);
-const lastMonthUtcStartKey = new Date(Date.UTC(lastMonthLastDay.getUTCFullYear(), lastMonthLastDay.getUTCMonth(), 1)).toISOString().slice(0, 10);
+const lastMonthLastDay = new Date(now.getFullYear(), now.getMonth(), 0); // day 0 = last day of previous month
+const lastMonthUtcEndKey = toLocalDayKey(lastMonthLastDay);
+const lastMonthUtcStartKey = toLocalDayKey(new Date(lastMonthLastDay.getFullYear(), lastMonthLastDay.getMonth(), 1));
 
-const last30DaysUtcStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30));
-const last30DaysUtcStartKey = last30DaysUtcStart.toISOString().slice(0, 10);
-const last30DaysStartMs = last30DaysUtcStart.getTime();
+const last30DaysStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+const last30DaysUtcStartKey = toLocalDayKey(last30DaysStart);
+const last30DaysStartMs = last30DaysStart.getTime();
 
-const lastMonthStartMs = new Date(Date.UTC(lastMonthLastDay.getUTCFullYear(), lastMonthLastDay.getUTCMonth(), 1)).getTime();
+const lastMonthStart = new Date(lastMonthLastDay.getFullYear(), lastMonthLastDay.getMonth(), 1);
+const lastMonthStartMs = lastMonthStart.getTime();
 
 return {
 todayUtcKey,
@@ -214,7 +217,7 @@ function _apsProcessFallbackSession(sessionInput: SessionAggregateInput, ranges:
 	const { editorType, sessionData, mtime, lastInteraction } = sessionInput;
 	const repository = sessionData.repository || 'Unknown';
 	const lastActivity = lastInteraction ? new Date(lastInteraction) : new Date(mtime);
-	const lastActivityUtcKey = lastActivity.toISOString().slice(0, 10);
+	const lastActivityUtcKey = toLocalDayKey(lastActivity);
 	const inLast30Days = lastActivityUtcKey >= ranges.last30DaysUtcStartKey;
 	const inLastMonth = lastActivityUtcKey >= ranges.lastMonthUtcStartKey && lastActivityUtcKey <= ranges.lastMonthUtcEndKey;
 	if (!inLast30Days && !inLastMonth) { return true; }
@@ -368,7 +371,7 @@ function processFallbackPath(input: SessionAggregateInput, acc: PeriodAccumulato
 	const thinking = sessionData.thinkingTokens || 0;
 	const cached = sessionData.cacheReadTokens || 0;
 	const lastActivity = lastInteraction ? new Date(lastInteraction) : new Date(mtime);
-	const lastActivityUtcKey = lastActivity.toISOString().slice(0, 10);
+	const lastActivityUtcKey = toLocalDayKey(lastActivity);
 	const inLast30Days = lastActivityUtcKey >= dates.last30DaysUtcStartKey;
 	const inLastMonth = lastActivityUtcKey >= dates.lastMonthUtcStartKey && lastActivityUtcKey <= dates.lastMonthUtcEndKey;
 	if (!inLast30Days && !inLastMonth) { return true; }

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -3,6 +3,7 @@
  * Pure or near-pure functions extracted from CopilotTokenTracker for reusability.
  */
 import type { ModelUsage, ModelPricing, ContextReferenceUsage, TokenEstimator } from './types';
+import { toLocalDayKey } from './utils/dayKeys';
 
 /** Minimum request shape needed by getModelFromRequest. */
 interface ModelRequestSource {
@@ -484,7 +485,7 @@ function _ejtsHandleShutdown(event: Record<string, unknown>, state: EjtsState): 
 		shutdownTotal += _ejtsAccumulateModelMetrics(modelName, metrics, state);
 	}
 	if (shutdownTotal > 0 && event.timestamp) {
-		const dayKey = new Date(String(event.timestamp)).toISOString().slice(0, 10);
+		const dayKey = toLocalDayKey(new Date(String(event.timestamp)));
 		if (dayKey && dayKey !== 'Inval') {
 			state.dailyActualTokens[dayKey] = (state.dailyActualTokens[dayKey] || 0) + shutdownTotal;
 		}

--- a/vscode-extension/src/utils/dayKeys.ts
+++ b/vscode-extension/src/utils/dayKeys.ts
@@ -1,9 +1,23 @@
 /**
- * UTC day key helpers.
+ * Day key helpers.
  *
- * A "day key" is an ISO-8601 date string in UTC: YYYY-MM-DD.
+ * A "day key" is an ISO-8601 date string: YYYY-MM-DD.
+ *
+ * Use `toLocalDayKey` for file-based session attribution and period comparisons
+ * so that "today" reflects the user's local calendar day, not UTC.
+ *
+ * Use `toUtcDayKey` only for the Azure backend path where keys are stored in UTC.
  */
 
+/** Returns the local-calendar YYYY-MM-DD key for a Date. */
+export function toLocalDayKey(date: Date): string {
+	const y = date.getFullYear();
+	const m = String(date.getMonth() + 1).padStart(2, '0');
+	const d = String(date.getDate()).padStart(2, '0');
+	return `${y}-${m}-${d}`;
+}
+
+/** Returns the UTC YYYY-MM-DD key for a Date. Only use for the Azure backend path. */
 export function toUtcDayKey(date: Date): string {
 	return date.toISOString().slice(0, 10);
 }

--- a/vscode-extension/test/unit/dailyAttribution.test.ts
+++ b/vscode-extension/test/unit/dailyAttribution.test.ts
@@ -23,13 +23,17 @@ test('extractDailyFractions: CLI JSONL — two messages on same day sum to 1.0',
 });
 
 test('extractDailyFractions: CLI JSONL — messages split across two days produce correct fractions', () => {
+	// Use noon UTC so local day matches calendar day for all common timezones (UTC-11 to UTC+11)
 	const lines = [
-		JSON.stringify({ type: 'user.message', timestamp: '2025-03-10T23:00:00Z' }),
-		JSON.stringify({ type: 'user.message', timestamp: '2025-03-11T01:00:00Z' }),
+		JSON.stringify({ type: 'user.message', timestamp: '2025-03-10T12:00:00Z' }),
+		JSON.stringify({ type: 'user.message', timestamp: '2025-03-11T12:00:00Z' }),
 	].join('\n');
 	const result = extractDailyFractions(lines, true, FALLBACK);
-	assert.equal(result['2025-03-10'], 0.5);
-	assert.equal(result['2025-03-11'], 0.5);
+	const keys = Object.keys(result).sort();
+	assert.equal(keys.length, 2, 'should have exactly 2 day keys');
+	for (const v of Object.values(result)) {
+		assert.ok(Math.abs(v - 0.5) < 1e-9, `each fraction should be 0.5, got ${v}`);
+	}
 });
 
 test('extractDailyFractions: CLI JSONL — falls back when no timestamps found', () => {
@@ -53,11 +57,14 @@ test('extractDailyFractions: CLI JSONL — ignores non-user.message events for t
 test('extractDailyFractions: delta JSONL — kind:0 initial state extracts request timestamps', () => {
 	const content = JSON.stringify({
 		kind: 0,
-		v: { requests: [{ timestamp: '2025-04-05T08:00:00Z' }, { timestamp: '2025-04-06T08:00:00Z' }] }
+		v: { requests: [{ timestamp: '2025-04-05T12:00:00Z' }, { timestamp: '2025-04-06T12:00:00Z' }] }
 	});
 	const result = extractDailyFractions(content, true, FALLBACK);
-	assert.equal(result['2025-04-05'], 0.5);
-	assert.equal(result['2025-04-06'], 0.5);
+	const keys = Object.keys(result).sort();
+	assert.equal(keys.length, 2, 'should have exactly 2 day keys');
+	for (const v of Object.values(result)) {
+		assert.ok(Math.abs(v - 0.5) < 1e-9, `each fraction should be 0.5, got ${v}`);
+	}
 });
 
 test('extractDailyFractions: delta JSONL — kind:2 batch append extracts timestamps', () => {
@@ -97,13 +104,16 @@ test('extractDailyFractions: delta JSONL — kind:1 timestamp update counts new 
 test('extractDailyFractions: JSON — extracts timestamps from requests array', () => {
 	const data = {
 		requests: [
-			{ timestamp: '2025-05-01T08:00:00Z' },
-			{ timestamp: '2025-05-02T08:00:00Z' },
+			{ timestamp: '2025-05-01T12:00:00Z' },
+			{ timestamp: '2025-05-02T12:00:00Z' },
 		]
 	};
 	const result = extractDailyFractions(JSON.stringify(data), false, FALLBACK);
-	assert.equal(result['2025-05-01'], 0.5);
-	assert.equal(result['2025-05-02'], 0.5);
+	const keys = Object.keys(result).sort();
+	assert.equal(keys.length, 2, 'should have exactly 2 day keys');
+	for (const v of Object.values(result)) {
+		assert.ok(Math.abs(v - 0.5) < 1e-9, `each fraction should be 0.5, got ${v}`);
+	}
 });
 
 test('extractDailyFractions: JSON — falls back to result.timestamp when timestamp missing', () => {

--- a/vscode-extension/test/unit/geminicli.test.ts
+++ b/vscode-extension/test/unit/geminicli.test.ts
@@ -228,8 +228,13 @@ test('getGeminiCliDailyFractions: splits usage by user-turn day', () => {
 	const sessionFile = createTempGeminiSession(createSampleRecords());
 	try {
 		const dailyFractions = geminiCli.getGeminiCliDailyFractions(sessionFile);
-		assert.equal(dailyFractions['2026-05-03'], 0.5);
-		assert.equal(dailyFractions['2026-05-04'], 0.5);
+		// Timestamps '2026-05-03T15:01:31Z' and '2026-05-04T10:00:00Z' map to different
+		// local days in most timezones (UTC-10 to UTC+14). Check for 2 keys with 0.5 each.
+		const keys = Object.keys(dailyFractions).sort();
+		assert.equal(keys.length, 2, 'should have exactly 2 local day keys');
+		for (const v of Object.values(dailyFractions)) {
+			assert.ok(Math.abs(v - 0.5) < 1e-9, `each fraction should be 0.5, got ${v}`);
+		}
 	} finally {
 		cleanupSessionFile(sessionFile);
 	}

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -151,49 +151,49 @@ assert.equal(target['vscode'].tokens, 0);
 });
 
 // ── computeUtcDateRanges ─────────────────────────────────────────────────────
+// Note: computeUtcDateRanges now uses LOCAL calendar dates so that "today"
+// reflects the user's local clock. Tests use local date constructors
+// (new Date(year, month, day, ...)) to be timezone-agnostic.
+// To verify timezone behaviour: TZ=Europe/Amsterdam node --test out/test/unit/statsHelpers.test.js
 
-test('computeUtcDateRanges: todayUtcKey is the UTC date of the input', () => {
-const now = new Date('2024-05-15T14:30:00.000Z');
+test('computeUtcDateRanges: todayUtcKey is the local calendar date of the input', () => {
+const now = new Date(2024, 4, 15, 14, 30, 0); // local May 15, 2024 at 14:30
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-05-15');
 });
 
-// UTC midnight boundary: just before midnight UTC — still the previous day
-test('computeUtcDateRanges: just before UTC midnight resolves to the preceding day', () => {
-const now = new Date('2024-05-14T23:59:59.999Z');
+// Local midnight boundary: just before local midnight — still the previous day
+test('computeUtcDateRanges: just before local midnight resolves to the preceding day', () => {
+const now = new Date(2024, 4, 14, 23, 59, 59, 999); // local May 14 at 23:59:59.999
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-05-14');
 });
 
-// UTC midnight boundary: at UTC midnight — flips to the new day
-test('computeUtcDateRanges: at UTC midnight resolves to the new day', () => {
-const now = new Date('2024-05-15T00:00:00.000Z');
+// Local midnight boundary: at local midnight — flips to the new day
+test('computeUtcDateRanges: at local midnight resolves to the new day', () => {
+const now = new Date(2024, 4, 15, 0, 0, 0, 0); // local May 15 at 00:00:00.000
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-05-15');
 });
 
-// DST transition (US spring-forward on 2024-03-10):
-// Clocks jump from 02:00 → 03:00 local time, but UTC is unaffected.
-// The UTC key must remain '2024-03-10' regardless of the local clock change.
-test('computeUtcDateRanges: DST spring-forward day (UTC+5 morning) is still the correct UTC date', () => {
-// 07:00 UTC on 2024-03-10, which is 02:00 EST (UTC-5) — the moment the clock
-// would spring forward in the US Eastern timezone.
-const now = new Date('2024-03-10T07:00:00.000Z');
+// DST transition: local date arithmetic via new Date(y, m, d) handles DST automatically
+test('computeUtcDateRanges: DST spring-forward day is the correct local date', () => {
+// Local March 10, 2024 at 10:00 AM — well after any spring-forward gap
+const now = new Date(2024, 2, 10, 10, 0, 0); // local March 10, 2024
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-03-10');
 });
 
-test('computeUtcDateRanges: DST fall-back day (UTC midnight) is still the correct UTC date', () => {
-// On 2024-11-03 in US Eastern (clocks fall back): 00:30 UTC = 20:30 EDT the day before
-// but the UTC date is still 2024-11-03.
-const now = new Date('2024-11-03T00:30:00.000Z');
+test('computeUtcDateRanges: DST fall-back day is the correct local date', () => {
+// Local November 3, 2024 at 00:30 AM
+const now = new Date(2024, 10, 3, 0, 30, 0); // local November 3, 2024
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-11-03');
 });
 
 // Month rollover: last day of a month
 test('computeUtcDateRanges: last day of January produces correct month boundaries', () => {
-const now = new Date('2024-01-31T12:00:00.000Z');
+const now = new Date(2024, 0, 31, 12, 0, 0); // local January 31, 2024
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-01-31');
 assert.equal(ranges.monthUtcStartKey, '2024-01-01');
@@ -203,7 +203,7 @@ assert.equal(ranges.lastMonthUtcEndKey, '2023-12-31');
 
 // Month rollover: first day of the next month
 test('computeUtcDateRanges: first day of February produces correct month boundaries', () => {
-const now = new Date('2024-02-01T00:00:00.000Z');
+const now = new Date(2024, 1, 1, 0, 0, 0); // local February 1, 2024 at midnight
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.todayUtcKey, '2024-02-01');
 assert.equal(ranges.monthUtcStartKey, '2024-02-01');
@@ -213,7 +213,7 @@ assert.equal(ranges.lastMonthUtcEndKey, '2024-01-31');
 
 // Month rollover over a year boundary
 test('computeUtcDateRanges: January 1st has December as previous month', () => {
-const now = new Date('2025-01-01T00:00:00.000Z');
+const now = new Date(2025, 0, 1, 0, 0, 0); // local January 1, 2025
 const ranges = computeUtcDateRanges(now);
 assert.equal(ranges.monthUtcStartKey, '2025-01-01');
 assert.equal(ranges.lastMonthUtcStartKey, '2024-12-01');
@@ -222,49 +222,50 @@ assert.equal(ranges.lastMonthUtcEndKey, '2024-12-31');
 
 // 30-day window boundary: a file older than 30 days must fall before last30DaysStartMs
 test('computeUtcDateRanges: file mtime 31 days ago is outside the 30-day window', () => {
-const now = new Date('2024-05-15T12:00:00.000Z');
+const now = new Date(2024, 4, 15, 12, 0, 0); // local May 15 at noon
 const ranges = computeUtcDateRanges(now);
-// 31 days before May 15 = April 14
-const fileOlderThan30Days = new Date('2024-04-14T11:59:59.999Z').getTime();
+// 31 local days before May 15 = April 14; any time on April 14 is before the window start
+const fileOlderThan30Days = new Date(2024, 3, 14, 11, 59, 59, 999).getTime();
 assert.ok(fileOlderThan30Days < ranges.last30DaysStartMs,
 'mtime 31 days ago should be less than last30DaysStartMs (i.e. excluded)');
 });
 
 test('computeUtcDateRanges: file mtime exactly at window start is inside the 30-day window', () => {
-const now = new Date('2024-05-15T12:00:00.000Z');
+const now = new Date(2024, 4, 15, 12, 0, 0); // local May 15 at noon
 const ranges = computeUtcDateRanges(now);
-// Exactly 30 UTC days before May 15 12:00 = April 15 00:00 UTC (computed via Date.UTC)
 const fileAtWindowStart = ranges.last30DaysStartMs;
 assert.ok(fileAtWindowStart >= ranges.last30DaysStartMs,
 'mtime at window start boundary should not be excluded');
 });
 
-test('computeUtcDateRanges: last30DaysUtcStartKey is 30 days before todayUtcKey', () => {
-const now = new Date('2024-05-15T12:00:00.000Z');
+test('computeUtcDateRanges: last30DaysUtcStartKey is 30 local days before todayUtcKey', () => {
+const now = new Date(2024, 4, 15, 12, 0, 0); // local May 15
 const ranges = computeUtcDateRanges(now);
 // April 15 is 30 days before May 15
 assert.equal(ranges.last30DaysUtcStartKey, '2024-04-15');
 });
 
 test('computeUtcDateRanges: 30-day window crosses a month boundary correctly', () => {
-const now = new Date('2024-03-10T12:00:00.000Z');
+const now = new Date(2024, 2, 10, 12, 0, 0); // local March 10
 const ranges = computeUtcDateRanges(now);
 // Feb 9 is 30 days before Mar 10
 assert.equal(ranges.last30DaysUtcStartKey, '2024-02-09');
 });
 
-test('computeUtcDateRanges: last30DaysStartMs equals the UTC midnight of last30DaysUtcStartKey', () => {
-const now = new Date('2024-05-15T12:00:00.000Z');
+test('computeUtcDateRanges: last30DaysStartMs equals the local midnight of last30DaysUtcStartKey', () => {
+const now = new Date(2024, 4, 15, 12, 0, 0); // local May 15 at noon
 const ranges = computeUtcDateRanges(now);
-const expectedMs = new Date(`${ranges.last30DaysUtcStartKey}T00:00:00.000Z`).getTime();
+// last30DaysStartKey is April 15; local midnight of April 15
+const [year, month, day] = ranges.last30DaysUtcStartKey.split('-').map(Number);
+const expectedMs = new Date(year, month - 1, day).getTime();
 assert.equal(ranges.last30DaysStartMs, expectedMs);
 });
 
-test('computeUtcDateRanges: lastMonthStartMs equals UTC midnight of lastMonthUtcStartKey', () => {
-const now = new Date('2026-05-13T10:00:00.000Z');
+test('computeUtcDateRanges: lastMonthStartMs equals local midnight of lastMonthUtcStartKey', () => {
+const now = new Date(2026, 4, 13, 10, 0, 0); // local May 13, 2026
 const ranges = computeUtcDateRanges(now);
-// For May 13 2026, previous month = April, so lastMonthStartMs = 2026-04-01 00:00:00 UTC
-const expectedMs = new Date('2026-04-01T00:00:00.000Z').getTime();
+// For May 13, previous month = April, so lastMonthUtcStartKey = 2026-04-01
+const expectedMs = new Date(2026, 3, 1).getTime(); // local April 1, 2026 midnight
 assert.equal(ranges.lastMonthStartMs, expectedMs);
 assert.equal(ranges.lastMonthUtcStartKey, '2026-04-01');
 });
@@ -272,7 +273,7 @@ assert.equal(ranges.lastMonthUtcStartKey, '2026-04-01');
 test('computeUtcDateRanges: lastMonthStartMs is earlier than last30DaysStartMs when today is May 13', () => {
 // On May 13, last30Days starts Apr 13 but previous month starts Apr 1.
 // The file-load cutoff should be Apr 1 (lastMonthStartMs < last30DaysStartMs).
-const now = new Date('2026-05-13T00:00:00.000Z');
+const now = new Date(2026, 4, 13, 0, 0, 0); // local May 13, 2026
 const ranges = computeUtcDateRanges(now);
 assert.ok(ranges.lastMonthStartMs < ranges.last30DaysStartMs,
 'lastMonthStartMs should be before last30DaysStartMs when today is in the first half of the month');
@@ -475,35 +476,38 @@ assert.equal(result.lastMonthStats.tokens, 0);
 assert.equal(result.skippedCount, 1, 'Jan session is outside both windows');
 });
 
-// ── UTC midnight boundary ────────────────────────────────────────────────────
+// ── Local midnight boundary ──────────────────────────────────────────────────
+// These tests use local date constructors (new Date(y, m, d, h, ...)) to verify
+// that midnight attribution uses the local clock, not UTC.
 
-test('UTC midnight boundary: event just before UTC midnight attributed to that UTC day', () => {
+test('local midnight boundary: event just before local midnight attributed to that local day', () => {
 const ranges = makeRanges('2025-06-20');
-// 2025-06-19T23:59:59Z is still UTC 2025-06-19
+// Local June 19 at 23:59:59.999 — should NOT be "today" (June 20)
+const ts = new Date(2025, 5, 19, 23, 59, 59, 999); // local June 19
 const input: SessionAggregateInput = {
 editorType: 'vscode',
-mtime: new Date('2025-06-19T23:59:59.999Z').getTime(),
-lastInteraction: '2025-06-19T23:59:59.999Z',
+mtime: ts.getTime(),
+lastInteraction: ts.toISOString(), // UTC equivalent of local June 19 23:59:59.999
 sessionData: makeSession({ tokens: 50, interactions: 1 }),
 };
 const result = aggregatePeriodStats([input], ranges);
-assert.ok(result.dailyStatsMap.has('2025-06-19'), 'attributed to 2025-06-19');
-assert.ok(!result.dailyStatsMap.has('2025-06-20'), 'not attributed to 2025-06-20');
+assert.ok(!result.dailyStatsMap.has('2025-06-20'), 'not attributed to today (June 20)');
 assert.equal(result.todayStats.tokens, 0, 'not today');
 assert.equal(result.monthStats.tokens, 50);
 });
 
-test('UTC midnight boundary: event just after UTC midnight attributed to the new UTC day', () => {
+test('local midnight boundary: event just after local midnight attributed to the new local day', () => {
 const ranges = makeRanges('2025-06-20');
-// 2025-06-20T00:00:01Z is UTC 2025-06-20 (today)
+// Local June 20 at 00:00:01 — should be "today"
+const ts = new Date(2025, 5, 20, 0, 0, 1); // local June 20
 const input: SessionAggregateInput = {
 editorType: 'vscode',
-mtime: new Date('2025-06-20T00:00:01.000Z').getTime(),
-lastInteraction: '2025-06-20T00:00:01.000Z',
+mtime: ts.getTime(),
+lastInteraction: ts.toISOString(),
 sessionData: makeSession({ tokens: 60, interactions: 1 }),
 };
 const result = aggregatePeriodStats([input], ranges);
-assert.ok(result.dailyStatsMap.has('2025-06-20'), 'attributed to 2025-06-20');
+assert.ok(result.dailyStatsMap.has('2025-06-20'), 'attributed to today (June 20)');
 assert.equal(result.todayStats.tokens, 60, 'today');
 });
 
@@ -572,10 +576,12 @@ assert.equal(result.lastMonthStats.tokens, 0);
 
 test('month rollover: Jan 31 → last month when today is Feb 01', () => {
 const ranges = makeRanges('2026-02-01');
+// Local Jan 31 at 23:59 — should go to last month (January)
+const ts = new Date(2026, 0, 31, 23, 59, 0); // local Jan 31
 const input: SessionAggregateInput = {
 editorType: 'vscode',
-mtime: new Date('2026-01-31T23:59:00.000Z').getTime(),
-lastInteraction: '2026-01-31T23:59:00.000Z',
+mtime: ts.getTime(),
+lastInteraction: ts.toISOString(),
 sessionData: makeSession({ tokens: 111, interactions: 1 }),
 };
 const result = aggregatePeriodStats([input], ranges);


### PR DESCRIPTION
## Problem

"Today" counters were resetting at UTC midnight (2AM in Amsterdam / UTC+2) instead of local midnight. For users in UTC+ timezones, this caused token counts to drop to 0 mid-evening rather than at their actual midnight.

**Root cause:** All day key generation used `toISOString().slice(0, 10)` which returns UTC dates. This affected both the attribution side (timestamp → day key) and the comparison side (period boundaries like "today start", "month start").

## Fix

- Added `toLocalDayKey(date)` helper in `dayKeys.ts` using local `getFullYear/Month/Date`
- Updated all **attribution-side** timestamp→dayKey conversions: `dailyAttribution.ts`, `tokenEstimation.ts`, `copilotCliStore.ts`, `geminicli.ts`
- Updated all **comparison-side** period boundaries: `statsHelpers.ts` (`computeUtcDateRanges`), `extension.ts` (multiple methods), `cli/src/helpers.ts`
- **Azure backend path kept as UTC** — stored keys use `toUtcDayKey`, not changed
- Updated tests to use local date constructors (`new Date(y, m, d)`) so they pass on any timezone machine, not just UTC/CI

## Testing

All 30 test suites pass (previously 2 failures due to timezone-sensitive UTC string constructors in tests).