### PR TITLE
feat: surface exact Copilot billing cost from nanoAiu data

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -104,6 +104,7 @@ import {
   buildReasoningEffortTimeline as _buildReasoningEffortTimeline,
   extractAllTokensFromDebugLog as _extractAllTokensFromDebugLog,
   extractResponseItemText as _extractResponseItemText,
+  NANO_AIU_TO_DOLLARS,
 } from './tokenEstimation';
 import { SessionDiscovery } from './sessionDiscovery';
 
@@ -2639,7 +2640,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				modelUsage: todayStats.modelUsage, editorUsage: todayStats.editorUsage,
 				co2: todayCo2, treesEquivalent: todayCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: todayWater, estimatedCost: this.calculateEstimatedCost(todayStats.modelUsage),
-				estimatedCostCopilot: this.calculateEstimatedCost(todayStats.modelUsage, 'copilot'),
+				estimatedCostCopilot: todayStats.exactCopilotCostDollars + this.calculateEstimatedCost(todayStats.modelUsageNoExact, 'copilot'),
 				...(todayStats.cachedTokens > 0 ? { cachedTokens: todayStats.cachedTokens } : {})
 			},
 			month: {
@@ -2651,7 +2652,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				modelUsage: monthStats.modelUsage, editorUsage: monthStats.editorUsage,
 				co2: monthCo2, treesEquivalent: monthCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: monthWater, estimatedCost: this.calculateEstimatedCost(monthStats.modelUsage),
-				estimatedCostCopilot: this.calculateEstimatedCost(monthStats.modelUsage, 'copilot'),
+				estimatedCostCopilot: monthStats.exactCopilotCostDollars + this.calculateEstimatedCost(monthStats.modelUsageNoExact, 'copilot'),
 				...(monthStats.cachedTokens > 0 ? { cachedTokens: monthStats.cachedTokens } : {})
 			},
 			lastMonth: {
@@ -2663,7 +2664,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				modelUsage: lastMonthStats.modelUsage, editorUsage: lastMonthStats.editorUsage,
 				co2: lastMonthCo2, treesEquivalent: lastMonthCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: lastMonthWater, estimatedCost: this.calculateEstimatedCost(lastMonthStats.modelUsage),
-				estimatedCostCopilot: this.calculateEstimatedCost(lastMonthStats.modelUsage, 'copilot'),
+				estimatedCostCopilot: lastMonthStats.exactCopilotCostDollars + this.calculateEstimatedCost(lastMonthStats.modelUsageNoExact, 'copilot'),
 				...(lastMonthStats.cachedTokens > 0 ? { cachedTokens: lastMonthStats.cachedTokens } : {})
 			},
 			last30Days: {
@@ -2675,7 +2676,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				modelUsage: last30DaysStats.modelUsage, editorUsage: last30DaysStats.editorUsage,
 				co2: last30DaysCo2, treesEquivalent: last30DaysCo2 / this.co2AbsorptionPerTreePerYear,
 				waterUsage: last30DaysWater, estimatedCost: this.calculateEstimatedCost(last30DaysStats.modelUsage),
-				estimatedCostCopilot: this.calculateEstimatedCost(last30DaysStats.modelUsage, 'copilot'),
+				estimatedCostCopilot: last30DaysStats.exactCopilotCostDollars + this.calculateEstimatedCost(last30DaysStats.modelUsageNoExact, 'copilot'),
 				...(last30DaysStats.cachedTokens > 0 ? { cachedTokens: last30DaysStats.cachedTokens } : {})
 			},
 			lastUpdated: now
@@ -3137,7 +3138,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			toolCalls: analysis.toolCalls.total, inputTokens: inputTok, outputTokens: outputTok,
 			thinkingTokens: sessionData.thinkingTokens || 0, cachedTokens: cachedTok,
 			totalTokens: sessionData.actualTokens || sessionData.tokens || 0,
-			estimatedCost: this.calculateEstimatedCost(modelUsage),
+			estimatedCost: sessionData.copilotExactCostDollars ?? this.calculateEstimatedCost(modelUsage),
 			editor: this.detectEditorSource(sessionFile), models: Object.keys(modelUsage),
 			lastActivity: sessionData.lastInteraction || new Date(mtime).toISOString(),
 		};
