### PR TITLE
Fix diagnostics tabs overflow

### DIFF
--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -78,6 +78,7 @@ body {
 /* Tab styles */
 .tabs {
 	display: flex;
+	flex-wrap: wrap;
 	border-bottom: 1px solid var(--border-color);
 	margin-bottom: 16px;
 }


### PR DESCRIPTION
## Problem
The tabs in the diagnostics view were extending beyond the right edge of the viewport, causing horizontal overflow instead of wrapping to a new line.

## Solution
Added `flex-wrap: wrap` to the `.tabs` CSS class in the diagnostics view styles. This allows tabs to wrap onto multiple lines when they exceed the available viewport width, matching the behavior already implemented for the `.button-row` class above it.

## Changes
- Modified `vscode-extension/src/webview/diagnostics/styles.css` to add `flex-wrap: wrap` to `.tabs`

## Verification
- Extension compiled successfully with `npm run compile`
- No errors or warnings reported
- CSS change is minimal and focused