### PR TITLE
Fix JetBrains workflow artifact paths for release

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -298,14 +298,15 @@ jobs:
           mkdir -p cli/dist vscode-extension/dist/webview
 
           # CLI binaries (sql-wasm.wasm is the same on all platforms; one copy suffices)
-          cp artifacts/cli-windows/copilot-token-tracker.exe      cli/dist/
-          cp artifacts/cli-windows/sql-wasm.wasm                  cli/dist/
-          cp artifacts/cli-macos-arm64/copilot-token-tracker-macos-arm64  cli/dist/
-          cp artifacts/cli-macos-x64/copilot-token-tracker-macos-x64      cli/dist/
-          cp artifacts/cli-linux/copilot-token-tracker-linux       cli/dist/
+          # Note: artifact paths preserve the source directory structure
+          cp artifacts/cli-windows/cli/dist/copilot-token-tracker.exe      cli/dist/
+          cp artifacts/cli-windows/cli/dist/sql-wasm.wasm                  cli/dist/
+          cp artifacts/cli-macos-arm64/cli/dist/copilot-token-tracker-macos-arm64  cli/dist/
+          cp artifacts/cli-macos-x64/cli/dist/copilot-token-tracker-macos-x64      cli/dist/
+          cp artifacts/cli-linux/cli/dist/copilot-token-tracker-linux       cli/dist/
 
           # Webview JS bundles (built by vscode-extension)
-          cp artifacts/webview-bundles/*  vscode-extension/dist/webview/
+          cp artifacts/webview-bundles/vscode-extension/dist/webview/*  vscode-extension/dist/webview/
 
           # Make unix binaries executable
           chmod +x cli/dist/copilot-token-tracker-macos-arm64 cli/dist/copilot-token-tracker-macos-x64 cli/dist/copilot-token-tracker-linux

--- a/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/CopilotTokenTracker/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.13"
+              Version="1.0.14"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>


### PR DESCRIPTION
Fixes the JetBrains plugin release workflow and bumps Visual Studio extension version.

## JetBrains Workflow Fix
The JetBrains plugin release was failing because CLI binaries weren't being found in the plugin ZIP.

**Root cause:** When using `actions/download-artifact@v8`, the source directory structure is preserved. Files uploaded as `cli/dist/copilot-token-tracker.exe` are downloaded to `artifacts/cli-windows/cli/dist/copilot-token-tracker.exe`, not `artifacts/cli-windows/copilot-token-tracker.exe`.

**Fix:** Updated the "Place CLI binaries and webview bundles" step to look for artifacts in their actual downloaded locations.

## Visual Studio Extension Version Bump
The Visual Studio extension v1.0.13 was already published to the marketplace. Bumped to v1.0.14 to allow this release to publish.

These fixes will allow both JetBrains (v0.1.2) and Visual Studio (v1.0.14) extensions to publish successfully.