@@ -3774,7 +3775,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private buildSessionDataObject(
-		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; cacheReadTokens?: number },
+		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; cacheReadTokens?: number; copilotNanoAiu?: number },
 		interactions: number,
 		resolvedModelUsage: ModelUsage,
 		mtime: number,
@@ -3783,11 +3784,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 		sessionMeta: { title?: string; firstInteraction: string | null; lastInteraction: string | null },
 		resolvedActualTokens: number | undefined,
 		finalCacheReadTokens: number | undefined,
-		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number } | null | undefined,
+		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number; copilotNanoAiu?: number } | null | undefined,
 		dailyRollups: { [utcDayKey: string]: DailyRollupEntry }
 	): SessionFileCache {
 		const hasDebugLog = debugLogTokens && (debugLogTokens.inputTokens + debugLogTokens.outputTokens) > 0;
 		const hasEditScope = usageAnalysis?.editScope?.linesAdded !== undefined && usageAnalysis.editScope.linesAdded > 0;
+		const copilotNanoAiu = debugLogTokens?.copilotNanoAiu ?? tokenResult.copilotNanoAiu ?? 0;
+		const copilotExactCostDollars = copilotNanoAiu > 0 ? copilotNanoAiu * NANO_AIU_TO_DOLLARS : undefined;
 		return {
 			tokens: tokenResult.tokens, interactions, modelUsage: resolvedModelUsage, mtime, size: fileSize,
 			usageAnalysis, title: sessionMeta.title, firstInteraction: sessionMeta.firstInteraction,
@@ -3797,6 +3800,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(debugLogTokens?.modelTurns ? { modelTurns: debugLogTokens.modelTurns } : {}),
 			...(hasDebugLog ? { debugLogInputTokens: debugLogTokens!.inputTokens, debugLogOutputTokens: debugLogTokens!.outputTokens } : {}),
 			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
+			...(copilotExactCostDollars !== undefined ? { copilotExactCostDollars } : {}),
 			...(hasEditScope ? {
 				linesAdded: usageAnalysis!.editScope!.linesAdded,
 				linesRemoved: usageAnalysis!.editScope!.linesRemoved ?? 0,
@@ -3827,6 +3831,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(debugLogTokens.modelTurns ? { modelTurns: debugLogTokens.modelTurns } : {}),
 			debugLogInputTokens: debugLogTokens.inputTokens,
 			debugLogOutputTokens: debugLogTokens.outputTokens,
+			...(debugLogTokens.copilotNanoAiu > 0 ? { copilotExactCostDollars: debugLogTokens.copilotNanoAiu * NANO_AIU_TO_DOLLARS } : {}),
 		};
 		this.setCachedSessionData(sessionFilePath, supplemented, fileSize);
 		this._cacheHits++;
@@ -3835,11 +3840,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private computeDailyRollups(
 		sessionMeta: { firstInteraction: string | null; dailyInteractions: { [localDayKey: string]: number }; dailyFractions?: Record<string, number> },
-		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number },
+		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
 		modelUsage: ModelUsage,
 		interactions: number
 	): { dailyRollups: { [localDayKey: string]: DailyRollupEntry }; totalInteractions: number } {
 		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
+		const totalNanoAiu = tokenResult.copilotNanoAiu ?? 0;
 
 		// Prefer pre-computed fractions from ecosystem adapters (e.g. getDailyFractions()),
 		// which have accurate per-request timestamps. Fall back to dailyInteractions counts.
@@ -3848,7 +3854,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			for (const [dayKey, fraction] of Object.entries(sessionMeta.dailyFractions)) {
 				const dayModelUsage = this.scaledModelUsage(modelUsage, fraction);
 				const dayInteractions = Math.max(1, Math.round(totalFracInteractions * fraction));
-				dailyRollups[dayKey] = { tokens: Math.round(tokenResult.tokens * fraction), actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction), thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction), cachedReadTokens: 0, interactions: dayInteractions, modelUsage: dayModelUsage };
+				const dayExactCost = totalNanoAiu > 0 ? totalNanoAiu * NANO_AIU_TO_DOLLARS * fraction : undefined;
+				dailyRollups[dayKey] = { tokens: Math.round(tokenResult.tokens * fraction), actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction), thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction), cachedReadTokens: 0, interactions: dayInteractions, modelUsage: dayModelUsage, ...(dayExactCost !== undefined ? { copilotExactCostDollars: dayExactCost } : {}) };
 			}
 			return { dailyRollups, totalInteractions: totalFracInteractions };
 		}
