### PR TITLE
feat: detect auto-compaction as a negative insight signal (Claude Code)

### DIFF
--- a/docs/logFilesSchema/claude-code-session-schema.json
+++ b/docs/logFilesSchema/claude-code-session-schema.json
@@ -1,9 +1,15 @@
 {
   "title": "Claude Code Session File Schema Documentation",
   "description": "This document describes the structure of session log files created by Claude Code (Anthropic's CLI/IDE extension). These files contain actual Anthropic API token counts and can be used by the Copilot Token Tracker extension to report on Claude Code token usage.",
-  "version": "1.1",
-  "lastUpdated": "2026-03-28",
+  "version": "1.2",
+  "lastUpdated": "2026-06-03",
   "schemaChanges": {
+    "1.2": {
+      "date": "2026-06-03",
+      "changes": [
+        "Added systemEventSchema documenting the type: 'system' / subtype: 'compact_boundary' event written when Claude Code compacts a session"
+      ]
+    },
     "1.1": {
       "date": "2026-03-28",
       "changes": [
@@ -131,7 +137,7 @@
   "eventTypes": {
     "description": "Each line in the JSONL file is one of the following event types, distinguished by the 'type' field",
     "discriminatorField": "type",
-    "types": ["user", "assistant", "queue-operation", "file-history-snapshot", "ai-title"]
+    "types": ["user", "assistant", "system", "queue-operation", "file-history-snapshot", "ai-title"]
   },
   "commonFields": {
     "description": "Fields present on most or all event types",
@@ -558,6 +564,87 @@
       "sessionId": "4817b4d3-a794-4be1-ac45-ea05f7dc9f00",
       "version": "2.1.86",
       "gitBranch": "team-dashboard"
+    }
+  },
+  "systemEventSchema": {
+    "description": "A system-emitted metadata event. Not a user or assistant turn. Used to record internal Claude Code lifecycle events such as context compaction.",
+    "type_value": "system",
+    "usedBy": "Parse to detect context compaction events and attribute them to auto vs manual triggers",
+    "subtypes": {
+      "compact_boundary": {
+        "description": "Emitted when a session is compacted (context window summarised). The compactMetadata.trigger field distinguishes auto-compaction (context window exhausted) from manual compaction (user ran /compact).",
+        "fields": {
+          "subtype": {
+            "type": "string",
+            "value": "compact_boundary"
+          },
+          "content": {
+            "type": "string",
+            "example": "Conversation compacted",
+            "usedBy": "Informational only"
+          },
+          "isMeta": {
+            "type": "boolean",
+            "value": false
+          },
+          "uuid": {
+            "type": "string",
+            "format": "UUID"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "ISO 8601"
+          },
+          "entrypoint": {
+            "type": "string",
+            "description": "Which Claude Code client emitted this event",
+            "example": "claude-desktop",
+            "values": ["claude-desktop", "claude-vscode", "claude-cli"]
+          },
+          "compactMetadata": {
+            "type": "object",
+            "description": "Metadata about the compaction operation",
+            "properties": {
+              "trigger": {
+                "type": "string",
+                "values": ["auto", "manual"],
+                "description": "What triggered the compaction. 'auto' = context window limit reached without user action (negative signal — user was not proactively managing context). 'manual' = user explicitly ran /compact (positive signal).",
+                "usedBy": "Use to distinguish proactive context management (manual) from reactive auto-compaction (auto). Store auto count in toolCalls.byTool['__auto_compact__']."
+              },
+              "preTokens": {
+                "type": "number",
+                "description": "Token count of the conversation before compaction. Indicates how deep the session was when it hit the limit.",
+                "example": 170679
+              },
+              "postTokens": {
+                "type": "number",
+                "description": "Token count of the resulting summary after compaction.",
+                "example": 8697
+              },
+              "durationMs": {
+                "type": "number",
+                "description": "How long the compaction operation took in milliseconds.",
+                "example": 72528
+              }
+            }
+          }
+        },
+        "example": {
+          "type": "system",
+          "subtype": "compact_boundary",
+          "content": "Conversation compacted",
+          "isMeta": false,
+          "timestamp": "2026-05-06T10:15:34.700Z",
+          "uuid": "1d887419-0000-0000-0000-000000000000",
+          "compactMetadata": {
+            "trigger": "auto",
+            "preTokens": 170679,
+            "postTokens": 8697,
+            "durationMs": 72528
+          },
+          "entrypoint": "claude-desktop"
+        }
+      }
     }
   },
   "queueOperationEventSchema": {

--- a/vscode-extension/src/adapters/claudeCodeAdapter.ts
+++ b/vscode-extension/src/adapters/claudeCodeAdapter.ts
@@ -110,11 +110,21 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 				this.processUserEvent(event, analysis);
 			} else if (event.type === 'assistant') {
 				this.processAssistantEvent(event, analysis, ctx, models);
+			} else if (event.type === 'system' && event.subtype === 'compact_boundary') {
+				this.processCompactBoundaryEvent(event, analysis);
 			}
 		}
 		this.applyModelSwitchingStats(models, analysis);
 		applyModelTierClassification(ctx.modelPricing, analysis.modelSwitching.uniqueModels, models, analysis);
 		return analysis;
+	}
+
+	private processCompactBoundaryEvent(event: any, analysis: import('../types').SessionUsageAnalysis): void {
+		if (event.compactMetadata?.trigger === 'auto') {
+			// Auto-compaction means the context window was exhausted without user action — negative signal.
+			// Stored with a double-underscore prefix so it doesn't inflate toolCalls.total.
+			analysis.toolCalls.byTool['__auto_compact__'] = (analysis.toolCalls.byTool['__auto_compact__'] || 0) + 1;
+		}
 	}
 
 	private processUserEvent(event: any, analysis: import('../types').SessionUsageAnalysis): void {

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -141,6 +141,11 @@ interface InsightDefinition {
 }
 
 // ---------------------------------------------------------------------------
+/** Count of auto-compaction events in a period (Claude Code / Desktop only). */
+function autoCompactCount(p: UsageAnalysisPeriod): number {
+	return p.toolCalls.byTool['__auto_compact__'] ?? 0;
+}
+
 // Starter catalog
 // Sub-session agents will add entries here for trend data, context quality,
 // focus times, streaks, and MCP/tool adoption insights.
@@ -651,6 +656,21 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		},
 		appliesTo: (ctx) => manualCompactCount(ctx.last30Days) >= 5,
 		weight: 50,
+		allowToast: true,
+	},
+	{
+		id: 'auto-compaction-pattern',
+		category: 'consistency',
+		severity: 'opportunity',
+		title: '⚠️ Claude Code is auto-compacting your sessions',
+		buildBody: (ctx) => {
+			const n = autoCompactCount(ctx.last30Days);
+			return `Claude Code hit the context window limit and auto-compacted ${n} session${n !== 1 ? 's' : ''} in the last 30 days. ` +
+				`Auto-compaction means earlier context was lost without your control — you may have noticed replies suddenly lacking earlier detail. ` +
+				`To avoid this: start a fresh chat (\`/new\`) when switching tasks, and use \`/compact\` yourself before the window fills.`;
+		},
+		appliesTo: (ctx) => autoCompactCount(ctx.last30Days) >= 2,
+		weight: 65,
 		allowToast: true,
 	},
 

