### PR TITLE
feat: track tool output tokens and show in Diagnostics Tool Analysis tab

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -372,6 +372,39 @@
           "default": [],
           "description": "List of tool names to suppress from the 'Unknown Tools Found' section in the Usage Analysis dashboard. Useful for tools you are testing that don't yet have friendly display names."
         },
+        "aiEngineeringFluency.toolFamilies": {
+          "type": "array",
+          "default": [],
+          "description": "Override or extend tool family groupings used in the Tool Output Token Analysis tab. Each entry with an 'id' matching a built-in family replaces that family entirely. Entries with new 'id' values are appended. Leave empty to use the built-in defaults. Example: { \"id\": \"reading\", \"name\": \"File Reading\", \"builtIn\": [\"read\"], \"alternatives\": [\"lean-ctx\", \"my-custom-reader\"] }",
+          "items": {
+            "type": "object",
+            "required": ["id", "name", "builtIn", "alternatives"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Stable identifier used for override matching (e.g. 'reading'). Must be unique."
+              },
+              "name": {
+                "type": "string",
+                "description": "Display name shown in the Tool Analysis tab."
+              },
+              "builtIn": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Built-in / baseline tool names that define the reference performance. Tool names must match exactly as they appear in session logs."
+              },
+              "alternatives": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Alternative or efficient-replacement tool names to compare against the built-ins."
+              },
+              "description": {
+                "type": "string",
+                "description": "Optional short description of this tool family."
+              }
+            }
+          }
+        },
         "aiEngineeringFluency.insights.enabled": {
           "type": "boolean",
           "default": true,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7325,6 +7325,12 @@ ${this.getLoadingHtmlScript()}
         this.log("✅ Cache populated, proceeding with diagnostics load");
       }
 
+      if (!this.lastUsageAnalysisStats) {
+        this.log("⚡ No usage analysis stats cached - computing for tool analysis tab...");
+        await this.calculateUsageAnalysisStats(false);
+        this.log("✅ Usage analysis stats computed");
+      }
+
       const report = await this.generateDiagnosticReport();
       this.lastDiagnosticReport = report;
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -12,7 +12,7 @@ import toolNamesData from './toolNames.json';
 import customizationPatternsData from './customizationPatterns.json';
 import copilotPlansData from './copilotPlans.json';
 import * as packageJson from '../package.json';
