### PR TITLE
feat: personalized insights & nudges system for AI usage patterns

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -372,6 +372,23 @@
           "default": [],
           "description": "List of tool names to suppress from the 'Unknown Tools Found' section in the Usage Analysis dashboard. Useful for tools you are testing that don't yet have friendly display names."
         },
+        "aiEngineeringFluency.insights.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable personalized AI usage insights and nudges in the Usage Analysis dashboard and status bar."
+        },
+        "aiEngineeringFluency.insights.toastsEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show occasional toast notifications for high-value insights (e.g. missing copilot-instructions.md, new fluency stage). Respects the cadenceDays limit."
+        },
+        "aiEngineeringFluency.insights.cadenceDays": {
+          "type": "number",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 30,
+          "description": "Minimum number of days between insight toast notifications."
+        },
         "copilotTokenTracker.windsurf.enabled": {
           "type": "boolean",
           "default": true,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2253,6 +2253,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			last30Days: stats.last30Days,
 			missedPotential: stats.missedPotential ?? [],
 			customizationMatrix: stats.customizationMatrix,
+			todaySessions: stats.todaySessions,
 		};
 		return _evaluateInsights(ctx, this._insightStateBag, cadenceDays, this._lastInsightNudgeAt);
 	}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1241,10 +1241,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		if (count > 0) {
 			const label = count === 1 ? '1 insight' : `${count} insights`;
-			this.insightsStatusBarItem.text = `💡 AI Fluency Insights: ${label}`;
+			this.insightsStatusBarItem.text = `💡 ${label}`;
 			const tooltip = new vscode.MarkdownString();
 			tooltip.isTrusted = false;
-			tooltip.appendMarkdown(`**💡 ${label} waiting for you**\n\n`);
+			tooltip.appendMarkdown(`**AI Fluency Insights** — ${label} waiting for you\n\n`);
 			if (this._topInsightTitle) {
 				tooltip.appendMarkdown(`${this._topInsightTitle}\n\n`);
 			}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -377,6 +377,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private _newInsightCount = 0;
 	/** The last non-badge status bar text (so badge can be appended/removed). */
 	private _statusBarBaseText = '';
+	/** Cached top new insight title for tooltip display. */
+	private _topInsightTitle: string | null = null;
+	/** Cached last detailed stats for tooltip rebuilding. */
+	private _lastDetailedStats: DetailedStats | undefined;
 	private tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsData.estimators;
 	private co2Per1kTokens = 0.2; // gCO2e per 1000 tokens, a rough estimate
 	private co2AbsorptionPerTreePerYear = 21000; // grams of CO2 per tree per year
@@ -1221,9 +1225,31 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.statusBarItem.text = this._devBranch ? `${text}${badge} [${this._devBranch}]` : `${text}${badge}`;
 	}
 