--- a/vscode-extension/test/unit/claudecode.test.ts
+++ b/vscode-extension/test/unit/claudecode.test.ts
@@ -5,8 +5,10 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 
 import { ClaudeCodeDataAccess, normalizeClaudeModelId } from '../../src/claudecode';
+import { ClaudeCodeAdapter } from '../../src/adapters/claudeCodeAdapter';
 
 const claudeCode = new ClaudeCodeDataAccess();
+const claudeCodeAdapter = new ClaudeCodeAdapter(claudeCode);
 
 // ----- normalizeClaudeModelId -----
 
@@ -730,4 +732,103 @@ test('getClaudeCodeModelUsage: crashed session contributes partial tokens per mo
         } finally {
                 cleanup(filePath);
         }
+});
+// ----- ClaudeCodeAdapter.analyzeUsage: compact_boundary / __auto_compact__ -----
+
+const adapterCtx = { modelPricing: {}, toolNameMap: {} };
+
+test('ClaudeCodeAdapter.analyzeUsage: increments __auto_compact__ for trigger=auto', async () => {
+const events = [
+{
+type: 'system',
+subtype: 'compact_boundary',
+content: 'Conversation compacted',
+isMeta: false,
+timestamp: '2026-05-06T10:15:34.700Z',
+uuid: '1d887419-0000-0000-0000-000000000001',
+compactMetadata: { trigger: 'auto', preTokens: 170679, postTokens: 8697, durationMs: 72528 },
+entrypoint: 'claude-desktop'
+}
+];
+const filePath = createTempSession(events);
+try {
+const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+assert.equal(result.toolCalls.byTool['__auto_compact__'], 1);
+} finally {
+cleanup(filePath);
+}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: accumulates multiple auto-compact events', async () => {
+const events = [
+{
+type: 'system',
+subtype: 'compact_boundary',
+compactMetadata: { trigger: 'auto', preTokens: 170679, postTokens: 8697, durationMs: 72528 },
+},
+{
+type: 'system',
+subtype: 'compact_boundary',
+compactMetadata: { trigger: 'auto', preTokens: 180000, postTokens: 9000, durationMs: 60000 },
+}
+];
+const filePath = createTempSession(events);
+try {
+const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+assert.equal(result.toolCalls.byTool['__auto_compact__'], 2);
+} finally {
+cleanup(filePath);
+}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: does NOT count __auto_compact__ for trigger=manual', async () => {
+const events = [
+{
+type: 'system',
+subtype: 'compact_boundary',
+compactMetadata: { trigger: 'manual', preTokens: 50000, postTokens: 5000, durationMs: 10000 },
+}
+];
+const filePath = createTempSession(events);
+try {
+const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+assert.equal(result.toolCalls.byTool['__auto_compact__'] ?? 0, 0);
+} finally {
+cleanup(filePath);
+}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: auto-compact does NOT inflate toolCalls.total', async () => {
+const events = [
+{
+type: 'system',
+subtype: 'compact_boundary',
+compactMetadata: { trigger: 'auto', preTokens: 170679, postTokens: 8697, durationMs: 72528 },
+}
+];
+const filePath = createTempSession(events);
+try {
+const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+assert.equal(result.toolCalls.total, 0);
+} finally {
+cleanup(filePath);
+}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: ignores system events with unknown subtype', async () => {
+const events = [
+{
+type: 'system',
+subtype: 'something_else',
+content: 'unknown system event',
+}
+];
+const filePath = createTempSession(events);
+try {
+const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+assert.equal(result.toolCalls.byTool['__auto_compact__'] ?? 0, 0);
+assert.equal(result.toolCalls.total, 0);
+} finally {
+cleanup(filePath);
+}
 });

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import { INSIGHT_CATALOG, evaluateInsights } from '../../src/insightsEngine';
+import type { InsightContext } from '../../src/insightsEngine';
+import type { UsageAnalysisPeriod } from '../../src/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyPeriod(): UsageAnalysisPeriod {
+	return {
+		sessions: 0,
+		toolCalls: { total: 0, byTool: {} },
+		modeUsage: { ask: 0, edit: 0, agent: 0, plan: 0, customAgent: 0, cli: 0 },
+		contextReferences: {
+			file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0,
+			workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0,
+			terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0,
+			problemsPanel: 0, pullRequest: 0, byKind: {}, byPath: {}, copilotInstructions: 0, agentsMd: 0,
+		},
+		mcpTools: { total: 0, byServer: {}, byTool: {} },
+		modelSwitching: {
+			modelsPerSession: [], totalSessions: 0, averageModelsPerSession: 0,
+			maxModelsPerSession: 0, minModelsPerSession: 0, switchingFrequency: 0,
+			standardModels: [], premiumModels: [], unknownModels: [], mixedTierSessions: 0,
+			standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+		},
+		repositories: [], repositoriesWithCustomization: [],
+		editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
+		applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
+		sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+		conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
+		agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
+	};
+}
+
+function makeCtx(overrides?: { autoCompact?: number; manualCompact?: number }): InsightContext {
+	const last30Days = emptyPeriod();
+	last30Days.sessions = 20;
+	if (overrides?.autoCompact) {
+		last30Days.toolCalls.byTool['__auto_compact__'] = overrides.autoCompact;
+	}
+	if (overrides?.manualCompact) {
+		last30Days.toolCalls.byTool['__slash__compact'] = overrides.manualCompact;
+	}
+	return {
+		today: emptyPeriod(),
+		last30Days,
+		missedPotential: [],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// auto-compaction-pattern insight tests
+// ---------------------------------------------------------------------------
+
+const AUTO_COMPACT_ID = 'auto-compaction-pattern';
+
+test('auto-compaction-pattern: insight exists in INSIGHT_CATALOG', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === AUTO_COMPACT_ID);
+	assert.ok(def, 'auto-compaction-pattern should be in INSIGHT_CATALOG');
+});
+
+test('auto-compaction-pattern: does NOT fire when __auto_compact__ is absent', () => {
+	const ctx = makeCtx();
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
+	assert.equal(insight, undefined);
+});
+
+test('auto-compaction-pattern: does NOT fire when __auto_compact__ = 1 (below threshold)', () => {
+	const ctx = makeCtx({ autoCompact: 1 });
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
+	assert.equal(insight, undefined);
+});
+
+test('auto-compaction-pattern: fires when __auto_compact__ = 2 (threshold)', () => {
+	const ctx = makeCtx({ autoCompact: 2 });
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
+	assert.ok(insight, 'insight should fire at count = 2');
+});
+
+test('auto-compaction-pattern: fires when __auto_compact__ > 2', () => {
+	const ctx = makeCtx({ autoCompact: 7 });
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
+	assert.ok(insight, 'insight should fire when count > 2');
+});
+
+test('auto-compaction-pattern: body includes auto-compact count', () => {
+	const ctx = makeCtx({ autoCompact: 3 });
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
+	assert.ok(insight);
+	assert.ok(insight!.body.includes('3'), 'body should mention the count (3)');
+});
+
+test('auto-compaction-pattern: has severity=opportunity', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === AUTO_COMPACT_ID);
+	assert.equal(def?.severity, 'opportunity');
+});
+
+test('auto-compaction-pattern: has allowToast=true', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === AUTO_COMPACT_ID);
+	assert.equal(def?.allowToast, true);
+});
+
+test('auto-compaction-pattern: has category=consistency', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === AUTO_COMPACT_ID);
+	assert.equal(def?.category, 'consistency');
+});
+
+test('auto-compaction-pattern: body mentions /compact and /new', () => {
+	const ctx = makeCtx({ autoCompact: 2 });
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
+	assert.ok(insight);
+	assert.ok(insight!.body.includes('/compact'), 'body should mention /compact');
+	assert.ok(insight!.body.includes('/new'), 'body should mention /new');
+});


