### PR TITLE
fix: make fluency stage 2 and stage 4 visually distinct

### DIFF
--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -381,9 +381,9 @@ function layout(title: string, body: string): string {
   .fluency-stage-pill { display: inline-block; padding: 2px 8px; border-radius: 10px;
     font-size: 0.72rem; font-weight: 600; margin-left: auto; white-space: nowrap; flex-shrink: 0; }
   .stage-1 { background: rgba(147,197,253,0.15); color: #93c5fd; border: 1px solid rgba(147,197,253,0.4); }
-  .stage-2 { background: rgba(110,231,183,0.15); color: #6ee7b7; border: 1px solid rgba(110,231,183,0.4); }
+  .stage-2 { background: rgba(167,139,250,0.15); color: #a78bfa; border: 1px solid rgba(167,139,250,0.4); }
   .stage-3 { background: rgba(59,130,246,0.15);  color: #3b82f6; border: 1px solid rgba(59,130,246,0.4); }
-  .stage-4 { background: rgba(16,185,129,0.15);  color: #10b981; border: 1px solid rgba(16,185,129,0.4); }
+  .stage-4 { background: rgba(34,211,238,0.15);  color: #22d3ee; border: 1px solid rgba(34,211,238,0.4); }
   .fluency-tips { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
   .fluency-tips li { font-size: 0.8rem; color: #8b949e; padding-left: 14px; position: relative;
     overflow-wrap: break-word; word-break: break-word; }
@@ -848,7 +848,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean): s
 	const stageStars = fluencyScore
 		? ['', '⭐', '⭐⭐', '⭐⭐⭐', '⭐⭐⭐⭐'][fluencyScore.overallStage] ?? ''
 		: '';
-	const stageColorMap: Record<number, string> = { 1: '#93c5fd', 2: '#6ee7b7', 3: '#3b82f6', 4: '#10b981' };
+	const stageColorMap: Record<number, string> = { 1: '#93c5fd', 2: '#a78bfa', 3: '#3b82f6', 4: '#22d3ee' };
 	const stageColor = fluencyScore ? (stageColorMap[fluencyScore.overallStage] ?? '#93c5fd') : '#93c5fd';
 
 	const fluencyBadgeHtml = fluencyScore ? `

--- a/vscode-extension/src/webview/dashboard/styles.css
+++ b/vscode-extension/src/webview/dashboard/styles.css
@@ -247,9 +247,9 @@
 }
 
 .fluency-badge.stage-2 {
-	background-color: rgba(110, 231, 183, 0.15);
-	color: #6ee7b7;
-	border: 1px solid rgba(110, 231, 183, 0.4);
+	background-color: rgba(167, 139, 250, 0.15);
+	color: #a78bfa;
+	border: 1px solid rgba(167, 139, 250, 0.4);
 }
 
 .fluency-badge.stage-3 {
@@ -259,9 +259,9 @@
 }
 
 .fluency-badge.stage-4 {
-	background-color: rgba(16, 185, 129, 0.15);
-	color: #10b981;
-	border: 1px solid rgba(16, 185, 129, 0.4);
+	background-color: rgba(34, 211, 238, 0.15);
+	color: #22d3ee;
+	border: 1px solid rgba(34, 211, 238, 0.4);
 }
 
 .action-header {
@@ -385,15 +385,15 @@
 
 /* Re-use matching stage colors for inline badges */
 .fluency-category-badge.stage-1 { background: rgba(147,197,253,0.15); color: #93c5fd; }
-.fluency-category-badge.stage-2 { background: rgba(110,231,183,0.15); color: #6ee7b7; }
+.fluency-category-badge.stage-2 { background: rgba(167,139,250,0.15); color: #a78bfa; }
 .fluency-category-badge.stage-3 { background: rgba(59,130,246,0.15);  color: #3b82f6; }
-.fluency-category-badge.stage-4 { background: rgba(16,185,129,0.15);  color: #10b981; }
+.fluency-category-badge.stage-4 { background: rgba(34,211,238,0.15);  color: #22d3ee; }
 
 /* Left-border accent matching stage color */
 .stage-border-1 { border-left: 3px solid #93c5fd; }
-.stage-border-2 { border-left: 3px solid #6ee7b7; }
+.stage-border-2 { border-left: 3px solid #a78bfa; }
 .stage-border-3 { border-left: 3px solid #3b82f6; }
-.stage-border-4 { border-left: 3px solid #10b981; }
+.stage-border-4 { border-left: 3px solid #22d3ee; }
 
 /* Stage progress pips */
 .fluency-stage-bar {
@@ -409,9 +409,9 @@
 }
 
 .stage-pip.filled.stage-pip-1 { background: #93c5fd; }
-.stage-pip.filled.stage-pip-2 { background: #6ee7b7; }
+.stage-pip.filled.stage-pip-2 { background: #a78bfa; }
 .stage-pip.filled.stage-pip-3 { background: #3b82f6; }
-.stage-pip.filled.stage-pip-4 { background: #10b981; }
+.stage-pip.filled.stage-pip-4 { background: #22d3ee; }
 
 /* Tips */
 .fluency-tips {

--- a/vscode-extension/src/webview/fluency-level-viewer/styles.css
+++ b/vscode-extension/src/webview/fluency-level-viewer/styles.css
@@ -122,9 +122,9 @@
 }
 
 .level-card.stage-1 { border-left: 4px solid #93c5fd; }
-.level-card.stage-2 { border-left: 4px solid #6ee7b7; }
+.level-card.stage-2 { border-left: 4px solid #a78bfa; }
 .level-card.stage-3 { border-left: 4px solid #3b82f6; }
-.level-card.stage-4 { border-left: 4px solid #10b981; }
+.level-card.stage-4 { border-left: 4px solid #22d3ee; }
 
 .level-header {
 	display: flex;
@@ -146,9 +146,9 @@
 }
 
 .badge-1 { background: rgba(147, 197, 253, 0.2); color: #93c5fd; }
-.badge-2 { background: rgba(110, 231, 183, 0.2); color: #6ee7b7; }
+.badge-2 { background: rgba(167, 139, 250, 0.2); color: #a78bfa; }
 .badge-3 { background: rgba(59, 130, 246, 0.2); color: #3b82f6; }
-.badge-4 { background: rgba(16, 185, 129, 0.2); color: #10b981; }
+.badge-4 { background: rgba(34, 211, 238, 0.2); color: #22d3ee; }
 
 .level-description {
 	font-size: 12px;

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -538,7 +538,7 @@ details[open] > summary .collapse-arrow {
 }
 
 .tool-call-pretty:hover {
-	color: #6ee7b7;
+	color: #a78bfa;
 }
 
 .tool-details {

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -140,9 +140,9 @@ function renderRadarChart(categories: CategoryScore[], overallStage: number): st
 function stageColor(stage: number): string {
 	switch (stage) {
 		case 1: return '#93c5fd';
-		case 2: return '#6ee7b7';
+		case 2: return '#a78bfa';
 		case 3: return '#3b82f6';
-		case 4: return '#10b981';
+		case 4: return '#22d3ee';
 		default: return '#666';
 	}
 }

--- a/vscode-extension/src/webview/maturity/styles.css
+++ b/vscode-extension/src/webview/maturity/styles.css
@@ -86,19 +86,19 @@ body {
 
 /* Stage accent colors — dark theme defaults */
 .stage-1 { color: #93c5fd; }
-.stage-2 { color: #6ee7b7; }
+.stage-2 { color: #a78bfa; }
 .stage-3 { color: #3b82f6; }
-.stage-4 { color: #10b981; }
+.stage-4 { color: #22d3ee; }
 
 /* Light theme: darken pale stage colors for readable contrast */
 body[data-vscode-theme-kind="vscode-light"] .stage-1,
 body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-1 { color: #1d6fa4 !important; }
 body[data-vscode-theme-kind="vscode-light"] .stage-2,
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-2 { color: #059669 !important; }
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-2 { color: #7c3aed !important; }
 body[data-vscode-theme-kind="vscode-light"] .stage-3,
 body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-3 { color: #2563eb !important; }
 body[data-vscode-theme-kind="vscode-light"] .stage-4,
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-4 { color: #059669 !important; }
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-4 { color: #0891b2 !important; }
 
 /* Radar / spider chart container */
 .radar-wrapper {
@@ -178,9 +178,9 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-4 { color: #059
 }
 
 .stage-1-dot { background: #93c5fd; }
-.stage-2-dot { background: #6ee7b7; }
+.stage-2-dot { background: #a78bfa; }
 .stage-3-dot { background: #3b82f6; }
-.stage-4-dot { background: #10b981; }
+.stage-4-dot { background: #22d3ee; }
 
 .legend-content {
 	flex: 1;
@@ -244,9 +244,9 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-4 { color: #059
 }
 
 .badge-2 {
-	background: rgba(110, 231, 183, 0.15);
-	color: #6ee7b7;
-	border: 1px solid rgba(110, 231, 183, 0.4);
+	background: rgba(167, 139, 250, 0.15);
+	color: #a78bfa;
+	border: 1px solid rgba(167, 139, 250, 0.4);
 }
 
 .badge-3 {
@@ -256,20 +256,20 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-4 { color: #059
 }
 
 .badge-4 {
-	background: rgba(16, 185, 129, 0.15);
-	color: #10b981;
-	border: 1px solid rgba(16, 185, 129, 0.4);
+	background: rgba(34, 211, 238, 0.15);
+	color: #22d3ee;
+	border: 1px solid rgba(34, 211, 238, 0.4);
 }
 
 /* Light theme badge overrides — use darker text for contrast */
 body[data-vscode-theme-kind="vscode-light"] .badge-1,
 body[data-vscode-theme-kind="vscode-high-contrast-light"] .badge-1 { color: #1d6fa4; }
 body[data-vscode-theme-kind="vscode-light"] .badge-2,
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .badge-2 { color: #059669; }
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .badge-2 { color: #7c3aed; }
 body[data-vscode-theme-kind="vscode-light"] .badge-3,
 body[data-vscode-theme-kind="vscode-high-contrast-light"] .badge-3 { color: #2563eb; }
 body[data-vscode-theme-kind="vscode-light"] .badge-4,
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .badge-4 { color: #059669; }
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .badge-4 { color: #0891b2; }
 
 .category-stage-label {
 	font-size: 11px;
@@ -887,18 +887,18 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .share-btn-download { 
 }
 
 .demo-step-active.demo-step-1 { background: rgba(147, 197, 253, 0.2); color: #93c5fd; }
-.demo-step-active.demo-step-2 { background: rgba(110, 231, 183, 0.2); color: #6ee7b7; }
+.demo-step-active.demo-step-2 { background: rgba(167, 139, 250, 0.2); color: #a78bfa; }
 .demo-step-active.demo-step-3 { background: rgba(59, 130, 246, 0.2); color: #3b82f6; }
-.demo-step-active.demo-step-4 { background: rgba(16, 185, 129, 0.2); color: #10b981; }
+.demo-step-active.demo-step-4 { background: rgba(34, 211, 238, 0.2); color: #22d3ee; }
 
 body[data-vscode-theme-kind="vscode-light"] .demo-step-active.demo-step-1,
 body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo-step-1 { color: #1d6fa4; }
 body[data-vscode-theme-kind="vscode-light"] .demo-step-active.demo-step-2,
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo-step-2 { color: #059669; }
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo-step-2 { color: #7c3aed; }
 body[data-vscode-theme-kind="vscode-light"] .demo-step-active.demo-step-3,
 body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo-step-3 { color: #2563eb; }
 body[data-vscode-theme-kind="vscode-light"] .demo-step-active.demo-step-4,
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo-step-4 { color: #059669; }
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo-step-4 { color: #0891b2; }
 
 .demo-slider-value {
 	font-size: 11px;


### PR DESCRIPTION
## Problem

Stage 2 (mint green `#6ee7b7`) and Stage 4 (emerald green `#10b981`) were nearly indistinguishable at a glance — both in the green family.

## Solution

Replaced the two green stages with distinct hues from the cool-tone spectrum — no red/yellow that would imply good/bad:

| Stage | Before | After |
|-------|--------|-------|
| 1 | Light blue `#93c5fd` | Light blue `#93c5fd` *(unchanged)* |
| 2 | Mint green `#6ee7b7` | **Violet `#a78bfa`** |
| 3 | Blue `#3b82f6` | Blue `#3b82f6` *(unchanged)* |
| 4 | Emerald green `#10b981` | **Cyan `#22d3ee`** |

All four stages now occupy distinct hue families (blue → violet → blue → cyan) with no colour carrying a good/bad connotation.

## Files changed

- `vscode-extension/src/webview/fluency-level-viewer/styles.css` — level cards & badges
- `vscode-extension/src/webview/dashboard/styles.css` — fluency badges, category badges, border accents, stage pips
- `vscode-extension/src/webview/maturity/styles.css` — stage colors, dots, badges, light-theme overrides, demo steps
- `vscode-extension/src/webview/maturity/main.ts` — `stageColor()` function
- `vscode-extension/src/webview/logviewer/styles.css` — tool-call hover accent
- `sharing-server/src/routes/dashboard.ts` — inline stage CSS + stage color map