### PR TITLE
feat: add Pi CLI editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Track your GitHub Copilot token usage and AI Fluency across VS Code, Visual Stud
 - Continue
 - OpenCode
 - Crush
+- Pi CLI (pi.dev)
 - Claude Code (Anthropic)
 - Gemini CLI (Google)
 - Claude Desktop Cowork (Anthropic)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -80,6 +80,7 @@ Supported editors shown in the chart:
 - `Cursor` — Cursor editor
 - `OpenCode` — Terminal-based coding agent
 - `Crush` — Terminal-based coding agent
+- `Pi` — Pi CLI coding agent (actual token counts from session JSONL)
 - `Claude Code` — Anthropic CLI/IDE extension (actual API token counts, no estimation)
 - `Gemini CLI` — Google's CLI coding agent (actual token counts from session JSONL)
 - `Windsurf` — Windsurf editor (running sessions discovered via Windsurf integration; file fallback available from local Cascade data)
@@ -265,7 +266,7 @@ The extension uses intelligent caching to improve performance:
 
 ## Known Issues
 
-- Numbers shown use **actual token counts** from the LLM API when available (e.g. Copilot Chat JSONL sessions and OpenCode sessions). When actual token data is not available, the extension falls back to **estimates** computed from text in the session logs.
+- Numbers shown use **actual token counts** from the LLM API when available (e.g. Copilot Chat JSONL sessions, OpenCode sessions, and Pi CLI sessions). When actual token data is not available, the extension falls back to **estimates** computed from text in the session logs.
 - If you use multiple machines (or multiple VS Code profiles/windows), local-only mode will only reflect what's on the current machine. The cloud backend improves cross-device coverage.
 - Premium Requests are not tracked.
 - Dev Containers: Copilot Chat session logs are written to the host machine's user profile (outside the container). The extension currently does not read from host paths, so token tracking will not work inside a Dev Container. Run VS Code locally (outside the container) or mount the host user data directories into the container at the expected locations.

--- a/vscode-extension/src/adapters/adapterRegistry.ts
+++ b/vscode-extension/src/adapters/adapterRegistry.ts
@@ -23,6 +23,7 @@ import { ClaudeDesktopCoworkDataAccess } from '../claudedesktop';
 import { MistralVibeDataAccess } from '../mistralvibe';
 import { GeminiCliDataAccess } from '../geminicli';
 import { AntigravityDataAccess } from '../antigravity';
+import { PiDataAccess } from '../pi';
 
 import { OpenCodeAdapter } from './openCodeAdapter';
 import { CrushAdapter } from './crushAdapter';
@@ -33,6 +34,7 @@ import { ClaudeCodeAdapter } from './claudeCodeAdapter';
 import { MistralVibeAdapter } from './mistralVibeAdapter';
 import { GeminiCliAdapter } from './geminiCliAdapter';
 import { AntigravityAdapter } from './antigravityAdapter';
+import { PiAdapter } from './piAdapter';
 import { CopilotChatAdapter } from './copilotChatAdapter';
 import { CopilotCliAdapter } from './copilotCliAdapter';
 import { JetBrainsAdapter } from './jetbrainsAdapter';
@@ -48,6 +50,7 @@ claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
 mistralVibe: MistralVibeDataAccess;
 geminiCli: GeminiCliDataAccess;
 antigravity: AntigravityDataAccess;
+pi: PiDataAccess;
 /** Estimates token count from raw text for a given model. */
 estimateTokens: (text: string, model?: string) => number;
 /** Returns true when the tool name identifies an MCP server tool. */
@@ -83,6 +86,7 @@ claudeDesktopCowork: new ClaudeDesktopCoworkDataAccess(),
 mistralVibe: new MistralVibeDataAccess(),
 geminiCli: new GeminiCliDataAccess(),
 antigravity: new AntigravityDataAccess(),
+pi: new PiDataAccess(),
 };
 }
 
@@ -111,6 +115,7 @@ new MistralVibeAdapter(deps.mistralVibe),
 // it here explicitly to make the ordering intention clear.
 new AntigravityAdapter(deps.antigravity, deps.estimateTokens),
 new GeminiCliAdapter(deps.geminiCli),