-	private refreshStatusBarInsightBadge(count: number): void {
+	private refreshStatusBarInsightBadge(count: number, topInsightTitle?: string): void {
 		this._newInsightCount = count;
+		this._topInsightTitle = topInsightTitle ?? this._topInsightTitle;
 		this.setStatusBarText(this._statusBarBaseText);
+
+		if (count > 0) {
+			// Point the status bar click directly at the Insights tab
+			this.statusBarItem.command = 'aiEngineeringFluency.openInsightsTab';
+			// Rebuild tooltip with insight hint appended
+			if (this._lastDetailedStats) {
+				const tooltip = this.buildTooltipMarkdown(this._lastDetailedStats);
+				tooltip.appendMarkdown('\n---\n');
+				tooltip.appendMarkdown(`💡 **${count} new insight${count > 1 ? 's' : ''}** — click to open the Insights tab\n\n`);
+				if (this._topInsightTitle) {
+					tooltip.appendMarkdown(`> ${this._topInsightTitle}`);
+				}
+				this.statusBarItem.tooltip = tooltip;
+			}
+		} else {
+			this.statusBarItem.command = 'aiEngineeringFluency.showDetails';
+			// Restore plain tooltip
+			if (this._lastDetailedStats) {
+				this.statusBarItem.tooltip = this.buildTooltipMarkdown(this._lastDetailedStats);
+			}
+		}
 	}
 
 	private sendLoadingPanelMessage(msg: object): void {
@@ -1916,6 +1942,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private updateStatusBarAndTooltip(detailedStats: DetailedStats): void {
+		this._lastDetailedStats = detailedStats;
 		if (detailedStats.today.sessions === 0 && detailedStats.last30Days.sessions === 0) {
 			this.setStatusBarText('$(symbol-numeric) No session data yet');
 		} else {
@@ -2202,7 +2229,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		_mergeInsightStates(evaluated, this._insightStateBag, now);
 
 		const newCount = _countNewInsights(this._insightStateBag, now);
-		this.refreshStatusBarInsightBadge(newCount);
+		const topNew = evaluated.find(i => i.status === 'new');
+		this.refreshStatusBarInsightBadge(newCount, topNew?.title);
 
 		await this.context.globalState.update('insights.state', this._insightStateBag);
 
@@ -2225,7 +2253,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this._lastInsightNudgeAt = now;
 		await this.context.globalState.update('insights.lastNudgeAt', now);
 
-		const view = 'View Insights';
+		const view = 'Open Insights tab';
 		const dismiss = 'Dismiss';
 		const choice = await vscode.window.showInformationMessage(
 			`💡 ${toastCandidate.title}`,
@@ -2233,7 +2261,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			dismiss,
 		);
 		if (choice === view) {
-			await this.showUsageAnalysis();
+			await this.showUsageAnalysisOnInsightsTab();
 		} else if (choice === dismiss) {
 			this._insightStateBag[toastCandidate.id] = {
 				...(this._insightStateBag[toastCandidate.id] ?? { firstSurfacedAt: now }),
@@ -4988,6 +5016,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.analysisPanel.webview.html = this.getUsageAnalysisHtml(this.analysisPanel.webview, this.lastUsageAnalysisStats ?? null);
 		if (!this.lastUsageAnalysisStats) { void this.loadAnalysisStatsInBackground(this.analysisPanel); }
 		this.analysisPanel.onDidDispose(() => { this.log('📊 Usage Analysis dashboard closed'); this.analysisPanel = undefined; });
+	}
+
+	/** Opens the Usage Analysis panel and immediately activates the Insights tab. */
+	public async showUsageAnalysisOnInsightsTab(): Promise<void> {
+		await this.showUsageAnalysis();
+		void this.analysisPanel?.webview.postMessage({ command: 'switchTab', tab: 'insights' });
 	}
 
 	private async handleAnalysisMessage(message: any): Promise<void> {
@@ -8104,6 +8138,14 @@ function registerViewCommands(context: vscode.ExtensionContext, tokenTracker: Co
     },
   );
 
+  const openInsightsTabCommand = vscode.commands.registerCommand(
+    "aiEngineeringFluency.openInsightsTab",
+    async () => {
+      tokenTracker.log("Open Insights tab command called");
+      await tokenTracker.showUsageAnalysisOnInsightsTab();
+    },
+  );
+
   const showMaturityCommand = vscode.commands.registerCommand(
     "aiEngineeringFluency.showMaturity",
     async () => {
@@ -8133,6 +8175,7 @@ function registerViewCommands(context: vscode.ExtensionContext, tokenTracker: Co
     showDetailsCommand,
     showChartCommand,
     showUsageAnalysisCommand,
+    openInsightsTabCommand,
     showMaturityCommand,
     showDashboardCommand,
     showEnvironmentalCommand,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1241,7 +1241,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		if (count > 0) {
 			const label = count === 1 ? '1 insight' : `${count} insights`;
-			this.insightsStatusBarItem.text = `💡 ${label}`;
+			this.insightsStatusBarItem.text = `💡 AI Fluency Insights: ${label}`;
 			const tooltip = new vscode.MarkdownString();
 			tooltip.isTrusted = false;
 			tooltip.appendMarkdown(`**💡 ${label} waiting for you**\n\n`);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -310,6 +310,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 	public sessionDiscovery!: SessionDiscovery;
 	private statusBarItem!: vscode.StatusBarItem;
+	/** Dedicated status bar item for insights — shown only when new insights exist. */
+	private insightsStatusBarItem!: vscode.StatusBarItem;
 	private readonly extensionUri: vscode.Uri;
 	private readonly context: vscode.ExtensionContext;
 	private _devBranch: string | undefined;
@@ -1026,6 +1028,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.statusBarItem.tooltip = "AI Engineering Fluency — daily and 30-day token usage - Click to open details";
 		this.statusBarItem.command = 'aiEngineeringFluency.showDetails';
 		this.statusBarItem.show();
+
+		// Separate insights badge — hidden until there are new insights
+		this.insightsStatusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency-insights', vscode.StatusBarAlignment.Right, 99);
+		this.insightsStatusBarItem.name = "AI Engineering Fluency — Insights";
+		this.insightsStatusBarItem.command = 'aiEngineeringFluency.openInsightsTab';
+		// starts hidden; shown in refreshStatusBarInsightBadge when count > 0
+
 		this.log('Status bar item created and shown');
 	}
 
@@ -1221,34 +1230,29 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private setStatusBarText(text: string): void {
 		this._statusBarBaseText = text;
-		const badge = this._newInsightCount > 0 ? ' 💡' : '';
-		this.statusBarItem.text = this._devBranch ? `${text}${badge} [${this._devBranch}]` : `${text}${badge}`;
+		this.statusBarItem.text = this._devBranch ? `${text} [${this._devBranch}]` : text;
 	}
 
 	private refreshStatusBarInsightBadge(count: number, topInsightTitle?: string): void {
 		this._newInsightCount = count;
 		this._topInsightTitle = topInsightTitle ?? this._topInsightTitle;
+		// Main status bar: remove the 💡 badge — it now lives in its own item
 		this.setStatusBarText(this._statusBarBaseText);
 
 		if (count > 0) {
-			// Point the status bar click directly at the Insights tab
-			this.statusBarItem.command = 'aiEngineeringFluency.openInsightsTab';
-			// Rebuild tooltip with insight hint appended
-			if (this._lastDetailedStats) {
-				const tooltip = this.buildTooltipMarkdown(this._lastDetailedStats);
-				tooltip.appendMarkdown('\n---\n');
-				tooltip.appendMarkdown(`💡 **${count} new insight${count > 1 ? 's' : ''}** — click to open the Insights tab\n\n`);
-				if (this._topInsightTitle) {
-					tooltip.appendMarkdown(`> ${this._topInsightTitle}`);
-				}
-				this.statusBarItem.tooltip = tooltip;
+			const label = count === 1 ? '1 insight' : `${count} insights`;
+			this.insightsStatusBarItem.text = `💡 ${label}`;
+			const tooltip = new vscode.MarkdownString();
+			tooltip.isTrusted = false;
+			tooltip.appendMarkdown(`**💡 ${label} waiting for you**\n\n`);
+			if (this._topInsightTitle) {
+				tooltip.appendMarkdown(`${this._topInsightTitle}\n\n`);
 			}
+			tooltip.appendMarkdown('Click to open the Insights tab');
+			this.insightsStatusBarItem.tooltip = tooltip;
+			this.insightsStatusBarItem.show();
 		} else {
-			this.statusBarItem.command = 'aiEngineeringFluency.showDetails';
-			// Restore plain tooltip
-			if (this._lastDetailedStats) {
-				this.statusBarItem.tooltip = this.buildTooltipMarkdown(this._lastDetailedStats);
-			}
+			this.insightsStatusBarItem.hide();
 		}
 	}
 
@@ -7885,6 +7889,7 @@ ${this.getLoadingHtmlScript()}
     }
     this.openCode.dispose();
     this.statusBarItem.dispose();
+    this.insightsStatusBarItem.dispose();
     this._disposed = true;
     this.outputChannel.dispose();
   }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -54,7 +54,17 @@ import type {
   AgentSessionsResult,
   TokenEstimator,
   SessionRelationRef,
+  EvaluatedInsight,
+  InsightStateBag,
 } from './types';
+
+// --- Insights engine ---
+import {
+  evaluateInsights as _evaluateInsights,
+  mergeInsightStates as _mergeInsightStates,
+  countNewInsights as _countNewInsights,
+  isToastAllowed as _isToastAllowed,
+} from './insightsEngine';
 
 // --- Ecosystem adapter types & helpers ---
 import type { OpenCodeDataAccess } from './opencode';
@@ -359,6 +369,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private lastChartSplit: string = 'total';
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private lastDashboardData: any | undefined;
+	/** Insight engine: persisted state for all surfaced insights. */
+	private _insightStateBag: InsightStateBag = {};
+	/** ISO timestamp of the last time an insight toast was shown. */
+	private _lastInsightNudgeAt: string | null = null;
+	/** Count of insights currently in 'new' status (drives the status-bar badge). */
+	private _newInsightCount = 0;
+	/** The last non-badge status bar text (so badge can be appended/removed). */
+	private _statusBarBaseText = '';
 	private tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsData.estimators;
 	private co2Per1kTokens = 0.2; // gCO2e per 1000 tokens, a rough estimate
 	private co2AbsorptionPerTreePerYear = 21000; // grams of CO2 per tree per year
@@ -910,6 +928,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.sessionDiscovery.checkCopilotExtension();
 		this.initializeStatusBar();
 		this.setupConfigurationListener(context);
+		this.loadInsightState();
 		this.scheduleInitialUpdate();
 		this.updateInterval = setInterval(() => {
 			this.updateTokenStats(true, true);
@@ -942,6 +961,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 			windsurf: this.windsurf,
 			sampleDataDirectoryOverride: () => this.localRegressionSampleDataDir,
 		});
+	}
+
+	private loadInsightState(): void {
+		this._insightStateBag = this.context.globalState.get<InsightStateBag>('insights.state', {});
+		this._lastInsightNudgeAt = this.context.globalState.get<string>('insights.lastNudgeAt', '') || null;
 	}
 
 	private initializeOutputChannel(context: vscode.ExtensionContext): void {
@@ -1192,7 +1216,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private setStatusBarText(text: string): void {
-		this.statusBarItem.text = this._devBranch ? `${text} [${this._devBranch}]` : text;
+		this._statusBarBaseText = text;
+		const badge = this._newInsightCount > 0 ? ' 💡' : '';
+		this.statusBarItem.text = this._devBranch ? `${text}${badge} [${this._devBranch}]` : `${text}${badge}`;
+	}
+
+	private refreshStatusBarInsightBadge(count: number): void {
+		this._newInsightCount = count;
+		this.setStatusBarText(this._statusBarBaseText);
 	}
 
 	private sendLoadingPanelMessage(msg: object): void {
@@ -1749,6 +1780,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		await this.updateAnalysisPanelIfOpen(silent, preloaded);
 		await this.computeAndUploadFluencyScore(silent, preloaded);
 		this.updateEnvironmentalPanelIfOpen(detailedStats, silent);
+		await this.evaluateAndSurfaceInsights();
 
 		this.log(`Updated stats - Today: ${detailedStats.today.tokens}, Last 30 Days: ${detailedStats.last30Days.tokens}`);
 		this.lastDetailedStats = detailedStats;
@@ -2100,6 +2132,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					missedPotential: analysisStats.missedPotential || [],
 					lastUpdated: analysisStats.lastUpdated.toISOString(), backendConfigured: this.isBackendConfigured(),
 					currentWorkspacePaths: vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [],
+					insights: this.buildCurrentInsights(analysisStats),
 				},
 			});
 		} else {
@@ -2148,8 +2181,83 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 	}
 
-	private async calculateTokenUsage(): Promise<Pick<TokenUsageStats, 'todayTokens' | 'monthTokens'>> {
-		const now = new Date();
+	private async evaluateAndSurfaceInsights(): Promise<void> {
+		const stats = this.lastUsageAnalysisStats;
+		if (!stats) { return; }
+
+		const insightsEnabled = vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('insights.enabled', true);
+		if (!insightsEnabled) { return; }
+
+		const cadenceDays = vscode.workspace.getConfiguration('aiEngineeringFluency').get<number>('insights.cadenceDays', 2);
+		const now = new Date().toISOString();
+
+		const ctx = {
+			today: stats.today,
+			last30Days: stats.last30Days,
+			missedPotential: stats.missedPotential ?? [],
+			customizationMatrix: stats.customizationMatrix,
+		};
+
+		const evaluated = _evaluateInsights(ctx, this._insightStateBag, cadenceDays, this._lastInsightNudgeAt);
+		_mergeInsightStates(evaluated, this._insightStateBag, now);
+
+		const newCount = _countNewInsights(this._insightStateBag, now);
+		this.refreshStatusBarInsightBadge(newCount);
+
+		await this.context.globalState.update('insights.state', this._insightStateBag);
+
+		// Push updated insights to the analysis panel if it is open
+		if (this.analysisPanel) {
+			void this.analysisPanel.webview.postMessage({
+				command: 'updateInsights',
+				insights: evaluated,
+			});
+		}
+
+		// Surface a toast for the highest-weight 'new' allowToast insight (rate-limited)
+		const toastsEnabled = vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('insights.toastsEnabled', true);
+		if (!toastsEnabled) { return; }
+		if (!_isToastAllowed(cadenceDays, this._lastInsightNudgeAt, now)) { return; }
+
+		const toastCandidate = evaluated.find(i => i.allowToast && i.status === 'new');
+		if (!toastCandidate) { return; }
+
+		this._lastInsightNudgeAt = now;
+		await this.context.globalState.update('insights.lastNudgeAt', now);
+
+		const view = 'View Insights';
+		const dismiss = 'Dismiss';
+		const choice = await vscode.window.showInformationMessage(
+			`💡 ${toastCandidate.title}`,
+			view,
+			dismiss,
+		);
+		if (choice === view) {
+			await this.showUsageAnalysis();
+		} else if (choice === dismiss) {
+			this._insightStateBag[toastCandidate.id] = {
+				...(this._insightStateBag[toastCandidate.id] ?? { firstSurfacedAt: now }),
+				status: 'dismissed',
+				lastSurfacedAt: now,
+			};
+			await this.context.globalState.update('insights.state', this._insightStateBag);
+			this.refreshStatusBarInsightBadge(_countNewInsights(this._insightStateBag, now));
+		}
+	}
+
+	/** Builds the current evaluated insight list from cached state + latest stats. */
+	private buildCurrentInsights(stats: UsageAnalysisStats): EvaluatedInsight[] {
+		const cadenceDays = vscode.workspace.getConfiguration('aiEngineeringFluency').get<number>('insights.cadenceDays', 2);
+		const ctx = {
+			today: stats.today,
+			last30Days: stats.last30Days,
+			missedPotential: stats.missedPotential ?? [],
+			customizationMatrix: stats.customizationMatrix,
+		};
+		return _evaluateInsights(ctx, this._insightStateBag, cadenceDays, this._lastInsightNudgeAt);
+	}
+
+	private async calculateTokenUsage(): Promise<Pick<TokenUsageStats, 'todayTokens' | 'monthTokens'>> {		const now = new Date();
 		const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 		const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
@@ -4925,6 +5033,52 @@ class CopilotTokenTracker implements vscode.Disposable {
 					});
 				}
 				break;
+			case 'insightAction':
+					await this.dispatch('insightAction', () => this.handleInsightAction(message));
+					break;
+		}
+	}
+
+	private async handleInsightAction(message: any): Promise<void> {
+		const id = typeof message.id === 'string' ? message.id : '';
+		const action = typeof message.action === 'string' ? message.action : '';
+		if (!id || !action) { return; }
+		const now = new Date().toISOString();
+		const existing = this._insightStateBag[id] ?? { status: 'new', firstSurfacedAt: now, lastSurfacedAt: now };
+		switch (action) {
+			case 'seen':
+				if (existing.status === 'new') {
+					this._insightStateBag[id] = { ...existing, status: 'seen', lastSurfacedAt: now };
+					this.refreshStatusBarInsightBadge(_countNewInsights(this._insightStateBag, now));
+				}
+				break;
+			case 'dismiss':
+				this._insightStateBag[id] = { ...existing, status: 'dismissed', lastSurfacedAt: now };
+				this.refreshStatusBarInsightBadge(_countNewInsights(this._insightStateBag, now));
+				break;
+			case 'snooze': {
+				const snoozeUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+				this._insightStateBag[id] = { ...existing, status: 'snoozed', lastSurfacedAt: now, snoozeUntil };
+				this.refreshStatusBarInsightBadge(_countNewInsights(this._insightStateBag, now));
+				break;
+			}
+			case 'done':
+				this._insightStateBag[id] = { ...existing, status: 'done', lastSurfacedAt: now };
+				this.refreshStatusBarInsightBadge(_countNewInsights(this._insightStateBag, now));
+				break;
+		}
+		await this.context.globalState.update('insights.state', this._insightStateBag);
+		// Push refreshed state back to the webview
+		if (this.analysisPanel && this.lastUsageAnalysisStats) {
+			const cadenceDays = vscode.workspace.getConfiguration('aiEngineeringFluency').get<number>('insights.cadenceDays', 2);
+			const ctx = {
+				today: this.lastUsageAnalysisStats.today,
+				last30Days: this.lastUsageAnalysisStats.last30Days,
+				missedPotential: this.lastUsageAnalysisStats.missedPotential ?? [],
+				customizationMatrix: this.lastUsageAnalysisStats.customizationMatrix,
+			};
+			const evaluated = _evaluateInsights(ctx, this._insightStateBag, cadenceDays, this._lastInsightNudgeAt);
+			void this.analysisPanel.webview.postMessage({ command: 'updateInsights', insights: evaluated });
 		}
 	}
 
@@ -4940,6 +5094,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					missedPotential: analysisStats.missedPotential || [], lastUpdated: analysisStats.lastUpdated.toISOString(),
 					backendConfigured: this.isBackendConfigured(),
 					currentWorkspacePaths: vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [],
+					insights: this.buildCurrentInsights(analysisStats),
 				},
 			});
 		} catch (err) {
@@ -7631,6 +7786,7 @@ ${this.getLoadingHtmlScript()}
       suppressedUnknownTools,
       todaySessions: stats.todaySessions || [],
       use24HourTime: this.getUse24HourTimeSetting(),
+      insights: this.buildCurrentInsights(stats),
     }).replace(/</g, "\\u003c") : 'null';
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1022,7 +1022,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private initializeStatusBar(): void {
-		this.statusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency', vscode.StatusBarAlignment.Right, 100);
+		this.statusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency', vscode.StatusBarAlignment.Right, 102);
 		this.statusBarItem.name = "AI Engineering Fluency";
 		this.setStatusBarText("$(loading~spin) AI Fluency: Loading...");
 		this.statusBarItem.tooltip = "AI Engineering Fluency — daily and 30-day token usage - Click to open details";
@@ -1030,7 +1030,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.statusBarItem.show();
 
 		// Separate insights badge — hidden until there are new insights
-		this.insightsStatusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency-insights', vscode.StatusBarAlignment.Right, 99);
+		this.insightsStatusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency-insights', vscode.StatusBarAlignment.Right, 101);
 		this.insightsStatusBarItem.name = "AI Engineering Fluency — Insights";
 		this.insightsStatusBarItem.command = 'aiEngineeringFluency.openInsightsTab';
 		// starts hidden; shown in refreshStatusBarInsightBadge when count > 0

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -10,10 +10,35 @@ import type {
 	WorkspaceCustomizationMatrix,
 	TodaySessionSummary,
 } from './types';
+import toolNamesData from './toolNames.json';
+import { resolveGuidMcpToolName } from './utils/toolUtils';
 
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
+
+const TOOL_NAME_MAP: Record<string, string> = toolNamesData as Record<string, string>;
+
+/**
+ * Returns a human-friendly display name for an MCP tool ID.
+ * 1. Exact match in toolNames.json
+ * 2. GUID-keyed MCP pattern (e.g. M365 Connector)
+ * 3. Parse mcp__<server>__<tool> → "Server: Tool Name"
+ * 4. Fall back to the raw ID
+ */
+function friendlyToolName(id: string): string {
+	if (TOOL_NAME_MAP[id]) { return TOOL_NAME_MAP[id]; }
+	const guid = resolveGuidMcpToolName(id);
+	if (guid) { return guid; }
+	// Parse mcp__ServerName__tool_name → "Server Name: Tool Name"
+	const mcpMatch = /^mcp__([^_][^_]*)__(.+)$/.exec(id);
+	if (mcpMatch) {
+		const server = mcpMatch[1].replace(/_/g, ' ').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+		const tool = mcpMatch[2].replace(/_/g, ' ').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+		return `${server}: ${tool}`;
+	}
+	return id;
+}
 
 /** Sums all meaningful context reference counts for a period. */
 function totalContextRefs(p: UsageAnalysisPeriod): number {
@@ -336,7 +361,7 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 				}
 			}
 			if (topTool) {
-				return `You're actively using MCP tools in your Copilot sessions — great! Your most-used tool: ${topTool} (${topCount} calls).`;
+				return `You're actively using MCP tools in your Copilot sessions — great! Your most-used tool: ${friendlyToolName(topTool)} (${topCount} calls).`;
 			}
 			return `You're using ${total} MCP tool calls — great adoption of extended Copilot capabilities!`;
 		},

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -14,7 +14,7 @@ import type {
 // Public types
 // ---------------------------------------------------------------------------
 
-export type InsightCategory = 'context' | 'agentic' | 'customization' | 'consistency' | 'tools';
+export type InsightCategory = 'context' | 'agentic' | 'customization' | 'consistency' | 'tools' | 'trend';
 export type InsightSeverity = 'tip' | 'opportunity' | 'celebration';
 export type InsightStatus = 'new' | 'seen' | 'dismissed' | 'snoozed' | 'done';
 
@@ -165,6 +165,101 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 			return singleTurnSessions / total > 0.80;
 		},
 		weight: 50,
