### PR TITLE
fix: repair stale sanitizeStats schema for customizationMatrix (#1332)

### DIFF
--- a/vscode-extension/src/webview/usage/customizationSanitizer.ts
+++ b/vscode-extension/src/webview/usage/customizationSanitizer.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure data-sanitization helper for WorkspaceCustomizationMatrix objects received via postMessage.
+ * Extracted into its own module (no DOM / CSS dependencies) so it can be unit-tested in Node.js.
+ */
+
+export type CustomizationTypeStatus = '✅' | '⚠️' | '❌';
+
+const VALID_STATUSES = new Set<string>(['✅', '⚠️', '❌']);
+
+export interface SanitizedCustomizationType {
+	id: string;
+	icon: string;
+	label: string;
+}
+
+export interface SanitizedCustomizationRow {
+	workspacePath: string;
+	workspaceName: string;
+	sessionCount: number;
+	interactionCount: number;
+	typeStatuses: { [typeId: string]: CustomizationTypeStatus };
+}
+
+export interface SanitizedCustomizationMatrix {
+	customizationTypes: SanitizedCustomizationType[];
+	workspaces: SanitizedCustomizationRow[];
+	totalWorkspaces: number;
+	workspacesWithIssues: number;
+}
+
+function coerceNumber(value: unknown): number {
+	const n = Number(value);
+	return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Sanitizes a raw (untrusted) customization matrix from postMessage.
+ * Returns undefined when the input is not a valid object.
+ */
+export function sanitizeCustomizationMatrix(rawMatrix: unknown): SanitizedCustomizationMatrix | undefined {
+	if (!rawMatrix || typeof rawMatrix !== 'object') { return undefined; }
+	const m = rawMatrix as Record<string, unknown>;
+
+	const customizationTypes: SanitizedCustomizationType[] = Array.isArray(m.customizationTypes)
+		? (m.customizationTypes as unknown[])
+			.filter((t): t is Record<string, unknown> => !!t && typeof t === 'object')
+			.map(t => ({
+				id: typeof t.id === 'string' ? t.id : '',
+				icon: typeof t.icon === 'string' ? t.icon : '',
+				label: typeof t.label === 'string' ? t.label : '',
+			}))
+			.filter(t => t.id !== '')
+		: [];
+
+	const workspaces: SanitizedCustomizationRow[] = Array.isArray(m.workspaces)
+		? (m.workspaces as unknown[])
+			.filter((w): w is Record<string, unknown> => !!w && typeof w === 'object')
+			.map(w => {
+				const rawStatuses = (w.typeStatuses && typeof w.typeStatuses === 'object')
+					? w.typeStatuses as Record<string, unknown>
+					: {};
+				const typeStatuses: { [typeId: string]: CustomizationTypeStatus } = {};
+				for (const [key, val] of Object.entries(rawStatuses)) {
+					typeStatuses[key] = VALID_STATUSES.has(val as string) ? (val as CustomizationTypeStatus) : '❌';
+				}
+				return {
+					workspacePath: typeof w.workspacePath === 'string' ? w.workspacePath : '',
+					workspaceName: typeof w.workspaceName === 'string' ? w.workspaceName : '',
+					sessionCount: coerceNumber(w.sessionCount),
+					interactionCount: coerceNumber(w.interactionCount),
+					typeStatuses,
+				};
+			})
+		: [];
+
+	return {
+		customizationTypes,
+		workspaces,
+		totalWorkspaces: coerceNumber(m.totalWorkspaces),
+		workspacesWithIssues: coerceNumber(m.workspacesWithIssues),
+	};
+}

--- a/vscode-extension/src/webview/usage/customizationSanitizer.ts
+++ b/vscode-extension/src/webview/usage/customizationSanitizer.ts
@@ -1,32 +1,16 @@
 /**
  * Pure data-sanitization helper for WorkspaceCustomizationMatrix objects received via postMessage.
  * Extracted into its own module (no DOM / CSS dependencies) so it can be unit-tested in Node.js.
+ *
+ * Types are imported directly from types.ts (the extension's canonical source), so any schema
+ * change there will cause an immediate compile error here — preventing schema drift.
  */
+import type { CustomizationTypeStatus, WorkspaceCustomizationMatrix, WorkspaceCustomizationRow } from '../../types';
 
-export type CustomizationTypeStatus = '✅' | '⚠️' | '❌';
+// Re-export for consumers (tests etc.) so they don't need to depend on types.ts directly
+export type { CustomizationTypeStatus, WorkspaceCustomizationMatrix as SanitizedCustomizationMatrix, WorkspaceCustomizationRow as SanitizedCustomizationRow } from '../../types';
 
 const VALID_STATUSES = new Set<string>(['✅', '⚠️', '❌']);
-
-export interface SanitizedCustomizationType {
-	id: string;
-	icon: string;
-	label: string;
-}
-
-export interface SanitizedCustomizationRow {
-	workspacePath: string;
-	workspaceName: string;
-	sessionCount: number;
-	interactionCount: number;
-	typeStatuses: { [typeId: string]: CustomizationTypeStatus };
-}
-
-export interface SanitizedCustomizationMatrix {
-	customizationTypes: SanitizedCustomizationType[];
-	workspaces: SanitizedCustomizationRow[];
-	totalWorkspaces: number;
-	workspacesWithIssues: number;
-}
 
 function coerceNumber(value: unknown): number {
 	const n = Number(value);
@@ -37,11 +21,11 @@ function coerceNumber(value: unknown): number {
  * Sanitizes a raw (untrusted) customization matrix from postMessage.
  * Returns undefined when the input is not a valid object.
  */
-export function sanitizeCustomizationMatrix(rawMatrix: unknown): SanitizedCustomizationMatrix | undefined {
+export function sanitizeCustomizationMatrix(rawMatrix: unknown): WorkspaceCustomizationMatrix | undefined {
 	if (!rawMatrix || typeof rawMatrix !== 'object') { return undefined; }
 	const m = rawMatrix as Record<string, unknown>;
 
-	const customizationTypes: SanitizedCustomizationType[] = Array.isArray(m.customizationTypes)
+	const customizationTypes: WorkspaceCustomizationMatrix['customizationTypes'] = Array.isArray(m.customizationTypes)
 		? (m.customizationTypes as unknown[])
 			.filter((t): t is Record<string, unknown> => !!t && typeof t === 'object')
 			.map(t => ({
@@ -52,7 +36,7 @@ export function sanitizeCustomizationMatrix(rawMatrix: unknown): SanitizedCustom
 			.filter(t => t.id !== '')
 		: [];
 
-	const workspaces: SanitizedCustomizationRow[] = Array.isArray(m.workspaces)
+	const workspaces: WorkspaceCustomizationRow[] = Array.isArray(m.workspaces)
 		? (m.workspaces as unknown[])
 			.filter((w): w is Record<string, unknown> => !!w && typeof w === 'object')
 			.map(w => {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -11,6 +11,7 @@ import styles from './styles.css';
 import { getWindowData } from '../shared/dataLoader';
 import { registerMessageHandler } from '../shared/messageHandler';
 import { getModelDisplayName } from '../shared/modelUtils';
+import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
@@ -858,33 +859,9 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 		};
 
 		// Sanitize customizationMatrix (avoid pass-through of untrusted nested fields)
-		if (raw.customizationMatrix && typeof raw.customizationMatrix === 'object'
-			&& Array.isArray(raw.customizationMatrix.workspaces)) {
-			const rawMatrix = raw.customizationMatrix as any;
-			const safeWorkspaces = rawMatrix.workspaces
-				.filter((w: any) => w && typeof w === 'object')
-				.map((w: any) => ({
-					workspacePath: typeof w.workspacePath === 'string' ? w.workspacePath : '',
-					repoName: typeof w.repoName === 'string' ? w.repoName : '',
-					hasCopilotInstructionsMd: !!w.hasCopilotInstructionsMd,
-					hasAgentsMd: !!w.hasAgentsMd,
-					hasCopilotSetupStepsMd: !!w.hasCopilotSetupStepsMd,
-					hasCustomChatmodes: !!w.hasCustomChatmodes,
-					hasCustomPrompts: !!w.hasCustomPrompts,
-					totalFiles: coerceNumber(w.totalFiles),
-					missingTypes: Array.isArray(w.missingTypes)
-						? w.missingTypes.filter((t: unknown) => typeof t === 'string')
-						: [],
-					extraTypes: Array.isArray(w.extraTypes)
-						? w.extraTypes.filter((t: unknown) => typeof t === 'string')
-						: [],
-				}));
-
-			sanitized.customizationMatrix = {
-				workspaces: safeWorkspaces,
-				totalWorkspaces: coerceNumber(rawMatrix.totalWorkspaces),
-				workspacesWithIssues: coerceNumber(rawMatrix.workspacesWithIssues),
-			} as WorkspaceCustomizationMatrix;
+		const safeMatrix = sanitizeCustomizationMatrix(raw.customizationMatrix);
+		if (safeMatrix) {
+			sanitized.customizationMatrix = safeMatrix as WorkspaceCustomizationMatrix;
 		}
 
 		// Validated pass-through for missedPotential (array of objects)
@@ -1250,9 +1227,10 @@ function buildCustomizationSectionHtml(matrix: WorkspaceCustomizationMatrix | nu
 			</div>`;
 	}
 	const workspaceRows = matrix.workspaces.map(ws => {
-		const hasNoCustomization = Object.values(ws.typeStatuses).every(s => s === '❌');
-		const typeCells = matrix.customizationTypes.map(type => {
-			const status = ws.typeStatuses[type.id] || '❓';
+		const statuses = ws.typeStatuses ?? {};
+		const hasNoCustomization = Object.values(statuses).every(s => s === '❌');
+		const typeCells = (matrix.customizationTypes ?? []).map(type => {
+			const status = statuses[type.id] || '❓';
 			const statusLabel =
 				status === '✅' ? 'Present and fresh'
 				: status === '⚠️' ? 'Present but stale'
@@ -1291,7 +1269,7 @@ function buildCustomizationSectionHtml(matrix: WorkspaceCustomizationMatrix | nu
 						<tr>
 							<th style="text-align: left; padding: 8px; border-bottom: 2px solid var(--border-color);">📂 Workspace</th>
 							<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);">Sessions</th>
-							${matrix.customizationTypes.map(type => `
+							${(matrix.customizationTypes ?? []).map(type => `
 								<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);" title="${escapeHtml(type.label)}">
 									${escapeHtml(type.icon)}
 								</th>
@@ -1305,7 +1283,7 @@ function buildCustomizationSectionHtml(matrix: WorkspaceCustomizationMatrix | nu
 			</div>
 			<div style="margin-top: 12px; font-size: 10px; color: var(--text-muted); border-top: 1px solid var(--border-subtle); padding-top: 8px;">
 				<div style="display: flex; gap: 16px; flex-wrap: wrap;">
-					${matrix.customizationTypes.map(type => `
+					${(matrix.customizationTypes ?? []).map(type => `
 						<span>${escapeHtml(type.icon)} ${escapeHtml(type.label)}</span>
 					`).join('')}
 				</div>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -861,6 +861,8 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 		// Sanitize customizationMatrix (avoid pass-through of untrusted nested fields)
 		const safeMatrix = sanitizeCustomizationMatrix(raw.customizationMatrix);
 		if (safeMatrix) {
+			// sanitizeCustomizationMatrix returns WorkspaceCustomizationMatrix from types.ts;
+			// the local WorkspaceCustomizationMatrix interface is structurally identical.
 			sanitized.customizationMatrix = safeMatrix as WorkspaceCustomizationMatrix;
 		}
 

--- a/vscode-extension/test/unit/webview-customizationSanitizer.test.ts
+++ b/vscode-extension/test/unit/webview-customizationSanitizer.test.ts
@@ -1,6 +1,17 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { sanitizeCustomizationMatrix } from '../../src/webview/usage/customizationSanitizer';
+import type { WorkspaceCustomizationMatrix } from '../../src/types';
+
+// ── Compile-time schema parity guarantee ────────────────────────────────────────
+//
+// customizationSanitizer.ts imports WorkspaceCustomizationMatrix directly from types.ts
+// (the extension's canonical schema) and returns that exact type.  If anyone changes
+// the type in types.ts, this file will fail to compile unless the sanitizer is updated
+// to match — preventing the schema drift that caused issue #1332.
+//
+// The round-trip test below adds a runtime check: a valid WorkspaceCustomizationMatrix
+// fed through sanitizeCustomizationMatrix must come out unchanged.
 
 describe('sanitizeCustomizationMatrix', () => {
 	test('returns undefined for null / non-object input', () => {
@@ -174,5 +185,51 @@ describe('sanitizeCustomizationMatrix', () => {
 		});
 		assert.ok(result);
 		assert.deepEqual(result.customizationTypes, []);
+	});
+
+	// ── Schema parity round-trip ──────────────────────────────────────────────────
+	//
+	// This test verifies that a correctly-shaped WorkspaceCustomizationMatrix (the
+	// canonical type from types.ts that the extension sends) passes through
+	// sanitizeCustomizationMatrix unchanged.  If the sanitizer's internal field
+	// mapping ever drifts from the canonical type, deepEqual will catch it.
+	test('round-trip: valid WorkspaceCustomizationMatrix passes through unchanged', () => {
+		// This variable's type annotation is WorkspaceCustomizationMatrix from types.ts.
+		// If that interface gains or removes fields the sanitizer doesn't handle, the
+		// compile step will surface the mismatch before this test even runs.
+		const canonical: WorkspaceCustomizationMatrix = {
+			customizationTypes: [
+				{ id: 'copilot-instructions', icon: '📄', label: 'Copilot Instructions' },
+				{ id: 'agents-md', icon: '🤖', label: 'Agents MD' },
+			],
+			workspaces: [
+				{
+					workspacePath: '/home/user/project-a',
+					workspaceName: 'project-a',
+					sessionCount: 3,
+					interactionCount: 12,
+					typeStatuses: {
+						'copilot-instructions': '✅',
+						'agents-md': '❌',
+					},
+				},
+				{
+					workspacePath: '/home/user/project-b',
+					workspaceName: 'project-b',
+					sessionCount: 1,
+					interactionCount: 4,
+					typeStatuses: {
+						'copilot-instructions': '⚠️',
+						'agents-md': '✅',
+					},
+				},
+			],
+			totalWorkspaces: 2,
+			workspacesWithIssues: 1,
+		};
+
+		const result = sanitizeCustomizationMatrix(canonical);
+		assert.ok(result);
+		assert.deepEqual(result, canonical);
 	});
 });

--- a/vscode-extension/test/unit/webview-customizationSanitizer.test.ts
+++ b/vscode-extension/test/unit/webview-customizationSanitizer.test.ts
@@ -1,0 +1,178 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { sanitizeCustomizationMatrix } from '../../src/webview/usage/customizationSanitizer';
+
+describe('sanitizeCustomizationMatrix', () => {
+	test('returns undefined for null / non-object input', () => {
+		assert.equal(sanitizeCustomizationMatrix(null), undefined);
+		assert.equal(sanitizeCustomizationMatrix(undefined), undefined);
+		assert.equal(sanitizeCustomizationMatrix('string'), undefined);
+		assert.equal(sanitizeCustomizationMatrix(42), undefined);
+	});
+
+	test('returns empty matrix for empty-workspaces input', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [],
+			workspaces: [],
+			totalWorkspaces: 0,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.deepEqual(result.customizationTypes, []);
+		assert.deepEqual(result.workspaces, []);
+		assert.equal(result.totalWorkspaces, 0);
+		assert.equal(result.workspacesWithIssues, 0);
+	});
+
+	test('preserves customizationTypes with id, icon, label', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [
+				{ id: 'copilot-instructions', icon: '📄', label: 'Copilot Instructions' },
+				{ id: 'agents-md', icon: '🤖', label: 'Agents MD' },
+			],
+			workspaces: [],
+			totalWorkspaces: 0,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.equal(result.customizationTypes.length, 2);
+		assert.deepEqual(result.customizationTypes[0], { id: 'copilot-instructions', icon: '📄', label: 'Copilot Instructions' });
+		assert.deepEqual(result.customizationTypes[1], { id: 'agents-md', icon: '🤖', label: 'Agents MD' });
+	});
+
+	test('drops customizationType entries with missing id', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [
+				{ id: '', icon: '📄', label: 'No ID' },
+				{ id: 'valid', icon: '✅', label: 'Valid' },
+			],
+			workspaces: [],
+			totalWorkspaces: 0,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.equal(result.customizationTypes.length, 1);
+		assert.equal(result.customizationTypes[0].id, 'valid');
+	});
+
+	test('preserves workspace row fields with current schema', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [{ id: 'copilot-instructions', icon: '📄', label: 'Copilot Instructions' }],
+			workspaces: [
+				{
+					workspacePath: '/home/user/project',
+					workspaceName: 'project',
+					sessionCount: 5,
+					interactionCount: 20,
+					typeStatuses: {
+						'copilot-instructions': '✅',
+					},
+				},
+			],
+			totalWorkspaces: 1,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.equal(result.workspaces.length, 1);
+		const ws = result.workspaces[0];
+		assert.equal(ws.workspacePath, '/home/user/project');
+		assert.equal(ws.workspaceName, 'project');
+		assert.equal(ws.sessionCount, 5);
+		assert.equal(ws.interactionCount, 20);
+		assert.deepEqual(ws.typeStatuses, { 'copilot-instructions': '✅' });
+	});
+
+	test('sanitizes invalid typeStatuses values to ❌', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [],
+			workspaces: [
+				{
+					workspacePath: '/home/user/project',
+					workspaceName: 'project',
+					sessionCount: 1,
+					interactionCount: 3,
+					typeStatuses: {
+						'copilot-instructions': '✅',   // valid
+						'agents-md': '⚠️',              // valid
+						'setup-steps': '❌',             // valid
+						'unknown-field': 'invalid-value', // invalid → becomes ❌
+						'another-bad': 42,                // invalid → becomes ❌
+					},
+				},
+			],
+			totalWorkspaces: 1,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		const ws = result.workspaces[0];
+		assert.equal(ws.typeStatuses['copilot-instructions'], '✅');
+		assert.equal(ws.typeStatuses['agents-md'], '⚠️');
+		assert.equal(ws.typeStatuses['setup-steps'], '❌');
+		assert.equal(ws.typeStatuses['unknown-field'], '❌');
+		assert.equal(ws.typeStatuses['another-bad'], '❌');
+	});
+
+	test('handles workspace with missing typeStatuses gracefully', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [],
+			workspaces: [
+				{
+					workspacePath: '/home/user/project',
+					workspaceName: 'project',
+					sessionCount: 1,
+					interactionCount: 1,
+					// typeStatuses missing
+				},
+			],
+			totalWorkspaces: 1,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.deepEqual(result.workspaces[0].typeStatuses, {});
+	});
+
+	test('coerces numeric fields', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [],
+			workspaces: [
+				{
+					workspacePath: '',
+					workspaceName: '',
+					sessionCount: '7',    // string → number
+					interactionCount: null, // null → 0
+					typeStatuses: {},
+				},
+			],
+			totalWorkspaces: '3',
+			workspacesWithIssues: NaN,
+		});
+		assert.ok(result);
+		assert.equal(result.workspaces[0].sessionCount, 7);
+		assert.equal(result.workspaces[0].interactionCount, 0);
+		assert.equal(result.totalWorkspaces, 3);
+		assert.equal(result.workspacesWithIssues, 0);
+	});
+
+	test('filters out non-object workspace entries', () => {
+		const result = sanitizeCustomizationMatrix({
+			customizationTypes: [],
+			workspaces: [null, 'invalid', 42, { workspacePath: '/valid', workspaceName: 'valid', sessionCount: 0, interactionCount: 0, typeStatuses: {} }],
+			totalWorkspaces: 1,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.equal(result.workspaces.length, 1);
+		assert.equal(result.workspaces[0].workspaceName, 'valid');
+	});
+
+	test('handles missing customizationTypes gracefully', () => {
+		const result = sanitizeCustomizationMatrix({
+			// customizationTypes missing
+			workspaces: [],
+			totalWorkspaces: 0,
+			workspacesWithIssues: 0,
+		});
+		assert.ok(result);
+		assert.deepEqual(result.customizationTypes, []);
+	});
+});


### PR DESCRIPTION
## Problem

Fixes #1332 — Repo customizations not recognized, at all.

The `sanitizeStats` function in `webview/usage/main.ts` was mapping `customizationMatrix.workspaces` using an **old schema** with boolean flags (`hasCopilotInstructionsMd`, `hasAgentsMd`, `hasCopilotSetupStepsMd`, etc.) while the extension now sends the current schema with `typeStatuses`, `workspaceName`, `sessionCount`, and `interactionCount`. The sanitized matrix also dropped `customizationTypes` entirely.

This caused `buildCustomizationSectionHtml` to throw a `TypeError` on every `postMessage` update (`Object.values(undefined)` when `ws.typeStatuses` was missing), preventing the **Workspace Health / Customization matrix** from ever rendering after initial load. Users would see all customizations shown as ❌ or the section would be blank.

## Root Cause

The `sanitizeStats` function (called for every stats refresh from the extension) was not updated when the `WorkspaceCustomizationRow` interface changed from boolean per-type flags to a generic `typeStatuses` map. The schema mismatch caused silent runtime crashes in the webview.

**Only the `postMessage` update path was affected** — the initial render from `window.__INITIAL_USAGE__` bypasses `sanitizeStats` and worked correctly.

## Changes

- **`customizationSanitizer.ts`** (new): Pure data-sanitization module (no DOM/CSS dependencies) that correctly maps the current `WorkspaceCustomizationMatrix` schema, including `customizationTypes`, `typeStatuses`, `workspaceName`, `sessionCount`, and `interactionCount`. Validates status values to `'✅' | '⚠️' | '❌'`, coerces numeric fields, and filters invalid entries.

- **`main.ts`**: Replaces the 28-line stale mapping block in `sanitizeStats` with a call to `sanitizeCustomizationMatrix`. Also adds `?? []` / `?? {}` defensive guards in `buildCustomizationSectionHtml` as belt-and-suspenders protection.

- **`webview-customizationSanitizer.test.ts`** (new): 10 unit tests covering null/non-object input, field preservation, invalid `typeStatuses` coercion, missing `typeStatuses`, numeric field coercion, and non-object workspace filtering.