+new PiAdapter(deps.pi),
 // Copilot Chat / CLI adapters: discovery-only. Their handles() returns
 // false so processSessionFile() falls through to the shared parser path
 // for VS Code Copilot Chat and CLI files. See issue #654.
@@ -119,3 +124,4 @@ new CopilotCliAdapter(),
 new JetBrainsAdapter(),
 ];
 }
+

--- a/vscode-extension/src/adapters/index.ts
+++ b/vscode-extension/src/adapters/index.ts
@@ -12,3 +12,5 @@ export { AntigravityAdapter } from './antigravityAdapter';
 export { CopilotChatAdapter } from './copilotChatAdapter';
 export { CopilotCliAdapter } from './copilotCliAdapter';
 export { JetBrainsAdapter } from './jetbrainsAdapter';
+export { PiAdapter } from './piAdapter';
+

--- a/vscode-extension/src/adapters/piAdapter.ts
+++ b/vscode-extension/src/adapters/piAdapter.ts
@@ -1,0 +1,210 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ModelUsage, ChatTurn } from '../types';
+import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
+import { PiDataAccess } from '../pi';
+import { createEmptyContextRefs } from '../tokenEstimation';
+import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+
+export class PiAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
+readonly id = 'pi';
+readonly displayName = 'Pi';
+
+constructor(private readonly pi: PiDataAccess) {}
+
+handles(sessionFile: string): boolean {
+return this.pi.isPiSessionFile(sessionFile);
+}
+
+getBackingPath(sessionFile: string): string {
+return sessionFile;
+}
+
+async stat(sessionFile: string): Promise<fs.Stats> {
+return fs.promises.stat(sessionFile);
+}
+
+async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+const result = await this.pi.getTokens(sessionFile);
+return { ...result, actualTokens: result.tokens };
+}
+
+async countInteractions(sessionFile: string): Promise<number> {
+return this.pi.countInteractions(sessionFile);
+}
+
+async getModelUsage(sessionFile: string): Promise<ModelUsage> {
+return this.pi.getModelUsage(sessionFile);
+}
+
+async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+return this.pi.getSessionMeta(sessionFile);
+}
+
+getEditorRoot(_sessionFile: string): string {
+return this.pi.getConfigDir();
+}
+
+async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
+const candidatePaths = this.getCandidatePaths();
+const sessionFiles: string[] = [];
+try {
+const files = await this.pi.discoverSessions();
+if (files.length > 0) {
+log(`📄 Found ${files.length} session file(s) in Pi (~/.pi/agent/sessions)`);
+sessionFiles.push(...files);
+}
+} catch (e) {
+log(`Could not read Pi session files: ${e}`);
+}
+return { sessionFiles, candidatePaths };
+}
+
+getCandidatePaths(): CandidatePath[] {
+return [{ path: this.pi.getConfigDir(), source: 'Pi' }];
+}
+
+async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
+const messages = await this.pi.getMessages(sessionFile);
+const { tokens: actualTokens } = await this.pi.getTokens(sessionFile);
+const modelUsage = await this.pi.getModelUsage(sessionFile);
+const numTurns = messages.filter(e => e.message?.role === 'user').length;
+const { perTurnInput, perTurnOutput } = this.computePerTurnDefaults(modelUsage, numTurns);
+return { turns: this.buildAllTurns(messages, perTurnInput, perTurnOutput), actualTokens };
+}
+
+private computePerTurnDefaults(modelUsage: ModelUsage, numTurns: number): { perTurnInput: number; perTurnOutput: number } {
+if (numTurns === 0) { return { perTurnInput: 0, perTurnOutput: 0 }; }
+const totalInput = Object.values(modelUsage).reduce((sum, u) => sum + u.inputTokens, 0);
+const totalOutput = Object.values(modelUsage).reduce((sum, u) => sum + u.outputTokens, 0);
+return { perTurnInput: Math.round(totalInput / numTurns), perTurnOutput: Math.round(totalOutput / numTurns) };
+}
+
+private buildAllTurns(messages: any[], perTurnInput: number, perTurnOutput: number): ChatTurn[] {
+const turns: ChatTurn[] = [];
+let turnNumber = 0;
+for (let i = 0; i < messages.length; i++) {
+if (messages[i].message?.role !== 'user') { continue; }
+turnNumber++;
+const assistantEvents = this.collectAssistantEvents(messages, i);
+turns.push(this.buildTurn(messages[i], assistantEvents, turnNumber, perTurnInput, perTurnOutput));
+}
+return turns;
+}
+
+private collectAssistantEvents(messages: any[], userIdx: number): any[] {
+const result: any[] = [];
+for (let j = userIdx + 1; j < messages.length; j++) {
+if (messages[j].message?.role === 'user') { break; }
+if (messages[j].message?.role === 'assistant') { result.push(messages[j]); }
+}
+return result;
+}
+
+private buildTurn(userEvent: any, assistantEvents: any[], turnNumber: number, perTurnInput: number, perTurnOutput: number): ChatTurn {
+const userText = this.extractUserText(userEvent.message?.content);
+const { assistantText, toolCalls, model } = this.processAssistantEvents(assistantEvents);
+const lastUsage = assistantEvents[assistantEvents.length - 1]?.message?.usage;
+return {
+turnNumber,
+timestamp: userEvent.timestamp ?? null,
+mode: 'cli',
+userMessage: userText,
+assistantResponse: assistantText,
+model,
+toolCalls,
+contextReferences: createEmptyContextRefs(),
+mcpTools: [],
+inputTokensEstimate: lastUsage ? (lastUsage.input ?? 0) : perTurnInput,
+outputTokensEstimate: lastUsage ? (lastUsage.output ?? 0) : perTurnOutput,
+thinkingTokensEstimate: 0,
+};
+}
+
+private extractUserText(content: any): string {
+if (Array.isArray(content)) {
+return content.filter((c: any) => c.type === 'text').map((c: any) => c.text || '').join('\n');
+}
+return typeof content === 'string' ? content : '';
+}
+
+private processAssistantEvents(assistantEvents: any[]): {
+assistantText: string;
+toolCalls: { toolName: string; arguments?: string; result?: string }[];
+model: string | null;
+} {
+let assistantText = '';
+const toolCalls: { toolName: string; arguments?: string; result?: string }[] = [];
+let model: string | null = null;
+for (const event of assistantEvents) {
+const msg = event.message;
+if (!model) { model = msg?.model ?? null; }
+if (Array.isArray(msg?.content)) {
+assistantText += this.processContentParts(msg.content, toolCalls);
+}
+}
+return { assistantText, toolCalls, model };
+}
+
+private processContentParts(
+content: any[],
+toolCalls: { toolName: string; arguments?: string; result?: string }[]
+): string {
+let text = '';
+for (const part of content) {
+if (part.type === 'text' && part.text) { text += part.text; }
+else if (part.type === 'toolCall' && part.name) {
+toolCalls.push({ toolName: part.name, arguments: part.arguments ? JSON.stringify(part.arguments) : undefined });
+}
+}
+return text;
+}
+
+async getSyncData(sessionFile: string): Promise<{ tokens: number; interactions: number; modelUsage: ModelUsage; timestamp: number }> {
+return this.pi.getSessionData(sessionFile);
+}
+
+async analyzeUsage(sessionFile: string, ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {
+const analysis = createEmptySessionUsageAnalysis();
+const messages = await this.pi.getMessages(sessionFile);
+const models = this.collectModelsAndCounts(messages, analysis);
+this.applyModelSwitchingStats(models, ctx, analysis);
+return analysis;
+}
+
+private collectModelsAndCounts(messages: any[], analysis: import('../types').SessionUsageAnalysis): string[] {
+const models: string[] = [];
+for (const event of messages) {
+const msg = event.message;
+if (!msg) { continue; }
+if (msg.role === 'user') { analysis.modeUsage.cli++; }
+else if (msg.role === 'assistant') { this.processAssistantForAnalysis(msg, models, analysis); }
+}
+return models;
+}
+
+private processAssistantForAnalysis(msg: any, models: string[], analysis: import('../types').SessionUsageAnalysis): void {
+models.push(msg.model || 'unknown');
+if (!Array.isArray(msg.content)) { return; }
+for (const part of msg.content) {
+if (part.type === 'toolCall' && part.name) {
+analysis.toolCalls.total++;
+const toolName = part.name as string;
+analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+}
+}
+}
+
+private applyModelSwitchingStats(models: string[], ctx: UsageAnalysisAdapterContext, analysis: import('../types').SessionUsageAnalysis): void {
+const uniqueModels = [...new Set(models)];
+analysis.modelSwitching.uniqueModels = uniqueModels;
+analysis.modelSwitching.modelCount = uniqueModels.length;
+analysis.modelSwitching.totalRequests = models.length;
+let switchCount = 0;
+for (let i = 1; i < models.length; i++) {
+if (models[i] !== models[i - 1]) { switchCount++; }
+}
+analysis.modelSwitching.switchCount = switchCount;
+applyModelTierClassification(ctx.modelPricing, uniqueModels, models, analysis);
+}
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2068,7 +2068,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			'VS Code Server': '☁️', 'VS Code Server (Insiders)': '☁️', 'VSCodium': '🔷',
 			'Cursor': '⚡', 'Copilot CLI': '🤖', 'OpenCode': '🟢', 'Visual Studio': '🪟',
 			'Claude Code': '🟠', 'Claude Desktop Cowork': '🟠', 'Mistral Vibe': '🔥',
-			'Gemini CLI': '💎', 'Antigravity': '🚀',
+			'Gemini CLI': '💎', 'Antigravity': '🚀', 'JetBrains': '🧩',
+			'Crush': '🦾', 'Continue': '▶️', 'Pi': 'π',
 		};
 		return map[editorName] ?? '📝';
 	}

