### PR TITLE
chore: bump versions for release (vscode-extension, cli)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — patch version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version | Last release tag |
|-----------|-------------|-------------|-----------------|
| VS Code extension | v0.11.4 | v0.11.5 | \scode/v0.11.4\ |
| CLI | v0.2.6 | v0.2.7 | \cli/v0.0.8\ |

### After merging, run these workflows:

1. **Extensions - Release** (\elease.yml\)
   - Actions → _Extensions - Release_ → Run workflow (on \main\)
   - Publishes VS Code extension **v0.11.5** to the VS Code Marketplace

2. **CLI - Publish to npm and GitHub** (\cli-publish.yml\)
   - Actions → _CLI - Publish to npm and GitHub_ → Run workflow (on \main\)
   - Publishes **@rajbos/ai-engineering-fluency@0.2.7** to npm