### PR TITLE
fix: CLI editor names now match VS Code extension friendly display names

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -92,6 +92,20 @@ Agent Skills are directories containing a `SKILL.md` file and optional supportin
 - ESLint commands to identify violation candidates
 - Commit message and PR description templates
 
+### validate-editor-names
+
+**Purpose**: Verify that the CLI and VS Code extension always agree on editor display names, and every name has an icon in the webview icon map.
+
+**Use this skill when:**
+- Adding support for a new editor or AI coding tool
+- After modifying `getEditorSourceFromPath` in `cli/src/analysis.ts`
+- After modifying `getEditorTypeFromPath` in `vscode-extension/src/workspaceHelpers.ts`
+- After updating `EDITOR_ICON_MAP` in `formatUtils.ts`
+- When JetBrains or another CLI-based consumer shows raw editor keys instead of friendly names
+
+**Contents:**
+- `validate-editor-names.js` — dependency-free Node.js script that statically extracts path detection rules from both source files, runs 18 canonical test paths through the CLI rules, checks cross-function consistency, validates EDITOR_ICON_MAP coverage, and warns about ordering invariants (broad patterns shadowing specific ones)
+
 ### load-cache-data
 
 **Purpose**: Load and inspect the last 10 rows from the local session file cache to iterate with real data.

--- a/.github/skills/validate-editor-names/SKILL.md
+++ b/.github/skills/validate-editor-names/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: validate-editor-names
+description: Find all hardcoded path-to-editor-name mappings in the CLI (cli/src/analysis.ts::getEditorSourceFromPath) and VS Code extension (vscode-extension/src/workspaceHelpers.ts::getEditorTypeFromPath), verify they return matching friendly display names for the same path patterns, and confirm every CLI-returned name appears in the EDITOR_ICON_MAP in formatUtils.ts. Use after adding a new editor adapter, after CLI changes, or if JetBrains/other CLI-based consumers show raw editor keys instead of friendly names.
+---
+
+# Validate Editor Names Skill
+
+Checks that the CLI and the VS Code extension always agree on editor display
+names, and that every name has an icon in the webview icon map.
+
+There are **three sources of truth** that must stay in sync:
+
+| Source | File | Function / symbol |
+|--------|------|-------------------|
+| **CLI path detector** | `cli/src/analysis.ts` | `getEditorSourceFromPath` |
+| **VS Code path detector** | `vscode-extension/src/workspaceHelpers.ts` | `getEditorTypeFromPath` (delegates to `detectToolEditorFromPath` + `detectVSCodeVariantFromPath`) |
+| **Webview icon map** | `vscode-extension/src/webview/shared/formatUtils.ts` | `EDITOR_ICON_MAP` + `EditorName` union type |
+
+The JetBrains plugin (and any future CLI-based consumer) gets its editor names
+**exclusively from the CLI** via `CliBridge.kt`. If the CLI returns a raw
+lowercase key instead of a friendly display name the UI falls back to the raw
+key everywhere: chart labels, the session list, the stats command.
+
+## What the script checks
+
+1. **CLI-only coverage** — every unique name returned by
+   `getEditorSourceFromPath` exists in `EDITOR_ICON_MAP`.
+2. **VS Code-only coverage** — every unique name returned by
+   `getEditorTypeFromPath` exists in `EDITOR_ICON_MAP`.
+3. **Cross-function consistency** — for a canonical set of test paths the CLI
+   and VS Code detectors return **identical** names. Any mismatch is a bug.
+4. **Ordering invariants** — warns if a broad path pattern (e.g. `/.copilot/`)
+   appears before a more specific one (e.g. `/.copilot/jb/`) in the CLI
+   function, which would cause the broad check to shadow the specific one.
+
+## Usage
+
+```bash
+# Run all checks and print a human-readable report
+node .github/skills/validate-editor-names/validate-editor-names.js
+
+# Machine-readable JSON (for CI / further processing)
+node .github/skills/validate-editor-names/validate-editor-names.js --json
+
+# Show help
+node .github/skills/validate-editor-names/validate-editor-names.js --help
+```
+
+### Options
+
+| Flag | Meaning |
+|------|---------|
+| `--json` | Emit JSON only (no ANSI colour) |
+| `--help` | Usage |
+
+### Exit codes
+
+- `0` — all checks pass
+- `1` — one or more checks failed (missing icon, name mismatch, ordering issue)
+- `2` — configuration / environment error (source files not found)
+
+## When to run this skill
+
+- After **adding a new editor adapter** (`vscode-extension/src/adapters/`)
+- After **modifying `getEditorSourceFromPath`** or `getEditorTypeFromPath`
+- After **updating `EDITOR_ICON_MAP`** in `formatUtils.ts`
+- When **JetBrains (or another CLI-based view) shows raw editor keys** instead
+  of friendly names — this skill will pinpoint which path pattern is missing or
+  mismatched
+
+## How to fix failures
+
+| Failure type | Likely cause | Fix |
+|---|---|---|
+| **Missing icon** for CLI name | New editor added to CLI but not to `formatUtils.ts` | Add entry to `EditorName` union and `EDITOR_ICON_MAP` |
+| **Missing icon** for VS Code name | New editor added to VS Code adapter but not to `formatUtils.ts` | Same as above |
+| **Name mismatch** for a test path | CLI returns raw key; VS Code returns friendly name (or vice versa) | Align `getEditorSourceFromPath` to match `getEditorTypeFromPath` |
+| **Ordering issue** | Broad `includes` check appears before specific one in CLI function | Reorder checks in `getEditorSourceFromPath` so specific paths come first |
+
+## Related files
+
+- `cli/src/analysis.ts` — `getEditorSourceFromPath` (the CLI implementation)
+- `vscode-extension/src/workspaceHelpers.ts` — `getEditorTypeFromPath`,
+  `detectToolEditorFromPath`, `detectVSCodeVariantFromPath`
+- `vscode-extension/src/webview/shared/formatUtils.ts` — `EditorName` type +
+  `EDITOR_ICON_MAP`
+- `jetbrains-plugin/src/main/kotlin/.../CliBridge.kt` — the JetBrains host that
+  calls the CLI binary and feeds the returned editor names straight into the
+  shared webview bundle
+- `.github/skills/validate-session-schemas/` — validates session file schemas
+  (a complementary skill; run both when adding a new adapter)
+- `docs/logFilesSchema/` — per-platform schema documentation