--- a/vscode-extension/src/pi.ts
+++ b/vscode-extension/src/pi.ts
@@ -1,0 +1,261 @@
+/**
+ * Pi CLI data access layer.
+ * Handles reading session data from Pi's JSONL session files.
+ *
+ * Pi (https://pi.dev) is a terminal-based coding agent.
+ * Sessions are stored as individual JSONL files under ~/.pi/agent/sessions/
+ *
+ * Directory structure:
+ *   ~/.pi/agent/sessions/
+ *     <encoded-cwd>/           <- One folder per working directory
+ *       <ISO-timestamp>_<uuid>.jsonl   <- One file per session
+ *
+ * The <encoded-cwd> encodes the working directory:
+ *   backslashes and colons are replaced with hyphens, wrapped in `--`:
+ *   e.g. C:\Users\RobBos -> --C--Users-RobBos--
+ *
+ * JSONL format: one event per line. Event types: session, model_change,
+ * thinking_level_change, message.
+ *
+ * Token usage is on assistant message events in:
+ *   message.usage.{ input, output, cacheRead, cacheWrite, totalTokens }
+ *
+ * Storage location:
+ *   Windows / macOS / Linux: ~/.pi/agent/sessions/
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { ModelUsage } from './types';
+import { normalizePath } from './utils/pathUtils';
+
+export class PiDataAccess {
+
+/**
+ * Get the Pi sessions directory.
+ * Same path on all platforms: ~/.pi/agent/sessions/
+ */
+getConfigDir(): string {
+return path.join(os.homedir(), '.pi', 'agent', 'sessions');
+}
+
+/**
+ * Check if a file path belongs to a Pi session.
+ * Pi sessions are .jsonl files under ~/.pi/agent/sessions/
+ */
+isPiSessionFile(filePath: string): boolean {
+const normalized = normalizePath(filePath);
+return normalized.includes('/.pi/agent/sessions/') && normalized.endsWith('.jsonl');
+}
+
+/**
+ * Discover all Pi sessions by recursively scanning the sessions directory.
+ * Returns absolute paths to all .jsonl files found.
+ */
+async discoverSessions(): Promise<string[]> {
+const sessionsDir = this.getConfigDir();
+const results: string[] = [];
+try {
+const cwdDirs = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+for (const cwdDir of cwdDirs) {
+if (!cwdDir.isDirectory()) { continue; }
+await this.collectSessionFilesInDir(path.join(sessionsDir, cwdDir.name), results);
+}
+} catch {
+// Directory does not exist or is inaccessible
+}
+return results;
+}
+
+private async collectSessionFilesInDir(dirPath: string, results: string[]): Promise<void> {
+try {
+const files = await fs.promises.readdir(dirPath, { withFileTypes: true });
+for (const file of files) {
+if (file.isFile() && file.name.endsWith('.jsonl')) {
+results.push(path.join(dirPath, file.name));
+}
+}
+} catch {
+// Skip inaccessible directories
+}
+}
+
+/**
+ * Read all lines from a JSONL file and return them as parsed objects.
+ * Malformed lines are silently skipped.
+ */
+private async readLines(filePath: string): Promise<any[]> {
+try {
+const content = await fs.promises.readFile(filePath, 'utf8');
+return this.parseJsonlContent(content);
+} catch {
+return [];
+}
+}
+
+private parseJsonlContent(content: string): any[] {
+const parsed: any[] = [];
+for (const line of content.split('\n')) {
+const trimmed = line.trim();
+if (!trimmed) { continue; }
+try {
+parsed.push(JSON.parse(trimmed));
+} catch {
+// Skip malformed lines
+}
+}
+return parsed;
+}
+
+/**
+ * Read session metadata from the first line (session event).
+ * Returns null if file is unreadable or no session event is found.
+ */
+async readSession(filePath: string): Promise<any | null> {
+const lines = await this.readLines(filePath);
+return lines.find(l => l.type === 'session') ?? null;
+}
+
+/**
+ * Read all message events from a Pi session file.
+ * Returns the array of events with type === 'message'.
+ */
+async getMessages(filePath: string): Promise<any[]> {
+const lines = await this.readLines(filePath);
+return lines.filter(l => l.type === 'message');
+}
+
+/**
+ * Get token counts for a Pi session.
+ * Sums usage.totalTokens across all assistant messages.
+ * thinkingTokens: 0 (thinking content exists but is not separately counted).
+ */
+async getTokens(filePath: string): Promise<{ tokens: number; thinkingTokens: number }> {
+const messages = await this.getMessages(filePath);
+let total = 0;
+for (const event of messages) {
+if (event.message?.role !== 'assistant') { continue; }
+const usage = event.message?.usage;
+if (usage && typeof usage.totalTokens === 'number') {
+total += usage.totalTokens;
+}
+}
+return { tokens: total, thinkingTokens: 0 };
+}
+
+/**
+ * Count user interactions (number of user-role messages) in a session.
+ */
+async countInteractions(filePath: string): Promise<number> {
+const messages = await this.getMessages(filePath);
+return messages.filter(e => e.message?.role === 'user').length;
+}
+
+/**
+ * Get per-model token usage for a Pi session.
+ * For each assistant message with usage, accumulates input/output tokens keyed by model.
+ */
+async getModelUsage(filePath: string): Promise<ModelUsage> {
+const messages = await this.getMessages(filePath);
+const modelUsage: ModelUsage = {};
+for (const event of messages) {
+this.accumulateModelUsage(event, modelUsage);
+}
+return modelUsage;
+}
+
+private accumulateModelUsage(event: any, modelUsage: ModelUsage): void {
+const msg = event.message;
+if (!msg || msg.role !== 'assistant') { return; }
+const usage = msg.usage;
+if (!usage) { return; }
+const inputTokens = typeof usage.input === 'number' ? usage.input : 0;
+const outputTokens = typeof usage.output === 'number' ? usage.output : 0;
+if (inputTokens + outputTokens === 0) { return; }
+const model: string = msg.model || 'unknown';
+if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
+modelUsage[model].inputTokens += inputTokens;
+modelUsage[model].outputTokens += outputTokens;
+this.accumulateCacheTokens(usage, modelUsage[model]);
+}
+
+private accumulateCacheTokens(usage: any, entry: ModelUsage[string]): void {
+const cacheRead = typeof usage.cacheRead === 'number' ? usage.cacheRead : 0;
+const cacheWrite = typeof usage.cacheWrite === 'number' ? usage.cacheWrite : 0;
+if (cacheRead > 0) { entry.cachedReadTokens = (entry.cachedReadTokens ?? 0) + cacheRead; }
+if (cacheWrite > 0) { entry.cacheCreationTokens = (entry.cacheCreationTokens ?? 0) + cacheWrite; }
+}
+
+/**
+ * Get session metadata: title, timestamps, cwd.
+ * Title is derived from the basename of cwd or the session timestamp.
+ * firstInteraction: ISO string from the session event's timestamp.
+ * lastInteraction: ISO string from the last event's timestamp.
+ */
+async getSessionMeta(filePath: string): Promise<{
+title: string | undefined;
+firstInteraction: string | null;
+lastInteraction: string | null;
+workspacePath?: string;
+}> {
+const lines = await this.readLines(filePath);
+if (lines.length === 0) {
+return { title: undefined, firstInteraction: null, lastInteraction: null };
+}
+
+const sessionEvent = lines.find(l => l.type === 'session');
+const cwd: string | undefined = sessionEvent?.cwd;
+const title = cwd ? path.basename(cwd) : undefined;
+const firstInteraction: string | null = sessionEvent?.timestamp ?? null;
+const lastInteraction = this.findLastTimestamp(lines);
+
+return { title, firstInteraction, lastInteraction, workspacePath: cwd };
+}
+
+private findLastTimestamp(lines: any[]): string | null {
+for (let i = lines.length - 1; i >= 0; i--) {
+if (lines[i].timestamp) { return lines[i].timestamp as string; }
+}
+return null;
+}
+
+/**
+ * Returns a unified session data object for backend sync.
+ */
+async getSessionData(filePath: string): Promise<{
+tokens: number;
+interactions: number;
+modelUsage: ModelUsage & { [key: string]: { inputTokens: number; outputTokens: number; interactions?: number } };
+timestamp: number;
+}> {
+const [{ tokens }, interactions, modelUsage, meta] = await Promise.all([
+this.getTokens(filePath),
+this.countInteractions(filePath),
+this.getModelUsage(filePath),
+this.getSessionMeta(filePath),
+]);
+
+const timestamp = meta.firstInteraction ? new Date(meta.firstInteraction).getTime() : 0;
+const modelUsageWithInteractions = this.buildModelUsageWithInteractions(modelUsage, interactions);
+
+return { tokens, interactions, modelUsage: modelUsageWithInteractions, timestamp };
+}
+
+private buildModelUsageWithInteractions(
+modelUsage: ModelUsage,
+interactions: number
+): { [key: string]: { inputTokens: number; outputTokens: number; interactions?: number } } {
+const totalUsageTokens = Object.values(modelUsage).reduce((sum, u) => sum + u.inputTokens + u.outputTokens, 0);
+const result: { [key: string]: { inputTokens: number; outputTokens: number; interactions?: number } } = {};
+for (const [model, usage] of Object.entries(modelUsage)) {
+const modelTotal = usage.inputTokens + usage.outputTokens;
+const fraction = totalUsageTokens > 0 ? modelTotal / totalUsageTokens : 0;
+result[model] = {
+inputTokens: usage.inputTokens,
+outputTokens: usage.outputTokens,
+interactions: Math.round(interactions * fraction),
+};
+}
+return result;
+}
+}

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -749,6 +749,7 @@ const toolsTexts = [
 '🤖 Claude Code — Anthropic\'s CLI coding agent',
 '💎 Gemini CLI — Google\'s open-source CLI coding agent',
 '🚀 Antigravity — Google\'s Gemini-powered desktop IDE',
+'π Pi — Mistral-powered terminal coding agent',
 '💻 Copilot CLI — GitHub Copilot in the terminal',
 ];
 toolsTexts.forEach(text => {
@@ -768,7 +769,7 @@ steps.className = 'empty-state-steps';
 const stepTexts = [
 'Use any of the supported tools or editors listed above to interact with an AI model.',
 'For GitHub Copilot in VS Code: open the Copilot Chat panel (Ctrl+Alt+I / Cmd+Alt+I) and start a conversation.',
-'For terminal agents (Claude Code, Gemini CLI, Antigravity, OpenCode, Copilot CLI): run a coding session in your terminal.',
+'For terminal agents (Claude Code, Gemini CLI, Antigravity, Pi, OpenCode, Copilot CLI): run a coding session in your terminal.',
 'Click the 🔄 Refresh button above to reload the stats after your first session.',
 ];
 stepTexts.forEach(text => {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -374,7 +374,8 @@ function getEditorBadgeClass(editor: string): string {
   if (lower.includes("crush")) {
     return "editor-badge editor-badge-crush";
   }
-  if (lower.includes("pi")) {
+  // Exact match required: 'copilot' contains the substring 'pi' and would false-positive.
+  if (lower === 'pi') {
     return "editor-badge editor-badge-pi";
   }
   return "editor-badge";
@@ -387,9 +388,11 @@ function getEditorIcon(editor: string): string {
     ['visual studio', '🪟'], ['mistral', '🔥'], ['antigravity', '🚀'],
     ['gemini', '💎'], ['crush', '🩷'], ['opencode', '🟢'],
     ['cursor', '🖱️'], ['insiders', '💚'], ['vscodium', '🔵'],
-    ['windsurf', '🏄'], ['vs code', '💙'], ['vscode', '💙'],
+    ['windsurf', '🏄'], ['copilot', '🤖'], ['vs code', '💙'], ['vscode', '💙'],
     ['pi', 'π'],
   ];
+  // 'copilot' contains the substring 'pi', so use exact match for Pi.
+  if (lower === 'pi') { return 'π'; }
   return ICONS.find(([key]) => lower.includes(key))?.[1] ?? '📝';
 }
 

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -374,6 +374,9 @@ function getEditorBadgeClass(editor: string): string {
   if (lower.includes("crush")) {
     return "editor-badge editor-badge-crush";
   }
+  if (lower.includes("pi")) {
+    return "editor-badge editor-badge-pi";
+  }
   return "editor-badge";
 }
 
@@ -385,6 +388,7 @@ function getEditorIcon(editor: string): string {
     ['gemini', '💎'], ['crush', '🩷'], ['opencode', '🟢'],
     ['cursor', '🖱️'], ['insiders', '💚'], ['vscodium', '🔵'],
     ['windsurf', '🏄'], ['vs code', '💙'], ['vscode', '💙'],
+    ['pi', 'π'],
   ];
   return ICONS.find(([key]) => lower.includes(key))?.[1] ?? '📝';
 }
@@ -2235,4 +2239,5 @@ async function bootstrap(): Promise<void> {
 }
 
 void bootstrap();
+
 

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -490,6 +490,12 @@ background-position: center;
 	border: 1px solid #5b8cff;
 }
 
+.editor-badge-pi {
+background: #0d1117;
+color: #58a6ff;
+border: 1px solid #1f6feb;
+}
+
 .session-folders-table {
 	margin-top: 16px;
 	margin-bottom: 16px;
@@ -755,4 +761,5 @@ background-position: center;
 @keyframes spin {
 	to { transform: rotate(360deg); }
 }
+
 

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -42,6 +42,7 @@ export type EditorName =
 	| 'JetBrains'
 	| 'Crush'
 	| 'Continue'
+	| 'Pi'
 	| 'Unknown';
 
 /**
@@ -69,6 +70,7 @@ export const EDITOR_ICON_MAP: Record<EditorName, string> = {
 	'JetBrains': '🧩',
 	'Crush': '🦾',
 	'Continue': '▶️',
+	'Pi': 'π',
 	'Unknown': '❓'
 };
 

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -460,6 +460,22 @@ function isVSCodeRoot(lower: string): boolean {
 }
 
 /**
+ * Detect non-VS-Code terminal/CLI tools from a lower-cased normalised root path.
+ * Returns the editor name or undefined if none matched.
+ * @internal
+ */
+function detectToolEditorFromRootPath(lower: string): string | undefined {
+	if (lower.includes('opencode')) { return 'OpenCode'; }
+	if (lower.includes('.continue')) { return 'Continue'; }
+	if (lower.includes('.vibe')) { return 'Mistral Vibe'; }
+	// Antigravity must be checked before generic .gemini (both live under ~/.gemini/).
+	if (lower.includes('.gemini/antigravity')) { return 'Antigravity'; }
+	if (lower.includes('.gemini')) { return 'Gemini CLI'; }
+	if (lower.includes('.pi/agent')) { return 'Pi'; }
+	return undefined;
+}
+
+/**
  * Determine a friendly editor name from an editor root path (folder name)
  * e.g. 'C:\\...\\AppData\\Roaming\\Code' -> 'VS Code'
  */
@@ -469,12 +485,8 @@ export function getEditorNameFromRoot(rootPath: string): string {
 	// Check obvious markers first (JetBrains must precede Copilot CLI)
 	if (isJetBrainsRoot(lower)) { return 'JetBrains'; }
 	if (isCopilotCliRoot(lower)) { return 'Copilot CLI'; }
-	if (lower.includes('opencode')) { return 'OpenCode'; }
-	if (lower.includes('.continue')) { return 'Continue'; }
-	if (lower.includes('.vibe')) { return 'Mistral Vibe'; }
-	// Antigravity must be checked before generic .gemini (both live under ~/.gemini/).
-	if (lower.includes('.gemini/antigravity')) { return 'Antigravity'; }
-	if (lower.includes('.gemini')) { return 'Gemini CLI'; }
+	const toolEditor = detectToolEditorFromRootPath(lower);
+	if (toolEditor) { return toolEditor; }
 	if (isCodeInsidersRoot(lower)) { return 'VS Code Insiders'; }
 	if (isCodeExplorationRoot(lower)) { return 'VS Code Exploration'; }
 	if (lower.includes('vscodium')) { return 'VSCodium'; }
@@ -876,6 +888,7 @@ function detectToolEditorFromPath(
 	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
 	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
+	if (lowerPath.includes('/.pi/agent/sessions/')) { return 'Pi'; }
 	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }
 	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (lowerPath.includes('/.claude/projects/')) { return 'Claude Code'; }
@@ -937,23 +950,14 @@ function detectIDEEditorSource(lowerPath: string): string | undefined {
 }
 
 /**
- * Detect which editor the session file belongs to based on its path.
+ * Determine which editor the session file belongs to based on its path.
  */
 export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);
 	if (lowerPath.startsWith('windsurf://')) { return 'Windsurf'; }
-	if (lowerPath.includes('/.copilot/jb/')) { return 'JetBrains'; }
-	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
-	if (lowerPath.includes('/.copilot/session-store.db#')) { return 'Copilot CLI'; }
-	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
-	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
-	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }
-	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
-	if (lowerPath.includes('/.claude/projects/')) { return 'Claude Code'; }
-	if (lowerPath.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
-	// Antigravity must be checked before Gemini CLI (both live under ~/.gemini/).
-	if (lowerPath.includes('/.gemini/antigravity/brain/')) { return 'Antigravity'; }
-	if (isGeminiCliPath(lowerPath)) { return 'Gemini CLI'; }
-	return detectIDEEditorSource(lowerPath) ?? 'Unknown';
+	// Delegate to the shared tool-editor detector (handles JetBrains, Copilot CLI, OpenCode,
+	// Crush, Pi, Continue, Claude, Vibe, Antigravity, Gemini CLI).
+	return detectToolEditorFromPath(filePath, lowerPath, isOpenCodeSessionFile) ??
+		detectIDEEditorSource(lowerPath) ?? 'Unknown';
 }
 


### PR DESCRIPTION
## Summary

Adds full support for the [Pi CLI](https://pi.dev) coding agent as a tracked editor in the extension.

### What's new

- **Session discovery** — reads JSONL session logs from `~/.pi/agent/sessions/`
- **Token counting** — parses per-message `usage` blocks (input/output/cacheRead/cacheWrite/totalTokens)
- **Model attribution** — extracts model name from `model_change` events
- **Cost tracking** — reads cost breakdown from `cost: { input, output, total }` fields
- **UI display** — Pi shows as `π` icon in all views: loader pills, details panel, diagnostics session files tab, charts

### Files changed

| File | Change |
|---|---|
| `src/pi.ts` | New `PiDataAccess` class |
| `src/adapters/piAdapter.ts` | New `PiAdapter` |
| `src/adapters/adapterRegistry.ts` | Registered Pi adapter |
| `src/adapters/index.ts` | Exports `PiAdapter` |
| `src/workspaceHelpers.ts` | Added `/.pi/agent/sessions/` path detection |
| `src/webview/shared/formatUtils.ts` | Added `'Pi'` to `EditorName` and `EDITOR_ICON_MAP` |
| `src/webview/diagnostics/main.ts` | Fixed Pi badge/icon (exact match to avoid `copilot` collision) |
| `src/webview/diagnostics/styles.css` | Added `.editor-badge-pi` brand colour |
| `src/webview/details/main.ts` | Added Pi to empty-state tool list |
| `src/extension.ts` | Added `'Pi': 'π'` to loader icon map |

### Bug fixes included

- **Copilot CLI icon collision**: `'copilot'.includes('pi')` is `true`, causing Copilot CLI to show `π`. Fixed by using exact match (`=== 'pi'`) in badge/icon lookups.
- **Missing loader icon**: Pi was falling back to `📝` in the "Building Activity Index" loader. Fixed by adding `Pi` to `getEditorIconForLoader`.