@@ -3860,7 +3867,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			for (const [dayKey, dayInteractionCount] of Object.entries(dailyInteractionMap)) {
 				const fraction = dayInteractionCount / totalInteractions;
 				const dayModelUsage = this.scaledModelUsage(modelUsage, fraction);
-				dailyRollups[dayKey] = { tokens: Math.round(tokenResult.tokens * fraction), actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction), thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction), cachedReadTokens: 0, interactions: dayInteractionCount, modelUsage: dayModelUsage };
+				const dayExactCost = totalNanoAiu > 0 ? totalNanoAiu * NANO_AIU_TO_DOLLARS * fraction : undefined;
+				dailyRollups[dayKey] = { tokens: Math.round(tokenResult.tokens * fraction), actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction), thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction), cachedReadTokens: 0, interactions: dayInteractionCount, modelUsage: dayModelUsage, ...(dayExactCost !== undefined ? { copilotExactCostDollars: dayExactCost } : {}) };
 			}
 		} else {
 			this.computeFallbackDailyRollup(dailyRollups, sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
@@ -4915,7 +4923,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return 0;
 	}
 
-	private estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number } {
+	private estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number; copilotNanoAiu: number } {
 		return _estimateTokensFromJsonlSession(fileContent);
 	}
 
@@ -4929,7 +4937,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 * When found, sums `inputTokens`, `outputTokens`, and `cachedTokens` across every
 	 * `llm_request` event to give true totals for agent-mode multi-call sessions.
 	 */
-	private async readTokensFromDebugLog(sessionFilePath: string): Promise<{ inputTokens: number; outputTokens: number; cachedTokens: number; modelTurns: number; modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }> } | null> {
+	private async readTokensFromDebugLog(sessionFilePath: string): Promise<{ inputTokens: number; outputTokens: number; cachedTokens: number; modelTurns: number; modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }>; copilotNanoAiu: number } | null> {
 		const norm = _normalizePath(sessionFilePath);
 		const sessionId = path.basename(sessionFilePath, path.extname(sessionFilePath));
 		// Only process UUID-named session files (e.g. e84b3e82-c1fb-43de-8f52-367f4c74826a)

--- a/vscode-extension/src/statsHelpers.ts
+++ b/vscode-extension/src/statsHelpers.ts
@@ -263,6 +263,10 @@ sessions: number;
 interactions: number;
 modelUsage: ModelUsage;
 editorUsage: EditorUsage;
+/** Sum of exact Copilot billing costs (in USD) for sessions that have nanoAiu data. */
+exactCopilotCostDollars: number;
+/** Model usage for sessions that do NOT have exact nanoAiu billing data (used as fallback for Copilot cost estimate). */
+modelUsageNoExact: ModelUsage;
 }
 
 /** Result returned by `aggregatePeriodStats`. */
@@ -287,6 +291,8 @@ sessions: 0,
 interactions: 0,
 modelUsage: {},
 editorUsage: {},
+exactCopilotCostDollars: 0,
+modelUsageNoExact: {},
 };
 }
 
@@ -313,12 +319,17 @@ function addToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: n
 	addModelUsage(entry.modelUsage, modelUsage);
 }
 
