### PR TITLE
chore: bump versions for release (VS Code extension, CLI, JetBrains plugin)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.1.1
+pluginVersion = 0.1.2
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {
@@ -378,7 +378,12 @@
           "description": "Override or extend tool family groupings used in the Tool Output Token Analysis tab. Each entry with an 'id' matching a built-in family replaces that family entirely. Entries with new 'id' values are appended. Leave empty to use the built-in defaults. Example: { \"id\": \"reading\", \"name\": \"File Reading\", \"builtIn\": [\"read\"], \"alternatives\": [\"lean-ctx\", \"my-custom-reader\"] }",
           "items": {
             "type": "object",
-            "required": ["id", "name", "builtIn", "alternatives"],
+            "required": [
+              "id",
+              "name",
+              "builtIn",
+              "alternatives"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -390,12 +395,16 @@
               },
               "builtIn": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Built-in / baseline tool names that define the reference performance. Tool names must match exactly as they appear in session logs."
               },
               "alternatives": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Alternative or efficient-replacement tool names to compare against the built-ins."
               },
               "description": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for all three components that have changed since their last release tags.

| Component | Old version | New version | Last release tag |
|-----------|-------------|-------------|-----------------|
| VS Code extension | v0.11.3 | v0.11.4 | \scode/v0.11.3\ (116 files changed) |
| CLI | v0.2.4 | v0.2.5 | \cli/v0.0.8\ (26 files changed) |
| JetBrains plugin | v0.1.1 | v0.1.2 | *(first release — no previous tag)* |

> **Note on CLI versioning:** The last CLI git tag is \cli/v0.0.8\ but \cli/package.json\ was already at \