### PR TITLE
JetBrains: add Retry and Wait longer buttons on CLI timeout

### DIFF
--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -29,7 +29,15 @@ import java.util.concurrent.TimeUnit
 object CliBridge {
 
     private val log = Logger.getInstance(CliBridge::class.java)
-    private const val CLI_TIMEOUT_SECONDS = 120L
+    private const val DEFAULT_TIMEOUT_SECONDS = 120L
+
+    /** Timeout used for CLI invocations; can be overridden (e.g. for "wait longer" retry). */
+    @Volatile var timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS
+
+    /** Resets [timeoutSeconds] back to the default (120 s). */
+    fun resetTimeout() {
+        timeoutSeconds = DEFAULT_TIMEOUT_SECONDS
+    }
 
     @Volatile private var cachedExePath: Path? = null
 
@@ -114,11 +122,11 @@ object CliBridge {
             process.errorStream.bufferedReader().use { stderrBuilder.append(it.readText()) }
         }, "cli-stderr-reader").apply { isDaemon = true; start() }
 
-        val finished = process.waitFor(CLI_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
         val elapsedMs = System.currentTimeMillis() - startMs
         if (!finished) {
             process.destroyForcibly()
-            throw IOException("CLI timed out after ${CLI_TIMEOUT_SECONDS}s")
+            throw IOException("CLI timed out after ${timeoutSeconds}s")
         }
 
         // Wait for reader threads to finish (they should complete almost

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/TokenTrackerPanel.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/TokenTrackerPanel.kt
@@ -62,11 +62,16 @@ class TokenTrackerPanel(
      * Prefetches all CLI data (all --json + fluency --json in parallel) on a
      * background thread, then reloads [view] with the data pre-embedded.
      * Subsequent navigations use the warm cache — no spinner needed.
+     *
+     * [onComplete] is invoked on the EDT after the fetch finishes (success or
+     * failure), before the result is applied. Use it for cleanup such as
+     * resetting a timeout override.
      */
-    private fun prefetchAndLoadView(view: String) {
+    private fun prefetchAndLoadView(view: String, onComplete: (() -> Unit)? = null) {
         ApplicationManager.getApplication().executeOnPooledThread {
             val result = runCatching { CliBridge.prefetchAll() }
             ApplicationManager.getApplication().invokeLater {
+                onComplete?.invoke()
                 result.fold(
                     onSuccess = {
                         // Cache is now warm — load the current view with data embedded
@@ -187,13 +192,35 @@ class TokenTrackerPanel(
     }
 
     private fun showError(message: String) {
+        val isTimeout = message.contains("timed out", ignoreCase = true)
         val safe = message
             .replace("\\", "\\\\")
             .replace("'", "\\'")
             .replace("\n", "\\n")
             .replace("\r", "\\r")
+
+        // When the error is a timeout, define a JS helper for the retry buttons and
+        // render the buttons themselves inline in the overlay.
+        val retrySetup = if (isTimeout) """
+            window.__retryLoad = function(ext) {
+                window.chrome.webview.postMessage(JSON.stringify(
+                    ext ? {command:'retryWithExtendedTimeout'} : {command:'retry'}
+                ));
+            };
+        """.trimIndent() else ""
+
+        // Produces a JS string fragment ending with ' +' so it can be concatenated
+        // into the innerHTML assignment below; empty when not a timeout.
+        val retryBlock = if (isTimeout) """
+            '<div style="margin-top:12px;display:flex;gap:8px;justify-content:center">' +
+            '<button onclick="__retryLoad(false)" style="padding:6px 14px;background:#0e639c;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:12px">Retry</button>' +
+            '<button onclick="__retryLoad(true)" style="padding:6px 14px;background:#3a3d41;color:#ccc;border:1px solid #555;border-radius:4px;cursor:pointer;font-size:12px">Wait longer (5 min)</button>' +
+            '</div>' +
+        """.trimIndent() else ""
+
         val js = """
             (function() {
+                $retrySetup
                 var overlay = document.getElementById('loading-overlay');
                 if (overlay) {
                     overlay.innerHTML =
@@ -202,6 +229,7 @@ class TokenTrackerPanel(
                         '<div style="font-size:12px;color:#999;max-width:480px;white-space:pre-wrap;word-break:break-word">' +
                             '$safe' +
                         '</div>' +
+                        $retryBlock
                         '<div style="margin-top:16px;font-size:12px">' +
                             'Something unexpected? <a href="https://github.com/rajbos/ai-engineering-fluency/issues" target="_blank" style="color:#4daafc;text-decoration:none">Report an issue</a>' +
                         '</div>';
@@ -225,6 +253,21 @@ class TokenTrackerPanel(
 
             when (command) {
                 "refresh" -> refreshStatsAsync()
+
+                "retry" -> {
+                    // Reload the spinner page and re-run the prefetch with the default timeout.
+                    CliBridge.invalidateCache()
+                    browser.loadHTML(WebviewResources.buildHtml(currentView, hostBridgeInjectFunction = hostBridge.inject("payload")))
+                    prefetchAndLoadView(currentView)
+                }
+
+                "retryWithExtendedTimeout" -> {
+                    // Use a 5-minute timeout for the next fetch, then reset to default.
+                    CliBridge.timeoutSeconds = 300L
+                    CliBridge.invalidateCache()
+                    browser.loadHTML(WebviewResources.buildHtml(currentView, hostBridgeInjectFunction = hostBridge.inject("payload")))
+                    prefetchAndLoadView(currentView, onComplete = { CliBridge.resetTimeout() })
+                }
 
                 "showDetails" -> navigateToView("details")
                 "showChart" -> navigateToView("chart")


### PR DESCRIPTION
## Summary

When the CLI call times out (currently after 120 s), the error overlay previously showed only a static "Report an issue" link. This PR adds two action buttons so the user can act without restarting the IDE.

## Changes

**`CliBridge.kt`**
- Added `timeoutSeconds` `@Volatile var` (default 120 s) so the timeout is now configurable at runtime.
- Added `resetTimeout()` helper to restore the default after an extended-timeout retry.
- `fetchRaw` now uses `timeoutSeconds` instead of the old `CLI_TIMEOUT_SECONDS` constant.

**`TokenTrackerPanel.kt`**
- `showError` detects timeout messages and injects two buttons into the overlay:
  - **Retry** — reloads the spinner and re-runs the prefetch with the default timeout.
  - **Wait longer (5 min)** — sets the timeout to 300 s, retries, then resets the timeout back to default.
- `prefetchAndLoadView` gains an optional `onComplete` callback (called on the EDT after the fetch, regardless of success/failure) — used to reset the timeout override after "Wait longer" completes.
- Two new `handleWebviewMessage` cases: `retry` and `retryWithExtendedTimeout`.

## UX behaviour

| Action | What happens |
|---|---|
| Click **Retry** | Spinner reappears; prefetch runs with the default 120 s limit |
| Click **Wait longer (5 min)** | Spinner reappears; prefetch runs with 300 s limit; timeout resets to 120 s afterward |
| Success | Spinner hides, data loads normally |
| Another timeout | Error overlay reappears with the same two buttons |