--- a/.github/skills/validate-editor-names/validate-editor-names.js
+++ b/.github/skills/validate-editor-names/validate-editor-names.js
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+/**
+ * validate-editor-names.js
+ *
+ * Verifies that:
+ *  1. Every editor name returned by cli/src/analysis.ts::getEditorSourceFromPath
+ *     has an entry in the EDITOR_ICON_MAP in formatUtils.ts.
+ *  2. Every editor name returned by vscode-extension/src/workspaceHelpers.ts::
+ *     getEditorTypeFromPath has an entry in the EDITOR_ICON_MAP.
+ *  3. For a canonical set of test paths the CLI and VS Code detectors return
+ *     identical friendly names.
+ *  4. No broad path pattern shadows a more specific one in the CLI function
+ *     (e.g. /.copilot/ before /.copilot/jb/).
+ *
+ * Exit codes:  0 = all checks pass
+ *              1 = one or more checks failed
+ *              2 = configuration / environment error (source files not found)
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = { json: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json')  { opts.json  = true; continue; }
+    if (a === '-h' || a === '--help') { opts.help = true; continue; }
+    process.stderr.write(`Unknown flag: ${a}\n`);
+    process.exit(2);
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const ROOT              = path.resolve(__dirname, '..', '..', '..');
+const CLI_ANALYSIS      = path.join(ROOT, 'cli', 'src', 'analysis.ts');
+const WS_HELPERS        = path.join(ROOT, 'vscode-extension', 'src', 'workspaceHelpers.ts');
+const FORMAT_UTILS      = path.join(ROOT, 'vscode-extension', 'src', 'webview', 'shared', 'formatUtils.ts');
+
+// ---------------------------------------------------------------------------
+// Source file reading
+// ---------------------------------------------------------------------------
+
+function readFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    process.stderr.write(`ERROR: File not found: ${filePath}\n`);
+    process.exit(2);
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Extract function body
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the body of a named function from TypeScript source (first match).
+ * Works for both `export function foo(` and `function foo(` declarations.
+ */
+function extractFunctionBody(source, functionName) {
+  const startRe = new RegExp(`(?:export\\s+)?(?:async\\s+)?function\\s+${functionName}\\s*\\(`);
+  const startIdx = source.search(startRe);
+  if (startIdx === -1) return null;
+
+  // Walk forward to find the opening brace
+  let braceIdx = source.indexOf('{', startIdx);
+  if (braceIdx === -1) return null;
+
+  let depth = 0;
+  let i = braceIdx;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(braceIdx, i + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Extract return-value names from a function body
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans all `return 'SomeName'` and `return "SomeName"` statements and
+ * collects the unique string values, excluding obvious non-name returns
+ * (numbers, undefined, null, booleans, 0, 1).
+ */
+function extractReturnedNames(body) {
+  const names = new Set();
+  const re = /\breturn\s+['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const v = m[1];
+    // Skip numeric strings or control values
+    if (/^\d+$/.test(v)) continue;
+    names.add(v);
+  }
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Extract EDITOR_ICON_MAP keys from formatUtils.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads formatUtils.ts and extracts the string keys of EDITOR_ICON_MAP.
+ */
+function extractIconMapKeys(source) {
+  const mapMatch = source.match(/EDITOR_ICON_MAP[^=]*=\s*\{([^}]+)\}/s);
+  if (!mapMatch) return new Set();
+  const body = mapMatch[1];
+  const keys = new Set();
+  const re = /['"]([^'"]+)['"]\s*:/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    keys.add(m[1]);
+  }
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// Extract ordered includes-patterns → returned name from a function body
+// ---------------------------------------------------------------------------
+
+/**
+ * For a function body like `if (x.includes('/.copilot/jb/')) { return 'JetBrains'; }`
+ * extracts an ordered list of { patterns, name } objects so we can:
+ *   a) simulate path detection
+ *   b) check ordering invariants
+ *
+ * Uses balanced-paren extraction so multi-condition (&&) if statements are
+ * handled correctly (e.g. the Gemini CLI check uses three sub-conditions).
+ */
+function extractIncludesRules(body) {
+  const rules = [];
+  // Find every `return 'Name';` statement, then look backward for its `if (`.
+  const returnRe = /\breturn\s+'([^']+)'\s*;/g;
+  let m;
+  while ((m = returnRe.exec(body)) !== null) {
+    const name = m[1];
+    if (/^\d+$/.test(name)) continue; // skip numeric strings
+
+    // Look backward for the nearest "if (" or "if(" before this return
+    const before = body.slice(0, m.index);
+    const ifIdx = Math.max(before.lastIndexOf('if ('), before.lastIndexOf('if('));
+    if (ifIdx === -1) continue;
+
+    // Use balanced-paren walk to extract the full if condition
+    let depth = 0;
+    let condStart = -1;
+    let condEnd   = -1;
+    for (let i = ifIdx + 2; i < body.length; i++) {
+      const ch = body[i];
+      if (ch === '(') {
+        if (depth === 0) condStart = i + 1;
+        depth++;
+      } else if (ch === ')') {
+        depth--;
+        if (depth === 0) { condEnd = i; break; }
+      }
+    }
+    if (condStart === -1 || condEnd === -1) continue;
+
+    const condition = body.slice(condStart, condEnd);
+
+    // Extract all .includes('pattern') from the condition
+    const patterns = [];
+    const incRe = /\.includes\(['"]([^'"]+)['"]\)/g;
+    let inc;
+    while ((inc = incRe.exec(condition)) !== null) {
+      patterns.push(inc[1]);
+    }
+    if (patterns.length > 0) {
+      rules.push({ patterns, name });
+    }
+  }
+  return rules;
+}
+
+// ---------------------------------------------------------------------------
+// Simulate path detection (mirrors includes-based logic)
+// ---------------------------------------------------------------------------
+
+/**
+ * Given ordered rules, returns the first matching name for a given path.
+ * Matches if ALL patterns in a rule are found in the normalized path.
+ */
+function detectEditor(rules, filePath) {
+  const normalized = filePath.replace(/\\/g, '/').toLowerCase();
+  for (const rule of rules) {
+    if (rule.patterns.every(p => normalized.includes(p))) {
+      return rule.name;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical test cases
+// ---------------------------------------------------------------------------
+
+const TEST_CASES = [
+  // JetBrains — must not be misclassified as Copilot CLI
+  {
+    path: '/home/user/.copilot/jb/uuid-abc/partition-0.jsonl',
+    expected: 'JetBrains',
+    label: 'JetBrains partition file'
+  },
+  // Copilot CLI session-state
+  {
+    path: '/home/user/.copilot/session-state/uuid-abc/session.jsonl',
+    expected: 'Copilot CLI',
+    label: 'Copilot CLI session-state'
+  },
+  // Copilot CLI session-store
+  {
+    path: '/home/user/.copilot/session-store.db#uuid',
+    expected: 'Copilot CLI',
+    label: 'Copilot CLI session-store DB'
+  },
+  // Claude Code
+  {
+    path: '/home/user/.claude/projects/abc123/session.jsonl',
+    expected: 'Claude Code',
+    label: 'Claude Code session'
+  },
+  // VS Code (generic)
+  {
+    path: '/home/user/.config/Code/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'VS Code',
+    label: 'VS Code chat session'
+  },
+  // VS Code Insiders
+  {
+    path: '/home/user/.config/Code - Insiders/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'VS Code Insiders',
+    label: 'VS Code Insiders chat session'
+  },
+  // VS Code Exploration
+  {
+    path: '/home/user/.config/Code - Exploration/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'VS Code Exploration',
+    label: 'VS Code Exploration chat session'
+  },
+  // VSCodium
+  {
+    path: '/home/user/.config/VSCodium/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'VSCodium',
+    label: 'VSCodium chat session'
+  },
+  // Cursor
+  {
+    path: '/home/user/.config/Cursor/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'Cursor',
+    label: 'Cursor chat session'
+  },
+  // Gemini CLI — must not be misclassified as Antigravity
+  {
+    path: '/home/user/.gemini/tmp/session-xyz/chats/session-001.jsonl',
+    expected: 'Gemini CLI',
+    label: 'Gemini CLI session'
+  },
+  // Antigravity — must not be misclassified as Gemini CLI
+  {
+    path: '/home/user/.gemini/antigravity/brain/project/.system_generated/logs/transcript.jsonl',
+    expected: 'Antigravity',
+    label: 'Antigravity session'
+  },
+  // Continue
+  {
+    path: '/home/user/.continue/sessions/abc.jsonl',
+    expected: 'Continue',
+    label: 'Continue session'
+  },
+  // Crush
+  {
+    path: '/home/user/.crush/crush.db#rowid',
+    expected: 'Crush',
+    label: 'Crush DB session'
+  },
+  // Mistral Vibe
+  {
+    path: '/home/user/.vibe/logs/session/session-abc.jsonl',
+    expected: 'Mistral Vibe',
+    label: 'Mistral Vibe session'
+  },
+  // Claude Desktop Cowork
+  {
+    path: '/home/user/Library/Application Support/Claude/local-agent-mode-sessions/abc.jsonl',
+    expected: 'Claude Desktop Cowork',
+    label: 'Claude Desktop Cowork session'
+  },
+  // Visual Studio
+  {
+    path: 'C:/Users/user/AppData/Local/Microsoft/VisualStudio/17/.vs/project/copilot-chat/abc.json',
+    expected: 'Visual Studio',
+    label: 'Visual Studio chat session'
+  },
+  // VS Code Server
+  {
+    path: '/home/user/.vscode-server/data/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'VS Code Server',
+    label: 'VS Code Server session'
+  },
+  // VS Code Server (Insiders)
+  {
+    path: '/home/user/.vscode-server-insiders/data/User/workspaceStorage/abc/chatSessions/session.json',
+    expected: 'VS Code Server (Insiders)',
+    label: 'VS Code Server (Insiders) session'
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Ordering invariant check
+// ---------------------------------------------------------------------------
+
+/**
+ * Detects pairs of rules where a broad pattern (broadPat) would match any path
+ * that also matches a more specific pattern (specificPat), and the broad rule
+ * appears first. This causes the specific rule to be unreachable.
+ *
+ * Checks: if every path that includes specificPat also includes broadPat, and
+ * the broad rule comes first, that's a shadow.
+ */
+function checkOrderingInvariants(rules) {
+  const issues = [];
+  for (let i = 0; i < rules.length; i++) {
+    for (let j = i + 1; j < rules.length; j++) {
+      const broad    = rules[i];
+      const specific = rules[j];
+      // A broad rule shadows a specific rule when:
+      //   - broad has exactly 1 pattern
+      //   - specific.patterns includes that broad pattern as a substring prefix
+      //   - the two return different names
+      if (broad.patterns.length !== 1) continue;
+      const broadPat = broad.patterns[0];
+      const isShadowing = specific.patterns.some(p => p.startsWith(broadPat) && p !== broadPat);
+      if (isShadowing && broad.name !== specific.name) {
+        issues.push({
+          broadPattern:    broadPat,
+          broadName:       broad.name,
+          specificPattern: specific.patterns.join(' && '),
+          specificName:    specific.name,
+          broadIndex:      i,
+          specificIndex:   j,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    console.log([
+      'Usage: node validate-editor-names.js [--json] [--help]',
+      '',
+      'Validates that the CLI and VS Code extension return matching friendly',
+      'editor names for the same path patterns, and that every name has an',
+      'icon in the EDITOR_ICON_MAP.',
+      '',
+      'Options:',
+      '  --json   Emit JSON only (no ANSI colour)',
+      '  --help   Show this message',
+      '',
+      'Exit codes:  0 = all checks pass',
+      '             1 = one or more checks failed',
+      '             2 = configuration / environment error',
+    ].join('\n'));
+    process.exit(0);
+  }
+
+  // -- Read source files -----------------------------------------------------
+
+  const cliSource        = readFile(CLI_ANALYSIS);
+  const wsHelpersSource  = readFile(WS_HELPERS);
+  const formatSource     = readFile(FORMAT_UTILS);
+
+  // -- Extract function bodies -----------------------------------------------
+
+  const cliFnBody = extractFunctionBody(cliSource, 'getEditorSourceFromPath');
+  if (!cliFnBody) {
+    process.stderr.write('ERROR: Could not find getEditorSourceFromPath in analysis.ts\n');
+    process.exit(2);
+  }
+
+  const detectToolFnBody = extractFunctionBody(wsHelpersSource, 'detectToolEditorFromPath');
+  const detectVSFnBody   = extractFunctionBody(wsHelpersSource, 'detectVSCodeVariantFromPath');
+  if (!detectToolFnBody || !detectVSFnBody) {
+    process.stderr.write('ERROR: Could not find detectToolEditorFromPath or detectVSCodeVariantFromPath in workspaceHelpers.ts\n');
+    process.exit(2);
+  }
+  const wsComboBody = detectToolFnBody + '\n' + detectVSFnBody;
+
+  // -- Extract rules ---------------------------------------------------------
+
+  const cliRules = extractIncludesRules(cliFnBody);
+  const wsRules  = extractIncludesRules(wsComboBody);
+
+  // -- Extract returned names ------------------------------------------------
+
+  const cliNames = extractReturnedNames(cliFnBody);
+  const wsNames  = extractReturnedNames(wsComboBody);
+
+  // -- Extract icon map keys -------------------------------------------------
+
+  const iconMapKeys = extractIconMapKeys(formatSource);
+
+  // -- CHECKS ----------------------------------------------------------------
+
+  const failures = [];
+  const warnings = [];
+
+  // 1. CLI names in EDITOR_ICON_MAP
+  const cliMissingIcons = [...cliNames].filter(n => !iconMapKeys.has(n));
+
+  // 2. VS Code names in EDITOR_ICON_MAP
+  const wsMissingIcons = [...wsNames].filter(n => !iconMapKeys.has(n));
+
+  // 3. Cross-function consistency for test cases
+  const testResults = TEST_CASES.map(tc => {
+    const cliDetected = detectEditor(cliRules, tc.path) ?? 'VS Code';
+    const wsDetected  = detectEditor(wsRules, tc.path)  ?? null;
+    // wsDetected === null means VS Code uses helper functions not visible to
+    // static includes-extraction (e.g. isCodeInsidersPath, isVisualStudioPath).
+    // Those paths are marked as "not cross-checkable" and never count as failures.
+    const cliMatch   = cliDetected === tc.expected;
+    const wsMatch    = wsDetected === null || wsDetected === tc.expected;
+    // A real cross-mismatch requires both sides to return a concrete different name.
+    const crossMatch = wsDetected === null || cliDetected === wsDetected;
+    return { ...tc, cliDetected, wsDetected: wsDetected ?? '(uses helpers)', cliMatch, wsMatch, crossMatch };
+  });
+  const testFailures = testResults.filter(r => !r.cliMatch || !r.crossMatch);
+
+  // 4. Ordering invariants in CLI function
+  const orderingIssues = checkOrderingInvariants(cliRules);
+
+  // -- Accumulate failures ---------------------------------------------------
+
+  if (cliMissingIcons.length > 0) {
+    failures.push({
+      check: 'cli-icon-coverage',
+      description: 'CLI returns names with no EDITOR_ICON_MAP entry',
+      items: cliMissingIcons,
+    });
+  }
+  if (wsMissingIcons.length > 0) {
+    failures.push({
+      check: 'vscode-icon-coverage',
+      description: 'VS Code extension returns names with no EDITOR_ICON_MAP entry',
+      items: wsMissingIcons,
+    });
+  }
+  if (testFailures.length > 0) {
+    failures.push({
+      check: 'cross-function-consistency',
+      description: 'CLI and VS Code return different names for the same path',
+      items: testFailures.map(r => ({
+        label:       r.label,
+        path:        r.path,
+        expected:    r.expected,
+        cli:         r.cliDetected,
+        vscode:      r.wsDetected,
+        cliOk:       r.cliMatch,
+        vscodeOk:    r.wsMatch,
+        crossMatch:  r.crossMatch,
+      })),
+    });
+  }
+  if (orderingIssues.length > 0) {
+    // Ordering issues are warnings, not hard failures — they may be intentional
+    warnings.push({
+      check: 'ordering-invariants',
+      description: 'Broad pattern appears before specific pattern (possible shadowing)',
+      items: orderingIssues,
+    });
+  }
+
+  // -- Output ----------------------------------------------------------------
+
+  const result = {
+    passed:   failures.length === 0,
+    summary: {
+      cliReturnedNames:   [...cliNames].sort(),
+      vsCodeReturnedNames: [...wsNames].sort(),
+      iconMapKeys:        [...iconMapKeys].sort(),
+      testCasesRun:       TEST_CASES.length,
+      testCasesFailed:    testFailures.length,
+    },
+    failures,
+    warnings,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printHumanReport(result);
+  }
+
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable output
+// ---------------------------------------------------------------------------
+
+const C = {
+  reset:  '\x1b[0m',
+  bold:   '\x1b[1m',
+  green:  '\x1b[32m',
+  red:    '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan:   '\x1b[36m',
+  gray:   '\x1b[90m',
+};
+
+function printHumanReport(result) {
+  const isTTY = process.stdout.isTTY;
+  const c = (code, text) => isTTY ? `${code}${text}${C.reset}` : text;
+
+  console.log();
+  console.log(c(C.bold, '=== validate-editor-names ==='));
+  console.log();
+
+  const { summary } = result;
+  console.log(`CLI returned names      : ${c(C.cyan, summary.cliReturnedNames.join(', '))}`);
+  console.log(`VS Code returned names  : ${c(C.cyan, summary.vsCodeReturnedNames.join(', '))}`);
+  console.log(`Icon map keys           : ${c(C.cyan, summary.iconMapKeys.join(', '))}`);
+  console.log(`Test cases run          : ${summary.testCasesRun}`);
+  console.log(`Test cases failed       : ${summary.testCasesFailed > 0 ? c(C.red, String(summary.testCasesFailed)) : c(C.green, '0')}`);
+  console.log();
+
+  if (result.failures.length === 0 && result.warnings.length === 0) {
+    console.log(c(C.green, '✔ All checks passed'));
+    console.log();
+    return;
+  }
+
+  for (const failure of result.failures) {
+    console.log(c(C.red, `✖ FAIL: ${failure.check}`));
+    console.log(`  ${failure.description}`);
+    for (const item of failure.items) {
+      if (typeof item === 'string') {
+        console.log(`  - ${c(C.red, item)}`);
+      } else if (item.label) {
+        // Test case failure
+        const cliStatus   = item.cliOk   ? c(C.green, '✔') : c(C.red, '✖');
+        const vsStatus    = item.vscodeOk ? c(C.green, '✔') : c(C.red, '✖');
+        const crossStatus = item.crossMatch ? c(C.green, 'match') : c(C.red, 'MISMATCH');
+        console.log(`  - ${c(C.bold, item.label)}`);
+        console.log(`    Path     : ${c(C.gray, item.path)}`);
+        console.log(`    Expected : ${c(C.cyan, item.expected)}`);
+        console.log(`    CLI      : ${cliStatus} ${item.cli}`);
+        console.log(`    VS Code  : ${vsStatus} ${item.vscode}`);
+        console.log(`    Cross    : ${crossStatus}`);
+      } else {
+        // Ordering issue
+        console.log(`  - Broad '${c(C.yellow, item.broadPattern)}' (→ '${item.broadName}') at rule #${item.broadIndex} shadows`);
+        console.log(`    specific '${c(C.yellow, item.specificPattern)}' (→ '${item.specificName}') at rule #${item.specificIndex}`);
+      }
+    }
+    console.log();
+  }
+
+  for (const warning of result.warnings) {
+    console.log(c(C.yellow, `⚠ WARN: ${warning.check}`));
+    console.log(`  ${warning.description}`);
+    for (const item of warning.items) {
+      if (item.broadPattern) {
+        console.log(`  - '${c(C.yellow, item.broadPattern)}' (→ '${item.broadName}') at rule #${item.broadIndex} may shadow`);
+        console.log(`    '${c(C.yellow, item.specificPattern)}' (→ '${item.specificName}') at rule #${item.specificIndex}`);
+      } else {
+        console.log(`  - ${JSON.stringify(item)}`);
+      }
+    }
+    console.log();
+  }
+
+  if (result.failures.length > 0) {
+    console.log(c(C.red, `✖ ${result.failures.length} check(s) failed`));
+  }
+  console.log();
+}
+
+main();

--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -61,23 +61,31 @@ export function effectiveTokens(data: SessionData): number {
 	return data.actualTokens > 0 ? data.actualTokens : data.tokens;
 }
 
-/** Determine editor source from file path */
+/** Determine editor source from file path, returning the same friendly display names used by the VS Code extension. */
 export function getEditorSourceFromPath(filePath: string): string {
 	const normalized = normalizePathForComparison(filePath);
-	if (normalized.includes('/cursor/')) { return 'cursor'; }
-	if (normalized.includes('/code - insiders/')) { return 'vscode-insiders'; }
-	if (normalized.includes('/code - exploration/')) { return 'vscode-exploration'; }
-	if (normalized.includes('/vscodium/')) { return 'vscodium'; }
-	if (normalized.includes('/.copilot/')) { return 'copilot-cli'; }
-	if (normalized.includes('/.crush/crush.db#')) { return 'crush'; }
-	if (normalized.includes('/opencode/')) { return 'opencode'; }
-	if (normalized.includes('/local-agent-mode-sessions/')) { return 'claude-desktop-cowork'; }
-	if (normalized.includes('/.claude/projects/')) { return 'claude-code'; }
-	if (normalized.includes('/.vibe/logs/session/')) { return 'mistral-vibe'; }
-	if (normalized.includes('/.gemini/tmp/') && normalized.includes('/chats/session-') && normalized.endsWith('.jsonl')) { return 'gemini-cli'; }
-	if (normalized.includes('.vscode-server')) { return 'vscode-remote'; }
+	// JetBrains must be checked before the broad /.copilot/ check (both use /.copilot/).
+	if (normalized.includes('/.copilot/jb/')) { return 'JetBrains'; }
+	// Copilot CLI: check specific sub-paths to avoid misclassifying JetBrains or other /.copilot/ entries.
+	if (normalized.includes('/.copilot/session-store.db#')) { return 'Copilot CLI'; }
+	if (normalized.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
+	if (normalized.includes('/.crush/crush.db#')) { return 'Crush'; }
+	if (normalized.includes('/opencode/')) { return 'OpenCode'; }
+	if (normalized.includes('/.continue/sessions/')) { return 'Continue'; }
+	if (normalized.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
+	if (normalized.includes('/.claude/projects/')) { return 'Claude Code'; }
+	if (normalized.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
+	// Antigravity must be checked before Gemini CLI: both live under ~/.gemini/.
+	if (normalized.includes('/.gemini/antigravity/brain/')) { return 'Antigravity'; }
+	if (normalized.includes('/.gemini/tmp/') && normalized.includes('/chats/session-') && normalized.endsWith('.jsonl')) { return 'Gemini CLI'; }
+	if (normalized.includes('/cursor/')) { return 'Cursor'; }
+	if (normalized.includes('/code - insiders/')) { return 'VS Code Insiders'; }
+	if (normalized.includes('/code - exploration/')) { return 'VS Code Exploration'; }
+	if (normalized.includes('/vscodium/')) { return 'VSCodium'; }
+	if (normalized.includes('.vscode-server-insiders/')) { return 'VS Code Server (Insiders)'; }
+	if (normalized.includes('.vscode-server')) { return 'VS Code Server'; }
 	if (normalized.includes('/.vs/') && normalized.includes('/copilot-chat/')) { return 'Visual Studio'; }
-	return 'vscode';
+	return 'VS Code';
 }
 
 /**

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -39,6 +39,9 @@ export type EditorName =
 	| 'Mistral Vibe'
 	| 'Gemini CLI'
 	| 'Antigravity'
+	| 'JetBrains'
+	| 'Crush'
+	| 'Continue'
 	| 'Unknown';
 
 /**
@@ -63,6 +66,9 @@ export const EDITOR_ICON_MAP: Record<EditorName, string> = {
 	'Mistral Vibe': '🔥',
 	'Gemini CLI': '💎',
 	'Antigravity': '🚀',
+	'JetBrains': '🧩',
+	'Crush': '🦾',
+	'Continue': '▶️',
 	'Unknown': '❓'
 };
 


### PR DESCRIPTION
## Problem

The JetBrains plugin (and any other consumer of the CLI) was showing raw lowercase editor keys in the "Usage by Editor" table instead of friendly display names. For example:

| Before (JetBrains) | After |
|---|---|
| `claude-code` | Claude Code 🟠 |
| `vscode` | VS Code 💙 |
| `copilot-cli` | Copilot CLI 🤖 |
| `mistral-vibe` | Mistral Vibe 🔥 |
| `gemini-cli` | Gemini CLI 💎 |
| `vscode-insiders` | VS Code Insiders 💚 |
| `opencode` | OpenCode 🟢 |
| `crush` | Crush 🦾 |

## Root cause

The CLI's `getEditorSourceFromPath` in `cli/src/analysis.ts` was returning raw lowercase identifiers. The VS Code extension uses `getEditorTypeFromPath` from `workspaceHelpers.ts` which returns friendly display names. The JetBrains plugin uses the CLI for all its data, so it inherited the raw names.

There was also a bug: `/.copilot/` was checked too broadly — it would misclassify JetBrains sessions (`/.copilot/jb/`) as `copilot-cli`. The fix checks JetBrains' specific path first.

## Changes

**`cli/src/analysis.ts`**
- Updated `getEditorSourceFromPath` to return the same friendly display names as `workspaceHelpers.ts::getEditorTypeFromPath`
- Fixed check ordering: JetBrains (`/.copilot/jb/`) now checked before Copilot CLI; Antigravity before Gemini CLI
- Added missing entries: Continue, VS Code Server (Insiders), VS Code Server

**`vscode-extension/src/webview/shared/formatUtils.ts`**
- Added `JetBrains` (🧩), `Crush` (🦾), and `Continue` (▶️) to `EditorName` type and `EDITOR_ICON_MAP` — these now show proper icons instead of the 📝 fallback

## Testing

All 63 VS Code extension unit tests pass. CLI builds successfully.