+	},
+
+	// ── Trend ────────────────────────────────────────────────────────────────
+	{
+		id: 'sessions-trending-up',
+		category: 'trend',
+		severity: 'celebration',
+		title: '🚀 Your Copilot usage is on the rise!',
+		buildBody: (ctx) => {
+			const dailyAvg = ctx.last30Days.sessions / 30;
+			const pct = Math.round((ctx.today.sessions / dailyAvg - 1) * 100);
+			return `You've had ${ctx.today.sessions} session${ctx.today.sessions !== 1 ? 's' : ''} today — ` +
+				`${pct}% above your daily average of ${dailyAvg.toFixed(1)} over the last 30 days. ` +
+				`Great momentum! Keep the streak going.`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.sessions <= 0) { return false; }
+			const dailyAvg = ctx.last30Days.sessions / 30;
+			return ctx.today.sessions > dailyAvg * 1.3;
+		},
+		weight: 40,
+		allowToast: true,
+	},
+	{
+		id: 'sessions-trending-down',
+		category: 'trend',
+		severity: 'opportunity',
+		title: '💡 No Copilot session yet today',
+		buildBody: (_ctx) => {
+			return `You haven't started a Copilot session yet today — open a project and let Copilot help.`;
+		},
+		appliesTo: (ctx) => {
+			return ctx.last30Days.sessions > 10 && ctx.today.sessions === 0;
+		},
+		weight: 55,
+	},
+	{
+		id: 'agent-mode-growth',
+		category: 'trend',
+		severity: 'celebration',
+		title: '🤖 You\'re using Agent mode more — nice!',
+		buildBody: (ctx) => {
+			const todayTotal = ctx.today.modeUsage.ask + ctx.today.modeUsage.edit + ctx.today.modeUsage.agent;
+			const last30Total = ctx.last30Days.modeUsage.ask + ctx.last30Days.modeUsage.edit + ctx.last30Days.modeUsage.agent;
+			const todayPct = Math.round((ctx.today.modeUsage.agent / todayTotal) * 100);
+			const last30Pct = Math.round((ctx.last30Days.modeUsage.agent / last30Total) * 100);
+			return `Agent mode made up ${todayPct}% of your interactions today, up from ${last30Pct}% over the last 30 days. ` +
+				`Leaning into Agent mode for complex, multi-file tasks is a sign of growing AI engineering fluency!`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.modeUsage.agent <= 0 || ctx.today.modeUsage.agent <= 0) { return false; }
+			const todayTotal = ctx.today.modeUsage.ask + ctx.today.modeUsage.edit + ctx.today.modeUsage.agent;
+			const last30Total = ctx.last30Days.modeUsage.ask + ctx.last30Days.modeUsage.edit + ctx.last30Days.modeUsage.agent;
+			if (todayTotal <= 0 || last30Total <= 0) { return false; }
+			const todayShare = ctx.today.modeUsage.agent / todayTotal;
+			const last30Share = ctx.last30Days.modeUsage.agent / last30Total;
+			return (todayShare - last30Share) > 0.10;
+		},
+		weight: 45,
+		allowToast: true,
+	},
+	{
+		id: 'context-refs-trending-up',
+		category: 'trend',
+		severity: 'celebration',
+		title: '📎 Your context usage is improving!',
+		buildBody: (ctx) => {
+			const todayRefs = ctx.today.contextReferences.file + ctx.today.contextReferences.codebase
+				+ ctx.today.contextReferences.selection + ctx.today.contextReferences.symbol
+				+ ctx.today.contextReferences.workspace + ctx.today.contextReferences.terminal
+				+ ctx.today.contextReferences.vscode + ctx.today.contextReferences.implicitSelection;
+			const last30Total = ctx.last30Days.contextReferences.file + ctx.last30Days.contextReferences.codebase
+				+ ctx.last30Days.contextReferences.selection + ctx.last30Days.contextReferences.symbol
+				+ ctx.last30Days.contextReferences.workspace + ctx.last30Days.contextReferences.terminal
+				+ ctx.last30Days.contextReferences.vscode + ctx.last30Days.contextReferences.implicitSelection;
+			const dailyAvg = last30Total / 30;
+			const pct = Math.round((todayRefs / dailyAvg - 1) * 100);
+			return `You used ${todayRefs} context reference${todayRefs !== 1 ? 's' : ''} today — ` +
+				`${pct}% above your 30-day daily average of ${dailyAvg.toFixed(1)}. ` +
+				`Rich context (files, symbols, codebase) helps Copilot give more precise, targeted answers.`;
+		},
+		appliesTo: (ctx) => {
+			const last30Total = ctx.last30Days.contextReferences.file + ctx.last30Days.contextReferences.codebase
+				+ ctx.last30Days.contextReferences.selection + ctx.last30Days.contextReferences.symbol
+				+ ctx.last30Days.contextReferences.workspace + ctx.last30Days.contextReferences.terminal
+				+ ctx.last30Days.contextReferences.vscode + ctx.last30Days.contextReferences.implicitSelection;
+			if (last30Total <= 0) { return false; }
+			const dailyAvg = last30Total / 30;
+			const todayTotal = ctx.today.contextReferences.file + ctx.today.contextReferences.codebase
+				+ ctx.today.contextReferences.selection + ctx.today.contextReferences.symbol
+				+ ctx.today.contextReferences.workspace + ctx.today.contextReferences.terminal
+				+ ctx.today.contextReferences.vscode + ctx.today.contextReferences.implicitSelection;
+			return todayTotal > dailyAvg * 1.4;
+		},
+		weight: 35,
 	},
 ];
 

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -11,6 +11,18 @@ import type {
 } from './types';
 
 // ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/** Sums all meaningful context reference counts for a period. */
+function totalContextRefs(p: UsageAnalysisPeriod): number {
+	const r = p.contextReferences;
+	return (r.file ?? 0) + (r.codebase ?? 0) + (r.workspace ?? 0) + (r.selection ?? 0)
+		+ (r.symbol ?? 0) + (r.terminal ?? 0) + (r.clipboard ?? 0) + (r.changes ?? 0)
+		+ (r.pullRequest ?? 0);
+}
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -142,6 +154,96 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 			return (m.agent ?? 0) === 0 && (m.edit ?? 0) > 3;
 		},
 		weight: 60,
+	},
+
+	// ── Context quality ──────────────────────────────────────────────────────
+	{
+		id: 'low-context-diversity',
+		category: 'context',
+		severity: 'opportunity',
+		title: '🔍 Most of your sessions have no context attached',
+		buildBody: (ctx) => {
+			const sessions = ctx.last30Days.sessions;
+			const total = totalContextRefs(ctx.last30Days);
+			const noContextPct = Math.round(Math.max(0, 1 - total / sessions) * 100);
+			return `About ${noContextPct}% of your ${sessions} sessions in the last 30 days had no context references. ` +
+				`Try using \`#file\` to attach relevant files, \`@workspace\` to search your codebase, ` +
+				`or select code before asking — Copilot's answers improve significantly with relevant context.`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.sessions < 10) { return false; }
+			const total = totalContextRefs(ctx.last30Days);
+			return total < ctx.last30Days.sessions * 0.3;
+		},
+		weight: 65,
+	},
+	{
+		id: 'only-using-file-refs',
+		category: 'context',
+		severity: 'tip',
+		title: '📂 Broaden your context beyond file references',
+		buildBody: (_ctx) => {
+			return `You attach files frequently, but there's more context available. ` +
+				`Try \`#codebase\` or \`@workspace\` to let Copilot search across your entire project for relevant code, ` +
+				`or select a specific code block before asking for precision on a particular snippet.`;
+		},
+		appliesTo: (ctx) => {
+			const refs = ctx.last30Days.contextReferences;
+			return (refs.file ?? 0) > 20 && (refs.codebase ?? 0) < 5 && (refs.selection ?? 0) < 5;
+		},
+		weight: 45,
+	},
+	{
+		id: 'good-context-variety',
+		category: 'context',
+		severity: 'celebration',
+		title: '🌟 Great job using diverse context references',
+		buildBody: (ctx) => {
+			const refs = ctx.last30Days.contextReferences;
+			const activeTypes = [
+				refs.file,
+				(refs.codebase ?? 0) + (refs.workspace ?? 0),
+				refs.selection,
+				refs.symbol,
+				refs.terminal,
+				refs.clipboard,
+				refs.changes,
+			].filter(v => (v ?? 0) > 3).length;
+			return `You're using ${activeTypes} different types of context references in the last 30 days — ` +
+				`\`#file\`, \`#selection\`, \`@workspace\`, and more. ` +
+				`Diverse context helps Copilot understand exactly what you're working with and deliver more precise answers.`;
+		},
+		appliesTo: (ctx) => {
+			const refs = ctx.last30Days.contextReferences;
+			const countAboveThreshold = [
+				refs.file,
+				(refs.codebase ?? 0) + (refs.workspace ?? 0),
+				refs.selection,
+				refs.symbol,
+				refs.terminal,
+				refs.clipboard,
+				refs.changes,
+			].filter(v => (v ?? 0) > 3).length;
+			return countAboveThreshold >= 4;
+		},
+		weight: 30,
+	},
+	{
+		id: 'conversation-depth-low',
+		category: 'consistency',
+		severity: 'tip',
+		title: '💬 Try refining answers within the same conversation',
+		buildBody: (ctx) => {
+			const avg = ctx.last30Days.conversationPatterns.avgTurnsPerSession.toFixed(1);
+			return `Your conversations average ${avg} turns per session in the last 30 days. ` +
+				`When Copilot's first answer isn't quite right, follow up in the same conversation — ` +
+				`it retains context across turns and often converges to the right answer faster than starting fresh.`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.sessions < 10) { return false; }
+			return ctx.last30Days.conversationPatterns.avgTurnsPerSession < 1.5;
+		},
+		weight: 50,
 	},
 
 	// ── Consistency ─────────────────────────────────────────────────────────

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -144,7 +144,62 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		weight: 60,
 	},
 
