### PR TITLE
fix(opencode): make DB cache WAL-aware to expose in-progress sessions

### DIFF
--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -558,10 +558,11 @@ export class OpenCodeDataAccess {
 	async getOpenCodeSessionData(sessionFilePath: string): Promise<{ tokens: number; interactions: number; modelUsage: OpenCodeModelUsageWithInteractions; timestamp: number }> {
 		const messages = await this.getOpenCodeMessagesForSession(sessionFilePath);
 
-		// Get timestamp from the first message
+		// Use the first message's creation time as the session timestamp.
+		// Messages store their timestamp in the nested `time.created` field.
 		let timestamp = Date.now();
-		if (messages.length > 0 && messages[0].time_created) {
-			timestamp = messages[0].time_created;
+		if (messages.length > 0 && messages[0].time?.created) {
+			timestamp = messages[0].time.created;
 		}
 
 		const { tokens } = this.getTokensFromOpenCodeMessages(messages);

--- a/vscode-extension/src/opencode.ts
+++ b/vscode-extension/src/opencode.ts
@@ -21,7 +21,7 @@ export interface UriLike {
 	readonly scheme: string;
 }
 
-type OpenCodeDbCache = { db: SqlDatabase; mtimeMs: number; size: number; path: string };
+type OpenCodeDbCache = { db: SqlDatabase; mtimeMs: number; size: number; path: string; walMtimeMs: number };
 type OpenCodeModelUsageWithInteractions = {
 	[modelName: string]: ModelUsage[string] & { interactions?: number };
 };
@@ -135,25 +135,80 @@ export class OpenCodeDataAccess {
 		}
 	}
 
+	/** Returns the WAL file's mtime in milliseconds, or 0 if no WAL file exists. */
+	private getWalMtimeMs(dbPath: string): number {
+		try {
+			return fs.statSync(dbPath + '-wal').mtimeMs;
+		} catch {
+			return 0;
+		}
+	}
+
 	private isCachedDbCurrent(dbPath: string, stats: fs.Stats): boolean {
 		return this._dbCache?.path === dbPath
 			&& this._dbCache.mtimeMs === stats.mtimeMs
-			&& this._dbCache.size === stats.size;
+			&& this._dbCache.size === stats.size
+			&& this._dbCache.walMtimeMs === this.getWalMtimeMs(dbPath);
 	}
 
 	private getDbCacheKey(dbPath: string, stats: fs.Stats): string {
-		return `${dbPath}:${stats.mtimeMs}:${stats.size}`;
+		return `${dbPath}:${stats.mtimeMs}:${stats.size}:wal${this.getWalMtimeMs(dbPath)}`;
 	}
 
 	private sameDbStats(left: fs.Stats, right: fs.Stats): boolean {
 		return left.mtimeMs === right.mtimeMs && left.size === right.size;
 	}
 
+	/**
+	 * When an active WAL file is present, sql.js cannot see uncommitted WAL frames because
+	 * it reads only the raw `.db` bytes. This method copies the DB + WAL to a temp location,
+	 * opens the copy with Node's built-in SQLite (available in Node.js 22+), forces a WAL
+	 * checkpoint to merge all frames into the temp DB file, and returns the resulting buffer
+	 * so that sql.js can load a fully up-to-date snapshot.
+	 *
+	 * Returns null when no WAL is present, when the WAL is empty, or when node:sqlite is
+	 * unavailable — in all those cases the caller falls back to reading the DB file directly.
+	 */
+	private async tryReadDbWithWal(dbPath: string): Promise<Buffer | null> {
+		const walPath = dbPath + '-wal';
+		let walSize: number;
+		try {
+			walSize = fs.statSync(walPath).size;
+		} catch {
+			return null; // No WAL file — no merge needed
+		}
+		if (walSize === 0) { return null; }
+
+		try {
+			const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+			const tmpDir = os.tmpdir();
+			const tmpDb = path.join(tmpDir, `opencode-wal-${Date.now()}.db`);
+			const tmpWal = tmpDb + '-wal';
+			const tmpShm = tmpDb + '-shm';
+			const shmPath = dbPath + '-shm';
+
+			fs.copyFileSync(dbPath, tmpDb);
+			fs.copyFileSync(walPath, tmpWal);
+			if (fs.existsSync(shmPath)) { fs.copyFileSync(shmPath, tmpShm); }
+
+			const nativeDb = new DatabaseSync(tmpDb);
+			nativeDb.exec('PRAGMA wal_checkpoint(TRUNCATE);');
+			nativeDb.close();
+
+			const buffer = fs.readFileSync(tmpDb);
+			for (const f of [tmpDb, tmpWal, tmpShm]) { try { fs.unlinkSync(f); } catch { /* ignore */ } }
+			return buffer;
+		} catch {
+			return null; // node:sqlite unavailable or copy failed — fall back to direct read
+		}
+	}
+
 	private async refreshOpenCodeDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
 		let db: SqlDatabase;
 		try {
 			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
+			const walBuffer = await this.tryReadDbWithWal(dbPath);
+			const buffer = walBuffer ?? fs.readFileSync(dbPath);
 			db = new SQL.Database(buffer);
 		} catch {
 			return this.getCachedDbForPath(dbPath);
@@ -169,7 +224,7 @@ export class OpenCodeDataAccess {
 		}
 
 		this.closeDbCache();
-		this._dbCache = { db, path: dbPath, mtimeMs: stats.mtimeMs, size: stats.size };
+		this._dbCache = { db, path: dbPath, mtimeMs: stats.mtimeMs, size: stats.size, walMtimeMs: this.getWalMtimeMs(dbPath) };
 		return db;
 	}
 

--- a/vscode-extension/test/unit/opencode-cache.test.ts
+++ b/vscode-extension/test/unit/opencode-cache.test.ts
@@ -198,3 +198,64 @@ test('OpenCode DB cache does not install a DB if the file changes during refresh
 		harness.cleanup();
 	}
 });