### PR DESCRIPTION
## Summary

Closes #1280

When Claude Code exhausts its context window it emits a `type: "system"` / `subtype: "compact_boundary"` event with `compactMetadata.trigger === "auto"`. Previously these events were silently ignored by the adapter.

## Changes

### Core logic
- **`claudeCodeAdapter.ts`**: Handle `system/compact_boundary` events in `analyzeUsage()`. Increments `toolCalls.byTool['__auto_compact__']` when `trigger === 'auto'`. Does **not** inflate `toolCalls.total` (same pattern as `__slash__compact`).
- **`insightsEngine.ts`**: Add `autoCompactCount()` helper and new `auto-compaction-pattern` insight:
  - Category: `consistency`, Severity: `opportunity`, Weight: 65
  - Fires when ≥ 2 auto-compactions in the last 30 days
  - Suggests using `/compact` proactively and `/new` to start fresh

### Documentation
- **`claude-code-session-schema.json`**: Bumped to v1.2, added `"system"` to event types, added `systemEventSchema` section documenting `compact_boundary` and all `compactMetadata` fields

### Tests
- **`claudecode.test.ts`**: 5 new unit tests — counts auto trigger, accumulates multiple events, ignores manual trigger, doesn't inflate `toolCalls.total`, ignores unknown subtype
- **`insightsEngine.test.ts`** (new file): 9 unit tests — catalog presence, threshold behavior (0/1/2/>2 counts), body content, severity, allowToast, category

All 48 tests pass (5 adapter + 9 insight + 34 existing).