### PR TITLE
Update insights tab count when insights are dismissed or snoozed

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1599,6 +1599,17 @@ function buildInsightsTabPanelHtml(insights: EvaluatedInsight[]): string {
 		</div>`;
 }
 
+function updateTabButtonCount(insights: EvaluatedInsight[]): void {
+	const tabButton = document.querySelector<HTMLButtonElement>('.tab-button[data-tab="insights"]');
+	if (!tabButton) { return; }
+	const newCount = insights.filter(i => i.status === 'new').length;
+	const badgeHtml = newCount > 0
+		? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${newCount}</span>`
+		: '';
+	const titleOnly = '💡 Insights';
+	tabButton.innerHTML = titleOnly + badgeHtml;
+}
+
 function refreshInsightsPanel(insights: EvaluatedInsight[]): void {
 	const container = document.getElementById('insights-container');
 	if (!container) { return; }
@@ -1624,6 +1635,7 @@ function refreshInsightsPanel(insights: EvaluatedInsight[]): void {
 
 	container.innerHTML = forYouSection + allSection;
 	wireInsightCardButtons();
+	updateTabButtonCount(insights);
 }
 
 function wireInsightCardButtons(): void {


### PR DESCRIPTION
## Problem

When users dismissed or snoozed insights in the Insights tab, the tab badge count wasn't updated, making it unclear how many new insights remained to review.

## Solution

Added a new `updateTabButtonCount()` function that dynamically updates the tab badge to reflect only "new" insights. The function is called after each insight action (dismiss, snooze, mark as done) to provide immediate visual feedback.

## Changes

- **New function**: `updateTabButtonCount()` - Updates the Insights tab badge count
- **Updated function**: `refreshInsightsPanel()` - Now calls `updateTabButtonCount()` to refresh the badge whenever insights are modified

## Testing

✅ TypeScript compilation passes  
✅ All 61 unit tests pass