### PR TITLE
Potential fix for code scanning alert no. 64: Client-side cross-site scripting

### DIFF
--- a/usage-data/agent-sessions.json
+++ b/usage-data/agent-sessions.json
@@ -15,6 +15,6 @@
   "totalSessions": 0,
   "totalCredits": 0,
   "authenticated": true,
-  "since": "2026-05-03T21:23:27.091Z",
-  "fetchedAt": "2026-06-02T21:23:27.480Z"
+  "since": "2026-05-06T12:39:58.178Z",
+  "fetchedAt": "2026-06-05T12:39:58.569Z"
 }

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1689,13 +1689,17 @@ function sanitizeDetailedSessionFiles(input: unknown): SessionFileDetails[] {
 
     return {
       ...sf,
+      file: String(sf.file ?? sf.sessionFile ?? ""),
       editorSource: String(sf.editorSource ?? ""),
       title: String(sf.title ?? ""),
       repository: String(sf.repository ?? ""),
       sessionFile: String(sf.sessionFile ?? ""),
       size: Number(sf.size ?? 0) || 0,
+      modified: String(sf.modified ?? ""),
       tokens: Number(sf.tokens ?? 0) || 0,
       interactions: Number(sf.interactions ?? 0) || 0,
+      firstInteraction: sf.firstInteraction == null ? null : String(sf.firstInteraction),
+      lastInteraction: sf.lastInteraction == null ? null : String(sf.lastInteraction),
       contextReferences: {
         file: Number(contextRefs.file ?? 0) || 0,
         symbol: Number(contextRefs.symbol ?? 0) || 0,
@@ -1705,8 +1709,21 @@ function sanitizeDetailedSessionFiles(input: unknown): SessionFileDetails[] {
         workspace: Number(contextRefs.workspace ?? 0) || 0,
         terminal: Number(contextRefs.terminal ?? 0) || 0,
         vscode: Number(contextRefs.vscode ?? 0) || 0,
+        terminalLastCommand: Number(contextRefs.terminalLastCommand ?? 0) || 0,
+        terminalSelection: Number(contextRefs.terminalSelection ?? 0) || 0,
+        clipboard: Number(contextRefs.clipboard ?? 0) || 0,
+        changes: Number(contextRefs.changes ?? 0) || 0,
+        outputPanel: Number(contextRefs.outputPanel ?? 0) || 0,
+        problemsPanel: Number(contextRefs.problemsPanel ?? 0) || 0,
+        pullRequest: Number(contextRefs.pullRequest ?? 0) || 0,
+        byKind: contextRefs.byKind && typeof contextRefs.byKind === "object"
+          ? (contextRefs.byKind as Record<string, number>)
+          : {},
         copilotInstructions: Number(contextRefs.copilotInstructions ?? 0) || 0,
         agentsMd: Number(contextRefs.agentsMd ?? 0) || 0,
+        byPath: contextRefs.byPath && typeof contextRefs.byPath === "object"
+          ? (contextRefs.byPath as Record<string, number>)
+          : {},
       },
       parentInfo: parentInfo
         ? {
@@ -2286,5 +2303,3 @@ async function bootstrap(): Promise<void> {
 }
 
 void bootstrap();
-
-

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1675,8 +1675,52 @@ function handleDiagnosticDataError(message: DiagMessage): void {
   }
 }
 
+function sanitizeDetailedSessionFiles(input: unknown): SessionFileDetails[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.map((item) => {
+    const sf = (item ?? {}) as Record<string, unknown>;
+    const contextRefs = (sf.contextReferences ?? {}) as Record<string, unknown>;
+    const parentInfo = sf.parentInfo && typeof sf.parentInfo === "object"
+      ? (sf.parentInfo as Record<string, unknown>)
+      : undefined;
+
+    return {
+      ...sf,
+      editorSource: String(sf.editorSource ?? ""),
+      title: String(sf.title ?? ""),
+      repository: String(sf.repository ?? ""),
+      sessionFile: String(sf.sessionFile ?? ""),
+      size: Number(sf.size ?? 0) || 0,
+      tokens: Number(sf.tokens ?? 0) || 0,
+      interactions: Number(sf.interactions ?? 0) || 0,
+      contextReferences: {
+        file: Number(contextRefs.file ?? 0) || 0,
+        symbol: Number(contextRefs.symbol ?? 0) || 0,
+        selection: Number(contextRefs.selection ?? 0) || 0,
+        implicitSelection: Number(contextRefs.implicitSelection ?? 0) || 0,
+        codebase: Number(contextRefs.codebase ?? 0) || 0,
+        workspace: Number(contextRefs.workspace ?? 0) || 0,
+        terminal: Number(contextRefs.terminal ?? 0) || 0,
+        vscode: Number(contextRefs.vscode ?? 0) || 0,
+        copilotInstructions: Number(contextRefs.copilotInstructions ?? 0) || 0,
+        agentsMd: Number(contextRefs.agentsMd ?? 0) || 0,
+      },
+      parentInfo: parentInfo
+        ? {
+            ...parentInfo,
+            name: String(parentInfo.name ?? ""),
+            sessionFile: parentInfo.sessionFile == null ? undefined : String(parentInfo.sessionFile),
+          }
+        : undefined,
+    } as SessionFileDetails;
+  });
+}
+
 function handleSessionFilesLoaded(message: DiagMessage): void {
-  storedDetailedFiles = message.detailedSessionFiles;
+  storedDetailedFiles = sanitizeDetailedSessionFiles(message.detailedSessionFiles);
   isLoading = false;
 
   const sessionsTab = document.querySelector('.tab[data-tab="sessions"]');

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1675,6 +1675,15 @@ function handleDiagnosticDataError(message: DiagMessage): void {
   }
 }
 
+function sanitizeNumericRecord(input: unknown): Record<string, number> {
+  if (!input || typeof input !== "object") {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(input as Record<string, unknown>).map(([key, value]) => [key, Number(value ?? 0) || 0]),
+  );
+}
+
 function sanitizeDetailedSessionFiles(input: unknown): SessionFileDetails[] {
   if (!Array.isArray(input)) {
     return [];
@@ -1687,13 +1696,23 @@ function sanitizeDetailedSessionFiles(input: unknown): SessionFileDetails[] {
       ? (sf.parentInfo as Record<string, unknown>)
       : undefined;
 
+    const childInfo = Array.isArray(sf.childInfo)
+      ? sf.childInfo
+        .filter((child): child is Record<string, unknown> => !!child && typeof child === "object")
+        .map((child) => ({
+          uuid: String(child.uuid ?? ""),
+          name: String(child.name ?? ""),
+          sessionFile: child.sessionFile == null ? undefined : String(child.sessionFile),
+        }))
+      : undefined;
+
     return {
-      ...sf,
       file: String(sf.file ?? sf.sessionFile ?? ""),
       editorSource: String(sf.editorSource ?? ""),
-      title: String(sf.title ?? ""),
-      repository: String(sf.repository ?? ""),
-      sessionFile: String(sf.sessionFile ?? ""),
+      editorRoot: sf.editorRoot == null ? undefined : String(sf.editorRoot),
+      editorName: sf.editorName == null ? undefined : String(sf.editorName),
+      title: sf.title == null ? undefined : String(sf.title),
+      repository: sf.repository == null ? undefined : String(sf.repository),
       size: Number(sf.size ?? 0) || 0,
       modified: String(sf.modified ?? ""),
       tokens: Number(sf.tokens ?? 0) || 0,
@@ -1716,22 +1735,20 @@ function sanitizeDetailedSessionFiles(input: unknown): SessionFileDetails[] {
         outputPanel: Number(contextRefs.outputPanel ?? 0) || 0,
         problemsPanel: Number(contextRefs.problemsPanel ?? 0) || 0,
         pullRequest: Number(contextRefs.pullRequest ?? 0) || 0,
-        byKind: contextRefs.byKind && typeof contextRefs.byKind === "object"
-          ? (contextRefs.byKind as Record<string, number>)
-          : {},
+        byKind: sanitizeNumericRecord(contextRefs.byKind),
         copilotInstructions: Number(contextRefs.copilotInstructions ?? 0) || 0,
         agentsMd: Number(contextRefs.agentsMd ?? 0) || 0,
-        byPath: contextRefs.byPath && typeof contextRefs.byPath === "object"
-          ? (contextRefs.byPath as Record<string, number>)
-          : {},
+        byPath: sanitizeNumericRecord(contextRefs.byPath),
       },
       parentInfo: parentInfo
         ? {
-            ...parentInfo,
+            uuid: String(parentInfo.uuid ?? ""),
             name: String(parentInfo.name ?? ""),
             sessionFile: parentInfo.sessionFile == null ? undefined : String(parentInfo.sessionFile),
           }
         : undefined,
+      childInfo,
+      totalChildCount: sf.totalChildCount == null ? undefined : Number(sf.totalChildCount),
     } as SessionFileDetails;
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/ai-engineering-fluency/security/code-scanning/64](https://github.com/rajbos/ai-engineering-fluency/security/code-scanning/64)

Best fix: **validate and sanitize untrusted message payload before storing/using it**, and ensure HTML-producing code only receives normalized safe data.

In this file, the single best minimal-change approach is:

1. Add a sanitizer/normalizer for `message.detailedSessionFiles` that:
   - Verifies it is an array.
   - Coerces expected string fields to safe strings (`escapeHtml`-encoded before HTML insertion paths, or at minimum strict string coercion + safe defaults).
   - Coerces numeric fields with `Number(...)` and fallback `0`.
   - Normalizes nested structures (`contextReferences`, `parentInfo`) with safe defaults.
2. Use this sanitizer in `handleSessionFilesLoaded` before assigning to `storedDetailedFiles`.
3. Keep existing behavior (same table rendering, sorting, filtering), just with trusted normalized data.

This change should be made only in `vscode-extension/src/webview/diagnostics/main.ts`, near `handleSessionFilesLoaded` and helper-function area.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
