### PR TITLE
feat(vscode): adaptive hover tooltip shows Current Month when configured

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -231,7 +231,22 @@ type SessionFilePreload = {
 	details?: SessionFileDetails;
 };
 
-type StatusBarDisplaySetting = 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth';
+export type StatusBarDisplaySetting = 'none' | 'today' | 'last30days' | 'currentMonth' | 'both' | 'todayAndCurrentMonth';
+
+/**
+ * Determines which secondary period section to show in the hover tooltip.
+ * Returns 'last30days' if either setting explicitly requests a rolling 30-day window
+ * (i.e. 'last30days' or 'both'), preserving backwards-compatible behaviour.
+ * Otherwise returns 'currentMonth' so users who opted into current-month views
+ * see a consistent tooltip.
+ */
+export function tooltipSecondaryPeriod(
+	tokensSetting: StatusBarDisplaySetting,
+	costSetting: StatusBarDisplaySetting,
+): 'last30days' | 'currentMonth' {
+	const usesLast30 = (s: StatusBarDisplaySetting) => s === 'last30days' || s === 'both';
+	return usesLast30(tokensSetting) || usesLast30(costSetting) ? 'last30days' : 'currentMonth';
+}
 
 // ── extension.ts module-level helpers ────────────────────────────────────────
 
