### PR TITLE
fix: improve JetBrains error page layout

### DIFF
--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/TokenTrackerPanel.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/TokenTrackerPanel.kt
@@ -224,14 +224,16 @@ class TokenTrackerPanel(
                 var overlay = document.getElementById('loading-overlay');
                 if (overlay) {
                     overlay.innerHTML =
-                        '<div style="font-size:32px">&#x26A0;</div>' +
-                        '<div style="font-size:15px;font-weight:600;margin:8px 0">Error loading Copilot usage data</div>' +
-                        '<div style="font-size:12px;color:#999;max-width:480px;white-space:pre-wrap;word-break:break-word">' +
-                            '$safe' +
-                        '</div>' +
-                        $retryBlock
-                        '<div style="margin-top:16px;font-size:12px">' +
-                            'Something unexpected? <a href="https://github.com/rajbos/ai-engineering-fluency/issues" target="_blank" style="color:#4daafc;text-decoration:none">Report an issue</a>' +
+                        '<div style="width:100%;max-width:600px;background:var(--vscode-sideBar-background);border:1px solid var(--vscode-panel-border);border-radius:16px;padding:24px 28px;box-shadow:0 8px 32px rgba(0,0,0,0.3);text-align:center">' +
+                            '<div style="font-size:32px;margin-bottom:8px">&#x26A0;</div>' +
+                            '<div style="font-size:15px;font-weight:600;margin-bottom:8px">Error loading Copilot usage data</div>' +
+                            '<div style="font-size:12px;color:#999;max-width:480px;margin:0 auto;white-space:pre-wrap;word-break:break-word;text-align:left">' +
+                                '$safe' +
+                            '</div>' +
+                            $retryBlock
+                            '<div style="margin-top:16px;font-size:12px">' +
+                                'Something unexpected? <a href="https://github.com/rajbos/ai-engineering-fluency/issues" target="_blank" style="color:#4daafc;text-decoration:none">Report an issue</a>' +
+                            '</div>' +
                         '</div>';
                 }
             })();

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/WebviewResources.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/WebviewResources.kt
@@ -62,7 +62,7 @@ object WebviewResources {
         // assigns the real value as soon as the CLI returns.
         // When initial data is provided, hide the loading overlay and show root immediately
         val overlayDisplayStyle = if (initialStatsJson != null) "display: none"
-            else "display: flex; align-items: center; justify-content: center; min-height: calc(100vh - 32px); padding: 20px; box-sizing: border-box"
+            else "display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: calc(100vh - 32px); padding: 20px; box-sizing: border-box"
         val rootStyle = if (initialStatsJson != null) "" else "display: none"
 
         return """


### PR DESCRIPTION
## Problem
The error page in the JetBrains plugin was rendering all elements (icon, title, error message, buttons) on a single horizontal row due to the `#loading-overlay` flex container defaulting to `flex-direction: row`.

## Changes
- **`WebviewResources.kt`**: Added `flex-direction: column` to the `#loading-overlay` CSS so its children stack vertically
- **`TokenTrackerPanel.kt`**: Wrapped the error HTML in a card-style container div (matching the loading card design) with:
  - Centered icon and title
  - Left-aligned error message text for readability
  - Centered retry buttons and "Report an issue" link