-function accumulatePeriod(acc: PeriodAccumulator, tokens: number, estimated: number, actual: number, thinking: number, cached: number, interactions: number, countSession: boolean, editorType: string, modelUsage: ModelUsage): void {
+function accumulatePeriod(acc: PeriodAccumulator, tokens: number, estimated: number, actual: number, thinking: number, cached: number, interactions: number, countSession: boolean, editorType: string, modelUsage: ModelUsage, copilotExactCostDollars?: number): void {
 	acc.tokens += tokens; acc.estimatedTokens += estimated; acc.actualTokens += actual;
 	acc.thinkingTokens += thinking; acc.cachedTokens += cached; acc.interactions += interactions;
 	if (countSession) { acc.sessions += 1; }
 	addEditorUsage(acc.editorUsage, editorType, tokens);
 	addModelUsage(acc.modelUsage, modelUsage);
+	if (copilotExactCostDollars !== undefined) {
+		acc.exactCopilotCostDollars += copilotExactCostDollars;
+	} else {
+		addModelUsage(acc.modelUsageNoExact, modelUsage);
+	}
 }
 
 function processOneRollupDay(dayKey: string, dayRollup: any, flags: { addedToLast30Days: boolean; addedToMonth: boolean; addedToLastMonth: boolean; addedToToday: boolean }, acc: PeriodAccumulators, dates: UtcDateRanges, editorType: string, dailyStatsMap: Map<string, DailyTokenStats>, repository: string): void {
@@ -331,18 +342,18 @@ function processOneRollupDay(dayKey: string, dayRollup: any, flags: { addedToLas
 	if (inLast30Days) {
 		const entry = getOrCreateDailyEntry(dailyStatsMap, dayKey);
 		addToDailyEntry(entry, dayTokens, dayInteractions, editorType, repository, dayRollup.modelUsage);
-		accumulatePeriod(acc.last30DaysStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToLast30Days, editorType, dayRollup.modelUsage);
+		accumulatePeriod(acc.last30DaysStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToLast30Days, editorType, dayRollup.modelUsage, dayRollup.copilotExactCostDollars);
 		flags.addedToLast30Days = true;
 	}
 	if (dayKey >= dates.monthUtcStartKey) {
-		accumulatePeriod(acc.monthStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToMonth, editorType, dayRollup.modelUsage);
+		accumulatePeriod(acc.monthStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToMonth, editorType, dayRollup.modelUsage, dayRollup.copilotExactCostDollars);
 		flags.addedToMonth = true;
 		if (dayKey === dates.todayUtcKey) {
-			accumulatePeriod(acc.todayStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToToday, editorType, dayRollup.modelUsage);
+			accumulatePeriod(acc.todayStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToToday, editorType, dayRollup.modelUsage, dayRollup.copilotExactCostDollars);
 			flags.addedToToday = true;
 		}
 	} else if (inLastMonth) {
-		accumulatePeriod(acc.lastMonthStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToLastMonth, editorType, dayRollup.modelUsage);
+		accumulatePeriod(acc.lastMonthStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToLastMonth, editorType, dayRollup.modelUsage, dayRollup.copilotExactCostDollars);
 		flags.addedToLastMonth = true;
 	}
 }
@@ -379,15 +390,15 @@ function processFallbackPath(input: SessionAggregateInput, acc: PeriodAccumulato
 		const dailyEntry = getOrCreateDailyEntry(dailyStatsMap, lastActivityUtcKey);
 		addToDailyEntry(dailyEntry, tokens, sessionData.interactions, editorType, repository, sessionData.modelUsage);
 		if (sessionData.linesAdded !== undefined) { attributeLocToDay(dailyEntry, sessionData, editorType, repository); }
-		accumulatePeriod(acc.last30DaysStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage);
+		accumulatePeriod(acc.last30DaysStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage, sessionData.copilotExactCostDollars);
 	}
 	if (lastActivityUtcKey >= dates.monthUtcStartKey) {
-		accumulatePeriod(acc.monthStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage);
+		accumulatePeriod(acc.monthStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage, sessionData.copilotExactCostDollars);
 		if (lastActivityUtcKey === dates.todayUtcKey) {
-			accumulatePeriod(acc.todayStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage);
+			accumulatePeriod(acc.todayStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage, sessionData.copilotExactCostDollars);
 		}
 	} else if (inLastMonth) {
-		accumulatePeriod(acc.lastMonthStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage);
+		accumulatePeriod(acc.lastMonthStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage, sessionData.copilotExactCostDollars);
 	}
 	return false;
 }

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -259,6 +259,14 @@ export function extractResponseItemText(item: unknown): { text: string; isThinki
 	return { text: '', isThinking: false };
 }
 
+/**
+ * Conversion factor from GitHub Copilot nano-AI-units (nanoAiu) to US dollars.
+ * GitHub Copilot billing reports costs in nano-AI-units; dividing by 1e11 gives USD.
+ * Verified: `session.shutdown.totalNanoAiu / NANO_AIU_TO_DOLLARS` matches
+ * manual calculation using modelPricing.json rates for the session's token counts.
+ */
+export const NANO_AIU_TO_DOLLARS = 1 / 1e11;
+
 /** Return type for all token estimation strategies. */
 export type TokenEstimationResult = {
 	tokens: number;
@@ -267,6 +275,8 @@ export type TokenEstimationResult = {
 	cacheReadTokens: number;
 	modelUsage: ModelUsage;
 	dailyActualTokens: Record<string, number>;
+	/** Exact GitHub Copilot billing amount in nano-AI-units (0 when unavailable). Divide by 1e11 for USD. */
+	copilotNanoAiu: number;
 };
 
 /**
@@ -433,6 +443,7 @@ export class DeltaTokenStrategy implements TokenEstimationStrategy {
 			cacheReadTokens: 0,
 			modelUsage: {},
 			dailyActualTokens: {},
+			copilotNanoAiu: 0,
 		};
 	}
 }
@@ -449,6 +460,8 @@ interface EjtsState {
 	cliRealOutputByModel: { [model: string]: number } | null;
 	totalEstToolCalls: number;
 	dailyActualTokens: Record<string, number>;
+	/** Sum of totalNanoAiu from all session.shutdown events (exact Copilot billing). */
+	cliTotalNanoAiu: number;
 }
 
 /** Accumulate one model's metrics from a session.shutdown event into state. Returns the total tokens added. */
@@ -484,6 +497,8 @@ function _ejtsHandleShutdown(event: Record<string, unknown>, state: EjtsState): 
 	for (const [modelName, metrics] of Object.entries(data.modelMetrics) as [string, ShutdownModelMetrics][]) {
 		shutdownTotal += _ejtsAccumulateModelMetrics(modelName, metrics, state);
 	}
+	const nanoAiu = typeof data.totalNanoAiu === 'number' ? data.totalNanoAiu : 0;
+	if (nanoAiu > 0) { state.cliTotalNanoAiu += nanoAiu; }
 	if (shutdownTotal > 0 && event.timestamp) {
 		const dayKey = toLocalDayKey(new Date(String(event.timestamp)));
 		if (dayKey && dayKey !== 'Inval') {
@@ -577,6 +592,7 @@ export class EventJsonlTokenStrategy implements TokenEstimationStrategy {
 			cliRealOutputByModel: null,
 			totalEstToolCalls: 0,
 			dailyActualTokens: {},
+			cliTotalNanoAiu: 0,
 		};
 
 		for (const line of lines) {
@@ -598,6 +614,7 @@ export class EventJsonlTokenStrategy implements TokenEstimationStrategy {
 			cacheReadTokens: state.cliCacheReadTokens,
 			modelUsage: state.cliShutdownModelUsage ?? {},
 			dailyActualTokens: state.dailyActualTokens,
+			copilotNanoAiu: state.cliTotalNanoAiu,
 		};
 	}
 }
@@ -666,6 +683,7 @@ interface EatdlAcc {
 	cachedTokens: number;
 	modelTurns: number;
 	modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }>;
+	copilotNanoAiu: number;
 }
 
 /** Process one llm_request event into the accumulator. */
@@ -675,9 +693,11 @@ function _eatdlProcessLlmRequest(event: Record<string, unknown>, acc: EatdlAcc):
 	const inp = typeof attrs?.inputTokens === 'number' ? attrs.inputTokens : 0;
 	const out = typeof attrs?.outputTokens === 'number' ? attrs.outputTokens : 0;
 	const cached = typeof attrs?.cachedTokens === 'number' ? attrs.cachedTokens : 0;
+	const nanoAiu = typeof attrs?.copilotUsageNanoAiu === 'number' ? attrs.copilotUsageNanoAiu : 0;
 	acc.inputTokens += inp;
 	acc.outputTokens += out;
 	acc.cachedTokens += cached;
+	acc.copilotNanoAiu += nanoAiu;
 	const model = typeof attrs?.model === 'string' && attrs.model ? attrs.model : '';
 	if (!model) { return; }
 	const entry = acc.modelBreakdown[model] ?? { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
@@ -726,8 +746,9 @@ export function extractAllTokensFromDebugLog(content: string): {
 	cachedTokens: number;
 	modelTurns: number;
 	modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }>;
+	copilotNanoAiu: number;
 } | null {
-	const acc: EatdlAcc = { inputTokens: 0, outputTokens: 0, cachedTokens: 0, modelTurns: 0, modelBreakdown: {} };
+	const acc: EatdlAcc = { inputTokens: 0, outputTokens: 0, cachedTokens: 0, modelTurns: 0, modelBreakdown: {}, copilotNanoAiu: 0 };
 	for (const line of content.split(/\r?\n/)) {
 		if (!line.trim()) { continue; }
 		try {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -191,6 +191,8 @@ export interface DailyRollupEntry {
   cachedReadTokens?: number;
   interactions: number;
   modelUsage: ModelUsage;
+  /** Per-day share of the session's exact Copilot billing (in USD). Set when session has nanoAiu data. */
+  copilotExactCostDollars?: number;
 }
 
 export interface SessionFileCache {
@@ -212,6 +214,8 @@ export interface SessionFileCache {
   debugLogInputTokens?: number; // Input token total from debug log (sum across all llm_request events)
   debugLogOutputTokens?: number; // Output token total from debug log (sum across all llm_request events)
   debugLogChecked?: boolean; // Sentinel: true means we already looked for a debug log and found none
+  /** Exact GitHub Copilot billing for this session in USD (from session.shutdown.totalNanoAiu or debug log copilotUsageNanoAiu). */
+  copilotExactCostDollars?: number;
   /** Per-UTC-day token/interaction breakdown (keyed by YYYY-MM-DD UTC). Used for consistent daily stats. */
   dailyRollups?: { [utcDayKey: string]: DailyRollupEntry };
   linesAdded?: number;


### PR DESCRIPTION
## Summary

Reads actual GitHub Copilot billing data from session logs and uses it for cost display, with hardcoded model pricing as fallback for sessions that don't have exact data.

## Data sources for exact cost

| Source | Field | Sessions |
|--------|-------|----------|
| CLI `events.jsonl` | `session.shutdown.data.totalNanoAiu` | Copilot CLI sessions |
| VS Code debug log `main.jsonl` | `attrs.copilotUsageNanoAiu` per `llm_request` event | VS Code Chat with debug logging |

Conversion: `nanoAiu / 1e11 = USD`

## Changes

### `tokenEstimation.ts`
- Export `NANO_AIU_TO_DOLLARS = 1/1e11` constant
- Add `copilotNanoAiu: number` to `TokenEstimationResult`
- `EventJsonlTokenStrategy` (CLI): extract `data.totalNanoAiu` from `session.shutdown`
- `extractAllTokensFromDebugLog` (VS Code): sum `attrs.copilotUsageNanoAiu` across all `llm_request` events
- `DeltaTokenStrategy`: return `copilotNanoAiu: 0` (no exact cost for plain JSON sessions)

### `types.ts`
- `DailyRollupEntry`: add `copilotExactCostDollars?: number` (per-day share via fractional split)
- `SessionFileCache`: add `copilotExactCostDollars?: number` (session total)

### `statsHelpers.ts`
- `PeriodAccumulator`: add `exactCopilotCostDollars` and `modelUsageNoExact` fields
- `accumulatePeriod`: if session has exact cost → add to `exactCopilotCostDollars`; otherwise → add modelUsage to `modelUsageNoExact`
- Rollup and fallback paths both thread through `copilotExactCostDollars`

### `extension.ts`
- `computeDailyRollups`: splits `copilotNanoAiu * NANO_AIU_TO_DOLLARS` proportionally by day fraction
- `buildSessionDataObject`: computes and stores `copilotExactCostDollars` (debug log nanoAiu takes precedence over CLI nanoAiu)
- `supplementCacheWithDebugLog`: stores `copilotExactCostDollars` from debug log data
- Stats assembly: `estimatedCostCopilot = exactCopilotCostDollars + calculateEstimatedCost(modelUsageNoExact, 'copilot')`
- `collectTodaySessionInfo`: per-session cost uses `copilotExactCostDollars` when available

## Testing

All 71 unit tests pass. Build clean (0 errors, 2 pre-existing warnings).