@@ -2286,15 +2301,18 @@ class CopilotTokenTracker implements vscode.Disposable {
 		tooltip.appendMarkdown(`| Average interactions/session :     | ${detailedStats.today.avgInteractionsPerSession} |\n`);
 		tooltip.appendMarkdown(`| Average tokens/session :            | ${detailedStats.today.avgTokensPerSession.toLocaleString()} |\n`);
 		tooltip.appendMarkdown('\n---\n');
-		tooltip.appendMarkdown(`📊 Last 30 Days  \n`);
+		const secondaryPeriod = tooltipSecondaryPeriod(this.getStatusBarShowTokensSetting(), this.getStatusBarShowCostSetting());
+		const secondaryStats = secondaryPeriod === 'currentMonth' ? detailedStats.month : detailedStats.last30Days;
+		const secondaryLabel = secondaryPeriod === 'currentMonth' ? '📅 Current Month' : '📊 Last 30 Days';
+		tooltip.appendMarkdown(`${secondaryLabel}  \n`);
 		tooltip.appendMarkdown(`|                 |  |\n|-----------------------|-------|\n`);
-		tooltip.appendMarkdown(`| Tokens :                | ${detailedStats.last30Days.tokens.toLocaleString()} |\n`);
-		tooltip.appendMarkdown(`| Estimated cost (UBB) :       | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
-		tooltip.appendMarkdown(`| CO₂ estimated :              | ${detailedStats.last30Days.co2.toFixed(2)} grams |\n`);
-		tooltip.appendMarkdown(`| Water estimated :           | ${detailedStats.last30Days.waterUsage.toFixed(3)} liters |\n`);
-		tooltip.appendMarkdown(`| Sessions :             | ${detailedStats.last30Days.sessions} |\n`);
-		tooltip.appendMarkdown(`| Average interactions/session :      | ${detailedStats.last30Days.avgInteractionsPerSession} |\n`);
-		tooltip.appendMarkdown(`| Average tokens/session :            | ${detailedStats.last30Days.avgTokensPerSession.toLocaleString()} |\n`);
+		tooltip.appendMarkdown(`| Tokens :                | ${secondaryStats.tokens.toLocaleString()} |\n`);
+		tooltip.appendMarkdown(`| Estimated cost (UBB) :       | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
+		tooltip.appendMarkdown(`| CO₂ estimated :              | ${secondaryStats.co2.toFixed(2)} grams |\n`);
+		tooltip.appendMarkdown(`| Water estimated :           | ${secondaryStats.waterUsage.toFixed(3)} liters |\n`);
+		tooltip.appendMarkdown(`| Sessions :             | ${secondaryStats.sessions} |\n`);
+		tooltip.appendMarkdown(`| Average interactions/session :      | ${secondaryStats.avgInteractionsPerSession} |\n`);
+		tooltip.appendMarkdown(`| Average tokens/session :            | ${secondaryStats.avgTokensPerSession.toLocaleString()} |\n`);
 		tooltip.appendMarkdown('\n---\n');
 		const budget = this.getEffectiveMonthlyBudget();
 		if (budget > 0) {

--- a/vscode-extension/test/unit/extension-tooltipPeriod.test.ts
+++ b/vscode-extension/test/unit/extension-tooltipPeriod.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { tooltipSecondaryPeriod, type StatusBarDisplaySetting } from '../../src/extension';
+
+test('tooltipSecondaryPeriod: default both/none shows last30days', () => {
+	assert.equal(tooltipSecondaryPeriod('both', 'none'), 'last30days');
+});
+
+test('tooltipSecondaryPeriod: last30days tokens shows last30days', () => {
+	assert.equal(tooltipSecondaryPeriod('last30days', 'none'), 'last30days');
+});
+
+test('tooltipSecondaryPeriod: both cost setting shows last30days', () => {
+	assert.equal(tooltipSecondaryPeriod('none', 'both'), 'last30days');
+});
+
+test('tooltipSecondaryPeriod: last30days cost setting shows last30days', () => {
+	assert.equal(tooltipSecondaryPeriod('today', 'last30days'), 'last30days');
+});
+
+test('tooltipSecondaryPeriod: currentMonth tokens shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('currentMonth', 'none'), 'currentMonth');
+});
+
+test('tooltipSecondaryPeriod: todayAndCurrentMonth tokens shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('todayAndCurrentMonth', 'none'), 'currentMonth');
+});
+
+test('tooltipSecondaryPeriod: today tokens shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('today', 'none'), 'currentMonth');
+});
+
+test('tooltipSecondaryPeriod: none/none shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('none', 'none'), 'currentMonth');
+});
+
+test('tooltipSecondaryPeriod: both settings are today shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('today', 'today'), 'currentMonth');
+});
+
+test('tooltipSecondaryPeriod: currentMonth tokens and currentMonth cost shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('currentMonth', 'currentMonth'), 'currentMonth');
+});
+
+test('tooltipSecondaryPeriod: todayAndCurrentMonth both settings shows currentMonth', () => {
+	assert.equal(tooltipSecondaryPeriod('todayAndCurrentMonth', 'todayAndCurrentMonth'), 'currentMonth');
+});
+
+// Verify the type export is usable
+test('StatusBarDisplaySetting type is exported', () => {
+	const val: StatusBarDisplaySetting = 'both';
+	assert.equal(val, 'both');
+});


### PR DESCRIPTION
## Summary

Fixes #1328

When hovering the status bar item, the tooltip's secondary period section now adapts to the user's display settings:

- If either `showTokens` or `showCost` is set to `last30days` or `both` → tooltip shows **"Last 30 Days"** (existing behaviour, default)
- Otherwise (e.g. both set to `currentMonth`, `todayAndCurrentMonth`, `today`, or `none`) → tooltip shows **"Current Month"**

This means users who configure their status bar for current-month visibility now see consistent information in the hover tooltip, without needing a separate setting.

## Changes

- **`vscode-extension/src/extension.ts`**
  - `StatusBarDisplaySetting` type is now exported
  - New exported pure helper `tooltipSecondaryPeriod(tokensSetting, costSetting)` determines which period to show
  - `buildTooltipMarkdown` uses `tooltipSecondaryPeriod` to select between `detailedStats.last30Days` and `detailedStats.month`

- **`vscode-extension/test/unit/extension-tooltipPeriod.test.ts`** (new)
  - 12 unit tests covering all relevant setting combinations

## Backwards compatibility

The default `showTokens` value is `'both'`, which triggers `'last30days'` — so all existing users see no change in behaviour.