+
+test('OpenCode DB cache is invalidated when WAL file appears', async () => {
+	const harness = createHarness();
+	const walPath = harness.dbPath + '-wal';
+	try {
+		// Initial read — no WAL, opens once
+		await harness.access.readOpenCodeDbMessages('ses_1');
+		assert.equal(harness.openAttempts, 1);
+
+		// WAL appears — cache key changes even though main DB is untouched
+		fs.writeFileSync(walPath, 'fake-wal-data');
+		await harness.access.readOpenCodeDbMessages('ses_1');
+
+		// tryReadDbWithWal falls back (not a real SQLite file), but re-open is triggered
+		assert.equal(harness.openAttempts, 2);
+	} finally {
+		try { fs.unlinkSync(walPath); } catch { /* ignore */ }
+		harness.cleanup();
+	}
+});
+
+test('OpenCode DB cache is invalidated when WAL file changes', async () => {
+	const harness = createHarness();
+	const walPath = harness.dbPath + '-wal';
+	try {
+		fs.writeFileSync(walPath, 'wal-v1');
+		const t1 = new Date(Date.UTC(2026, 0, 1, 0, 0, 10));
+		fs.utimesSync(walPath, t1, t1);
+
+		await harness.access.readOpenCodeDbMessages('ses_1');
+		assert.equal(harness.openAttempts, 1);
+
+		// Bump WAL mtime — cache key differs, re-open should happen
+		const t2 = new Date(Date.UTC(2026, 0, 1, 0, 0, 20));
+		fs.utimesSync(walPath, t2, t2);
+		await harness.access.readOpenCodeDbMessages('ses_1');
+
+		assert.equal(harness.openAttempts, 2);
+	} finally {
+		try { fs.unlinkSync(walPath); } catch { /* ignore */ }
+		harness.cleanup();
+	}
+});
+
+test('OpenCode DB cache is invalidated when WAL file disappears', async () => {
+	const harness = createHarness();
+	const walPath = harness.dbPath + '-wal';
+	try {
+		fs.writeFileSync(walPath, 'wal-data');
+		await harness.access.readOpenCodeDbMessages('ses_1');
+		assert.equal(harness.openAttempts, 1);
+
+		// WAL removed (checkpointed by OpenCode) — cache key changes, re-open
+		fs.unlinkSync(walPath);
+		await harness.access.readOpenCodeDbMessages('ses_1');
+		assert.equal(harness.openAttempts, 2);
+	} finally {
+		try { fs.unlinkSync(walPath); } catch { /* ignore */ }
+		harness.cleanup();
+	}
+});


### PR DESCRIPTION
## Problem

When investigating why an OpenCode session wasn't visible in the extension, I found two issues:

### Root cause (today's specific session)
OpenCode ran today only for an **auto-update to v1.16.1** — no chat messages were exchanged. No new session record was created because OpenCode only creates a `session` DB row when you start a conversation.

### Secondary bug — WAL blindspot (fixed here)
`sql.js` reads only the raw `opencode.db` file bytes and is **completely blind to the SQLite WAL** (Write-Ahead Log). Proof from local investigation:

- `project_directory` table (created by today's migration) **does not exist** when queried via sql.js
- The same query via `node:sqlite` (WAL-aware) **sees the table correctly**
- 350 KB WAL with active frames from today's run was fully invisible to sql.js

When OpenCode is actively running and a user is chatting, new sessions and schema migrations land in the WAL first. Our extension would show zero sessions for that conversation until OpenCode exits and checkpoints the WAL.

## Fix

- **`getWalMtimeMs()`** — reads WAL file mtime; returns 0 if absent  
- **Cache key now includes WAL mtime** — any WAL write invalidates the cache and triggers a re-read  
- **`isCachedDbCurrent()`** checks WAL staleness via `walMtimeMs` stored in `OpenCodeDbCache`  
- **`tryReadDbWithWal()`** — when WAL is non-empty, copies `opencode.db` + `opencode.db-wal` to a temp location, uses `node:sqlite` (Node.js 22+, built-in) to force `PRAGMA wal_checkpoint(TRUNCATE)`, reads the merged bytes, then loads them into sql.js as before. Falls back silently to direct DB read if `node:sqlite` is unavailable or copy fails  

## Tests added

Three new tests in `opencode-cache.test.ts`:
- WAL file **appears** → cache invalidated, re-open triggered  
- WAL file **changes** (mtime bumped) → cache invalidated  
- WAL file **disappears** (checkpointed) → cache invalidated  

All existing tests pass unchanged.