### PR TITLE
fix: migrate session file cache from globalState to disk snapshot

### DIFF
--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -251,87 +251,107 @@ export class CacheManager {
 	}
 
 	// Persistent cache storage methods
-	loadCacheFromStorage(): void {
+
+	/**
+	 * Load the session file cache from the shared on-disk snapshot.
+	 * The cache is now stored exclusively on disk (globalStorageUri) to avoid
+	 * hitting VS Code's globalState size limit (~2-3 MB warning threshold).
+	 * Also removes any legacy cache data from globalState as a one-time migration.
+	 */
+	async loadCacheFromStorage(): Promise<void> {
 		try {
 			const cacheId = this.getCacheIdentifier();
-			const versionKey = `sessionFileCacheVersion_${cacheId}`;
-			const cacheKey = `sessionFileCache_${cacheId}`;
-			
-			// One-time migration: clean up old per-session cache keys from previous versions
-			this.migrateOldCacheKeys(cacheId);
-			
-			// Check cache version first
-			const storedVersion = this.context.globalState.get<number>(versionKey);
-			if (storedVersion !== this.cacheVersion) {
-				this.deps.log(`Cache version mismatch (stored: ${storedVersion}, current: ${this.cacheVersion}) for ${cacheId}. Clearing cache.`);
-				this.sessionFileCache = new Map();
-				// Reset the clean-sync flag so the next sync deletes stale Azure entities
-				try { this.context.globalState.update('backend.lastCleanSyncVersion', undefined); } catch { /* best-effort */ }
-				return;
-			}
 
-			const cacheData = this.context.globalState.get<Record<string, SessionFileCache>>(cacheKey);
-			if (cacheData) {
-				this.sessionFileCache = new Map(Object.entries(cacheData));
-				this.deps.log(`Loaded ${this.sessionFileCache.size} cached session files from storage (${cacheId})`);
-			} else {
-				this.deps.log(`No cached session files found in storage for ${cacheId}`);
+			// One-time migration: remove all cache entries from globalState now that
+			// the disk snapshot is the sole source of truth.
+			this.migrateOldCacheKeys(cacheId);
+
+			// Load from the shared on-disk snapshot (globalStorageUri).
+			const snapshotPath = this.getSharedSnapshotPath();
+			try {
+				const content = await fs.promises.readFile(snapshotPath, 'utf-8');
+				const envelope = JSON.parse(content);
+
+				if (!envelope || typeof envelope !== 'object') {
+					this.deps.log(`No valid snapshot found for ${cacheId}, starting with empty cache`);
+					return;
+				}
+
+				// Cache version mismatch: reset stale-entity cleanup flag so the next
+				// sync will re-verify and delete obsolete Azure entities.
+				if (envelope.cacheVersion !== this.cacheVersion) {
+					this.deps.log(`Cache version mismatch (stored: ${envelope.cacheVersion}, current: ${this.cacheVersion}) for ${cacheId}. Clearing cache.`);
+					this.sessionFileCache = new Map();
+					try { this.context.globalState.update('backend.lastCleanSyncVersion', undefined); } catch { /* best-effort */ }
+					return;
+				}
+
+				if (
+					envelope.schemaVersion !== CacheManager.SNAPSHOT_SCHEMA_VERSION ||
+					typeof envelope.entries !== 'object'
+				) {
+					this.deps.log(`Snapshot schema mismatch or missing entries for ${cacheId}, starting with empty cache`);
+					return;
+				}
+
+				this.sessionFileCache = new Map(
+					Object.entries(envelope.entries as Record<string, SessionFileCache>),
+				);
+				this.deps.log(`Loaded ${this.sessionFileCache.size} cached session files from disk snapshot (${cacheId})`);
+
+				// Record the snapshot mtime so loadSharedSnapshotIfChanged won't reload it redundantly.
+				try {
+					const stat = await fs.promises.stat(snapshotPath);
+					this.lastLoadedSnapshotMtime = stat.mtimeMs;
+				} catch { /* best-effort */ }
+
+			} catch (readErr: unknown) {
+				if ((readErr as NodeJS.ErrnoException).code === 'ENOENT') {
+					this.deps.log(`No snapshot found for ${cacheId}, starting with empty cache`);
+				} else {
+					throw readErr;
+				}
 			}
 		} catch (error) {
 			this.deps.error(`Error loading cache from storage: ${error}`);
-			// Start with empty cache on error
 			this.sessionFileCache = new Map();
 		}
 	}
 
 	/**
-	 * One-time migration: remove old per-session cache keys that were created by
-	 * earlier versions of the extension (keys containing sessionId or timestamp).
-	 * Also removes the legacy unscoped keys ('sessionFileCache', 'sessionFileCacheVersion').
+	 * Remove all session file cache entries from globalState.
+	 * The cache now lives exclusively on disk (globalStorageUri snapshot).
+	 * Clears both legacy keys from old extension versions AND the current scoped keys
+	 * so that existing installations shed the large payload on their next startup.
+	 * Idempotent: calling on an already-migrated store is a no-op.
 	 */
-	migrateOldCacheKeys(currentCacheId: string): void {
+	migrateOldCacheKeys(_currentCacheId: string): void {
 		try {
 			const allKeys = this.context.globalState.keys();
-			const currentCacheKey = `sessionFileCache_${currentCacheId}`;
-			const currentVersionKey = `sessionFileCacheVersion_${currentCacheId}`;
 			let removedCount = 0;
 			for (const key of allKeys) {
-				if (this.removeObsoleteCacheKey(key, currentCacheKey, currentVersionKey)) {
+				if (this.isCacheGlobalStateKey(key)) {
+					this.context.globalState.update(key, undefined);
 					removedCount++;
 				}
 			}
 			if (removedCount > 0) {
-				this.deps.log(`Migrated: removed ${removedCount} old cache keys from globalState`);
+				this.deps.log(`Migrated: removed ${removedCount} cache keys from globalState (cache now on disk)`);
 			}
 		} catch (error) {
 			this.deps.error(`Error migrating old cache keys: ${error}`);
 		}
 	}
 
-	private removeObsoleteCacheKey(key: string, currentCacheKey: string, currentVersionKey: string): boolean {
-		if (key.startsWith('sessionFileCacheTimestamp_')) {
-			this.context.globalState.update(key, undefined);
-			return true;
-		}
-		if (key.startsWith('sessionFileCache_') && key !== currentCacheKey) {
-			const suffix = key.replace('sessionFileCache_', '');
-			if (suffix !== 'dev' && suffix !== 'prod') {
-				this.context.globalState.update(key, undefined);
-				return true;
-			}
-		}
-		if (key.startsWith('sessionFileCacheVersion_') && key !== currentVersionKey) {
-			const suffix = key.replace('sessionFileCacheVersion_', '');
-			if (suffix !== 'dev' && suffix !== 'prod') {
-				this.context.globalState.update(key, undefined);
-				return true;
-			}
-		}
-		if (key === 'sessionFileCache' || key === 'sessionFileCacheVersion') {
-			this.context.globalState.update(key, undefined);
-			return true;
-		}
-		return false;
+	/** Returns true for any globalState key that holds session-file cache payload. */
+	private isCacheGlobalStateKey(key: string): boolean {
+		return (
+			key === 'sessionFileCache' ||
+			key === 'sessionFileCacheVersion' ||
+			key.startsWith('sessionFileCache_') ||
+			key.startsWith('sessionFileCacheVersion_') ||
+			key.startsWith('sessionFileCacheTimestamp_')
+		);
 	}
 
 	async saveCacheToStorage(): Promise<void> {
@@ -342,16 +362,10 @@ export class CacheManager {
 		}
 		try {
 			const cacheId = this.getCacheIdentifier();
-			const versionKey = `sessionFileCacheVersion_${cacheId}`;
-			const cacheKey = `sessionFileCache_${cacheId}`;
-			
-			// Convert Map to plain object for storage
-			const cacheData = Object.fromEntries(this.sessionFileCache);
-			await this.context.globalState.update(cacheKey, cacheData);
-			await this.context.globalState.update(versionKey, this.cacheVersion);
-			this.deps.log(`Saved ${this.sessionFileCache.size} cached session files to storage (version ${this.cacheVersion}, ${cacheId})`);
-			// Publish a shared on-disk snapshot so other VS Code windows can reload the
-			// parsed data instead of re-reading every session file themselves.
+
+			// Persist to the shared on-disk snapshot only (no globalState write to
+			// avoid VS Code's large-extension-state warning).
+			this.deps.log(`Saving ${this.sessionFileCache.size} cached session files to disk snapshot (version ${this.cacheVersion}, ${cacheId})`);
 			await this.writeSharedSnapshot();
 		} catch (error) {
 			this.deps.error(`Error saving cache to storage: ${error}`);
@@ -421,7 +435,23 @@ export class CacheManager {
 	}
 
 	/**
-	 * Union the existing on-disk snapshot with the in-memory cache, keeping the
+	 * Delete the shared on-disk snapshot and reset the loaded-mtime bookmark.
+	 * Called by clearCache() so that restarting VS Code does not restore cleared data.
+	 */
+	async deleteSharedSnapshot(): Promise<void> {
+		const snapshotPath = this.getSharedSnapshotPath();
+		try {
+			await fs.promises.unlink(snapshotPath);
+			this.lastLoadedSnapshotMtime = 0;
+			this.deps.log(`Deleted shared cache snapshot (${this.getCacheIdentifier()})`);
+		} catch (err: unknown) {
+			if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+				this.deps.warn(`Failed to delete shared cache snapshot: ${err}`);
+			}
+		}
+	}
+
+	/**
 	 * newer entry by mtime, and cap the result to the newest SNAPSHOT_MAX_ENTRIES.
 	 */
 	private async buildMergedSnapshotEntries(): Promise<Record<string, SessionFileCache>> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -443,6 +443,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	public githubSession: vscode.AuthenticationSession | undefined;
 	// Promise that resolves when the startup session restore completes
 	private _sessionRestorePromise: Promise<void> | undefined;
+	// Promise that resolves when the initial cache load from disk completes
+	private _cacheLoadPromise: Promise<void> | undefined;
 	/** True when the user explicitly signed out from our extension this VS Code session. Gated by globalState so it survives reloads. */
 	private _githubSignedOutByUser: boolean = false;
 	/** Resolved Copilot plan details fetched from copilot_internal/user after sign-in. */
@@ -893,14 +895,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.outputChannel.show(true);
 			this.log('Clearing session file cache...');
 
-				const cacheId = this.cacheManager.getCacheIdentifier();
-			const cacheKey = `sessionFileCache_${cacheId}`;
-			const versionKey = `sessionFileCacheVersion_${cacheId}`;
-			
 			const cacheSize = this.cacheManager.cache.size;
 			this.cacheManager.cache.clear();
-			await this.context.globalState.update(cacheKey, undefined);
-			await this.context.globalState.update(versionKey, undefined);
+
+			// Delete the on-disk snapshot so it isn't reloaded after restart.
+			await this.cacheManager.deleteSharedSnapshot();
+
 			// Reset diagnostics loaded flag so the diagnostics view will reload files
 			this.diagnosticsHasLoadedFiles = false;
 			this.diagnosticsCachedFiles = [];
@@ -929,7 +929,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.context = context;
 		this.initializeAdapters(extensionUri, context);
 		this.initializeOutputChannel(context);
-		this.cacheManager.loadCacheFromStorage();
+		this._cacheLoadPromise = this.cacheManager.loadCacheFromStorage().finally(() => {
+			this._cacheLoadPromise = undefined;
+		});
 		this._sessionRestorePromise = this.restoreGitHubSession();
 		this.setupGitHubAuthListener(context);
 		this.sessionDiscovery.checkCopilotExtension();
@@ -1747,6 +1749,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private async _runUpdateTokenStats(silent: boolean): Promise<DetailedStats | undefined> {
+		// Ensure the initial cache load from disk has completed before parsing.
+		if (this._cacheLoadPromise) {
+			try { await this._cacheLoadPromise; } catch { /* already logged in loadCacheFromStorage */ }
+		}
+
 		// Warm the in-memory cache from any newer snapshot another window published,
 		// so most files become cache hits and parsing is skipped.
 		try { await this.cacheManager.loadSharedSnapshotIfChanged(); }
@@ -7717,15 +7724,12 @@ ${this.getLoadingHtmlScript()}
 
   private resolvePersistedCacheSummary(): string {
     try {
-      const persisted = this.context.globalState.get<Record<string, SessionFileCache>>("sessionFileCache");
-      if (persisted && typeof persisted === "object") {
-        const count = Object.keys(persisted).length;
-        return `VS Code Global State - sessionFileCache (${count} entr${count === 1 ? "y" : "ies"})`;
-      }
+      const snapshotPath = this.cacheManager.getSharedSnapshotPath();
+      const entries = this.cacheManager.cache.size;
+      return `Disk snapshot: ${snapshotPath} (${entries} entr${entries === 1 ? 'y' : 'ies'} in-memory)`;
     } catch {
-      return "Error reading VS Code Global State";
+      return "Error reading cache snapshot path";
     }
-    return "Not found in VS Code Global State";
   }
 
   private findGlobalStateStoragePath(): string | null {

--- a/vscode-extension/test/unit/cacheManager-snapshot.test.ts
+++ b/vscode-extension/test/unit/cacheManager-snapshot.test.ts
@@ -149,3 +149,138 @@ test('refresh lock and cache lock are independent files', async () => {
 	await m.releaseRefreshLock();
 	await m.releaseCacheLock();
 });
+
+// ---------------------------------------------------------------------------
+// loadCacheFromStorage (disk-based)
+// ---------------------------------------------------------------------------
+
+test('loadCacheFromStorage: loads entries from existing snapshot', async () => {
+	const dir = tmpDir();
+	const writer = makeManager(dir);
+	writer.setCachedSessionData('/a.json', entry(1000), 10);
+	writer.setCachedSessionData('/b.json', entry(2000), 20);
+	await writer.writeSharedSnapshot();
+
+	const reader = makeManager(dir);
+	await reader.loadCacheFromStorage();
+	assert.equal(reader.cache.size, 2, 'should load both entries');
+	assert.equal(reader.cache.get('/a.json')?.mtime, 1000);
+	assert.equal(reader.cache.get('/b.json')?.mtime, 2000);
+});
+
+test('loadCacheFromStorage: starts with empty cache when no snapshot exists', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+	await m.loadCacheFromStorage();
+	assert.equal(m.cache.size, 0, 'cache should be empty when no snapshot exists');
+});
+
+test('loadCacheFromStorage: clears cache and resets lastCleanSyncVersion on version mismatch', async () => {
+	const dir = tmpDir();
+	const writer = makeManager(dir, 1);
+	writer.setCachedSessionData('/a.json', entry(1000), 10);
+	await writer.writeSharedSnapshot();
+
+	// Reader uses a different cache version
+	const logs: string[] = [];
+	const context: any = {
+		extensionMode: 1,
+		globalStorageUri: { fsPath: dir },
+		globalState: createMockMemento(),
+	};
+	// Pre-set a lastCleanSyncVersion to verify it gets cleared
+	context.globalState.update('backend.lastCleanSyncVersion', 5);
+	const reader = new CacheManager(context, { log: (m: string) => logs.push(m), warn: () => {}, error: () => {} }, 2);
+	await reader.loadCacheFromStorage();
+	assert.equal(reader.cache.size, 0, 'cache should be empty on version mismatch');
+	assert.ok(logs.some(l => l.includes('version mismatch')), 'should log version mismatch');
+	assert.equal(context.globalState.get('backend.lastCleanSyncVersion'), undefined,
+		'lastCleanSyncVersion should be cleared on version mismatch');
+});
+
+test('loadCacheFromStorage: removes large globalState cache entries (migration)', async () => {
+	const dir = tmpDir();
+	const context: any = {
+		extensionMode: 1,
+		globalStorageUri: { fsPath: dir },
+		globalState: createMockMemento(),
+	};
+	// Simulate old large entries in globalState
+	await context.globalState.update('sessionFileCache_prod', { '/a.json': entry(1000) });
+	await context.globalState.update('sessionFileCacheVersion_prod', 1);
+	await context.globalState.update('sessionFileCache', { '/b.json': entry(2000) });
+
+	const m = new CacheManager(context, { log: () => {}, warn: () => {}, error: () => {} }, 1);
+	await m.loadCacheFromStorage();
+
+	assert.equal(context.globalState.get('sessionFileCache_prod'), undefined,
+		'current scoped key should be removed from globalState');
+	assert.equal(context.globalState.get('sessionFileCacheVersion_prod'), undefined,
+		'version key should be removed from globalState');
+	assert.equal(context.globalState.get('sessionFileCache'), undefined,
+		'legacy unscoped key should be removed from globalState');
+});
+
+// ---------------------------------------------------------------------------
+// deleteSharedSnapshot
+// ---------------------------------------------------------------------------
+
+test('deleteSharedSnapshot: removes the snapshot file', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+	m.setCachedSessionData('/a.json', entry(1000), 10);
+	await m.writeSharedSnapshot();
+	assert.ok(fs.existsSync(m.getSharedSnapshotPath()), 'snapshot should exist before delete');
+
+	await m.deleteSharedSnapshot();
+	assert.equal(fs.existsSync(m.getSharedSnapshotPath()), false, 'snapshot should be removed');
+});
+
+test('deleteSharedSnapshot: is a no-op when snapshot does not exist', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+	// Should not throw
+	await assert.doesNotReject(() => m.deleteSharedSnapshot());
+});
+
+test('deleteSharedSnapshot: prevents reloading cleared cache after restart', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+	m.setCachedSessionData('/a.json', entry(1000), 10);
+	await m.writeSharedSnapshot();
+	await m.deleteSharedSnapshot();
+
+	const reader = makeManager(dir);
+	await reader.loadCacheFromStorage();
+	assert.equal(reader.cache.size, 0, 'cleared cache should not be reloaded from disk');
+});
+
+// ---------------------------------------------------------------------------
+// migrateOldCacheKeys: now removes all cache keys (including current scoped)
+// ---------------------------------------------------------------------------
+
+test('migrateOldCacheKeys: removes all sessionFileCache* keys from globalState', () => {
+	const dir = tmpDir();
+	const context: any = {
+		extensionMode: 1,
+		globalStorageUri: { fsPath: dir },
+		globalState: createMockMemento(),
+	};
+	context.globalState.update('sessionFileCache_prod', { data: 'big' });
+	context.globalState.update('sessionFileCacheVersion_prod', 1);
+	context.globalState.update('sessionFileCache_dev-abc123', { data: 'big' });
+	context.globalState.update('sessionFileCacheTimestamp_prod', 12345);
+	context.globalState.update('sessionFileCache', { data: 'legacy' });
+	context.globalState.update('github.authenticated', true); // should NOT be removed
+
+	const m = new CacheManager(context, { log: () => {}, warn: () => {}, error: () => {} }, 1);
+	m.migrateOldCacheKeys('prod');
+
+	assert.equal(context.globalState.get('sessionFileCache_prod'), undefined);
+	assert.equal(context.globalState.get('sessionFileCacheVersion_prod'), undefined);
+	assert.equal(context.globalState.get('sessionFileCache_dev-abc123'), undefined);
+	assert.equal(context.globalState.get('sessionFileCacheTimestamp_prod'), undefined);
+	assert.equal(context.globalState.get('sessionFileCache'), undefined);
+	// Unrelated keys must be preserved
+	assert.equal(context.globalState.get('github.authenticated'), true);
+});


### PR DESCRIPTION
## Problem

VS Code was emitting this warning at runtime:

```
[warning] [mainThreadStorage] large extension state detected (extensionId: RobBos.ai-engineering-fluency, global: true): 2929.962890625kb. Consider to use 'storageUri' or 'globalStorageUri' to store this data on disk instead.
```

The entire session file cache (up to 3,100 `SessionFileCache` entries, ~2.9 MB) was being written to `context.globalState` on every save.

## Root Cause

`CacheManager.saveCacheToStorage()` wrote the cache to both:
1. `globalState` (the large payload causing the warning)
2. An on-disk snapshot file at `globalStorageUri/cache_<id>.snapshot.json` (already used for cross-window sharing)

The disk snapshot was already a complete, versioned persistence mechanism — `globalState` was redundant.

## Fix

- **`loadCacheFromStorage()`** is now `async` and reads from the disk snapshot instead of `globalState`. Cache-version mismatch detection is preserved (resets `backend.lastCleanSyncVersion` when versions differ).
- **`saveCacheToStorage()`** no longer writes to `globalState`; the existing `writeSharedSnapshot()` call handles all disk persistence.
- **`migrateOldCacheKeys()`** now removes **all** `sessionFileCache*` keys from `globalState` (including the current scoped keys like `sessionFileCache_prod`), so existing installations shed the large payload on their very next startup.
- **`deleteSharedSnapshot()`** new method called by `clearCache()` so a cleared cache is not reloaded from disk on the next VS Code restart.
- **`extension.ts`**: stores a `_cacheLoadPromise` so `_runUpdateTokenStats()` can await it; `clearCache()` uses the new `deleteSharedSnapshot()`; diagnostics summary now reports the snapshot path instead of the old globalState key.

## Tests

8 new tests added to `cacheManager-snapshot.test.ts`:
- `loadCacheFromStorage` happy path, first-run (no snapshot), version mismatch + lastCleanSyncVersion reset, globalState migration
- `deleteSharedSnapshot` removes file, no-op on missing, prevents reload after clear
- `migrateOldCacheKeys` removes all cache keys without touching unrelated ones

All unit test files pass.