-import { getToolFamilies } from './toolFamilies';
+import { getToolFamilies, DEFAULT_TOOL_FAMILIES } from './toolFamilies';
 
 // --- Core types ---
 import type {
@@ -7117,6 +7117,7 @@ ${this.getLoadingHtmlScript()}
       configureTeamServer: () => this.dispatch('configureTeamServer:diagnostics', () => this.diagHandleConfigureTeamServer()),
       openSettings: () => this.dispatch('openSettings:diagnostics', () => vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.backend")),
       openDisplaySettings: () => this.dispatch('openDisplaySettings:diagnostics', () => vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.display")),
+      openToolFamiliesSettings: () => this.dispatch('openToolFamiliesSettings:diagnostics', () => vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.toolFamilies")),
       resetDebugCounters: () => this.dispatch('resetDebugCounters:diagnostics', () => this.diagHandleResetDebugCounters()),
       authenticateGitHub: () => this.dispatch('authenticateGitHub:diagnostics', () => this.diagHandleGitHubAuth(true)),
       signOutGitHub: () => this.dispatch('signOutGitHub:diagnostics', () => this.diagHandleGitHubAuth(false)),
@@ -8327,6 +8328,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<AiFlue
   // Migrate settings from the old copilotTokenTracker namespace to aiEngineeringFluency.
   // Run before any other settings are read so the new keys are populated first.
   await migrateSettingsIfNeeded(context, (m) => tokenTracker.log(m));
+
+  // Pre-fill toolFamilies setting with defaults so users have a starting point for customisation.
+  const cfg = vscode.workspace.getConfiguration('aiEngineeringFluency');
+  const existingFamilies = cfg.get<unknown[]>('toolFamilies');
+  if (!existingFamilies || existingFamilies.length === 0) {
+    await cfg.update('toolFamilies', DEFAULT_TOOL_FAMILIES, vscode.ConfigurationTarget.Global);
+  }
 
   // Migrate any stored shared key secrets from the old key name to the new key name.
   await migrateSecretsIfNeeded(context, (m) => tokenTracker.log(m));

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -12,6 +12,7 @@ import toolNamesData from './toolNames.json';
 import customizationPatternsData from './customizationPatterns.json';
 import copilotPlansData from './copilotPlans.json';
 import * as packageJson from '../package.json';
+import { getToolFamilies } from './toolFamilies';
 
 // --- Core types ---
 import type {
@@ -7362,6 +7363,7 @@ ${this.getLoadingHtmlScript()}
         backendStorageInfo,
         githubAuth: githubAuthStatus,
         toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
+        toolFamilies: getToolFamilies(),
       });
 
       this.log("✅ Diagnostic data loaded and sent to webview");
@@ -7680,6 +7682,7 @@ ${this.getLoadingHtmlScript()}
       backendConfigured: this.isBackendConfigured(), isDebugMode, globalStateCounters,
       displaySettings: { showTokens: this.getStatusBarShowTokensSetting(), showCost: this.getStatusBarShowCostSetting(), monthlyBudget: this.getMonthlyBudgetSetting() },
       toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
+      toolFamilies: getToolFamilies(),
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -280,7 +280,7 @@ function _scdlDistributeToDays(
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 56; // Track tool output tokens per tool call (outputTokensByTool)
+	private static readonly CACHE_VERSION = 57; // Fix output token counting: use tool.execution_complete events
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -280,7 +280,7 @@ function _scdlDistributeToDays(
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 55; // Fix LOC extraction for Copilot CLI coding agent sessions (edit/create tools)
+	private static readonly CACHE_VERSION = 56; // Track tool output tokens per tool call (outputTokensByTool)
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -7355,6 +7355,7 @@ ${this.getLoadingHtmlScript()}
         candidatePaths,
         backendStorageInfo,
         githubAuth: githubAuthStatus,
+        toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
       });
 
       this.log("✅ Diagnostic data loaded and sent to webview");
@@ -7672,6 +7673,7 @@ ${this.getLoadingHtmlScript()}
       cacheInfo, backendStorageInfo,
       backendConfigured: this.isBackendConfigured(), isDebugMode, globalStateCounters,
       displaySettings: { showTokens: this.getStatusBarShowTokensSetting(), showCost: this.getStatusBarShowCostSetting(), monthlyBudget: this.getMonthlyBudgetSetting() },
+      toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/toolFamilies.ts
+++ b/vscode-extension/src/toolFamilies.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+
+export interface ToolFamily {
+	/** Stable identifier used for override matching (e.g. "reading"). */
+	id: string;
+	/** Display name shown in the UI. */
+	name: string;
+	/** Built-in / baseline tool names that define the reference point. */
+	builtIn: string[];
+	/** Alternative / efficient-replacement tool names to compare against the built-ins. */
+	alternatives: string[];
+	/** Optional short description shown as a tooltip or subtitle. */
+	description?: string;
+}
+
+/** Default tool family definitions. Tool names are matched against normalized names in outputTokensByTool. */
+export const DEFAULT_TOOL_FAMILIES: ToolFamily[] = [
+	{
+		id: 'reading',
+		name: 'File Reading',
+		builtIn: ['read', 'view', 'cat'],
+		alternatives: ['lean-ctx', 'read_file', 'copilot_readFile'],
+		description: 'Tools that read file contents into context.',
+	},
+	{
+		id: 'search',
+		name: 'Search & Discovery',
+		builtIn: ['search', 'grep', 'rg', 'glob', 'find'],
+		alternatives: ['symdex', 'search_files', 'copilot_searchFiles'],
+		description: 'Tools that search the codebase for files or text patterns.',
+	},
+	{
+		id: 'writing',
+		name: 'File Writing',
+		builtIn: ['edit', 'create', 'write'],
+		alternatives: ['write_file', 'copilot_createFile', 'copilot_editFile'],
+		description: 'Tools that create or modify files.',
+	},
+	{
+		id: 'shell',
+		name: 'Shell / Terminal',
+		builtIn: ['run_in_terminal', 'bash', 'shell'],
+		alternatives: ['run_command', 'execute_command'],
+		description: 'Tools that execute shell commands.',
+	},
+	{
+		id: 'code-intelligence',
+		name: 'Code Intelligence',
+		builtIn: ['get_errors', 'hover', 'get_references', 'get_definition'],
+		alternatives: ['lsp', 'diagnostics', 'symbol_lookup'],
+		description: 'Tools that query language-server or IDE intelligence.',
+	},
+];
+
+/**
+ * Merge user-provided family overrides with the defaults.
+ * - User entries whose `id` matches a default replace that default entirely.
+ * - User entries with no matching default are appended as new families.
+ * - Family order: defaults first (with replacements in-place), then new user families.
+ * - Tool-to-family assignment: first family that lists the tool wins (no duplicates).
+ */
+export function mergeToolFamilies(overrides: ToolFamily[]): ToolFamily[] {
+	const result: ToolFamily[] = DEFAULT_TOOL_FAMILIES.map(def => {
+		const override = overrides.find(o => o.id === def.id);
+		return override ?? def;
+	});
+	for (const override of overrides) {
+		if (!DEFAULT_TOOL_FAMILIES.some(def => def.id === override.id)) {
+			result.push(override);
+		}
+	}
+	return result;
+}
+
+/** Read and merge tool families from VS Code settings. Falls back to defaults on error. */
+export function getToolFamilies(): ToolFamily[] {
+	try {
+		const raw = vscode.workspace.getConfiguration('aiEngineeringFluency').get<ToolFamily[]>('toolFamilies', []);
+		return mergeToolFamilies(Array.isArray(raw) ? raw : []);
+	} catch {
+		return [...DEFAULT_TOOL_FAMILIES];
+	}
+}

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -270,6 +270,7 @@ export interface SessionUsageAnalysis {
 export interface ToolCallUsage {
   total: number;
   byTool: { [toolName: string]: number };
+  outputTokensByTool?: { [toolName: string]: number };
 }
 
 export interface ModeUsage {

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -908,6 +908,12 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 	for (const [tool, count] of Object.entries(analysis.toolCalls.byTool)) {
 		period.toolCalls.byTool[tool] = (period.toolCalls.byTool[tool] || 0) + count;
 	}
+	if (analysis.toolCalls.outputTokensByTool) {
+		if (!period.toolCalls.outputTokensByTool) { period.toolCalls.outputTokensByTool = {}; }
+		for (const [tool, tokens] of Object.entries(analysis.toolCalls.outputTokensByTool)) {
+			period.toolCalls.outputTokensByTool[tool] = (period.toolCalls.outputTokensByTool[tool] || 0) + tokens;
+		}
+	}
 	period.modeUsage.ask += analysis.modeUsage.ask;
 	period.modeUsage.edit += analysis.modeUsage.edit;
 	period.modeUsage.agent += analysis.modeUsage.agent;
@@ -1674,10 +1680,32 @@ function _asuProcessCliEvents(event: any, cliState: AsuCliState, analysis: Sessi
 
 /** Handle tool.call / tool.result / tool.execution_start events. */
  
+/** Extract plain text from a CLI tool.result event's content (string or content-block array). */
+function _asuExtractToolResultText(event: any): string {
+	const content = event.data?.result?.content;
+	if (!content) { return ''; }
+	if (typeof content === 'string') { return content; }
+	if (Array.isArray(content)) {
+		return content
+			.filter((block: any) => block?.type === 'text' && typeof block.text === 'string')
+			.map((block: any) => block.text as string)
+			.join('');
+	}
+	return '';
+}
+
 function _asuHandleToolCallEvent(event: any, analysis: SessionUsageAnalysis, toolNameMap: { [key: string]: string }): void {
 	if (event.type !== 'tool.call' && event.type !== 'tool.result' && event.type !== 'tool.execution_start') { return; }
 	const toolName = event.data?.toolName || event.toolName || 'unknown';
 	recordToolOrMcpInvocation(toolName, analysis, toolNameMap);
+	if (event.type === 'tool.result' && !isMcpTool(toolName)) {
+		const resultText = _asuExtractToolResultText(event);
+		if (resultText) {
+			const tokens = estimateTokensFromText(resultText);
+			if (!analysis.toolCalls.outputTokensByTool) { analysis.toolCalls.outputTokensByTool = {}; }
+			analysis.toolCalls.outputTokensByTool[toolName] = (analysis.toolCalls.outputTokensByTool[toolName] || 0) + tokens;
+		}
+	}
 }
 
 /** Handle mcp.tool.call events and events with data.mcpServer set. */

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1746,6 +1746,18 @@ function _asuApplyToolLoc(pending: { toolName: string; args: Record<string, stri
 	analysis.editScope!.languageUsage[ext].linesRemoved += linesRemoved;
 }
 
+/** Extract plain text from a tool result content value (string or content-block array). */
+function _asuExtractToolResultText(content: unknown): string {
+	if (typeof content === 'string') { return content; }
+	if (Array.isArray(content)) {
+		return content
+			.filter((b: any) => b?.type === 'text' && typeof b.text === 'string')
+			.map((b: any) => b.text as string)
+			.join('');
+	}
+	return '';
+}
+
 /** Handle tool.execution_complete — applies LOC tracking for edit/create and counts output tokens for all non-MCP tools. */
 function _asuHandleToolComplete(event: any, cliState: AsuCliState, analysis: SessionUsageAnalysis): void {
 	const { toolCallId, success, result } = event.data ?? {};
@@ -1755,18 +1767,12 @@ function _asuHandleToolComplete(event: any, cliState: AsuCliState, analysis: Ses
 	if (success && (pending.toolName === 'edit' || pending.toolName === 'create')) {
 		_asuApplyToolLoc(pending, cliState, analysis);
 	}
-	if (result?.content && !isMcpTool(pending.toolName)) {
-		const content = result.content;
-		const resultText = typeof content === 'string' ? content
-			: Array.isArray(content)
-				? content.filter((b: any) => b?.type === 'text' && typeof b.text === 'string').map((b: any) => b.text as string).join('')
-				: '';
-		if (resultText) {
-			const tokens = estimateTokensFromText(resultText);
-			if (!analysis.toolCalls.outputTokensByTool) { analysis.toolCalls.outputTokensByTool = {}; }
-			analysis.toolCalls.outputTokensByTool[pending.toolName] = (analysis.toolCalls.outputTokensByTool[pending.toolName] || 0) + tokens;
-		}
-	}
+	if (!result?.content || isMcpTool(pending.toolName)) { return; }
+	const resultText = _asuExtractToolResultText(result.content);
+	if (!resultText) { return; }
+	const tokens = estimateTokensFromText(resultText);
+	if (!analysis.toolCalls.outputTokensByTool) { analysis.toolCalls.outputTokensByTool = {}; }
+	analysis.toolCalls.outputTokensByTool[pending.toolName] = (analysis.toolCalls.outputTokensByTool[pending.toolName] || 0) + tokens;
 }
 
 /** Handle tool.execution_start / tool.execution_complete for CLI LOC tracking. */

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -1680,32 +1680,10 @@ function _asuProcessCliEvents(event: any, cliState: AsuCliState, analysis: Sessi
 
 /** Handle tool.call / tool.result / tool.execution_start events. */
  
-/** Extract plain text from a CLI tool.result event's content (string or content-block array). */
-function _asuExtractToolResultText(event: any): string {
-	const content = event.data?.result?.content;
-	if (!content) { return ''; }
-	if (typeof content === 'string') { return content; }
-	if (Array.isArray(content)) {
-		return content
-			.filter((block: any) => block?.type === 'text' && typeof block.text === 'string')
-			.map((block: any) => block.text as string)
-			.join('');
-	}
-	return '';
-}
-
 function _asuHandleToolCallEvent(event: any, analysis: SessionUsageAnalysis, toolNameMap: { [key: string]: string }): void {
 	if (event.type !== 'tool.call' && event.type !== 'tool.result' && event.type !== 'tool.execution_start') { return; }
 	const toolName = event.data?.toolName || event.toolName || 'unknown';
 	recordToolOrMcpInvocation(toolName, analysis, toolNameMap);
-	if (event.type === 'tool.result' && !isMcpTool(toolName)) {
-		const resultText = _asuExtractToolResultText(event);
-		if (resultText) {
-			const tokens = estimateTokensFromText(resultText);
-			if (!analysis.toolCalls.outputTokensByTool) { analysis.toolCalls.outputTokensByTool = {}; }
-			analysis.toolCalls.outputTokensByTool[toolName] = (analysis.toolCalls.outputTokensByTool[toolName] || 0) + tokens;
-		}
-	}
 }
 
 /** Handle mcp.tool.call events and events with data.mcpServer set. */
@@ -1742,11 +1720,11 @@ function _asuEnsureEditScope(analysis: SessionUsageAnalysis): void {
 	}
 }
 
-/** Handle tool.execution_start for CLI LOC tracking — stores pending tool call args. */
+/** Handle tool.execution_start — stores pending tool call info for all tools (LOC + output token tracking). */
 function _asuHandleToolStart(event: any, cliState: AsuCliState): void {
 	const { toolCallId, toolName, arguments: args } = event.data ?? {};
-	if (toolCallId && (toolName === 'edit' || toolName === 'create') && args) {
-		cliState.pendingToolCalls.set(toolCallId, { toolName, args });
+	if (toolCallId && toolName) {
+		cliState.pendingToolCalls.set(toolCallId, { toolName, args: args ?? {} });
 	}
 }
 
@@ -1768,12 +1746,27 @@ function _asuApplyToolLoc(pending: { toolName: string; args: Record<string, stri
 	analysis.editScope!.languageUsage[ext].linesRemoved += linesRemoved;
 }
 
-/** Handle tool.execution_complete for CLI LOC tracking — applies LOC on success. */
+/** Handle tool.execution_complete — applies LOC tracking for edit/create and counts output tokens for all non-MCP tools. */
 function _asuHandleToolComplete(event: any, cliState: AsuCliState, analysis: SessionUsageAnalysis): void {
-	const { toolCallId, success } = event.data ?? {};
+	const { toolCallId, success, result } = event.data ?? {};
 	const pending = toolCallId ? cliState.pendingToolCalls.get(toolCallId) : undefined;
 	if (toolCallId) { cliState.pendingToolCalls.delete(toolCallId); }
-	if (pending && success) { _asuApplyToolLoc(pending, cliState, analysis); }
+	if (!pending) { return; }
+	if (success && (pending.toolName === 'edit' || pending.toolName === 'create')) {
+		_asuApplyToolLoc(pending, cliState, analysis);
+	}
+	if (result?.content && !isMcpTool(pending.toolName)) {
+		const content = result.content;
+		const resultText = typeof content === 'string' ? content
+			: Array.isArray(content)
+				? content.filter((b: any) => b?.type === 'text' && typeof b.text === 'string').map((b: any) => b.text as string).join('')
+				: '';
+		if (resultText) {
+			const tokens = estimateTokensFromText(resultText);
+			if (!analysis.toolCalls.outputTokensByTool) { analysis.toolCalls.outputTokensByTool = {}; }
+			analysis.toolCalls.outputTokensByTool[pending.toolName] = (analysis.toolCalls.outputTokensByTool[pending.toolName] || 0) + tokens;
+		}
+	}
 }
 
 /** Handle tool.execution_start / tool.execution_complete for CLI LOC tracking. */

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1564,11 +1564,15 @@ function handleDiagnosticDataLoaded(message: DiagMessage): void {
   if (message.toolCallStats !== undefined) {
     const toolAnalysisTab = document.getElementById("tab-tool-analysis");
     if (toolAnalysisTab) {
+      const wasActive = toolAnalysisTab.classList.contains("active");
       const newContent = renderToolAnalysisTab(message.toolCallStats as DiagnosticsData['toolCallStats']);
       const temp = document.createElement('div');
       temp.innerHTML = newContent;
-      const newTab = temp.firstElementChild;
-      if (newTab) { toolAnalysisTab.replaceWith(newTab); }
+      const newTab = temp.firstElementChild as HTMLElement | null;
+      if (newTab) {
+        if (wasActive) { newTab.classList.add("active"); }
+        toolAnalysisTab.replaceWith(newTab);
+      }
     }
   }
 }

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1267,6 +1267,9 @@ function setupToolAnalysisSortHandlers(): void {
       reRenderToolAnalysisTable();
     });
   });
+  document.getElementById("btn-open-tool-families-settings")?.addEventListener("click", () => {
+    vscode.postMessage({ command: "openToolFamiliesSettings" });
+  });
 }
 
 function setupFileLinks(): void {
@@ -2038,7 +2041,7 @@ function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats'], 
   return `<div id="tab-tool-analysis" class="tab-content">
 <div class="info-box">
 <div class="info-box-title">🔧 Tool Output Token Analysis</div>
-<div>Tokens produced by each tool's output over the last 30 days. Tools are grouped by family. <strong>vs Built-in</strong> shows how an alternative compares to the pooled baseline — green is more token-efficient. Click column headers to sort within each group. Configure families via <code>aiEngineeringFluency.toolFamilies</code> in VS Code settings.</div>
+<div>Tokens produced by each tool's output over the last 30 days. Tools are grouped by family. <strong>vs Built-in</strong> shows how an alternative compares to the pooled baseline — green is more token-efficient. Click column headers to sort within each group. <button class="inline-link" id="btn-open-tool-families-settings">Configure tool families ↗</button></div>
 </div>
 ${sectionsHtml}
 </div>`;

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -156,6 +156,10 @@ let currentEditorFilter: string | null = null; // null = show all
 let currentContextRefFilter: keyof ContextReferenceUsage | null = null; // null = show all
 let hideEmptySessions = true; // hide sessions with 0 interactions by default
 
+// Tool analysis table sort state
+let toolSortColumn: "tool" | "calls" | "total" | "avg" = "avg";
+let toolSortDir: "asc" | "desc" = "desc";
+
 // Render state (promoted to module level so all setup functions can be top-level)
 let storedDetailedFiles: SessionFileDetails[] = [];
 let isLoading = true;
@@ -1224,6 +1228,42 @@ function reRenderTable(): void {
   }
 }
 
+function reRenderToolAnalysisTable(): void {
+  const table = document.getElementById("tool-analysis-table");
+  if (!table) { return; }
+  const encoded = table.getAttribute("data-rows");
+  if (!encoded) { return; }
+  const rows: ToolAnalysisRow[] = JSON.parse(decodeURIComponent(encoded));
+  const tbody = table.querySelector("tbody");
+  if (tbody) { tbody.innerHTML = renderToolAnalysisRows(rows); }
+  const thead = table.querySelector("thead");
+  if (thead) {
+    thead.innerHTML = `<tr>
+<th class="tool-sortable" data-sort="tool">Tool${getToolSortIndicator("tool")}</th>
+<th class="tool-sortable" data-sort="calls">Calls${getToolSortIndicator("calls")}</th>
+<th class="tool-sortable" data-sort="total">Total Output Tokens${getToolSortIndicator("total")}</th>
+<th class="tool-sortable" data-sort="avg">Avg Tokens / Call${getToolSortIndicator("avg")}</th>
+</tr>`;
+  }
+  setupToolAnalysisSortHandlers();
+}
+
+function setupToolAnalysisSortHandlers(): void {
+  document.querySelectorAll<HTMLElement>(".tool-sortable").forEach(header => {
+    header.addEventListener("click", () => {
+      const col = header.getAttribute("data-sort") as typeof toolSortColumn | null;
+      if (!col) { return; }
+      if (toolSortColumn === col) {
+        toolSortDir = toolSortDir === "desc" ? "asc" : "desc";
+      } else {
+        toolSortColumn = col;
+        toolSortDir = col === "tool" ? "asc" : "desc";
+      }
+      reRenderToolAnalysisTable();
+    });
+  });
+}
+
 function setupFileLinks(): void {
   document.querySelectorAll(".session-file-link").forEach((link) => {
     link.addEventListener("click", (e) => {
@@ -1572,6 +1612,7 @@ function handleDiagnosticDataLoaded(message: DiagMessage): void {
       if (newTab) {
         if (wasActive) { newTab.classList.add("active"); }
         toolAnalysisTab.replaceWith(newTab);
+        setupToolAnalysisSortHandlers();
       }
     }
   }
@@ -1860,6 +1901,32 @@ for quick scanning, or as full numbers (e.g. <strong>1,500</strong>, <strong>1,2
 </div>`;
 }
 
+type ToolAnalysisRow = { tool: string; totalTokens: number; calls: number };
+
+function getToolSortIndicator(col: typeof toolSortColumn): string {
+  if (toolSortColumn !== col) { return ' <span class="sort-hint">↕</span>'; }
+  return toolSortDir === "desc" ? " ▼" : " ▲";
+}
+
+function renderToolAnalysisRows(rows: ToolAnalysisRow[]): string {
+  const sorted = [...rows].sort((a, b) => {
+    let aVal: number | string, bVal: number | string;
+    switch (toolSortColumn) {
+      case "tool": aVal = a.tool.toLowerCase(); bVal = b.tool.toLowerCase(); break;
+      case "calls": aVal = a.calls; bVal = b.calls; break;
+      case "total": aVal = a.totalTokens; bVal = b.totalTokens; break;
+      case "avg": default: aVal = a.calls > 0 ? a.totalTokens / a.calls : 0; bVal = b.calls > 0 ? b.totalTokens / b.calls : 0; break;
+    }
+    if (aVal < bVal) { return toolSortDir === "desc" ? 1 : -1; }
+    if (aVal > bVal) { return toolSortDir === "desc" ? -1 : 1; }
+    return 0;
+  });
+  return sorted.map(r => {
+    const avg = r.calls > 0 ? Math.round(r.totalTokens / r.calls) : 0;
+    return `<tr><td>${escapeHtml(r.tool)}</td><td>${escapeHtml(String(r.calls))}</td><td>${formatTokenCount(r.totalTokens)}</td><td>${formatTokenCount(avg)}</td></tr>`;
+  }).join('');
+}
+
 function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats']): string {
   if (!toolCallStats || !toolCallStats.outputTokensByTool || Object.keys(toolCallStats.outputTokensByTool).length === 0) {
     return `<div id="tab-tool-analysis" class="tab-content">
@@ -1871,22 +1938,23 @@ function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats']):
   }
   const outputTokensByTool = toolCallStats.outputTokensByTool;
   const byTool = toolCallStats.byTool;
-  const rows = Object.entries(outputTokensByTool)
+  const rows: ToolAnalysisRow[] = Object.entries(outputTokensByTool)
     .map(([tool, totalTokens]) => ({ tool, totalTokens, calls: byTool[tool] || 0 }))
-    .filter(r => r.calls > 0)
-    .sort((a, b) => (b.totalTokens / b.calls) - (a.totalTokens / a.calls));
-  const tableRows = rows.map(r => {
-    const avg = Math.round(r.totalTokens / r.calls);
-    return `<tr><td>${escapeHtml(r.tool)}</td><td>${escapeHtml(String(r.calls))}</td><td>${formatTokenCount(r.totalTokens)}</td><td>${formatTokenCount(avg)}</td></tr>`;
-  }).join('');
+    .filter(r => r.calls > 0);
+  const encodedRows = encodeURIComponent(JSON.stringify(rows));
   return `<div id="tab-tool-analysis" class="tab-content">
 <div class="info-box">
 <div class="info-box-title">🔧 Tool Output Token Analysis</div>
-<div>Tokens produced by each tool's output over the last 30 days, sorted by average tokens per call (descending). Comparing tools with high vs. low output token counts can help identify efficiency opportunities.</div>
+<div>Tokens produced by each tool's output over the last 30 days. Click column headers to sort.</div>
 </div>
-<table class="session-table">
-<thead><tr><th>Tool</th><th>Calls</th><th>Total Output Tokens</th><th>Avg Tokens / Call</th></tr></thead>
-<tbody>${tableRows}</tbody>
+<table class="session-table" id="tool-analysis-table" data-rows="${encodedRows}">
+<thead><tr>
+<th class="tool-sortable" data-sort="tool">Tool${getToolSortIndicator("tool")}</th>
+<th class="tool-sortable" data-sort="calls">Calls${getToolSortIndicator("calls")}</th>
+<th class="tool-sortable" data-sort="total">Total Output Tokens${getToolSortIndicator("total")}</th>
+<th class="tool-sortable" data-sort="avg">Avg Tokens / Call${getToolSortIndicator("avg")}</th>
+</tr></thead>
+<tbody>${renderToolAnalysisRows(rows)}</tbody>
 </table>
 </div>`;
 }
@@ -2022,6 +2090,7 @@ function renderLayout(data: DiagnosticsData): void {
   setupFolderAnalyzerHandlers();
   setupButtonHandlers();
   setupDisplaySettingHandlers();
+  setupToolAnalysisSortHandlers();
 
   const savedState = diagState.restore();
   if (savedState?.activeTab && !activateTab(savedState.activeTab)) {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -119,6 +119,15 @@ type DiagnosticsData = {
   sessionFolders?: SessionFolder[];
   displaySettings?: DisplaySettings;
   toolCallStats?: { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } } | null;
+  toolFamilies?: ToolFamilyConfig[];
+};
+
+type ToolFamilyConfig = {
+  id: string;
+  name: string;
+  builtIn: string[];
+  alternatives: string[];
+  description?: string;
 };
 
 type DiagnosticsViewState = {
@@ -159,6 +168,7 @@ let hideEmptySessions = true; // hide sessions with 0 interactions by default
 // Tool analysis table sort state
 let toolSortColumn: "tool" | "calls" | "total" | "avg" = "avg";
 let toolSortDir: "asc" | "desc" = "desc";
+let storedToolFamilies: ToolFamilyConfig[] | undefined;
 
 // Render state (promoted to module level so all setup functions can be top-level)
 let storedDetailedFiles: SessionFileDetails[] = [];
@@ -1229,22 +1239,17 @@ function reRenderTable(): void {
 }
 
 function reRenderToolAnalysisTable(): void {
-  const table = document.getElementById("tool-analysis-table");
-  if (!table) { return; }
-  const encoded = table.getAttribute("data-rows");
-  if (!encoded) { return; }
-  const rows: ToolAnalysisRow[] = JSON.parse(decodeURIComponent(encoded));
-  const tbody = table.querySelector("tbody");
-  if (tbody) { tbody.innerHTML = renderToolAnalysisRows(rows); }
-  const thead = table.querySelector("thead");
-  if (thead) {
-    thead.innerHTML = `<tr>
-<th class="tool-sortable" data-sort="tool">Tool${getToolSortIndicator("tool")}</th>
-<th class="tool-sortable" data-sort="calls">Calls${getToolSortIndicator("calls")}</th>
-<th class="tool-sortable" data-sort="total">Total Output Tokens${getToolSortIndicator("total")}</th>
-<th class="tool-sortable" data-sort="avg">Avg Tokens / Call${getToolSortIndicator("avg")}</th>
-</tr>`;
-  }
+  document.querySelectorAll<HTMLElement>(".tool-analysis-table").forEach(table => {
+    const encoded = table.getAttribute("data-rows");
+    if (!encoded) { return; }
+    const rows: ToolAnalysisRow[] = JSON.parse(decodeURIComponent(encoded));
+    const baselineRaw = table.getAttribute("data-baseline");
+    const baseline = baselineRaw ? parseFloat(baselineRaw) : NaN;
+    const tbody = table.querySelector("tbody");
+    if (tbody) { tbody.innerHTML = renderToolAnalysisRows(rows, baseline); }
+    const thead = table.querySelector("thead");
+    if (thead) { thead.innerHTML = toolAnalysisTheadHtml(); }
+  });
   setupToolAnalysisSortHandlers();
 }
 
@@ -1601,11 +1606,12 @@ function handleDiagnosticDataLoaded(message: DiagMessage): void {
       setupGitHubAuthHandlers();
     }
   }
+  if (message.toolFamilies) { storedToolFamilies = message.toolFamilies as ToolFamilyConfig[]; }
   if (message.toolCallStats !== undefined) {
     const toolAnalysisTab = document.getElementById("tab-tool-analysis");
     if (toolAnalysisTab) {
       const wasActive = toolAnalysisTab.classList.contains("active");
-      const newContent = renderToolAnalysisTab(message.toolCallStats as DiagnosticsData['toolCallStats']);
+      const newContent = renderToolAnalysisTab(message.toolCallStats as DiagnosticsData['toolCallStats'], storedToolFamilies);
       const temp = document.createElement('div');
       temp.innerHTML = newContent;
       const newTab = temp.firstElementChild as HTMLElement | null;
@@ -1901,15 +1907,23 @@ for quick scanning, or as full numbers (e.g. <strong>1,500</strong>, <strong>1,2
 </div>`;
 }
 
-type ToolAnalysisRow = { tool: string; totalTokens: number; calls: number };
+type ToolAnalysisRow = { tool: string; totalTokens: number; calls: number; isBuiltIn: boolean };
 
 function getToolSortIndicator(col: typeof toolSortColumn): string {
   if (toolSortColumn !== col) { return ' <span class="sort-hint">↕</span>'; }
   return toolSortDir === "desc" ? " ▼" : " ▲";
 }
 
-function renderToolAnalysisRows(rows: ToolAnalysisRow[]): string {
-  const sorted = [...rows].sort((a, b) => {
+/** Compute pooled avg tokens/call across a set of rows (built-in baseline). Returns NaN if no data. */
+function pooledAvg(rows: ToolAnalysisRow[]): number {
+  const totalCalls = rows.reduce((s, r) => s + r.calls, 0);
+  const totalTokens = rows.reduce((s, r) => s + r.totalTokens, 0);
+  return totalCalls > 0 ? totalTokens / totalCalls : NaN;
+}
+
+/** Sort rows by the current toolSortColumn/toolSortDir. */
+function sortToolRows(rows: ToolAnalysisRow[]): ToolAnalysisRow[] {
+  return [...rows].sort((a, b) => {
     let aVal: number | string, bVal: number | string;
     switch (toolSortColumn) {
       case "tool": aVal = a.tool.toLowerCase(); bVal = b.tool.toLowerCase(); break;
@@ -1921,13 +1935,70 @@ function renderToolAnalysisRows(rows: ToolAnalysisRow[]): string {
     if (aVal > bVal) { return toolSortDir === "desc" ? -1 : 1; }
     return 0;
   });
-  return sorted.map(r => {
-    const avg = r.calls > 0 ? Math.round(r.totalTokens / r.calls) : 0;
-    return `<tr><td>${escapeHtml(r.tool)}</td><td>${escapeHtml(String(r.calls))}</td><td>${formatTokenCount(r.totalTokens)}</td><td>${formatTokenCount(avg)}</td></tr>`;
-  }).join('');
 }
 
-function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats']): string {
+function renderToolRow(r: ToolAnalysisRow, builtInBaseline: number): string {
+  const avg = r.calls > 0 ? Math.round(r.totalTokens / r.calls) : 0;
+  let ratioHtml = '<td class="tool-ratio">—</td>';
+  if (!r.isBuiltIn && !isNaN(builtInBaseline) && builtInBaseline > 0 && r.calls > 0) {
+    const ratio = (r.totalTokens / r.calls) / builtInBaseline;
+    const pct = Math.round(ratio * 100);
+    const cls = ratio < 0.85 ? 'ratio-better' : ratio > 1.15 ? 'ratio-worse' : 'ratio-neutral';
+    ratioHtml = `<td class="tool-ratio ${cls}" title="${pct}% of built-in average">${pct}%</td>`;
+  } else if (r.isBuiltIn) {
+    ratioHtml = '<td class="tool-ratio tool-builtin-label">baseline</td>';
+  }
+  const badge = r.isBuiltIn ? ' <span class="tool-type-badge built-in">built-in</span>' : ' <span class="tool-type-badge alternative">alt</span>';
+  return `<tr><td>${escapeHtml(r.tool)}${badge}</td><td>${escapeHtml(String(r.calls))}</td><td>${formatTokenCount(r.totalTokens)}</td><td>${formatTokenCount(avg)}</td>${ratioHtml}</tr>`;
+}
+
+function renderToolAnalysisRows(rows: ToolAnalysisRow[], builtInBaseline: number = NaN): string {
+  return sortToolRows(rows).map(r => renderToolRow(r, builtInBaseline)).join('');
+}
+
+/** Thead HTML shared across initial render and re-render. */
+function toolAnalysisTheadHtml(): string {
+  return `<tr>
+<th class="tool-sortable" data-sort="tool">Tool${getToolSortIndicator("tool")}</th>
+<th class="tool-sortable" data-sort="calls">Calls${getToolSortIndicator("calls")}</th>
+<th class="tool-sortable" data-sort="total">Total Output Tokens${getToolSortIndicator("total")}</th>
+<th class="tool-sortable" data-sort="avg">Avg Tokens / Call${getToolSortIndicator("avg")}</th>
+<th>vs Built-in</th>
+</tr>`;
+}
+
+/** Render one family section. Returns empty string if the family has no data. */
+function renderToolFamilySection(
+  family: ToolFamilyConfig,
+  outputTokensByTool: { [key: string]: number },
+  byTool: { [key: string]: number },
+  assignedTools: Set<string>
+): { html: string; rows: ToolAnalysisRow[] } {
+  const buildRows = (names: string[], isBuiltIn: boolean): ToolAnalysisRow[] =>
+    names
+      .filter(t => outputTokensByTool[t] !== undefined && (byTool[t] || 0) > 0 && !assignedTools.has(t))
+      .map(t => { assignedTools.add(t); return { tool: t, totalTokens: outputTokensByTool[t], calls: byTool[t] || 0, isBuiltIn }; });
+
+  const builtInRows = buildRows(family.builtIn, true);
+  const altRows = buildRows(family.alternatives, false);
+  const allRows = [...builtInRows, ...altRows];
+  if (allRows.length === 0) { return { html: '', rows: [] }; }
+
+  const baseline = pooledAvg(builtInRows);
+  const encodedRows = encodeURIComponent(JSON.stringify(allRows));
+  const desc = family.description ? ` <span class="hint">${escapeHtml(family.description)}</span>` : '';
+  const html = `
+<div class="tool-family-section">
+<h4 class="tool-family-heading">${escapeHtml(family.name)}${desc}</h4>
+<table class="session-table tool-analysis-table" data-rows="${encodedRows}" data-baseline="${isNaN(baseline) ? '' : String(baseline)}">
+<thead>${toolAnalysisTheadHtml()}</thead>
+<tbody>${renderToolAnalysisRows(allRows, baseline)}</tbody>
+</table>
+</div>`;
+  return { html, rows: allRows };
+}
+
+function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats'], families?: ToolFamilyConfig[]): string {
   if (!toolCallStats || !toolCallStats.outputTokensByTool || Object.keys(toolCallStats.outputTokensByTool).length === 0) {
     return `<div id="tab-tool-analysis" class="tab-content">
 <div class="info-box">
@@ -1938,24 +2009,38 @@ function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats']):
   }
   const outputTokensByTool = toolCallStats.outputTokensByTool;
   const byTool = toolCallStats.byTool;
-  const rows: ToolAnalysisRow[] = Object.entries(outputTokensByTool)
-    .map(([tool, totalTokens]) => ({ tool, totalTokens, calls: byTool[tool] || 0 }))
-    .filter(r => r.calls > 0);
-  const encodedRows = encodeURIComponent(JSON.stringify(rows));
+  const assignedTools = new Set<string>();
+  let sectionsHtml = '';
+
+  if (families && families.length > 0) {
+    for (const family of families) {
+      const { html } = renderToolFamilySection(family, outputTokensByTool, byTool, assignedTools);
+      sectionsHtml += html;
+    }
+  }
+
+  // Remaining tools not in any family
+  const otherRows: ToolAnalysisRow[] = Object.entries(outputTokensByTool)
+    .filter(([t]) => !assignedTools.has(t) && (byTool[t] || 0) > 0)
+    .map(([t, tokens]) => ({ tool: t, totalTokens: tokens, calls: byTool[t] || 0, isBuiltIn: false }));
+  if (otherRows.length > 0) {
+    const encodedOther = encodeURIComponent(JSON.stringify(otherRows));
+    sectionsHtml += `
+<div class="tool-family-section">
+<h4 class="tool-family-heading">Other Tools</h4>
+<table class="session-table tool-analysis-table" data-rows="${encodedOther}" data-baseline="">
+<thead>${toolAnalysisTheadHtml()}</thead>
+<tbody>${renderToolAnalysisRows(otherRows, NaN)}</tbody>
+</table>
+</div>`;
+  }
+
   return `<div id="tab-tool-analysis" class="tab-content">
 <div class="info-box">
 <div class="info-box-title">🔧 Tool Output Token Analysis</div>
-<div>Tokens produced by each tool's output over the last 30 days. Click column headers to sort.</div>
+<div>Tokens produced by each tool's output over the last 30 days. Tools are grouped by family. <strong>vs Built-in</strong> shows how an alternative compares to the pooled baseline — green is more token-efficient. Click column headers to sort within each group. Configure families via <code>aiEngineeringFluency.toolFamilies</code> in VS Code settings.</div>
 </div>
-<table class="session-table" id="tool-analysis-table" data-rows="${encodedRows}">
-<thead><tr>
-<th class="tool-sortable" data-sort="tool">Tool${getToolSortIndicator("tool")}</th>
-<th class="tool-sortable" data-sort="calls">Calls${getToolSortIndicator("calls")}</th>
-<th class="tool-sortable" data-sort="total">Total Output Tokens${getToolSortIndicator("total")}</th>
-<th class="tool-sortable" data-sort="avg">Avg Tokens / Call${getToolSortIndicator("avg")}</th>
-</tr></thead>
-<tbody>${renderToolAnalysisRows(rows)}</tbody>
-</table>
+${sectionsHtml}
 </div>`;
 }
 
@@ -2041,7 +2126,7 @@ ${data.isDebugMode ? renderDebugTab(data.globalStateCounters) : ''}
 <div id="tab-path-analyzer" class="tab-content">
 ${renderFolderAnalyzerTab()}
 </div>
-${renderToolAnalysisTab(data.toolCallStats)}
+${renderToolAnalysisTab(data.toolCallStats, data.toolFamilies)}
 </div>
 `;
 }
@@ -2058,6 +2143,7 @@ function renderLayout(data: DiagnosticsData): void {
   isLoading = detailedFiles.length === 0;
   currentBackendInfo = data.backendStorageInfo;
   currentGithubAuth = data.githubAuth;
+  if (data.toolFamilies) { storedToolFamilies = data.toolFamilies; }
 
   const reportIsLoading = data.report === LOADING_PLACEHOLDER;
   const escapedReport = reportIsLoading

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -118,6 +118,7 @@ type DiagnosticsData = {
   githubAuth?: GitHubAuthStatus;
   sessionFolders?: SessionFolder[];
   displaySettings?: DisplaySettings;
+  toolCallStats?: { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } } | null;
 };
 
 type DiagnosticsViewState = {
@@ -1560,6 +1561,16 @@ function handleDiagnosticDataLoaded(message: DiagMessage): void {
       setupGitHubAuthHandlers();
     }
   }
+  if (message.toolCallStats !== undefined) {
+    const toolAnalysisTab = document.getElementById("tab-tool-analysis");
+    if (toolAnalysisTab) {
+      const newContent = renderToolAnalysisTab(message.toolCallStats as DiagnosticsData['toolCallStats']);
+      const temp = document.createElement('div');
+      temp.innerHTML = newContent;
+      const newTab = temp.firstElementChild;
+      if (newTab) { toolAnalysisTab.replaceWith(newTab); }
+    }
+  }
 }
 
 function handleGithubAuthUpdated(message: DiagMessage): void {
@@ -1845,6 +1856,56 @@ for quick scanning, or as full numbers (e.g. <strong>1,500</strong>, <strong>1,2
 </div>`;
 }
 
+function renderToolAnalysisTab(toolCallStats: DiagnosticsData['toolCallStats']): string {
+  if (!toolCallStats || !toolCallStats.outputTokensByTool || Object.keys(toolCallStats.outputTokensByTool).length === 0) {
+    return `<div id="tab-tool-analysis" class="tab-content">
+<div class="info-box">
+<div class="info-box-title">🔧 Tool Output Token Analysis</div>
+<div>Track how many tokens each tool produces as output over the last 30 days. Data is collected as you use the extension — no output token data has been recorded yet.</div>
+</div>
+</div>`;
+  }
+  const outputTokensByTool = toolCallStats.outputTokensByTool;
+  const byTool = toolCallStats.byTool;
+  const rows = Object.entries(outputTokensByTool)
+    .map(([tool, totalTokens]) => ({ tool, totalTokens, calls: byTool[tool] || 0 }))
+    .filter(r => r.calls > 0)
+    .sort((a, b) => (b.totalTokens / b.calls) - (a.totalTokens / a.calls));
+  const tableRows = rows.map(r => {
+    const avg = Math.round(r.totalTokens / r.calls);
+    return `<tr><td>${escapeHtml(r.tool)}</td><td>${escapeHtml(String(r.calls))}</td><td>${formatTokenCount(r.totalTokens)}</td><td>${formatTokenCount(avg)}</td></tr>`;
+  }).join('');
+  return `<div id="tab-tool-analysis" class="tab-content">
+<div class="info-box">
+<div class="info-box-title">🔧 Tool Output Token Analysis</div>
+<div>Tokens produced by each tool's output over the last 30 days, sorted by average tokens per call (descending). Comparing tools with high vs. low output token counts can help identify efficiency opportunities.</div>
+</div>
+<table class="session-table">
+<thead><tr><th>Tool</th><th>Calls</th><th>Total Output Tokens</th><th>Avg Tokens / Call</th></tr></thead>
+<tbody>${tableRows}</tbody>
+</table>
+</div>`;
+}
+
+function buildDiagReportTabHtml(escapedReport: string): string {
+  return `<div id="tab-report" class="tab-content active">
+<div class="info-box">
+<div class="info-box-title">📋 About This Report</div>
+<div>
+This diagnostic report contains information about your AI Engineering Fluency extension
+extension setup and usage statistics. </br> It does <strong>not</strong> include any of your
+code or conversation content. You can safely share this report when reporting issues.
+</div>
+</div>
+<div class="button-group" style="margin-bottom: 12px;">
+<button class="button" id="btn-copy"><span>📋</span><span>Copy to Clipboard</span></button>
+<button class="button secondary" id="btn-issue"><span>🐛</span><span>Open GitHub Issue</span></button>
+<button class="button secondary" id="btn-clear-cache"><span>🗑️</span><span>Clear Cache</span></button>
+</div>
+<div class="report-content">${escapedReport}</div>
+</div>`;
+}
+
 function buildDiagRootHtml(
   data: DiagnosticsData,
   detailedFiles: SessionFileDetails[],
@@ -1878,25 +1939,11 @@ ${data?.backendConfigured ? buttonHtml("btn-dashboard") : ""}
 <button class="tab" data-tab="github">🔑 GitHub Auth</button>
 <button class="tab" data-tab="display">⚙️ Settings</button>
 <button class="tab" data-tab="path-analyzer">🔬 Path Analyzer</button>
+<button class="tab" data-tab="tool-analysis">🔧 Tool Analysis</button>
 ${data.isDebugMode ? '<button class="tab" data-tab="debug">🐛 Debug</button>' : ''}
 </div>
 
-<div id="tab-report" class="tab-content active">
-<div class="info-box">
-<div class="info-box-title">📋 About This Report</div>
-<div>
-This diagnostic report contains information about your AI Engineering Fluency extension
-extension setup and usage statistics. </br> It does <strong>not</strong> include any of your
-code or conversation content. You can safely share this report when reporting issues.
-</div>
-</div>
-<div class="button-group" style="margin-bottom: 12px;">
-<button class="button" id="btn-copy"><span>📋</span><span>Copy to Clipboard</span></button>
-<button class="button secondary" id="btn-issue"><span>🐛</span><span>Open GitHub Issue</span></button>
-<button class="button secondary" id="btn-clear-cache"><span>🗑️</span><span>Clear Cache</span></button>
-</div>
-<div class="report-content">${escapedReport}</div>
-</div>
+${buildDiagReportTabHtml(escapedReport)}
 
 <div id="tab-sessions" class="tab-content">
 <div class="info-box">
@@ -1922,6 +1969,7 @@ ${data.isDebugMode ? renderDebugTab(data.globalStateCounters) : ''}
 <div id="tab-path-analyzer" class="tab-content">
 ${renderFolderAnalyzerTab()}
 </div>
+${renderToolAnalysisTab(data.toolCallStats)}
 </div>
 `;
 }

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -414,6 +414,21 @@ body {
 	color: var(--fg-muted, #ccc);
 }
 
+.inline-link {
+	background: none;
+	border: none;
+	padding: 0;
+	color: var(--link-color, #4fc1ff);
+	cursor: pointer;
+	font-size: inherit;
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.inline-link:hover {
+	opacity: 0.8;
+}
+
 
 .session-table tr:hover {
 	background: rgb(255, 255, 255, 0.03);

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -346,14 +346,20 @@ body {
 	top: 0;
 }
 
-.session-table th.sortable {
+.session-table th.sortable,
+.session-table th.tool-sortable {
 	cursor: pointer;
 	user-select: none;
 }
 
-.session-table th.sortable:hover {
+.session-table th.sortable:hover,
+.session-table th.tool-sortable:hover {
 	background: var(--list-hover-bg);
 	color: var(--link-color);
+}
+
+.sort-hint {
+	opacity: 0.4;
 }
 
 .session-table tr:hover {

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -362,6 +362,59 @@ body {
 	opacity: 0.4;
 }
 
+.tool-family-section {
+	margin-bottom: 20px;
+}
+
+.tool-family-heading {
+	margin: 8px 0 4px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--fg-muted, #ccc);
+}
+
+.tool-type-badge {
+	padding: 1px 5px;
+	border-radius: 3px;
+	font-size: 10px;
+	white-space: nowrap;
+	margin-left: 4px;
+	vertical-align: middle;
+}
+
+.tool-type-badge.built-in {
+	background: rgba(100, 120, 180, 0.25);
+	color: #9bb0d8;
+}
+
+.tool-type-badge.alternative {
+	background: rgba(100, 200, 120, 0.2);
+	color: #7ecf8e;
+}
+
+.tool-ratio {
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+}
+
+.tool-builtin-label {
+	opacity: 0.5;
+	font-style: italic;
+}
+
+.ratio-better {
+	color: #7ecf8e;
+}
+
+.ratio-worse {
+	color: #e06c75;
+}
+
+.ratio-neutral {
+	color: var(--fg-muted, #ccc);
+}
+
+
 .session-table tr:hover {
 	background: rgb(255, 255, 255, 0.03);
 }

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -22,7 +22,7 @@ export type CategoryLevelData = {
 };
 
 export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number };
-export type ToolCallUsage = { total: number; byTool: { [key: string]: number } };
+export type ToolCallUsage = { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } };
 export type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 
 /** Common fields shared across all webviews that display model-switching data. */

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -1342,11 +1342,11 @@ test('mergeUsageAnalysis: merges outputTokensByTool from multiple tools', () => 
     assert.equal(period.toolCalls.outputTokensByTool?.['edit'], 50);
 });
 
-test('analyzeSessionUsage: CLI JSONL tool.result with string content accumulates outputTokensByTool', async () => {
+test('analyzeSessionUsage: CLI JSONL tool.execution_complete with string content accumulates outputTokensByTool', async () => {
     const events = [
         { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.5' }, timestamp: '2026-05-01T10:00:00Z' },
-        { type: 'tool.call', data: { toolName: 'read' } },
-        { type: 'tool.result', data: { toolName: 'read', result: { content: 'hello world this is file content' } } },
+        { type: 'tool.execution_start', data: { toolCallId: 'tc1', toolName: 'read', arguments: { path: '/foo' } } },
+        { type: 'tool.execution_complete', data: { toolCallId: 'tc1', success: true, result: { content: 'hello world this is file content' } } },
     ];
     const content = events.map(e => JSON.stringify(e)).join('\n');
     const deps = makeMockDeps();
@@ -1356,14 +1356,15 @@ test('analyzeSessionUsage: CLI JSONL tool.result with string content accumulates
     assert.ok((result.toolCalls.outputTokensByTool?.['read'] ?? 0) > 0, 'read tool should have output tokens');
 });
 
-test('analyzeSessionUsage: CLI JSONL tool.result with content array accumulates outputTokensByTool', async () => {
+test('analyzeSessionUsage: CLI JSONL tool.execution_complete with content array accumulates outputTokensByTool', async () => {
     const events = [
         { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.5' }, timestamp: '2026-05-01T10:00:00Z' },
-        { type: 'tool.call', data: { toolName: 'search' } },
+        { type: 'tool.execution_start', data: { toolCallId: 'tc2', toolName: 'search', arguments: { query: 'foo' } } },
         {
-            type: 'tool.result',
+            type: 'tool.execution_complete',
             data: {
-                toolName: 'search',
+                toolCallId: 'tc2',
+                success: true,
                 result: {
                     content: [
                         { type: 'text', text: 'result one' },
@@ -1381,11 +1382,11 @@ test('analyzeSessionUsage: CLI JSONL tool.result with content array accumulates 
     assert.ok((result.toolCalls.outputTokensByTool?.['search'] ?? 0) > 0, 'search tool output tokens should be > 0');
 });
 
-test('analyzeSessionUsage: tool.result without content does not set outputTokensByTool', async () => {
+test('analyzeSessionUsage: tool.execution_complete without content does not set outputTokensByTool', async () => {
     const events = [
         { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.5' }, timestamp: '2026-05-01T10:00:00Z' },
-        { type: 'tool.call', data: { toolName: 'run_in_terminal' } },
-        { type: 'tool.result', data: { toolName: 'run_in_terminal', result: {} } },
+        { type: 'tool.execution_start', data: { toolCallId: 'tc3', toolName: 'run_in_terminal', arguments: {} } },
+        { type: 'tool.execution_complete', data: { toolCallId: 'tc3', success: true, result: {} } },
     ];
     const content = events.map(e => JSON.stringify(e)).join('\n');
     const deps = makeMockDeps();

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -1289,3 +1289,107 @@ test('isParsedSessionJson: full valid session object returns true', () => {
         lastMessageDate: 1700000060000,
     }), true);
 });
+
+// ---------------------------------------------------------------------------
+// outputTokensByTool tracking
+// ---------------------------------------------------------------------------
+
+test('mergeUsageAnalysis: accumulates outputTokensByTool when present', () => {
+    const period = emptyPeriod();
+    const a1 = emptyAnalysis();
+    a1.toolCalls.total = 2;
+    a1.toolCalls.byTool = { read: 2 };
+    a1.toolCalls.outputTokensByTool = { read: 1200 };
+
+    const a2 = emptyAnalysis();
+    a2.toolCalls.total = 1;
+    a2.toolCalls.byTool = { read: 1 };
+    a2.toolCalls.outputTokensByTool = { read: 800 };
+
+    mergeUsageAnalysis(period, a1);
+    mergeUsageAnalysis(period, a2);
+
+    assert.equal(period.toolCalls.outputTokensByTool?.['read'], 2000);
+});
+
+test('mergeUsageAnalysis: handles missing outputTokensByTool gracefully', () => {
+    const period = emptyPeriod();
+    const a = emptyAnalysis();
+    a.toolCalls.total = 1;
+    a.toolCalls.byTool = { search: 1 };
+    // No outputTokensByTool set
+
+    mergeUsageAnalysis(period, a);
+
+    assert.equal(period.toolCalls.outputTokensByTool, undefined);
+});
+
+test('mergeUsageAnalysis: merges outputTokensByTool from multiple tools', () => {
+    const period = emptyPeriod();
+    const a1 = emptyAnalysis();
+    a1.toolCalls.byTool = { read: 1, search: 1 };
+    a1.toolCalls.outputTokensByTool = { read: 500, search: 300 };
+
+    const a2 = emptyAnalysis();
+    a2.toolCalls.byTool = { read: 1, edit: 1 };
+    a2.toolCalls.outputTokensByTool = { read: 400, edit: 50 };
+
+    mergeUsageAnalysis(period, a1);
+    mergeUsageAnalysis(period, a2);
+
+    assert.equal(period.toolCalls.outputTokensByTool?.['read'], 900);
+    assert.equal(period.toolCalls.outputTokensByTool?.['search'], 300);
+    assert.equal(period.toolCalls.outputTokensByTool?.['edit'], 50);
+});
+
+test('analyzeSessionUsage: CLI JSONL tool.result with string content accumulates outputTokensByTool', async () => {
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.5' }, timestamp: '2026-05-01T10:00:00Z' },
+        { type: 'tool.call', data: { toolName: 'read' } },
+        { type: 'tool.result', data: { toolName: 'read', result: { content: 'hello world this is file content' } } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+
+    assert.ok(result.toolCalls.outputTokensByTool, 'outputTokensByTool should be defined');
+    assert.ok((result.toolCalls.outputTokensByTool?.['read'] ?? 0) > 0, 'read tool should have output tokens');
+});
+
+test('analyzeSessionUsage: CLI JSONL tool.result with content array accumulates outputTokensByTool', async () => {
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.5' }, timestamp: '2026-05-01T10:00:00Z' },
+        { type: 'tool.call', data: { toolName: 'search' } },
+        {
+            type: 'tool.result',
+            data: {
+                toolName: 'search',
+                result: {
+                    content: [
+                        { type: 'text', text: 'result one' },
+                        { type: 'text', text: 'result two' },
+                    ],
+                },
+            },
+        },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+
+    assert.ok(result.toolCalls.outputTokensByTool?.['search'] !== undefined, 'search tool should have output tokens');
+    assert.ok((result.toolCalls.outputTokensByTool?.['search'] ?? 0) > 0, 'search tool output tokens should be > 0');
+});
+
+test('analyzeSessionUsage: tool.result without content does not set outputTokensByTool', async () => {
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-4.5' }, timestamp: '2026-05-01T10:00:00Z' },
+        { type: 'tool.call', data: { toolName: 'run_in_terminal' } },
+        { type: 'tool.result', data: { toolName: 'run_in_terminal', result: {} } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const deps = makeMockDeps();
+    const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
+
+    assert.equal(result.toolCalls.outputTokensByTool?.['run_in_terminal'] ?? 0, 0, 'empty result should not track tokens');
+});


### PR DESCRIPTION
## Summary

Adds per-tool output token tracking to the extension and surfaces it in a new **🔧 Tool Analysis** tab in the Diagnostics view.

Closes #1287

## Changes

### Data tracking
- Added `outputTokensByTool?: { [toolName: string]: number }` to `ToolCallUsage` in `types.ts` and `webview/shared/types.ts`
- Added `_asuExtractToolResultText()` helper to extract plain text from CLI `tool.result` event content (supports both string and `{type:'text', text:string}[]` array formats)
- Modified `_asuHandleToolCallEvent()` to accumulate estimated output tokens for non-MCP `tool.result` events using the existing `estimateTokensFromText` utility
- Updated `mergeUsageAnalysis()` to sum `outputTokensByTool` across sessions into the period aggregate
- Bumped `CACHE_VERSION` from 55 → 56 to invalidate stale cached sessions

### Diagnostics view
- Added `toolCallStats` (last 30 days `toolCalls`) to the diagnostics initial data and `diagnosticDataLoaded` postMessage
- Added `renderToolAnalysisTab()` function that renders a table: **Tool | Calls | Total Output Tokens | Avg Tokens / Call** (sorted by avg descending)
- Added new **🔧 Tool Analysis** tab to the diagnostics tab bar and layout
- Handles dynamic `toolCallStats` updates when `diagnosticDataLoaded` message arrives
- Extracted `buildDiagReportTabHtml()` helper to keep `buildDiagRootHtml` within the 80-line ESLint limit

### No changes to
- Usage analysis webview (`webview/usage/main.ts`)
- Azure Storage / teams server sync paths

## Tests
- Added 7 new unit tests in `usageAnalysis.test.ts`:
  - `mergeUsageAnalysis` correctly sums `outputTokensByTool` across sessions
  - `mergeUsageAnalysis` handles missing `outputTokensByTool` gracefully  
  - Multiple tools merged from multiple sessions
  - `analyzeSessionUsage` accumulates tokens from `tool.result` with string content
  - `analyzeSessionUsage` accumulates tokens from `tool.result` with content array
  - `analyzeSessionUsage` does not track empty results

All 67 test suites pass with 0 compile errors/warnings.