-	// ── Consistency ─────────────────────────────────────────────────────────
+	// ── Streaks / Consistency ───────────────────────────────────────────────
+	{
+		id: 'consistent-daily-user',
+		category: 'consistency',
+		severity: 'celebration',
+		title: '🔥 You\'re a consistent Copilot user!',
+		buildBody: (ctx) => {
+			const n = ctx.last30Days.sessions;
+			return `You've been consistently using Copilot — ${n} sessions over the last 30 days. ` +
+				`Consistent AI use builds stronger intuition over time.`;
+		},
+		appliesTo: (ctx) => ctx.last30Days.sessions >= 25,
+		weight: 45,
+		allowToast: true,
+	},
+	{
+		id: 'irregular-usage',
+		category: 'consistency',
+		severity: 'opportunity',
+		title: '📅 Build a Copilot habit with daily use',
+		buildBody: (ctx) => {
+			const n = ctx.last30Days.sessions;
+			return `You've used Copilot ${n} time${n !== 1 ? 's' : ''} in the last 30 days. ` +
+				`Regular daily use (even for small tasks) helps you build intuition and flow with AI-assisted coding.`;
+		},
+		appliesTo: (ctx) => ctx.last30Days.sessions > 0 && ctx.last30Days.sessions < 10,
+		weight: 60,
+	},
+	{
+		id: 'mode-diversity-low',
+		category: 'consistency',
+		severity: 'tip',
+		title: '🔀 Explore more Copilot modes',
+		buildBody: (ctx) => {
+			const sessions = ctx.last30Days.sessions;
+			const m = ctx.last30Days.modeUsage;
+			if ((m.ask ?? 0) > 0.85 * sessions) {
+				return 'You mostly use Ask mode. Try Edit mode for making code changes directly.';
+			}
+			if ((m.edit ?? 0) > 0.85 * sessions) {
+				return 'You mostly use Edit mode. Ask mode is great for questions and exploration.';
+			}
+			return 'You haven\'t tried Agent mode yet. It handles multi-step tasks autonomously — great for refactoring, adding tests, or implementing features.';
+		},
+		appliesTo: (ctx) => {
+			const sessions = ctx.last30Days.sessions;
+			if (sessions < 10) { return false; }
+			const m = ctx.last30Days.modeUsage;
+			return (m.ask ?? 0) > 0.85 * sessions
+				|| (m.edit ?? 0) > 0.85 * sessions
+				|| ((m.agent ?? 0) === 0 && sessions >= 15);
+		},
+		weight: 50,
+	},
+
+	// ── Conversation patterns ────────────────────────────────────────────────
 	{
 		id: 'mostly-single-turn',
 		category: 'consistency',

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -8,6 +8,7 @@ import type {
 	UsageAnalysisPeriod,
 	MissedPotentialWorkspace,
 	WorkspaceCustomizationMatrix,
+	TodaySessionSummary,
 } from './types';
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,7 @@ export interface InsightContext {
 	last30Days: UsageAnalysisPeriod;
 	missedPotential: MissedPotentialWorkspace[];
 	customizationMatrix?: WorkspaceCustomizationMatrix | null;
+	todaySessions?: TodaySessionSummary[];
 }
 
 export interface InsightState {
@@ -165,6 +167,64 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 			return singleTurnSessions / total > 0.80;
 		},
 		weight: 50,
+	},
+
+	// ── Focus & Productivity ─────────────────────────────────────────────────
+	{
+		id: 'productive-session-today',
+		category: 'consistency',
+		severity: 'celebration',
+		title: '🏆 Great deep-work session today!',
+		buildBody: (ctx) => {
+			const best = (ctx.todaySessions ?? [])
+				.filter(s => s.interactions > 20)
+				.sort((a, b) => b.interactions - a.interactions)[0];
+			return `Your session in ${best.editor} had ${best.interactions} interactions — a sign of great deep work!`;
+		},
+		appliesTo: (ctx) => {
+			if (!ctx.todaySessions || ctx.todaySessions.length === 0) { return false; }
+			return ctx.todaySessions.some(s => s.interactions > 20);
+		},
+		weight: 40,
+		allowToast: true,
+	},
+	{
+		id: 'morning-sessions-pattern',
+		category: 'consistency',
+		severity: 'tip',
+		title: '🌅 You code with AI best in the morning',
+		buildBody: () => {
+			return `You tend to start coding with AI early — your morning sessions show good focus habits.`;
+		},
+		appliesTo: (ctx) => {
+			const sessions = ctx.todaySessions ?? [];
+			if (sessions.length < 3) { return false; }
+			const morningSessions = sessions.filter(s => {
+				if (!s.lastActivity) { return false; }
+				return new Date(s.lastActivity).getHours() < 10;
+			});
+			return morningSessions.length >= 2;
+		},
+		weight: 35,
+	},
+	{
+		id: 'short-scattered-sessions',
+		category: 'consistency',
+		severity: 'opportunity',
+		title: '⚡ Consolidate short sessions for deeper focus',
+		buildBody: (ctx) => {
+			const sessions = ctx.todaySessions ?? [];
+			const avg = Math.round(sessions.reduce((sum, s) => sum + s.interactions, 0) / sessions.length);
+			return `You had ${sessions.length} short sessions today (avg ${avg} interactions each). ` +
+				`Fewer, deeper sessions often produce better results — try keeping context within one session.`;
+		},
+		appliesTo: (ctx) => {
+			const sessions = ctx.todaySessions ?? [];
+			if (sessions.length < 5) { return false; }
+			const avg = sessions.reduce((sum, s) => sum + s.interactions, 0) / sessions.length;
+			return avg < 5;
+		},
+		weight: 55,
 	},
 ];
 

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -640,16 +640,133 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 	{
 		id: 'frequent-manual-compaction',
 		category: 'consistency',
-		severity: 'tip',
-		title: '🗜️ You compact your sessions often',
+		severity: 'celebration',
+		title: '🎉 You\'re managing context like a pro',
 		buildBody: (ctx) => {
 			const n = manualCompactCount(ctx.last30Days);
-			return `You've used \`/compact\` ${n} times in the last 30 days. That's a great way to keep going when a single task's chat gets long. ` +
-				`But if you're starting a *new* subtask, a fresh chat (\`/new\`) usually preserves intent better than compacting — compaction works by summarizing, so earlier detail is already condensed away. ` +
-				`Rule of thumb: \`/compact\` to keep going on one task, \`/new\` when the goal changes.`;
+			return `You've used \`/compact\` ${n} times in the last 30 days — that shows deliberate context management, which is a real power-user habit. ` +
+				`One refinement: \`/compact\` is best for continuing the *same task* when a chat gets long. ` +
+				`When you're switching to a *new subtask*, a fresh chat (\`/new\`) with a short handoff summary usually produces sharper answers, since compaction already condenses earlier detail. ` +
+				`Rule of thumb: \`/compact\` = same task, \`/new\` = new goal.`;
 		},
 		appliesTo: (ctx) => manualCompactCount(ctx.last30Days) >= 5,
 		weight: 50,
+		allowToast: true,
+	},
+
+	// ── Model cost & efficiency ───────────────────────────────────────────────
+	{
+		id: 'high-cost-model-usage',
+		category: 'agentic',
+		severity: 'tip',
+		title: '💰 Most of your requests use cost-intensive models',
+		buildBody: (ctx) => {
+			const ms = ctx.last30Days.modelSwitching;
+			const pct = ms.totalRequests > 0 ? Math.round((ms.premiumRequests / ms.totalRequests) * 100) : 0;
+			const models = ms.premiumModels.slice(0, 3).join(', ');
+			return `${pct}% of your ${ms.totalRequests.toLocaleString()} requests over the last 30 days used higher-cost models${models ? ` (${models})` : ''}. ` +
+				`For routine tasks like quick questions, summaries, or boilerplate, lighter models often perform just as well at a fraction of the cost. ` +
+				`Reserve the heavier models for complex multi-step reasoning, architecture decisions, or subtle bugs.`;
+		},
+		appliesTo: (ctx) => {
+			const ms = ctx.last30Days.modelSwitching;
+			return ms.totalRequests >= 20
+				&& (ms.premiumRequests / ms.totalRequests) > 0.70;
+		},
+		weight: 45,
+	},
+
+	// ── Code application habits ───────────────────────────────────────────────
+	{
+		id: 'low-apply-rate',
+		category: 'agentic',
+		severity: 'opportunity',
+		title: '📋 You\'re not applying many suggested code blocks',
+		buildBody: (ctx) => {
+			const a = ctx.last30Days.applyUsage;
+			const pct = Math.round(a.applyRate);
+			return `You've applied ${pct}% of the ${a.totalCodeBlocks} code blocks Copilot suggested over the last 30 days. ` +
+				`A low apply rate often means the suggestions are off-target. Try: ` +
+				`attaching the specific file or selection (#file / select-then-ask), being more precise about what you need changed, or asking Copilot to explain its approach first so you can redirect it early.`;
+		},
+		appliesTo: (ctx) => {
+			const a = ctx.last30Days.applyUsage;
+			return a.totalCodeBlocks >= 20 && a.applyRate < 40;
+		},
+		weight: 52,
+	},
+
+	// ── Reasoning effort ─────────────────────────────────────────────────────
+	{
+		id: 'reasoning-effort-never-tuned',
+		category: 'agentic',
+		severity: 'tip',
+		title: '🧠 Try tuning reasoning effort for complex tasks',
+		buildBody: (ctx) => {
+			const eu = ctx.last30Days.thinkingEffortUsage;
+			const sessions = eu?.sessionCount ?? 0;
+			return `You've had ${sessions} sessions where reasoning effort data was tracked, but you haven't switched effort levels yet. ` +
+				`Raising effort to "high" gives the model more thinking budget for complex problems like architecture decisions, tricky bugs, or multi-step refactors — and you can keep it on "low" for quick questions to stay responsive.`;
+		},
+		appliesTo: (ctx) => {
+			const eu = ctx.last30Days.thinkingEffortUsage;
+			if (!eu) { return false; }
+			return eu.sessionCount >= 5 && eu.switchCount === 0;
+		},
+		weight: 40,
+	},
+	{
+		id: 'reasoning-effort-switcher',
+		category: 'agentic',
+		severity: 'celebration',
+		title: '🎯 You\'re tuning reasoning effort — nice!',
+		buildBody: (ctx) => {
+			const eu = ctx.last30Days.thinkingEffortUsage!;
+			return `You switched reasoning effort ${eu.switchCount} times across ${eu.sessionCount} sessions. ` +
+				`Adapting effort to task complexity is one of the clearest signs of AI-engineering fluency — you're getting more out of Copilot without wasting compute on simple asks.`;
+		},
+		appliesTo: (ctx) => {
+			const eu = ctx.last30Days.thinkingEffortUsage;
+			return !!eu && eu.sessionCount >= 3 && eu.switchCount >= 3;
+		},
+		weight: 30,
+		allowToast: false,
+	},
+
+	// ── Multi-agent orchestration ─────────────────────────────────────────────
+	{
+		id: 'multi-agent-orchestration',
+		category: 'agentic',
+		severity: 'celebration',
+		title: '🤖 You\'re orchestrating multi-agent sessions!',
+		buildBody: (ctx) => {
+			const n = ctx.last30Days.multiAgentParentSessions!;
+			return `You've run ${n} sessions that spawned parallel sub-agents over the last 30 days. ` +
+				`Multi-agent orchestration is advanced AI engineering — you're splitting complex tasks across focused agents running in parallel, which significantly increases throughput for large changes.`;
+		},
+		appliesTo: (ctx) => (ctx.last30Days.multiAgentParentSessions ?? 0) >= 3,
+		weight: 35,
+		allowToast: true,
+	},
+
+	// ── Edit scope ───────────────────────────────────────────────────────────
+	{
+		id: 'single-file-edits-only',
+		category: 'agentic',
+		severity: 'tip',
+		title: '📁 Try multi-file edits for larger refactors',
+		buildBody: (ctx) => {
+			const es = ctx.last30Days.editScope;
+			return `You've made ${es.singleFileEdits} edit-mode sessions over the last 30 days, all touching a single file. ` +
+				`For refactors that span multiple files — renaming a type, extracting a module, updating API contracts — switch to Agent mode (or Edit mode with multiple files selected). ` +
+				`It can make changes consistently across your whole codebase without you opening each file manually.`;
+		},
+		appliesTo: (ctx) => {
+			const es = ctx.last30Days.editScope;
+			return es.singleFileEdits >= 10
+				&& es.multiFileEdits === 0;
+		},
+		weight: 42,
 	},
 ];
 

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -1,0 +1,281 @@
+/**
+ * Insights engine — evaluates personalized, data-driven nudges from usage stats.
+ *
+ * This module is intentionally pure (no VS Code API dependencies) so it can be
+ * unit-tested with mocked data following the same pattern as onboarding.ts.
+ */
+import type {
+	UsageAnalysisPeriod,
+	MissedPotentialWorkspace,
+	WorkspaceCustomizationMatrix,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type InsightCategory = 'context' | 'agentic' | 'customization' | 'consistency' | 'tools';
+export type InsightSeverity = 'tip' | 'opportunity' | 'celebration';
+export type InsightStatus = 'new' | 'seen' | 'dismissed' | 'snoozed' | 'done';
+
+export interface InsightContext {
+	today: UsageAnalysisPeriod;
+	last30Days: UsageAnalysisPeriod;
+	missedPotential: MissedPotentialWorkspace[];
+	customizationMatrix?: WorkspaceCustomizationMatrix | null;
+}
+
+export interface InsightState {
+	status: InsightStatus;
+	firstSurfacedAt: string;   // ISO timestamp
+	lastSurfacedAt: string;    // ISO timestamp
+	snoozeUntil?: string;      // ISO timestamp; present when status === 'snoozed'
+}
+
+/** Persisted bag of per-insight state keyed by insight id. */
+export type InsightStateBag = Record<string, InsightState>;
+
+/** A fully evaluated, display-ready insight card. */
+export interface EvaluatedInsight {
+	id: string;
+	category: InsightCategory;
+	severity: InsightSeverity;
+	title: string;
+	body: string;
+	actionLabel?: string;
+	actionCommand?: string;
+	status: InsightStatus;
+	/** When true, this insight may also be surfaced as a VS Code toast notification. */
+	allowToast?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal definition shape (not exported — consumers only see EvaluatedInsight)
+// ---------------------------------------------------------------------------
+
+interface InsightDefinition {
+	id: string;
+	category: InsightCategory;
+	severity: InsightSeverity;
+	title: string;
+	buildBody: (ctx: InsightContext) => string;
+	actionLabel?: string;
+	actionCommand?: string;
+	/** Returns true when this insight is applicable given the current context. */
+	appliesTo: (ctx: InsightContext) => boolean;
+	/** Higher weight → surfaced earlier when multiple insights apply. */
+	weight: number;
+	allowToast?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Starter catalog
+// Sub-session agents will add entries here for trend data, context quality,
+// focus times, streaks, and MCP/tool adoption insights.
+// ---------------------------------------------------------------------------
+
+export const INSIGHT_CATALOG: InsightDefinition[] = [
+	// ── Customization ──────────────────────────────────────────────────────
+	{
+		id: 'missing-instructions',
+		category: 'customization',
+		severity: 'opportunity',
+		title: '🗒️ Add copilot-instructions.md to your repos',
+		buildBody: (ctx) => {
+			const count = ctx.missedPotential.length;
+			const names = ctx.missedPotential
+				.slice(0, 3)
+				.map(w => w.workspaceName)
+				.join(', ');
+			const suffix = count > 3 ? ` (+${count - 3} more)` : '';
+			return `${count} active workspace${count > 1 ? 's' : ''} (${names}${suffix}) ${count > 1 ? 'don\'t have' : 'doesn\'t have'} a \`copilot-instructions.md\` file. ` +
+				`Adding one gives Copilot project-specific context, reducing back-and-forth and improving response quality.`;
+		},
+		actionLabel: 'View Workspace Health',
+		actionCommand: 'aiEngineeringFluency.showUsageAnalysis',
+		appliesTo: (ctx) => ctx.missedPotential.length > 0,
+		weight: 90,
+		allowToast: true,
+	},
+
+	// ── Context ─────────────────────────────────────────────────────────────
+	{
+		id: 'no-context-refs',
+		category: 'context',
+		severity: 'tip',
+		title: '📎 Try anchoring Copilot with context references',
+		buildBody: (ctx) => {
+			const sessions = ctx.last30Days.sessions;
+			const total = (ctx.last30Days.contextReferences.file ?? 0)
+				+ (ctx.last30Days.contextReferences.codebase ?? 0)
+				+ (ctx.last30Days.contextReferences.selection ?? 0)
+				+ (ctx.last30Days.contextReferences.symbol ?? 0);
+			return `Across your ${sessions} sessions in the last 30 days you used only ${total} context ` +
+				`reference${total !== 1 ? 's' : ''} (#file, #codebase, @workspace, etc.). ` +
+				`Attaching relevant files or symbols helps Copilot give more accurate, targeted answers and reduces follow-up turns.`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.sessions < 10) { return false; }
+			const refs = ctx.last30Days.contextReferences;
+			const total = (refs.file ?? 0) + (refs.codebase ?? 0)
+				+ (refs.selection ?? 0) + (refs.symbol ?? 0);
+			return total < 5;
+		},
+		weight: 70,
+	},
+
+	// ── Agentic ─────────────────────────────────────────────────────────────
+	{
+		id: 'try-agent-mode',
+		category: 'agentic',
+		severity: 'tip',
+		title: '🤖 Try Agent mode for multi-file tasks',
+		buildBody: (ctx) => {
+			const editCount = ctx.last30Days.modeUsage.edit ?? 0;
+			return `You ran ${editCount} edit-mode interaction${editCount !== 1 ? 's' : ''} in the last 30 days but haven't used Agent mode yet. ` +
+				`Agent mode lets Copilot autonomously traverse, edit, and test across multiple files — ` +
+				`great for refactors, feature additions, or bug hunts that touch more than one file.`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.sessions < 5) { return false; }
+			const m = ctx.last30Days.modeUsage;
+			return (m.agent ?? 0) === 0 && (m.edit ?? 0) > 3;
+		},
+		weight: 60,
+	},
+
+	// ── Consistency ─────────────────────────────────────────────────────────
+	{
+		id: 'mostly-single-turn',
+		category: 'consistency',
+		severity: 'tip',
+		title: '🔄 Iterate with Copilot instead of starting fresh',
+		buildBody: (ctx) => {
+			const { singleTurnSessions, multiTurnSessions } = ctx.last30Days.conversationPatterns;
+			const total = singleTurnSessions + multiTurnSessions;
+			const pct = total > 0 ? Math.round((singleTurnSessions / total) * 100) : 0;
+			return `${pct}% of your last-30-day sessions ended after a single message (${singleTurnSessions} of ${total}). ` +
+				`When Copilot's first answer isn't quite right, follow up in the same conversation rather than ` +
+				`starting over — it retains context and typically converges faster.`;
+		},
+		appliesTo: (ctx) => {
+			const { singleTurnSessions, multiTurnSessions } = ctx.last30Days.conversationPatterns;
+			const total = singleTurnSessions + multiTurnSessions;
+			if (total < 10) { return false; }
+			return singleTurnSessions / total > 0.80;
+		},
+		weight: 50,
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Core evaluation functions (all pure)
+// ---------------------------------------------------------------------------
+
+/** Returns all applicable, non-dismissed insights, sorted by weight descending. */
+export function evaluateInsights(
+	ctx: InsightContext,
+	stateBag: InsightStateBag,
+	cadenceDays: number,
+	lastNudgeAt: string | null,
+): EvaluatedInsight[] {
+	const now = new Date().toISOString();
+	return INSIGHT_CATALOG
+		.filter(def => def.appliesTo(ctx))
+		.sort((a, b) => b.weight - a.weight)
+		.map(def => {
+			const existing = stateBag[def.id];
+			const status = resolveStatus(existing, cadenceDays, lastNudgeAt, now);
+			return {
+				id: def.id,
+				category: def.category,
+				severity: def.severity,
+				title: def.title,
+				body: def.buildBody(ctx),
+				actionLabel: def.actionLabel,
+				actionCommand: def.actionCommand,
+				status,
+				allowToast: def.allowToast,
+			};
+		})
+		.filter(i => i.status !== 'dismissed');
+}
+
+/**
+ * Merges newly evaluated insights into the state bag.
+ * - Applicable, unseen insights get status 'new'.
+ * - Existing states are preserved (seen/snoozed/done/dismissed).
+ * - Insights that no longer apply are left in the bag untouched.
+ * Returns the updated (mutated) bag.
+ */
+export function mergeInsightStates(
+	evaluated: EvaluatedInsight[],
+	stateBag: InsightStateBag,
+	now: string,
+): InsightStateBag {
+	for (const insight of evaluated) {
+		const existing = stateBag[insight.id];
+		if (!existing) {
+			stateBag[insight.id] = {
+				status: 'new',
+				firstSurfacedAt: now,
+				lastSurfacedAt: now,
+			};
+		} else if (existing.status === 'new' || existing.status === 'seen') {
+			// Refresh the lastSurfacedAt timestamp
+			existing.lastSurfacedAt = now;
+		}
+	}
+	return stateBag;
+}
+
+/** Counts insights with status 'new' (not snoozed, not dismissed). */
+export function countNewInsights(stateBag: InsightStateBag, now: string): number {
+	return Object.values(stateBag).filter(s => {
+		if (s.status !== 'new') { return false; }
+		if (s.snoozeUntil && s.snoozeUntil > now) { return false; }
+		return true;
+	}).length;
+}
+
+/**
+ * Returns true when a toast notification is allowed.
+ * Toast cadence: at most one per cadenceDays days.
+ */
+export function isToastAllowed(cadenceDays: number, lastNudgeAt: string | null, now: string): boolean {
+	if (!lastNudgeAt) { return true; }
+	const msSinceLastNudge = new Date(now).getTime() - new Date(lastNudgeAt).getTime();
+	const msPerDay = 24 * 60 * 60 * 1000;
+	return msSinceLastNudge >= cadenceDays * msPerDay;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function resolveStatus(
+	existing: InsightState | undefined,
+	cadenceDays: number,
+	lastNudgeAt: string | null,
+	now: string,
+): InsightStatus {
+	if (!existing) {
+		return 'new';
+	}
+	// Respect terminal states
+	if (existing.status === 'dismissed' || existing.status === 'done') {
+		return existing.status;
+	}
+	// Check snooze expiry
+	if (existing.status === 'snoozed') {
+		if (existing.snoozeUntil && existing.snoozeUntil <= now) {
+			// Snooze expired — resurface
+			if (isToastAllowed(cadenceDays, lastNudgeAt, now)) {
+				return 'new';
+			}
+			return 'seen';
+		}
+		return 'snoozed';
+	}
+	return existing.status;
+}

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -144,6 +144,65 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		weight: 60,
 	},
 
+	// ── Tools / MCP ─────────────────────────────────────────────────────────
+	{
+		id: 'no-mcp-in-agent-mode',
+		category: 'tools',
+		severity: 'tip',
+		title: '🔌 Extend Agent mode with MCP servers',
+		buildBody: (_ctx) => {
+			return `You use Agent mode regularly — MCP (Model Context Protocol) servers can extend what Copilot can do in agent sessions, ` +
+				`like reading databases, calling APIs, or browsing docs. Search for 'MCP servers VS Code' to explore options.`;
+		},
+		appliesTo: (ctx) => {
+			const m = ctx.last30Days.modeUsage;
+			return (m.agent ?? 0) >= 5 && ctx.last30Days.mcpTools.total === 0;
+		},
+		weight: 55,
+	},
+	{
+		id: 'mcp-tools-active',
+		category: 'tools',
+		severity: 'celebration',
+		title: '🛠️ You\'re actively using MCP tools',
+		buildBody: (ctx) => {
+			const byTool = ctx.last30Days.mcpTools.byTool;
+			const total = ctx.last30Days.mcpTools.total;
+			let topTool: string | null = null;
+			let topCount = 0;
+			for (const [tool, count] of Object.entries(byTool)) {
+				if (count > topCount) {
+					topCount = count;
+					topTool = tool;
+				}
+			}
+			if (topTool) {
+				return `You're actively using MCP tools in your Copilot sessions — great! Your most-used tool: ${topTool} (${topCount} calls).`;
+			}
+			return `You're using ${total} MCP tool calls — great adoption of extended Copilot capabilities!`;
+		},
+		appliesTo: (ctx) => ctx.last30Days.mcpTools.total >= 10,
+		weight: 35,
+		allowToast: false,
+	},
+	{
+		id: 'install-extensions',
+		category: 'tools',
+		severity: 'tip',
+		title: '🧩 Discover Agent mode and MCP extensions',
+		buildBody: (_ctx) => {
+			return `If you haven't explored Agent mode yet, it's worth trying for complex multi-file tasks. ` +
+				`Agent mode can use tools — including MCP servers you install — to complete tasks more autonomously.`;
+		},
+		appliesTo: (ctx) => {
+			if (ctx.last30Days.sessions < 10) { return false; }
+			const m = ctx.last30Days.modeUsage;
+			// Only show when try-agent-mode wouldn't fire (edit <= 3)
+			return (m.agent ?? 0) === 0 && (m.edit ?? 0) <= 3 && ctx.last30Days.mcpTools.total === 0;
+		},
+		weight: 40,
+	},
+
 	// ── Consistency ─────────────────────────────────────────────────────────
 	{
 		id: 'mostly-single-turn',

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -48,6 +48,39 @@ function totalContextRefs(p: UsageAnalysisPeriod): number {
 		+ (r.pullRequest ?? 0);
 }
 
+// ── Session-hygiene helpers ────────────────────────────────────────────────
+/** A single today-session is considered a "marathon" once it grows this long. */
+const MARATHON_TURNS = 50;
+/** ...or once it has processed this many cumulative tokens. */
+const MARATHON_TOKENS = 750_000;
+
+function isMarathonSession(s: TodaySessionSummary): boolean {
+	return s.interactions >= MARATHON_TURNS || s.totalTokens >= MARATHON_TOKENS;
+}
+
+function hasMarathonSessionToday(ctx: InsightContext): boolean {
+	return (ctx.todaySessions ?? []).some(isMarathonSession);
+}
+
+/** The largest today-session by turns, tie-broken by tokens. */
+function biggestSessionToday(ctx: InsightContext): TodaySessionSummary | undefined {
+	return (ctx.todaySessions ?? [])
+		.slice()
+		.sort((a, b) => (b.interactions - a.interactions) || (b.totalTokens - a.totalTokens))[0];
+}
+
+/** Short human-readable token count, e.g. 1_200_000 → "1.2M", 750_000 → "750K". */
+function formatTokensShort(n: number): string {
+	if (n >= 1_000_000) { return `${(n / 1_000_000).toFixed(1)}M`; }
+	if (n >= 1_000) { return `${Math.round(n / 1_000)}K`; }
+	return String(n);
+}
+
+/** Count of manual /compact commands in a period (Claude Code / Desktop only). */
+function manualCompactCount(p: UsageAnalysisPeriod): number {
+	return p.toolCalls.byTool['__slash__compact'] ?? 0;
+}
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -561,6 +594,62 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 			return avg < 5;
 		},
 		weight: 55,
+	},
+
+	// ── Session hygiene & compaction ─────────────────────────────────────────
+	{
+		id: 'marathon-session-today',
+		category: 'consistency',
+		severity: 'opportunity',
+		title: '🧵 A very long chat session today',
+		buildBody: (ctx) => {
+			const s = biggestSessionToday(ctx);
+			if (!s) { return ''; }
+			const where = s.editor ? ` in ${s.editor}` : '';
+			const turns = `${s.interactions} turn${s.interactions === 1 ? '' : 's'}`;
+			const tokens = s.totalTokens > 0 ? ` (~${formatTokensShort(s.totalTokens)} tokens)` : '';
+			return `Your longest chat today${where} reached ${turns}${tokens}. Deep work in one chat is great — but once a session gets this long, earlier context is more likely to be summarized, compressed, or dropped, so replies can drift and slow down. ` +
+				`When the goal changes, start a fresh chat (New Chat / \`/new\`) and paste a short handoff summary. A handy rule: one chat per bug, feature, or refactor.`;
+		},
+		appliesTo: (ctx) => hasMarathonSessionToday(ctx),
+		weight: 58,
+		allowToast: true,
+	},
+	{
+		id: 'very-long-sessions-pattern',
+		category: 'consistency',
+		severity: 'tip',
+		title: '📏 Your chats tend to run long',
+		buildBody: (ctx) => {
+			const maxTurns = ctx.last30Days.conversationPatterns.maxTurnsInSession;
+			const avg = ctx.last30Days.conversationPatterns.avgTurnsPerSession.toFixed(1);
+			return `Over the last 30 days your longest conversation reached ${maxTurns} prompts, and your sessions average ${avg} prompts each. ` +
+				`Very long chats make earlier context less reliable — the assistant may compress or ignore it as the window fills. ` +
+				`Keeping one focused chat per task (and starting fresh when the topic shifts) usually produces sharper, faster answers.`;
+		},
+		appliesTo: (ctx) => {
+			// Pattern-level insight: don't double up with the "today" marathon nudge.
+			if (hasMarathonSessionToday(ctx)) { return false; }
+			const cp = ctx.last30Days.conversationPatterns;
+			return ctx.last30Days.sessions >= 10
+				&& cp.maxTurnsInSession >= 80
+				&& cp.avgTurnsPerSession >= 12;
+		},
+		weight: 45,
+	},
+	{
+		id: 'frequent-manual-compaction',
+		category: 'consistency',
+		severity: 'tip',
+		title: '🗜️ You compact your sessions often',
+		buildBody: (ctx) => {
+			const n = manualCompactCount(ctx.last30Days);
+			return `You've used \`/compact\` ${n} times in the last 30 days. That's a great way to keep going when a single task's chat gets long. ` +
+				`But if you're starting a *new* subtask, a fresh chat (\`/new\`) usually preserves intent better than compacting — compaction works by summarizing, so earlier detail is already condensed away. ` +
+				`Rule of thumb: \`/compact\` to keep going on one task, \`/new\` when the goal changes.`;
+		},
+		appliesTo: (ctx) => manualCompactCount(ctx.last30Days) >= 5,
+		weight: 50,
 	},
 ];
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -606,7 +606,7 @@ export interface WorkspaceCustomizationSummary {
 // Insights / Nudges framework
 // ---------------------------------------------------------------------------
 
-export type InsightCategory = 'context' | 'agentic' | 'customization' | 'consistency' | 'tools';
+export type InsightCategory = 'context' | 'agentic' | 'customization' | 'consistency' | 'tools' | 'trend';
 export type InsightSeverity = 'tip' | 'opportunity' | 'celebration';
 export type InsightStatus = 'new' | 'seen' | 'dismissed' | 'snoozed' | 'done';
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -602,5 +602,33 @@ export interface WorkspaceCustomizationSummary {
   staleFiles: number;
 }
 
+// ---------------------------------------------------------------------------
+// Insights / Nudges framework
+// ---------------------------------------------------------------------------
 
+export type InsightCategory = 'context' | 'agentic' | 'customization' | 'consistency' | 'tools';
+export type InsightSeverity = 'tip' | 'opportunity' | 'celebration';
+export type InsightStatus = 'new' | 'seen' | 'dismissed' | 'snoozed' | 'done';
 
+export interface InsightState {
+  status: InsightStatus;
+  firstSurfacedAt: string;   // ISO timestamp
+  lastSurfacedAt: string;    // ISO timestamp
+  snoozeUntil?: string;      // ISO timestamp; present when status === 'snoozed'
+}
+
+/** Persisted bag of per-insight state keyed by insight id. */
+export type InsightStateBag = Record<string, InsightState>;
+
+/** A fully evaluated, display-ready insight card. */
+export interface EvaluatedInsight {
+  id: string;
+  category: InsightCategory;
+  severity: InsightSeverity;
+  title: string;
+  body: string;
+  actionLabel?: string;
+  actionCommand?: string;
+  status: InsightStatus;
+  allowToast?: boolean;
+}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1506,67 +1506,77 @@ function buildReposAndAgentTabPanelsHtml(): string {
 
 function buildInsightCardHtml(insight: EvaluatedInsight): string {
 	const severityColors: Record<InsightSeverity, string> = {
-		tip: 'rgba(96,165,250,0.15)',
-		opportunity: 'rgba(251,191,36,0.15)',
-		celebration: 'rgba(74,222,128,0.15)',
+		tip: 'rgba(96,165,250,0.12)',
+		opportunity: 'rgba(251,191,36,0.12)',
+		celebration: 'rgba(74,222,128,0.12)',
 	};
 	const severityBorder: Record<InsightSeverity, string> = {
-		tip: 'rgba(96,165,250,0.4)',
-		opportunity: 'rgba(251,191,36,0.4)',
-		celebration: 'rgba(74,222,128,0.4)',
+		tip: 'rgba(96,165,250,0.5)',
+		opportunity: 'rgba(251,191,36,0.5)',
+		celebration: 'rgba(74,222,128,0.5)',
+	};
+	// Accent colour used for the primary action button per severity
+	const severityAccent: Record<InsightSeverity, string> = {
+		tip: 'rgba(96,165,250,0.85)',
+		opportunity: 'rgba(251,191,36,0.85)',
+		celebration: 'rgba(74,222,128,0.85)',
 	};
 	const bg = severityColors[insight.severity] ?? severityColors.tip;
 	const border = severityBorder[insight.severity] ?? severityBorder.tip;
+	const accent = severityAccent[insight.severity] ?? severityAccent.tip;
 	const isNew = insight.status === 'new';
 	const isDone = insight.status === 'done';
 
 	const actionBtn = insight.actionLabel
 		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="execute" data-command="${escapeHtml(insight.actionCommand ?? '')}"
-				style="padding:4px 12px; font-size:12px; cursor:pointer; border:1px solid var(--border-color); border-radius:4px;
-				background:var(--bg-tertiary); color:var(--text-primary);">${escapeHtml(insight.actionLabel)}</button>`
+				style="padding:5px 14px; font-size:12px; font-weight:600; cursor:pointer;
+				border:1px solid ${border}; border-radius:5px;
+				background:${bg}; color:var(--text-primary);">${escapeHtml(insight.actionLabel)}</button>`
 		: '';
 
 	const doneBtn = !isDone
 		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="done"
 				title="Mark as done"
-				style="padding:4px 10px; font-size:11px; cursor:pointer; border:1px solid var(--border-color); border-radius:4px;
-				background:transparent; color:var(--text-secondary);">✓ Done</button>`
-		: `<span style="font-size:11px; color:var(--text-secondary); opacity:0.6;">✓ Done</span>`;
+				style="padding:5px 14px; font-size:12px; font-weight:600; cursor:pointer;
+				border:1px solid ${border}; border-radius:5px;
+				background:${accent}; color:#0d1117;">✓ Done</button>`
+		: `<span style="font-size:12px; color:var(--text-secondary); opacity:0.5; padding:5px 6px;">✓ Done</span>`;
 
 	const snoozeBtn = !isDone
 		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="snooze"
 				title="Snooze for 7 days"
-				style="padding:4px 10px; font-size:11px; cursor:pointer; border:1px solid var(--border-color); border-radius:4px;
-				background:transparent; color:var(--text-secondary);">⏸ Snooze</button>`
+				style="padding:5px 14px; font-size:12px; font-weight:500; cursor:pointer;
+				border:1px solid ${border}; border-radius:5px;
+				background:transparent; color:var(--text-primary);">⏸ Snooze</button>`
 		: '';
 
 	const dismissBtn = !isDone
 		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="dismiss"
 				title="Dismiss permanently"
-				style="padding:4px 10px; font-size:11px; cursor:pointer; border:none; border-radius:4px;
-				background:transparent; color:var(--text-secondary); opacity:0.6;">✕</button>`
+				style="padding:4px 8px; font-size:14px; line-height:1; cursor:pointer; border:none; border-radius:4px;
+				background:transparent; color:var(--text-primary); opacity:0.5;">✕</button>`
 		: '';
 
 	return `
 		<div class="insight-card" data-insight-id="${escapeHtml(insight.id)}"
-			style="margin-bottom:12px; padding:14px 16px; border-radius:8px;
+			style="margin-bottom:12px; padding:16px 18px; border-radius:8px;
 			background:${bg}; border:1px solid ${border};
-			${isNew ? 'box-shadow:0 0 0 1px ' + border + ';' : ''}
-			${isDone ? 'opacity:0.55;' : ''}">
+			${isNew ? 'box-shadow:0 2px 8px ' + bg + ';' : ''}
+			${isDone ? 'opacity:0.45;' : ''}">
 			<div style="display:flex; align-items:flex-start; gap:10px;">
 				<div style="flex:1;">
-					<div style="font-size:13px; font-weight:600; color:var(--text-primary); margin-bottom:6px;">
-						${isNew ? '<span style="font-size:10px; padding:2px 6px; border-radius:10px; background:rgba(96,165,250,0.3); color:#60a5fa; vertical-align:middle; margin-right:6px;">NEW</span>' : ''}
+					<div style="font-size:13px; font-weight:700; color:var(--text-primary); margin-bottom:8px; display:flex; align-items:center; gap:8px;">
+						${isNew ? `<span style="font-size:10px; padding:2px 7px; border-radius:10px; background:${accent}; color:#0d1117; font-weight:700; letter-spacing:0.04em;">NEW</span>` : ''}
 						${escapeHtml(insight.title)}
 					</div>
-					<div style="font-size:12px; color:var(--text-secondary); line-height:1.5; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
-					${actionBtn ? `<div style="margin-top:10px;">${actionBtn}</div>` : ''}
+					<div style="font-size:13px; color:var(--text-primary); line-height:1.6; opacity:0.85; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
+					${actionBtn ? `<div style="margin-top:12px;">${actionBtn}</div>` : ''}
 				</div>
-				<div style="display:flex; flex-direction:column; align-items:flex-end; gap:4px; flex-shrink:0;">
+				<div style="flex-shrink:0; margin-top:-4px;">
 					${dismissBtn}
 				</div>
 			</div>
-			<div style="display:flex; gap:6px; margin-top:10px; justify-content:flex-end;">
+			<div style="display:flex; gap:8px; margin-top:14px; justify-content:flex-end; border-top:1px solid ${border}; padding-top:10px;">
 				${doneBtn}
 				${snoozeBtn}
 			</div>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1569,7 +1569,7 @@ function buildInsightCardHtml(insight: EvaluatedInsight): string {
 						${isNew ? `<span style="font-size:10px; padding:2px 7px; border-radius:10px; background:${accent}; color:#0d1117; font-weight:700; letter-spacing:0.04em;">NEW</span>` : ''}
 						${escapeHtml(insight.title)}
 					</div>
-					<div style="font-size:13px; color:var(--text-primary); line-height:1.6; opacity:0.85; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
+					<div style="font-size:12px; color:var(--text-primary); line-height:1.5; opacity:0.85; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
 					${actionBtn ? `<div style="margin-top:12px;">${actionBtn}</div>` : ''}
 				</div>
 				<div style="flex-shrink:0; margin-top:-4px;">

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -50,6 +50,21 @@ type TodaySessionSummary = {
 	lastActivity: string;
 };
 
+type InsightSeverity = 'tip' | 'opportunity' | 'celebration';
+type InsightStatus = 'new' | 'seen' | 'dismissed' | 'snoozed' | 'done';
+
+type EvaluatedInsight = {
+	id: string;
+	category: string;
+	severity: InsightSeverity;
+	title: string;
+	body: string;
+	actionLabel?: string;
+	actionCommand?: string;
+	status: InsightStatus;
+	allowToast?: boolean;
+};
+
 type UsageAnalysisStats = {
 	today: UsageAnalysisPeriod;
 	last30Days: UsageAnalysisPeriod;
@@ -63,6 +78,7 @@ type UsageAnalysisStats = {
 	suppressedUnknownTools?: string[];
 	todaySessions?: TodaySessionSummary[];
 	use24HourTime?: boolean;
+	insights?: EvaluatedInsight[];
 };
 
 declare function acquireVsCodeApi<TState = unknown>(): {
@@ -173,6 +189,7 @@ let isBatchAnalysisInProgress = false;
 let currentWorkspacePaths: string[] = [];
 let activeTab = 'activity';
 let loadingTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let currentInsights: EvaluatedInsight[] = [];
 
 function clearLoadingTimeout(): void {
 	if (loadingTimeoutId !== null) {
@@ -803,6 +820,22 @@ function sanitizePeriod(period: any): UsageAnalysisPeriod {
 	};
 }
 
+function sanitizeInsights(rawInsights: any[]): EvaluatedInsight[] {
+	return rawInsights
+		.filter((i: any) => i && typeof i === 'object' && typeof i.id === 'string')
+		.map((i: any): EvaluatedInsight => ({
+			id: String(i.id),
+			category: typeof i.category === 'string' ? i.category : 'general',
+			severity: (['tip', 'opportunity', 'celebration'].includes(i.severity) ? i.severity : 'tip') as InsightSeverity,
+			title: typeof i.title === 'string' ? i.title : '',
+			body: typeof i.body === 'string' ? i.body : '',
+			actionLabel: typeof i.actionLabel === 'string' ? i.actionLabel : undefined,
+			actionCommand: typeof i.actionCommand === 'string' ? i.actionCommand : undefined,
+			status: (['new', 'seen', 'dismissed', 'snoozed', 'done'].includes(i.status) ? i.status : 'new') as InsightStatus,
+			allowToast: !!i.allowToast,
+		}));
+}
+
 function sanitizeStats(raw: any): UsageAnalysisStats | null {
 	if (!raw || typeof raw !== 'object') {
 		return null;
@@ -868,6 +901,11 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 			) as TodaySessionSummary[];
 		}
 
+		// Sanitize insights
+		if (Array.isArray(raw.insights)) {
+			sanitized.insights = sanitizeInsights(raw.insights);
+		}
+
 		return sanitized;
 	} catch {
 		return null;
@@ -896,6 +934,12 @@ function setupTabs(): void {
 			if (tab === 'agent' && !agentSessionsLoaded) {
 				agentSessionsLoaded = true;
 				vscode.postMessage({ command: 'loadAgentSessions' });
+			}
+			// Mark new insights as seen when visiting the Insights tab
+			if (tab === 'insights') {
+				currentInsights
+					.filter(i => i.status === 'new')
+					.forEach(i => vscode.postMessage({ command: 'insightAction', id: i.id, action: 'seen' }));
 			}
 		});
 	});
@@ -1460,6 +1504,157 @@ function buildReposAndAgentTabPanelsHtml(): string {
 		</div>`;
 }
 
+function buildInsightCardHtml(insight: EvaluatedInsight): string {
+	const severityColors: Record<InsightSeverity, string> = {
+		tip: 'rgba(96,165,250,0.15)',
+		opportunity: 'rgba(251,191,36,0.15)',
+		celebration: 'rgba(74,222,128,0.15)',
+	};
+	const severityBorder: Record<InsightSeverity, string> = {
+		tip: 'rgba(96,165,250,0.4)',
+		opportunity: 'rgba(251,191,36,0.4)',
+		celebration: 'rgba(74,222,128,0.4)',
+	};
+	const bg = severityColors[insight.severity] ?? severityColors.tip;
+	const border = severityBorder[insight.severity] ?? severityBorder.tip;
+	const isNew = insight.status === 'new';
+	const isDone = insight.status === 'done';
+
+	const actionBtn = insight.actionLabel
+		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="execute" data-command="${escapeHtml(insight.actionCommand ?? '')}"
+				style="padding:4px 12px; font-size:12px; cursor:pointer; border:1px solid var(--border-color); border-radius:4px;
+				background:var(--bg-tertiary); color:var(--text-primary);">${escapeHtml(insight.actionLabel)}</button>`
+		: '';
+
+	const doneBtn = !isDone
+		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="done"
+				title="Mark as done"
+				style="padding:4px 10px; font-size:11px; cursor:pointer; border:1px solid var(--border-color); border-radius:4px;
+				background:transparent; color:var(--text-secondary);">✓ Done</button>`
+		: `<span style="font-size:11px; color:var(--text-secondary); opacity:0.6;">✓ Done</span>`;
+
+	const snoozeBtn = !isDone
+		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="snooze"
+				title="Snooze for 7 days"
+				style="padding:4px 10px; font-size:11px; cursor:pointer; border:1px solid var(--border-color); border-radius:4px;
+				background:transparent; color:var(--text-secondary);">⏸ Snooze</button>`
+		: '';
+
+	const dismissBtn = !isDone
+		? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="dismiss"
+				title="Dismiss permanently"
+				style="padding:4px 10px; font-size:11px; cursor:pointer; border:none; border-radius:4px;
+				background:transparent; color:var(--text-secondary); opacity:0.6;">✕</button>`
+		: '';
+
+	return `
+		<div class="insight-card" data-insight-id="${escapeHtml(insight.id)}"
+			style="margin-bottom:12px; padding:14px 16px; border-radius:8px;
+			background:${bg}; border:1px solid ${border};
+			${isNew ? 'box-shadow:0 0 0 1px ' + border + ';' : ''}
+			${isDone ? 'opacity:0.55;' : ''}">
+			<div style="display:flex; align-items:flex-start; gap:10px;">
+				<div style="flex:1;">
+					<div style="font-size:13px; font-weight:600; color:var(--text-primary); margin-bottom:6px;">
+						${isNew ? '<span style="font-size:10px; padding:2px 6px; border-radius:10px; background:rgba(96,165,250,0.3); color:#60a5fa; vertical-align:middle; margin-right:6px;">NEW</span>' : ''}
+						${escapeHtml(insight.title)}
+					</div>
+					<div style="font-size:12px; color:var(--text-secondary); line-height:1.5; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
+					${actionBtn ? `<div style="margin-top:10px;">${actionBtn}</div>` : ''}
+				</div>
+				<div style="display:flex; flex-direction:column; align-items:flex-end; gap:4px; flex-shrink:0;">
+					${dismissBtn}
+				</div>
+			</div>
+			<div style="display:flex; gap:6px; margin-top:10px; justify-content:flex-end;">
+				${doneBtn}
+				${snoozeBtn}
+			</div>
+		</div>`;
+}
+
+function buildInsightsTabPanelHtml(insights: EvaluatedInsight[]): string {
+	const applicable = insights.filter(i => i.status !== 'dismissed');
+	const newInsights = applicable.filter(i => i.status === 'new');
+	const otherInsights = applicable.filter(i => i.status !== 'new');
+
+	const forYouSection = newInsights.length > 0
+		? `<div style="margin-bottom:20px;">
+			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">✨ For You</div>
+			${newInsights.map(buildInsightCardHtml).join('')}
+		</div>`
+		: `<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
+			🎉 No new insights right now — keep using Copilot and check back later!
+		</div>`;
+
+	const allSection = otherInsights.length > 0
+		? `<div>
+			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">All Tips</div>
+			${otherInsights.map(buildInsightCardHtml).join('')}
+		</div>`
+		: '';
+
+	return `
+		<div id="tab-panel-insights" class="tab-panel"${activeTab !== 'insights' ? ' style="display:none"' : ''}>
+			<div class="section">
+				<div class="section-title"><span>💡</span><span>Insights</span></div>
+				<div class="section-subtitle">
+					Personalized tips based on your usage patterns. Tips are data-driven — they only appear when relevant to how you code with AI.
+				</div>
+				<div id="insights-container" style="margin-top:16px;">
+					${forYouSection}
+					${allSection}
+				</div>
+			</div>
+		</div>`;
+}
+
+function refreshInsightsPanel(insights: EvaluatedInsight[]): void {
+	const container = document.getElementById('insights-container');
+	if (!container) { return; }
+	currentInsights = insights;
+	const forYou = insights.filter(i => i.status === 'new');
+	const other = insights.filter(i => i.status !== 'new' && i.status !== 'dismissed');
+
+	const forYouSection = forYou.length > 0
+		? `<div style="margin-bottom:20px;">
+			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">✨ For You</div>
+			${forYou.map(buildInsightCardHtml).join('')}
+		</div>`
+		: `<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
+			🎉 No new insights right now — keep using Copilot and check back later!
+		</div>`;
+
+	const allSection = other.length > 0
+		? `<div>
+			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">All Tips</div>
+			${other.map(buildInsightCardHtml).join('')}
+		</div>`
+		: '';
+
+	container.innerHTML = forYouSection + allSection;
+	wireInsightCardButtons();
+}
+
+function wireInsightCardButtons(): void {
+	const container = document.getElementById('insights-container');
+	if (!container) { return; }
+	container.querySelectorAll<HTMLButtonElement>('.insight-action-btn').forEach(btn => {
+		btn.addEventListener('click', () => {
+			const id = btn.getAttribute('data-insight-id');
+			const action = btn.getAttribute('data-action');
+			if (!id || !action) { return; }
+			if (action === 'execute') {
+				const command = btn.getAttribute('data-command');
+				if (command) { vscode.postMessage({ command }); }
+			} else {
+				vscode.postMessage({ command: 'insightAction', id, action });
+			}
+		});
+	});
+}
+
+
 function buildUsageRootHtml(
 	stats: UsageAnalysisStats,
 	customizationHtml: string,
@@ -1511,6 +1706,7 @@ function buildUsageRootHtml(
 				<button class="tab-button ${activeTab === 'health' ? 'active' : ''}" data-tab="health">🏗️ Workspace Health</button>
 				<button class="tab-button ${activeTab === 'repos' ? 'active' : ''}" data-tab="repos">🤖 Repository PRs</button>
 				<button class="tab-button ${activeTab === 'agent' ? 'active' : ''}" data-tab="agent">🤖 Cloud Agent</button>
+				<button class="tab-button ${activeTab === 'insights' ? 'active' : ''}" data-tab="insights">💡 Insights${(stats.insights ?? []).filter(i => i.status === 'new').length > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(stats.insights ?? []).filter(i => i.status === 'new').length}</span>` : ''}</button>
 			</div>
 
 			${buildSessionsTabPanelHtml(stats)}
@@ -1518,11 +1714,12 @@ function buildUsageRootHtml(
 			${buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allStandardModels, allPremiumModels, allUnknownModels)}
 			${buildHealthTabPanelHtml(customizationHtml, stats)}
 			${buildReposAndAgentTabPanelsHtml()}
+			${buildInsightsTabPanelHtml(stats.insights ?? [])}
 			<div class="footer">
 				Last updated: ${escapeHtml(new Date(stats.lastUpdated).toLocaleString())} · Updates every 5 minutes
 			</div>
 		</div>
-	`;
+`;
 }
 
 function buildSessionsTabPanelHtml(stats: UsageAnalysisStats): string {
@@ -1766,6 +1963,9 @@ function renderLayout(stats: UsageAnalysisStats): void {
 	renderRepositoryHygienePanels();
 	setupTabs();
 	wireCopyButtons();
+	// Initialize currentInsights from the stats and wire card buttons
+	currentInsights = stats.insights ?? [];
+	wireInsightCardButtons();
 }
 
 /** Wires up top-level navigation toolbar buttons (refresh, details, chart, etc.). */
@@ -1932,6 +2132,12 @@ function handleAgentSessionsLoaded(data: any): void {
 	updateAgentSessionsPanel(agentSessionsData);
 }
 
+function handleUpdateInsights(rawInsights: unknown): void {
+	if (!Array.isArray(rawInsights)) { return; }
+	const sanitized = sanitizeInsights(rawInsights);
+	refreshInsightsPanel(sanitized);
+}
+
 // Listen for messages from the extension
 registerMessageHandler<any>((message) => {
 	switch (message.command) {
@@ -1961,6 +2167,8 @@ registerMessageHandler<any>((message) => {
 		case 'agentSessionsProgress':
 			updateProgressPanel('#agent-sessions-content', 'agent-sessions-progress', 'Fetching agent sessions…', message.done as number, message.total as number);
 			break;
+		case 'updateInsights':
+			handleUpdateInsights(message.insights); break;
 	}
 });
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -2179,6 +2179,11 @@ registerMessageHandler<any>((message) => {
 			break;
 		case 'updateInsights':
 			handleUpdateInsights(message.insights); break;
+		case 'switchTab': {
+			const btn = document.querySelector<HTMLButtonElement>(`.tab-button[data-tab="${String(message.tab)}"]`);
+			btn?.click();
+			break;
+		}
 	}
 });
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1586,7 +1586,7 @@ function buildInsightCardHtml(insight: EvaluatedInsight): string {
 function buildInsightsTabPanelHtml(insights: EvaluatedInsight[]): string {
 	const applicable = insights.filter(i => i.status !== 'dismissed');
 	const newInsights = applicable.filter(i => i.status === 'new');
-	const otherInsights = applicable.filter(i => i.status !== 'new');
+	const otherInsights = applicable.filter(i => i.status !== 'new' && i.status !== 'done');
 
 	const forYouSection = newInsights.length > 0
 		? `<div style="margin-bottom:20px;">
@@ -1624,7 +1624,7 @@ function refreshInsightsPanel(insights: EvaluatedInsight[]): void {
 	if (!container) { return; }
 	currentInsights = insights;
 	const forYou = insights.filter(i => i.status === 'new');
-	const other = insights.filter(i => i.status !== 'new' && i.status !== 'dismissed');
+	const other = insights.filter(i => i.status !== 'new' && i.status !== 'dismissed' && i.status !== 'done');
 
 	const forYouSection = forYou.length > 0
 		? `<div style="margin-bottom:20px;">


### PR DESCRIPTION
## Summary

Adds a data-driven personalized insights system to the VS Code extension that helps users improve how they use AI while coding. Insights are evaluated from existing usage data — no extra scanning required.

## What's new

### Framework (`insightsEngine.ts`)
- Pure evaluation engine (zero VS Code API deps, fully unit-testable)
- `InsightDefinition` catalog pattern — easy to add new insights
- State persistence via `context.globalState` (new/seen/dismissed/snoozed/done lifecycle)
- Toast cadence control (default: one notification per 2 days)
- Status bar badge (`💡 N`) when new insights are available

### 💡 Insights tab in Usage Analysis webview
- New tab showing personalized insight cards
- **"For You"** section: unread insights with NEW badge
- **"All Tips"** section: seen/done insights
- Per-card actions: ✓ Done, ⏸ Snooze (7 days), ✕ Dismiss
- Marking insights as seen when visiting the tab
- Live updates via `updateInsights` message

### 19 insights across 6 categories

| Category | Insights |
|---|---|
| **Workspace health** | Missing instructions file, no context refs after 10+ sessions, try agent mode, mostly single-turn |
| **Trend** | Sessions trending up/down, agent mode growth, context refs trending up |
| **Context quality** | Low context diversity, only using file refs, good variety (celebration), conversation depth low |
| **Focus & Productivity** | Productive deep-work session, morning session pattern, short scattered sessions |
| **Streaks / Consistency** | Consistent daily user (celebration), irregular usage, mode diversity low |
| **Tools / MCP** | No MCP in agent mode, MCP tools active (celebration), agent/extensions discovery |

### Settings
- `aiEngineeringFluency.insights.enabled` (default: true)
- `aiEngineeringFluency.insights.toastsEnabled` (default: true)  
- `aiEngineeringFluency.insights.cadenceDays` (default: 2)

## Technical notes
- All new insights only fire when relevant conditions are met — no insight is shown without data to back it up
- MCP insights are gated on agent mode usage to avoid suggesting unavailable features
- Build: ✅ 0 TypeScript errors, 0 ESLint warnings

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>