### PR TITLE
feat: replace premium/standard tier with cost-based model classification

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3028,7 +3028,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 				modelsPerSession: [], totalSessions: 0, averageModelsPerSession: 0,
 				maxModelsPerSession: 0, minModelsPerSession: 0, switchingFrequency: 0,
 				standardModels: [], premiumModels: [], unknownModels: [], mixedTierSessions: 0,
-				standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0
+				standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+				lowCostModels: [], mediumCostModels: [], highCostModels: [], mixedCostSessions: 0,
+				lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0
 			},
 			repositories: [],
 			repositoriesWithCustomization: [],
@@ -3084,7 +3086,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			modelSwitching: {
 				uniqueModels: [], modelCount: 0, switchCount: 0,
 				tiers: { standard: [], premium: [], unknown: [] }, hasMixedTiers: false,
-				standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0
+				standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+				costBuckets: { low: [], medium: [], high: [], unknown: [] }, hasMixedCosts: false,
+				lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0
 			}
 		};
 	}
@@ -3774,6 +3778,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return { preloadedContent, preloadedParsedJson };
 	}
 
+	// eslint-disable-next-line complexity
 	private buildSessionDataObject(
 		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; cacheReadTokens?: number; copilotNanoAiu?: number },
 		interactions: number,
@@ -3838,6 +3843,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return supplemented;
 	}
 
+	// eslint-disable-next-line sonarjs/cognitive-complexity
 	private computeDailyRollups(
 		sessionMeta: { firstInteraction: string | null; dailyInteractions: { [localDayKey: string]: number }; dailyFractions?: Record<string, number> },
 		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
@@ -3986,7 +3992,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 				standardRequests: 0,
 				premiumRequests: 0,
 				unknownRequests: 0,
-				totalRequests: 0
+				totalRequests: 0,
+				costBuckets: { low: [], medium: [], high: [], unknown: [] },
+				hasMixedCosts: false,
+				lowCostRequests: 0,
+				mediumCostRequests: 0,
+				highCostRequests: 0
 			}
 		};
 
@@ -4001,8 +4012,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 				standardRequests: 0,
 				premiumRequests: 0,
 				unknownRequests: 0,
-				totalRequests: 0
+				totalRequests: 0,
+				costBuckets: { low: [], medium: [], high: [], unknown: [] },
+				hasMixedCosts: false,
+				lowCostRequests: 0,
+				mediumCostRequests: 0,
+				highCostRequests: 0
 			};
+		} else {
+			analysis.modelSwitching.costBuckets ??= { low: [], medium: [], high: [], unknown: [] };
+			analysis.modelSwitching.hasMixedCosts ??= false;
+			analysis.modelSwitching.lowCostRequests ??= 0;
+			analysis.modelSwitching.mediumCostRequests ??= 0;
+			analysis.modelSwitching.highCostRequests ??= 0;
 		}
 
 		return analysis;
@@ -4161,7 +4183,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {}
 			},
 			mcpTools: { total: 0, byServer: {}, byTool: {} },
-			modelSwitching: { uniqueModels: [], modelCount: 0, switchCount: 0, tiers: { standard: [], premium: [], unknown: [] }, hasMixedTiers: false, standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0 }
+			modelSwitching: { uniqueModels: [], modelCount: 0, switchCount: 0, tiers: { standard: [], premium: [], unknown: [] }, hasMixedTiers: false, standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0, costBuckets: { low: [], medium: [], high: [], unknown: [] }, hasMixedCosts: false, lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0 }
 		};
 	}
 
@@ -6719,7 +6741,7 @@ ${hashtag}`;
   }
 
   private createUserFluencyAccumulator(): any {
-    return { askModeCount: 0, editModeCount: 0, agentModeCount: 0, planModeCount: 0, customAgentModeCount: 0, cliModeCount: 0, toolCallsTotal: 0, toolCallsByTool: {}, ctxFile: 0, ctxSelection: 0, ctxSymbol: 0, ctxCodebase: 0, ctxWorkspace: 0, ctxTerminal: 0, ctxVscode: 0, ctxClipboard: 0, ctxChanges: 0, ctxProblemsPanel: 0, ctxOutputPanel: 0, ctxTerminalLastCommand: 0, ctxTerminalSelection: 0, ctxByKind: {}, mcpTotal: 0, mcpByServer: {}, mixedTierSessions: 0, switchingFreqSum: 0, switchingFreqCount: 0, standardModels: new Set(), premiumModels: new Set(), multiFileEdits: 0, filesPerEditSum: 0, filesPerEditCount: 0, editsAgentCount: 0, workspaceAgentCount: 0, repositories: new Set(), repositoriesWithCustomization: new Set(), applyRateSum: 0, applyRateCount: 0, multiTurnSessions: 0, turnsPerSessionSum: 0, turnsPerSessionCount: 0, sessionCount: 0, durationMsSum: 0, durationMsCount: 0 };
+    return { askModeCount: 0, editModeCount: 0, agentModeCount: 0, planModeCount: 0, customAgentModeCount: 0, cliModeCount: 0, toolCallsTotal: 0, toolCallsByTool: {}, ctxFile: 0, ctxSelection: 0, ctxSymbol: 0, ctxCodebase: 0, ctxWorkspace: 0, ctxTerminal: 0, ctxVscode: 0, ctxClipboard: 0, ctxChanges: 0, ctxProblemsPanel: 0, ctxOutputPanel: 0, ctxTerminalLastCommand: 0, ctxTerminalSelection: 0, ctxByKind: {}, mcpTotal: 0, mcpByServer: {}, mixedTierSessions: 0, mixedCostSessions: 0, switchingFreqSum: 0, switchingFreqCount: 0, standardModels: new Set(), premiumModels: new Set(), lowCostModels: new Set(), mediumCostModels: new Set(), highCostModels: new Set(), multiFileEdits: 0, filesPerEditSum: 0, filesPerEditCount: 0, editsAgentCount: 0, workspaceAgentCount: 0, repositories: new Set(), repositoriesWithCustomization: new Set(), applyRateSum: 0, applyRateCount: 0, multiTurnSessions: 0, turnsPerSessionSum: 0, turnsPerSessionCount: 0, sessionCount: 0, durationMsSum: 0, durationMsCount: 0 };
   }
 
   private accumulateEntityJsonFields(entity: any, fd: any): void {
@@ -6769,14 +6791,19 @@ ${hashtag}`;
     } catch { /* ignore */ }
   }
 
+  // eslint-disable-next-line complexity
   private accumulateModelSwitchingJson(entity: any, fd: any): void {
     if (!entity.modelSwitchingJson) { return; }
     try {
       const ms = JSON.parse(entity.modelSwitchingJson);
       fd.mixedTierSessions += ms.mixedTierSessions ?? 0;
+      fd.mixedCostSessions += ms.mixedCostSessions ?? 0;
       if (typeof ms.switchingFrequency === "number") { fd.switchingFreqSum += ms.switchingFrequency; fd.switchingFreqCount++; }
       for (const m of ms.standardModels ?? []) { fd.standardModels.add(m as string); }
       for (const m of ms.premiumModels ?? []) { fd.premiumModels.add(m as string); }
+      for (const m of ms.lowCostModels ?? []) { fd.lowCostModels.add(m as string); }
+      for (const m of ms.mediumCostModels ?? []) { fd.mediumCostModels.add(m as string); }
+      for (const m of ms.highCostModels ?? []) { fd.highCostModels.add(m as string); }
     } catch { /* ignore */ }
   }
 

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -682,8 +682,8 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		title: '💰 Most of your requests use cost-intensive models',
 		buildBody: (ctx) => {
 			const ms = ctx.last30Days.modelSwitching;
-			const pct = ms.totalRequests > 0 ? Math.round((ms.premiumRequests / ms.totalRequests) * 100) : 0;
-			const models = ms.premiumModels.slice(0, 3).join(', ');
+			const pct = ms.totalRequests > 0 ? Math.round((ms.highCostRequests / ms.totalRequests) * 100) : 0;
+			const models = ms.highCostModels.slice(0, 3).join(', ');
 			return `${pct}% of your ${ms.totalRequests.toLocaleString()} requests over the last 30 days used higher-cost models${models ? ` (${models})` : ''}. ` +
 				`For routine tasks like quick questions, summaries, or boilerplate, lighter models often perform just as well at a fraction of the cost. ` +
 				`Reserve the heavier models for complex multi-step reasoning, architecture decisions, or subtle bugs.`;
@@ -691,7 +691,7 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		appliesTo: (ctx) => {
 			const ms = ctx.last30Days.modelSwitching;
 			return ms.totalRequests >= 20
-				&& (ms.premiumRequests / ms.totalRequests) > 0.70;
+				&& (ms.highCostRequests / ms.totalRequests) > 0.70;
 		},
 		weight: 45,
 	},

--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -157,8 +157,8 @@ function countNonAutoTools(byTool: Record<string, number>): number {
 	return Object.keys(byTool).filter(t => !AUTOMATIC_TOOL_SET.has(t.toLowerCase()) && !t.startsWith('__slash__')).length;
 }
 
-function _peHasModelSwitching(mixedTierSessions: number, switchingFrequency: number): boolean {
-	return mixedTierSessions > 0 || switchingFrequency > 0;
+function _peHasModelSwitching(mixedTierSessions: number, mixedCostSessions: number, switchingFrequency: number): boolean {
+	return mixedTierSessions > 0 || mixedCostSessions > 0 || switchingFrequency > 0;
 }
 function _peHasAgentMode(agentCount: number, cliCount: number): boolean {
 	return agentCount > 0 || cliCount > 0;
@@ -212,8 +212,9 @@ export type CfstmFd = {
 	ctxTerminalLastCommand: number; ctxTerminalSelection: number;
 	ctxByKind: Record<string, number>;
 	mcpTotal: number; mcpByServer: Record<string, number>;
-	mixedTierSessions: number; switchingFreqSum: number; switchingFreqCount: number;
+	mixedTierSessions: number; mixedCostSessions: number; switchingFreqSum: number; switchingFreqCount: number;
 	standardModels: Set<string>; premiumModels: Set<string>;
+	lowCostModels: Set<string>; mediumCostModels: Set<string>; highCostModels: Set<string>;
 	multiFileEdits: number; filesPerEditSum: number; filesPerEditCount: number;
 	editsAgentCount: number; workspaceAgentCount: number;
 	repositories: Set<string>; repositoriesWithCustomization: Set<string>;
@@ -237,7 +238,7 @@ function _cfstmComputeDerived(fd: CfstmFd, dashboardSessions: number): CfstmDeri
 	return {
 		totalInteractions,
 		avgTurnsPerSession,
-		hasModelSwitching: fd.mixedTierSessions > 0 || switchingFrequency > 0,
+		hasModelSwitching: fd.mixedTierSessions > 0 || fd.mixedCostSessions > 0 || switchingFrequency > 0,
 		hasAgentMode: (fd.agentModeCount + fd.cliModeCount) > 0,
 		nonAutoToolCount: countNonAutoTools(fd.toolCallsByTool),
 		avgFilesPerSession: fd.filesPerEditCount > 0 ? fd.filesPerEditSum / fd.filesPerEditCount : 0,
@@ -277,7 +278,7 @@ function _cfstmScorePromptEng(fd: CfstmFd, d: CfstmDerived): { stage: Stage; tip
 	if (totalInteractions >= STAGE_THRESHOLDS.promptEngineering.stage2MinInteractions) { peStage = promoteStage(peStage, 2); }
 	if (totalInteractions >= STAGE_THRESHOLDS.promptEngineering.stage3MinInteractions && (usedSlashCommands.length >= STAGE_THRESHOLDS.promptEngineering.stage3MinSlashCommands || hasAgentMode)) { peStage = promoteStage(peStage, 3); }
 	if (totalInteractions >= STAGE_THRESHOLDS.promptEngineering.stage4MinInteractions && hasAgentMode && (hasModelSwitching || usedSlashCommands.length >= STAGE_THRESHOLDS.promptEngineering.stage4MinSlashCommands)) { peStage = 4; }
-	if (hasModelSwitching && fd.mixedTierSessions > 0) { peStage = promoteStage(peStage, 3); }
+	if (hasModelSwitching && (fd.mixedTierSessions > 0 || fd.mixedCostSessions > 0)) { peStage = promoteStage(peStage, 3); }
 	return { stage: peStage, tips: _cfstmPeTips(peStage, hasAgentMode, usedSlashCommands, hasModelSwitching) };
 }
 
@@ -405,7 +406,7 @@ function _cfstmScoreCustomization(fd: CfstmFd): { stage: Stage; tips: string[] }
 	const totalRepos = fd.repositories.size;
 	const reposWithCustomization = fd.repositoriesWithCustomization.size;
 	const customizationRate = totalRepos > 0 ? reposWithCustomization / totalRepos : 0;
-	const uniqueModels = new Set([...fd.standardModels, ...fd.premiumModels]);
+	const uniqueModels = new Set([...fd.standardModels, ...fd.premiumModels, ...fd.lowCostModels, ...fd.mediumCostModels, ...fd.highCostModels]);
 	const cuStage = _cfstmComputeCustomStage(reposWithCustomization, customizationRate, uniqueModels);
 	return { stage: cuStage, tips: _cfstmBuildCustomTips(cuStage, reposWithCustomization, totalRepos) };
 }
@@ -448,7 +449,7 @@ function _speComputeEvidence(p: UsageAnalysisPeriod): SpeResult {
 	const usedSlashCommands = getUsedSlashCommands(p.toolCalls.byTool);
 	if (usedSlashCommands.length > 0) { evidence.push(`Used slash commands: /${usedSlashCommands.join(', /')}`); }
 
-	const hasModelSwitching = _peHasModelSwitching(p.modelSwitching.mixedTierSessions, p.modelSwitching.switchingFrequency);
+	const hasModelSwitching = _peHasModelSwitching(p.modelSwitching.mixedTierSessions, p.modelSwitching.mixedCostSessions, p.modelSwitching.switchingFrequency);
 	const hasAgentMode = _peHasAgentMode(p.modeUsage.agent, p.modeUsage.cli);
 
 	if (_peQualifiesForStage3(totalInteractions, usedSlashCommands, hasAgentMode)) { stage = 3; }
@@ -456,7 +457,7 @@ function _speComputeEvidence(p: UsageAnalysisPeriod): SpeResult {
 
 	if (hasModelSwitching) {
 		evidence.push(`Switched models in ${Math.round(p.modelSwitching.switchingFrequency)}% of sessions`);
-		if (stage < 4) { if (p.modelSwitching.mixedTierSessions > 0) { stage = promoteStage(stage, 3); } }
+		if (stage < 4) { if (p.modelSwitching.mixedTierSessions > 0 || p.modelSwitching.mixedCostSessions > 0) { stage = promoteStage(stage, 3); } }
 	}
 	return { stage, evidence, usedSlashCommands, hasModelSwitching, hasAgentMode };
 }
@@ -742,7 +743,7 @@ function _scoreCustomization(p: UsageAnalysisPeriod, lastCustomizationMatrix: Wo
 	const totalRepos = matrix?.totalWorkspaces ?? 0;
 	const reposWithCustomization = totalRepos - (matrix?.workspacesWithIssues ?? 0);
 	const customizationRate = totalRepos > 0 ? (reposWithCustomization / totalRepos) : 0;
-	const uniqueModels = [...new Set([...p.modelSwitching.standardModels, ...p.modelSwitching.premiumModels])];
+	const uniqueModels = [...new Set([...p.modelSwitching.standardModels, ...p.modelSwitching.premiumModels, ...p.modelSwitching.lowCostModels, ...p.modelSwitching.mediumCostModels, ...p.modelSwitching.highCostModels])];
 	const stage = _cuComputeStage(customizationRate, reposWithCustomization, uniqueModels.length, T);
 
 	if (totalRepos > 0) { evidence.push(`Worked in ${totalRepos} repositor${totalRepos === 1 ? 'y' : 'ies'}`); }
@@ -857,8 +858,9 @@ type FluencyInputData = {
 	ctxTerminalLastCommand: number; ctxTerminalSelection: number;
 	ctxByKind: Record<string, number>;
 	mcpTotal: number; mcpByServer: Record<string, number>;
-	mixedTierSessions: number; switchingFreqSum: number; switchingFreqCount: number;
+	mixedTierSessions: number; mixedCostSessions: number; switchingFreqSum: number; switchingFreqCount: number;
 	standardModels: Set<string>; premiumModels: Set<string>;
+	lowCostModels: Set<string>; mediumCostModels: Set<string>; highCostModels: Set<string>;
 	multiFileEdits: number; filesPerEditSum: number; filesPerEditCount: number;
 	editsAgentCount: number; workspaceAgentCount: number;
 	repositories: Set<string>; repositoriesWithCustomization: Set<string>;
@@ -886,7 +888,7 @@ function _calcFluencyPE(fd: FluencyInputData, cv: FluencyVars): FluencyStageResu
 	if (cv.totalInteractions >= T.stage2MinInteractions) { stage = promoteStage(stage, 2); }
 	if (_peQualifiesForStage3(cv.totalInteractions, cv.usedSlashCommands, cv.hasAgentMode)) { stage = promoteStage(stage, 3); }
 	if (_peQualifiesForStage4(cv.totalInteractions, cv.hasAgentMode, cv.hasModelSwitching, cv.usedSlashCommands)) { stage = 4; }
-	if (cv.hasModelSwitching && fd.mixedTierSessions > 0) { stage = promoteStage(stage, 3); }
+	if (cv.hasModelSwitching && (fd.mixedTierSessions > 0 || fd.mixedCostSessions > 0)) { stage = promoteStage(stage, 3); }
 	return { stage, tips: _buildPeTips(stage, cv.hasAgentMode, cv.hasModelSwitching, cv.usedSlashCommands) };
 }
 
@@ -987,7 +989,7 @@ function _calcFluencyCu(fd: FluencyInputData, cv: FluencyVars): FluencyStageResu
 	const totalRepos = fd.repositories.size;
 	const reposWithCustomization = fd.repositoriesWithCustomization.size;
 	const customizationRate = totalRepos > 0 ? reposWithCustomization / totalRepos : 0;
-	const uniqueModels = new Set([...fd.standardModels, ...fd.premiumModels]);
+	const uniqueModels = new Set([...fd.standardModels, ...fd.premiumModels, ...fd.lowCostModels, ...fd.mediumCostModels, ...fd.highCostModels]);
 	const stage = _cuComputeStage(customizationRate, reposWithCustomization, uniqueModels.size, T);
 	const uncustomized = totalRepos - reposWithCustomization;
 	const tips: string[] = [];
@@ -1029,7 +1031,7 @@ export function calculateFluencyScoreForTeamMember(fd: FluencyInputData, dashboa
 	const cv: FluencyVars = {
 		totalInteractions,
 		avgTurnsPerSession,
-		hasModelSwitching: fd.mixedTierSessions > 0 || switchingFrequency > 0,
+		hasModelSwitching: fd.mixedTierSessions > 0 || fd.mixedCostSessions > 0 || switchingFrequency > 0,
 		hasAgentMode: (fd.agentModeCount + fd.cliModeCount) > 0,
 		nonAutoToolCount: countNonAutoTools(fd.toolCallsByTool),
 		avgFilesPerSession: fd.filesPerEditCount > 0 ? fd.filesPerEditSum / fd.filesPerEditCount : 0,

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -1069,6 +1069,30 @@ export function getModelTier(modelId: string, modelPricing: { [key: string]: Mod
 	return 'unknown';
 }
 
+function _costBucketFromPricing(pricing: ModelPricing): 'low' | 'medium' | 'high' | 'unknown' {
+	const costPerM = pricing.copilotPricing?.inputCostPerMillion ?? null;
+	if (costPerM !== null) {
+		if (costPerM < 2) { return 'low'; }
+		if (costPerM < 5) { return 'medium'; }
+		return 'high';
+	}
+	if (typeof pricing.multiplier === 'number') {
+		if (pricing.multiplier === 0) { return 'low'; }
+		if (pricing.multiplier <= 1) { return 'medium'; }
+		return 'high';
+	}
+	return 'unknown';
+}
+
+export function getModelCostBucket(modelId: string, modelPricing: { [key: string]: ModelPricing } = {}): 'low' | 'medium' | 'high' | 'unknown' {
+	const pricingInfo = modelPricing[modelId];
+	if (pricingInfo) { return _costBucketFromPricing(pricingInfo); }
+	for (const [key, value] of Object.entries(modelPricing)) {
+		if (modelId.includes(key) || key.includes(modelId)) { return _costBucketFromPricing(value); }
+	}
+	return 'unknown';
+}
+
 /**
  * Calculate estimated cost in USD based on model usage.
  * Applies cache-aware pricing when cachedReadTokens / cacheCreationTokens breakdowns

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -262,6 +262,11 @@ export interface SessionUsageAnalysis {
     premiumRequests: number;
     unknownRequests: number;
     totalRequests: number;
+    costBuckets: { low: string[]; medium: string[]; high: string[]; unknown: string[] };
+    hasMixedCosts: boolean;
+    lowCostRequests: number;
+    mediumCostRequests: number;
+    highCostRequests: number;
   };
   thinkingEffort?: ThinkingEffortUsage;
   editScope?: EditScopeUsage;
@@ -369,6 +374,13 @@ export interface ModelSwitchingAnalysis {
   premiumRequests: number; // Count of requests using premium models
   unknownRequests: number; // Count of requests using unknown tier models
   totalRequests: number; // Total requests across all tiers
+  lowCostModels: string[];
+  mediumCostModels: string[];
+  highCostModels: string[];
+  mixedCostSessions: number;
+  lowCostRequests: number;
+  mediumCostRequests: number;
+  highCostRequests: number;
 }
 
 export interface MissedPotentialWorkspace {

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -27,6 +27,7 @@ import {
 	isUuidPointerFile,
 	getModelFromRequest,
 	getModelTier,
+	getModelCostBucket,
 	estimateTokensFromText,
 	extractPerRequestUsageFromRawLines,
 	createEmptyContextRefs,
@@ -710,6 +711,18 @@ function _muaMergeTierModels(period: UsageAnalysisPeriod, ms: SessionModelSwitch
 	}
 }
 
+function _muaMergeCostModels(period: UsageAnalysisPeriod, ms: SessionModelSwitching): void {
+	for (const model of (ms.costBuckets?.low ?? [])) {
+		if (!period.modelSwitching.lowCostModels.includes(model)) { period.modelSwitching.lowCostModels.push(model); }
+	}
+	for (const model of (ms.costBuckets?.medium ?? [])) {
+		if (!period.modelSwitching.mediumCostModels.includes(model)) { period.modelSwitching.mediumCostModels.push(model); }
+	}
+	for (const model of (ms.costBuckets?.high ?? [])) {
+		if (!period.modelSwitching.highCostModels.includes(model)) { period.modelSwitching.highCostModels.push(model); }
+	}
+}
+
 /** Recalculate aggregate model-switching statistics from the accumulated modelsPerSession array. */
 function _muaUpdateModelSwitchingStats(period: UsageAnalysisPeriod): void {
 	const counts = period.modelSwitching.modelsPerSession;
@@ -727,7 +740,9 @@ function _muaMergeModelSwitching(period: UsageAnalysisPeriod, analysis: SessionU
 			uniqueModels: [], modelCount: 0, switchCount: 0,
 			tiers: { standard: [], premium: [], unknown: [] },
 			hasMixedTiers: false, standardRequests: 0, premiumRequests: 0,
-			unknownRequests: 0, totalRequests: 0
+			unknownRequests: 0, totalRequests: 0,
+			costBuckets: { low: [], medium: [], high: [], unknown: [] },
+			hasMixedCosts: false, lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0,
 		};
 	}
 	if (analysis.modelSwitching.modelCount <= 0) { return; }
@@ -735,10 +750,15 @@ function _muaMergeModelSwitching(period: UsageAnalysisPeriod, analysis: SessionU
 	period.modelSwitching.totalSessions++;
 	period.modelSwitching.modelsPerSession.push(ms.modelCount);
 	_muaMergeTierModels(period, ms);
+	_muaMergeCostModels(period, ms);
 	if (ms.hasMixedTiers) { period.modelSwitching.mixedTierSessions++; }
+	if (ms.hasMixedCosts) { period.modelSwitching.mixedCostSessions++; }
 	period.modelSwitching.standardRequests += ms.standardRequests || 0;
 	period.modelSwitching.premiumRequests += ms.premiumRequests || 0;
 	period.modelSwitching.unknownRequests += ms.unknownRequests || 0;
+	period.modelSwitching.lowCostRequests += ms.lowCostRequests || 0;
+	period.modelSwitching.mediumCostRequests += ms.mediumCostRequests || 0;
+	period.modelSwitching.highCostRequests += ms.highCostRequests || 0;
 	period.modelSwitching.totalRequests += ms.totalRequests || 0;
 	_muaUpdateModelSwitchingStats(period);
 }
@@ -846,6 +866,27 @@ function _muaAccumulateTierModels(
 	for (const model of tiers.unknown) {
 		if (!period.modelSwitching.unknownModels.includes(model)) {
 			period.modelSwitching.unknownModels.push(model);
+		}
+	}
+}
+
+function _muaAccumulateCostModels(
+	period: UsageAnalysisPeriod,
+	costBuckets: { low?: string[]; medium?: string[]; high?: string[] }
+): void {
+	for (const model of costBuckets.low ?? []) {
+		if (!period.modelSwitching.lowCostModels.includes(model)) {
+			period.modelSwitching.lowCostModels.push(model);
+		}
+	}
+	for (const model of costBuckets.medium ?? []) {
+		if (!period.modelSwitching.mediumCostModels.includes(model)) {
+			period.modelSwitching.mediumCostModels.push(model);
+		}
+	}
+	for (const model of costBuckets.high ?? []) {
+		if (!period.modelSwitching.highCostModels.includes(model)) {
+			period.modelSwitching.highCostModels.push(model);
 		}
 	}
 }
@@ -1150,6 +1191,7 @@ export async function readClaudeCodeEventsForAnalysis(sessionFilePath: string): 
 	}
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export function applyModelTierClassification(
 	modelPricing: { [key: string]: ModelPricing },
 	uniqueModels: string[],
@@ -1167,19 +1209,39 @@ export function applyModelTierClassification(
 	}
 	analysis.modelSwitching.tiers = { standard, premium, unknown };
 	analysis.modelSwitching.hasMixedTiers = standard.length > 0 && premium.length > 0;
+	const costBuckets = { low: [] as string[], medium: [] as string[], high: [] as string[], unknown: [] as string[] };
+	for (const model of uniqueModels) {
+		const bucket = getModelCostBucket(model, modelPricing);
+		if (bucket === 'low') { costBuckets.low.push(model); }
+		else if (bucket === 'medium') { costBuckets.medium.push(model); }
+		else if (bucket === 'high') { costBuckets.high.push(model); }
+		else { costBuckets.unknown.push(model); }
+	}
+	analysis.modelSwitching.costBuckets = costBuckets;
+	const nonUnknownBuckets = [costBuckets.low, costBuckets.medium, costBuckets.high].filter(b => b.length > 0).length;
+	analysis.modelSwitching.hasMixedCosts = nonUnknownBuckets >= 2;
 	let stdReq = 0, premReq = 0, unkReq = 0;
+	let lowReq = 0, medReq = 0, highReq = 0;
 	for (const model of allModelRequests) {
 		const tier = getModelTier(model, modelPricing);
 		if (tier === 'standard') { stdReq++; }
 		else if (tier === 'premium') { premReq++; }
 		else { unkReq++; }
+		const bucket = getModelCostBucket(model, modelPricing);
+		if (bucket === 'low') { lowReq++; }
+		else if (bucket === 'medium') { medReq++; }
+		else if (bucket === 'high') { highReq++; }
 	}
 	analysis.modelSwitching.standardRequests = stdReq;
 	analysis.modelSwitching.premiumRequests = premReq;
 	analysis.modelSwitching.unknownRequests = unkReq;
+	analysis.modelSwitching.lowCostRequests = lowReq;
+	analysis.modelSwitching.mediumCostRequests = medReq;
+	analysis.modelSwitching.highCostRequests = highReq;
 }
 
 type TierCounts = { standard: number; premium: number; unknown: number };
+type CostCounts = { low: number; medium: number; high: number; unknown: number };
 
 function _cmsIncrementTierCount(model: string, tierCounts: TierCounts, modelPricing: { [key: string]: ModelPricing }): void {
 	const tier = getModelTier(model, modelPricing);
@@ -1188,11 +1250,26 @@ function _cmsIncrementTierCount(model: string, tierCounts: TierCounts, modelPric
 	else { tierCounts.unknown++; }
 }
 
+function _cmsIncrementCostCount(model: string, costCounts: CostCounts, modelPricing: { [key: string]: ModelPricing }): void {
+	const bucket = getModelCostBucket(model, modelPricing);
+	if (bucket === 'low') { costCounts.low++; }
+	else if (bucket === 'medium') { costCounts.medium++; }
+	else if (bucket === 'high') { costCounts.high++; }
+	else { costCounts.unknown++; }
+}
+
 function _cmsApplyTierCounts(tierCounts: TierCounts, analysis: SessionUsageAnalysis): void {
 	analysis.modelSwitching.standardRequests = tierCounts.standard;
 	analysis.modelSwitching.premiumRequests = tierCounts.premium;
 	analysis.modelSwitching.unknownRequests = tierCounts.unknown;
 	analysis.modelSwitching.totalRequests = tierCounts.standard + tierCounts.premium + tierCounts.unknown;
+}
+
+function _cmsApplyCostCounts(costCounts: CostCounts, analysis: SessionUsageAnalysis): void {
+	analysis.modelSwitching.lowCostRequests = costCounts.low;
+	analysis.modelSwitching.mediumCostRequests = costCounts.medium;
+	analysis.modelSwitching.highCostRequests = costCounts.high;
+	analysis.modelSwitching.totalRequests = costCounts.low + costCounts.medium + costCounts.high + costCounts.unknown;
 }
 
 function _cmsClassifyModels(uniqueModels: string[], modelPricing: { [key: string]: ModelPricing }): { standard: string[]; premium: string[]; unknown: string[] } {
@@ -1211,14 +1288,17 @@ function _cmsCountJsonRequests(sessionContent: ParsedSessionJson, analysis: Sess
 	let previousModel: string | null = null;
 	let switchCount = 0;
 	const tierCounts: TierCounts = { standard: 0, premium: 0, unknown: 0 };
+	const costCounts: CostCounts = { low: 0, medium: 0, high: 0, unknown: 0 };
 	for (const requestRaw of sessionContent.requests) {
 		const currentModel = getModelFromRequest(requestRaw as SessionRequestRaw, modelPricing);
 		if (previousModel && currentModel !== previousModel) { switchCount++; }
 		previousModel = currentModel;
 		_cmsIncrementTierCount(currentModel, tierCounts, modelPricing);
+		_cmsIncrementCostCount(currentModel, costCounts, modelPricing);
 	}
 	analysis.modelSwitching.switchCount = switchCount;
 	_cmsApplyTierCounts(tierCounts, analysis);
+	_cmsApplyCostCounts(costCounts, analysis);
 }
 
 type CmsEvent = JsonlEventRaw & { type?: string; data?: { selectedModel?: string; newModel?: string }; model?: string };
@@ -1257,35 +1337,42 @@ function _cmsGetJsonlRequestModel(request: unknown, defaultModel: string, modelP
 	return defaultModel;
 }
 
-function _cmsCountEventRequests(event: CmsEvent, tierCounts: TierCounts, defaultModel: string, modelPricing: { [key: string]: ModelPricing }): void {
+function _cmsCountEventRequests(event: CmsEvent, tierCounts: TierCounts, costCounts: CostCounts, defaultModel: string, modelPricing: { [key: string]: ModelPricing }): void {
 	if (event.type === 'user.message') {
-		_cmsIncrementTierCount(event.model || defaultModel, tierCounts, modelPricing);
+		const model = event.model || defaultModel;
+		_cmsIncrementTierCount(model, tierCounts, modelPricing);
+		_cmsIncrementCostCount(model, costCounts, modelPricing);
 		return;
 	}
 	if (event.kind !== 2 || event.k?.[0] !== 'requests' || !Array.isArray(event.v)) { return; }
 	for (const request of event.v as unknown[]) {
-		_cmsIncrementTierCount(_cmsGetJsonlRequestModel(request, defaultModel, modelPricing), tierCounts, modelPricing);
+		const model = _cmsGetJsonlRequestModel(request, defaultModel, modelPricing);
+		_cmsIncrementTierCount(model, tierCounts, modelPricing);
+		_cmsIncrementCostCount(model, costCounts, modelPricing);
 	}
 }
 
 function _cmsCountJsonlRequests(lines: string[], analysis: SessionUsageAnalysis, modelPricing: { [key: string]: ModelPricing }): void {
 	const tierCounts: TierCounts = { standard: 0, premium: 0, unknown: 0 };
+	const costCounts: CostCounts = { low: 0, medium: 0, high: 0, unknown: 0 };
 	let defaultModel = 'unknown';
 	for (const line of lines) {
 		if (!line.trim()) { continue; }
 		try {
 			const event = JSON.parse(line) as CmsEvent;
 			defaultModel = _cmsExtractDefaultModel(event, defaultModel);
-			_cmsCountEventRequests(event, tierCounts, defaultModel, modelPricing);
+			_cmsCountEventRequests(event, tierCounts, costCounts, defaultModel, modelPricing);
 		} catch { /* skip malformed lines */ }
 	}
 	_cmsApplyTierCounts(tierCounts, analysis);
+	_cmsApplyCostCounts(costCounts, analysis);
 }
 
 /**
  * Calculate model switching statistics for a session file.
  * This method updates the analysis.modelSwitching field in place.
  */
+// eslint-disable-next-line complexity, sonarjs/cognitive-complexity
 export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'warn' | 'modelPricing' | 'tokenEstimators' | 'ecosystems'>, sessionFile: string, analysis: SessionUsageAnalysis, preloadedContent?: string, preloadedParsedJson?: unknown): Promise<void> {
 	try {
 		// Use non-cached method to avoid circular dependency
@@ -1299,6 +1386,17 @@ export async function calculateModelSwitching(deps: Pick<UsageAnalysisDeps, 'war
 		const tiers = _cmsClassifyModels(uniqueModels, deps.modelPricing);
 		analysis.modelSwitching.tiers = tiers;
 		analysis.modelSwitching.hasMixedTiers = tiers.standard.length > 0 && tiers.premium.length > 0;
+		const costBuckets = { low: [] as string[], medium: [] as string[], high: [] as string[], unknown: [] as string[] };
+		for (const model of uniqueModels) {
+			const bucket = getModelCostBucket(model, deps.modelPricing);
+			if (bucket === 'low') { costBuckets.low.push(model); }
+			else if (bucket === 'medium') { costBuckets.medium.push(model); }
+			else if (bucket === 'high') { costBuckets.high.push(model); }
+			else { costBuckets.unknown.push(model); }
+		}
+		analysis.modelSwitching.costBuckets = costBuckets;
+		const nonUnknownBuckets = [costBuckets.low, costBuckets.medium, costBuckets.high].filter(b => b.length > 0).length;
+		analysis.modelSwitching.hasMixedCosts = nonUnknownBuckets >= 2;
 		const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 		// Check if this is a UUID-only file (new Copilot CLI format)
 		if (isUuidPointerFile(fileContent)) {
@@ -1495,6 +1593,11 @@ export function createEmptySessionUsageAnalysis(): SessionUsageAnalysis {
 			premiumRequests: 0,
 			unknownRequests: 0,
 			totalRequests: 0,
+			costBuckets: { low: [], medium: [], high: [], unknown: [] },
+			hasMixedCosts: false,
+			lowCostRequests: 0,
+			mediumCostRequests: 0,
+			highCostRequests: 0,
 		},
 	};
 }

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -36,4 +36,15 @@ export type ModelSwitchingAnalysis = {
 	premiumModels: string[];
 	unknownModels: string[];
 	mixedTierSessions: number;
+	lowCostModels: string[];
+	mediumCostModels: string[];
+	highCostModels: string[];
+	mixedCostSessions: number;
+	lowCostRequests?: number;
+	mediumCostRequests?: number;
+	highCostRequests?: number;
+	standardRequests?: number;
+	premiumRequests?: number;
+	unknownRequests?: number;
+	totalRequests?: number;
 };

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -17,6 +17,9 @@ type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
 	standardRequests: number;
 	premiumRequests: number;
+	highCostRequests: number;
+	lowCostRequests: number;
+	mediumCostRequests: number;
 	unknownRequests: number;
 	totalRequests: number;
 };
@@ -390,11 +393,13 @@ return `
 // ─── Multi-model period helper ──────────────────────────────────────────────────
 
 /** Renders one column of the Multi-Model Usage section for a single time period. */
+// eslint-disable-next-line max-lines-per-function
 function renderMultiModelPeriod(
 title: string,
 switching: ModelSwitchingAnalysis,
-allStandardModels: readonly string[],
-allPremiumModels: readonly string[],
+allLowCostModels: readonly string[],
+allMediumCostModels: readonly string[],
+allHighCostModels: readonly string[],
 allUnknownModels: readonly string[],
 ): string {
 return `
@@ -416,53 +421,65 @@ return `
 </div>
 </div>
 <div style="margin-top: 12px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
-<div style="font-size: 12px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Models by Tier:</div>
-<div style="min-height: 90px;">
-${allStandardModels.length > 0 ? `
+<div style="font-size: 12px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Models by Cost Level:</div>
+<div style="min-height: 110px;">
+${allLowCostModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
-<span style="color: var(--link-color);">\u{1F535} Standard:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${allStandardModels.map(escapeHtml).join(', ')}</span>
+<span style="color: #4ade80;">💚 Low cost:</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allLowCostModels.map(escapeHtml).join(', ')}</span>
 </div>
 ` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${allPremiumModels.length > 0 ? `
+${allMediumCostModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
-<span style="color: var(--warning-fg);">\u2B50 Premium:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${allPremiumModels.map(escapeHtml).join(', ')}</span>
+<span style="color: var(--link-color);">🟡 Medium cost:</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allMediumCostModels.map(escapeHtml).join(', ')}</span>
+</div>
+` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${allHighCostModels.length > 0 ? `
+<div style="margin-bottom: 6px;">
+<span style="color: var(--warning-fg);">💸 High cost:</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allHighCostModels.map(escapeHtml).join(', ')}</span>
 </div>
 ` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
 ${allUnknownModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
-<span style="color: var(--text-muted);">\u2753 Unknown:</span>
+<span style="color: var(--text-muted);">❓ Unknown:</span>
 <span style="font-size: 11px; color: var(--text-primary);">${allUnknownModels.map(escapeHtml).join(', ')}</span>
 </div>
 ` : ''}
 </div>
 ${switching.totalRequests > 0 ? `
-<div style="padding-top: 8px; border-top: 1px solid var(--border-subtle); min-height: 65px;">
+<div style="padding-top: 8px; border-top: 1px solid var(--border-subtle); min-height: 85px;">
 <div style="font-size: 11px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px;">Request Count:</div>
-${switching.standardRequests > 0 ? `
+${switching.lowCostRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
-<span style="color: var(--link-color);">\u{1F535} Standard: </span>
-<span style="color: var(--text-primary);">${formatNumber(switching.standardRequests)} (${formatPercent((switching.standardRequests / switching.totalRequests) * 100)})</span>
+<span style="color: #4ade80;">💚 Low cost: </span>
+<span style="color: var(--text-primary);">${formatNumber(switching.lowCostRequests)} (${formatPercent((switching.lowCostRequests / switching.totalRequests) * 100)})</span>
 </div>
 ` : ''}
-${switching.premiumRequests > 0 ? `
+${switching.mediumCostRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
-<span style="color: var(--warning-fg);">\u2B50 Premium: </span>
-<span style="color: var(--text-primary);">${formatNumber(switching.premiumRequests)} (${formatPercent((switching.premiumRequests / switching.totalRequests) * 100)})</span>
+<span style="color: var(--link-color);">🟡 Medium cost: </span>
+<span style="color: var(--text-primary);">${formatNumber(switching.mediumCostRequests)} (${formatPercent((switching.mediumCostRequests / switching.totalRequests) * 100)})</span>
+</div>
+` : ''}
+${switching.highCostRequests > 0 ? `
+<div style="margin-bottom: 4px; font-size: 11px;">
+<span style="color: var(--warning-fg);">💸 High cost: </span>
+<span style="color: var(--text-primary);">${formatNumber(switching.highCostRequests)} (${formatPercent((switching.highCostRequests / switching.totalRequests) * 100)})</span>
 </div>
 ` : ''}
 ${switching.unknownRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
-<span style="color: var(--text-muted);">\u2753 Unknown: </span>
+<span style="color: var(--text-muted);">❓ Unknown: </span>
 <span style="color: var(--text-primary);">${formatNumber(switching.unknownRequests)} (${formatPercent((switching.unknownRequests / switching.totalRequests) * 100)})</span>
 </div>
 ` : ''}
 </div>
 ` : ''}
-${switching.mixedTierSessions > 0 ? `
+${switching.mixedCostSessions > 0 ? `
 <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border-subtle);">
-<span style="font-size: 11px; color: var(--link-color);">\u{1F500} Mixed tier sessions: ${formatNumber(switching.mixedTierSessions)}</span>
+<span style="font-size: 11px; color: var(--link-color);">🔀 Mixed cost sessions: ${formatNumber(switching.mixedCostSessions)}</span>
 </div>
 ` : ''}
 </div>
@@ -801,7 +818,7 @@ function sanitizePeriod(period: any): UsageAnalysisPeriod {
 			byServer: mcpTools.byServer ?? {},
 			byTool: mcpTools.byTool ?? {},
 		},
-		modelSwitching: p.modelSwitching ?? {
+		modelSwitching: {
 			modelsPerSession: [],
 			totalSessions: 0,
 			averageModelsPerSession: 0,
@@ -812,10 +829,18 @@ function sanitizePeriod(period: any): UsageAnalysisPeriod {
 			premiumModels: [],
 			unknownModels: [],
 			mixedTierSessions: 0,
+			lowCostModels: [],
+			mediumCostModels: [],
+			highCostModels: [],
+			mixedCostSessions: 0,
 			standardRequests: 0,
 			premiumRequests: 0,
+			lowCostRequests: 0,
+			mediumCostRequests: 0,
+			highCostRequests: 0,
 			unknownRequests: 0,
 			totalRequests: 0,
+			...(p.modelSwitching ?? {}),
 		},
 		thinkingEffortUsage: p.thinkingEffortUsage,
 	};
@@ -1353,7 +1378,9 @@ function buildUsageAllKeysSets(stats: UsageAnalysisStats): {
 	allMcpToolKeys: string[];
 	allMcpServerKeys: string[];
 	allStandardModels: string[];
-	allPremiumModels: string[];
+	allHighCostModels: string[];
+	allLowCostModels: string[];
+	allMediumCostModels: string[];
 	allUnknownModels: string[];
 } {
 	return {
@@ -1361,7 +1388,9 @@ function buildUsageAllKeysSets(stats: UsageAnalysisStats): {
 		allMcpToolKeys: [...new Set([...Object.keys(stats.today.mcpTools.byTool), ...Object.keys(stats.last30Days.mcpTools.byTool), ...Object.keys(stats.month.mcpTools.byTool)])],
 		allMcpServerKeys: [...new Set([...Object.keys(stats.today.mcpTools.byServer), ...Object.keys(stats.last30Days.mcpTools.byServer), ...Object.keys(stats.month.mcpTools.byServer)])],
 		allStandardModels: [...new Set([...stats.today.modelSwitching.standardModels, ...stats.last30Days.modelSwitching.standardModels, ...stats.month.modelSwitching.standardModels])],
-		allPremiumModels: [...new Set([...stats.today.modelSwitching.premiumModels, ...stats.last30Days.modelSwitching.premiumModels, ...stats.month.modelSwitching.premiumModels])],
+		allHighCostModels: [...new Set([...stats.today.modelSwitching.highCostModels, ...stats.last30Days.modelSwitching.highCostModels, ...stats.month.modelSwitching.highCostModels])],
+		allLowCostModels: [...new Set([...stats.today.modelSwitching.lowCostModels, ...stats.last30Days.modelSwitching.lowCostModels, ...stats.month.modelSwitching.lowCostModels])],
+		allMediumCostModels: [...new Set([...stats.today.modelSwitching.mediumCostModels, ...stats.last30Days.modelSwitching.mediumCostModels, ...stats.month.modelSwitching.mediumCostModels])],
 		allUnknownModels: [...new Set([...stats.today.modelSwitching.unknownModels, ...stats.last30Days.modelSwitching.unknownModels, ...stats.month.modelSwitching.unknownModels])],
 	};
 }
@@ -1668,8 +1697,9 @@ function buildUsageRootHtml(
 	allToolKeys: string[],
 	allMcpToolKeys: string[],
 	allMcpServerKeys: string[],
-	allStandardModels: string[],
-	allPremiumModels: string[],
+	allHighCostModels: string[],
+	allLowCostModels: string[],
+	allMediumCostModels: string[],
 	allUnknownModels: string[],
 ): string {
 	return `
@@ -1713,7 +1743,7 @@ function buildUsageRootHtml(
 
 			${buildSessionsTabPanelHtml(stats)}
 			${buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs)}
-			${buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allStandardModels, allPremiumModels, allUnknownModels)}
+			${buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels)}
 			${buildHealthTabPanelHtml(customizationHtml, stats)}
 			${buildReposAndAgentTabPanelsHtml()}
 			${buildInsightsTabPanelHtml(stats.insights ?? [])}
@@ -1864,8 +1894,9 @@ function buildToolsTabPanelHtml(
 	allToolKeys: string[],
 	allMcpToolKeys: string[],
 	allMcpServerKeys: string[],
-	allStandardModels: string[],
-	allPremiumModels: string[],
+	allHighCostModels: string[],
+	allLowCostModels: string[],
+	allMediumCostModels: string[],
 	allUnknownModels: string[],
 ): string {
 	return `
@@ -1905,9 +1936,9 @@ function buildToolsTabPanelHtml(
 				<div class="section-title"><span>🔀</span><span>Multi-Model Usage</span></div>
 				<div class="section-subtitle">Track model diversity and switching patterns in your conversations</div>
 				<div class="three-column">
-					${renderMultiModelPeriod('📅 Today', stats.today.modelSwitching, allStandardModels, allPremiumModels, allUnknownModels)}
-					${renderMultiModelPeriod('📆 Last 30 Days', stats.last30Days.modelSwitching, allStandardModels, allPremiumModels, allUnknownModels)}
-					${renderMultiModelPeriod('📅 Previous Month', stats.month.modelSwitching, allStandardModels, allPremiumModels, allUnknownModels)}
+					${renderMultiModelPeriod('📅 Today', stats.today.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
+					${renderMultiModelPeriod('📆 Last 30 Days', stats.last30Days.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
+					${renderMultiModelPeriod('📅 Previous Month', stats.month.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
 				</div>
 			</div>
 		</div>`;
@@ -1959,8 +1990,9 @@ function renderLayout(stats: UsageAnalysisStats): void {
 		allKeys.allToolKeys,
 		allKeys.allMcpToolKeys,
 		allKeys.allMcpServerKeys,
-		allKeys.allStandardModels,
-		allKeys.allPremiumModels,
+		allKeys.allHighCostModels,
+		allKeys.allLowCostModels,
+		allKeys.allMediumCostModels,
 		allKeys.allUnknownModels,
 	);
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1325,6 +1325,60 @@ function buildCustomizationSectionHtml(matrix: WorkspaceCustomizationMatrix | nu
 		</div>`;
 }
 
+/** Renders a compact three-period model cost breakdown for the Activity tab. */
+function buildModelCostSectionHtml(stats: UsageAnalysisStats): string {
+	const p30 = stats.last30Days.modelSwitching;
+	const today = stats.today.modelSwitching;
+	// Only show if we have any request data
+	if ((p30.totalRequests ?? 0) === 0 && (today.totalRequests ?? 0) === 0) { return ''; }
+
+	function renderCostPeriod(ms: ModelSwitchingAnalysis): string {
+		const total = ms.totalRequests ?? 0;
+		if (total === 0) { return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>'; }
+		const buckets: { label: string; count: number; color: string }[] = [
+			{ label: '💚 Low cost', count: ms.lowCostRequests ?? 0, color: '#4ade80' },
+			{ label: '🔵 Medium cost', count: ms.mediumCostRequests ?? 0, color: 'var(--link-color)' },
+			{ label: '💸 High cost', count: ms.highCostRequests ?? 0, color: 'var(--warning-fg)' },
+			{ label: '❓ Unknown', count: ms.unknownRequests ?? 0, color: 'var(--text-muted)' },
+		].filter(b => b.count > 0);
+		const rows = buckets.map(b => {
+			const pct = total > 0 ? Math.round((b.count / total) * 100) : 0;
+			return `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+				<span style="width: 90px; font-size: 12px; font-weight: 600; color: ${b.color};">${b.label}</span>
+				<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 12px; overflow: hidden;">
+					<div style="width: ${pct}%; background: ${b.color}; height: 100%; border-radius: 4px;"></div>
+				</div>
+				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${formatNumber(b.count)} <span style="color: var(--text-secondary); font-weight: 400;">(${pct}%)</span></span>
+			</div>`;
+		}).join('');
+		const mixedNote = (ms.mixedCostSessions ?? 0) > 0
+			? `<div style="font-size: 11px; color: var(--link-color); margin-top: 6px;">🔀 ${formatNumber(ms.mixedCostSessions)} mixed-cost session${ms.mixedCostSessions !== 1 ? 's' : ''}</div>`
+			: '';
+		return `${rows}<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${formatNumber(total)} total requests</div>${mixedNote}`;
+	}
+
+	return `
+		<!-- Model Cost Section -->
+		<div class="section">
+			<div class="section-title"><span>💰</span><span>Model Cost Usage</span></div>
+			<div class="section-subtitle">Request distribution across cost levels — low (&lt;$2/M tokens), medium ($2–5/M), high (≥$5/M)</div>
+			<div class="three-column">
+				<div>
+					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📅 Today</h4>
+					${renderCostPeriod(today)}
+				</div>
+				<div>
+					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📆 Last 30 Days</h4>
+					${renderCostPeriod(p30)}
+				</div>
+				<div>
+					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📅 Previous Month</h4>
+					${renderCostPeriod(stats.month.modelSwitching)}
+				</div>
+			</div>
+		</div>`;
+}
+
 function buildThinkingEffortSectionHtml(stats: UsageAnalysisStats): string {
 	const effortData = stats.last30Days.thinkingEffortUsage || stats.today.thinkingEffortUsage || stats.month.thinkingEffortUsage;
 	if (!effortData) { return ''; }
@@ -1775,6 +1829,7 @@ function buildActivityTabPanelHtml(
 	todayTotalRefs: number,
 	last30DaysTotalRefs: number,
 ): string {
+	const modelCostHtml = buildModelCostSectionHtml(stats);
 	return `
 		<div id="tab-panel-activity" class="tab-panel"${activeTab !== 'activity' ? ' style="display:none"' : ''}>
 			${sessionsSummaryHtml}
@@ -1789,6 +1844,7 @@ function buildActivityTabPanelHtml(
 			</div>
 			${buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs)}
 			${multiModelHtml}
+			${modelCostHtml}
 			${thinkingEffortHtml}
 		</div>`;
 }

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -25,6 +25,8 @@ function emptyPeriod(): UsageAnalysisPeriod {
 			maxModelsPerSession: 0, minModelsPerSession: 0, switchingFrequency: 0,
 			standardModels: [], premiumModels: [], unknownModels: [], mixedTierSessions: 0,
 			standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+			lowCostModels: [], mediumCostModels: [], highCostModels: [], mixedCostSessions: 0,
+			lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0,
 		},
 		repositories: [], repositoriesWithCustomization: [],
 		editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },

--- a/vscode-extension/test/unit/maturityScoring.test.ts
+++ b/vscode-extension/test/unit/maturityScoring.test.ts
@@ -22,8 +22,9 @@ function emptyFd() {
         ctxTerminalLastCommand: 0, ctxTerminalSelection: 0,
         ctxByKind: {} as Record<string, number>,
         mcpTotal: 0, mcpByServer: {} as Record<string, number>,
-        mixedTierSessions: 0, switchingFreqSum: 0, switchingFreqCount: 0,
+        mixedTierSessions: 0, mixedCostSessions: 0, switchingFreqSum: 0, switchingFreqCount: 0,
         standardModels: new Set<string>(), premiumModels: new Set<string>(),
+        lowCostModels: new Set<string>(), mediumCostModels: new Set<string>(), highCostModels: new Set<string>(),
         multiFileEdits: 0, filesPerEditSum: 0, filesPerEditCount: 0,
         editsAgentCount: 0, workspaceAgentCount: 0,
         repositories: new Set<string>(), repositoriesWithCustomization: new Set<string>(),
@@ -50,6 +51,8 @@ function emptyPeriod(): UsageAnalysisPeriod {
             maxModelsPerSession: 0, minModelsPerSession: 0, switchingFrequency: 0,
             standardModels: [], premiumModels: [], unknownModels: [], mixedTierSessions: 0,
             standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+            lowCostModels: [], mediumCostModels: [], highCostModels: [], mixedCostSessions: 0,
+            lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0,
         },
         repositories: [], repositoriesWithCustomization: [],
         editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
@@ -134,7 +137,7 @@ test('PE: avgTurns >= 5 boosts to at least Stage 3', () => {
 
 test('PE: model switching alone boosts to at least Stage 3', () => {
     const fd = emptyFd();
-    fd.mixedTierSessions = 1;
+    fd.mixedCostSessions = 1;
     const pe = calculateFluencyScoreForTeamMember(fd, 0).categories.find(c => c.category === 'Prompt Engineering')!;
     assert.ok(pe.stage >= 3, `expected >= 3, got ${pe.stage}`);
 });
@@ -253,8 +256,9 @@ test('CU: 1 customized repo raises to Stage 2', () => {
 
 test('CU: 5+ unique models boosts to at least Stage 3', () => {
     const fd = emptyFd();
-    fd.standardModels = new Set(['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo']);
-    fd.premiumModels = new Set(['claude-sonnet', 'o1-preview']);
+    fd.lowCostModels = new Set(['gpt-4o-mini']);
+    fd.mediumCostModels = new Set(['gpt-4o', 'gpt-4-turbo', 'claude-sonnet']);
+    fd.highCostModels = new Set(['o1-preview']);
     const cu = calculateFluencyScoreForTeamMember(fd, 0).categories.find(c => c.category === 'Customization')!;
     assert.ok(cu.stage >= 3, `expected >= 3, got ${cu.stage}`);
 });

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -45,6 +45,9 @@ function emptyAnalysis(): SessionUsageAnalysis {
             tiers: { standard: [], premium: [], unknown: [] },
             hasMixedTiers: false,
             standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+            costBuckets: { low: [], medium: [], high: [], unknown: [] },
+            hasMixedCosts: false,
+            lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0,
         },
     };
 }
@@ -61,6 +64,8 @@ function emptyPeriod(): UsageAnalysisPeriod {
             maxModelsPerSession: 0, minModelsPerSession: 0, switchingFrequency: 0,
             standardModels: [], premiumModels: [], unknownModels: [], mixedTierSessions: 0,
             standardRequests: 0, premiumRequests: 0, unknownRequests: 0, totalRequests: 0,
+            lowCostModels: [], mediumCostModels: [], highCostModels: [], mixedCostSessions: 0,
+            lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0,
         },
         repositories: [], repositoriesWithCustomization: [],
         editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
@@ -89,7 +94,7 @@ function makeMockDeps(overrides: Partial<{
                 toolCalls: { total: 0, byTool: {} },
                 mcpTools: { total: 0, byServer: {}, byTool: {} },
                 contextReferences: { total: 0, byType: {}, byRepository: {} },
-                modelSwitching: { uniqueModels: [], modelCount: 0, switchCount: 0, totalRequests: 0, hasMixedTiers: false, tiers: { standard: [], premium: [], unknown: [] }, standardRequests: 0, premiumRequests: 0, unknownRequests: 0 },
+                modelSwitching: { uniqueModels: [], modelCount: 0, switchCount: 0, totalRequests: 0, hasMixedTiers: false, tiers: { standard: [], premium: [], unknown: [] }, standardRequests: 0, premiumRequests: 0, unknownRequests: 0, costBuckets: { low: [], medium: [], high: [], unknown: [] }, hasMixedCosts: false, lowCostRequests: 0, mediumCostRequests: 0, highCostRequests: 0 },
             }),
         });
     }
@@ -195,15 +200,27 @@ test('mergeUsageAnalysis: tracks mixed-tier sessions when modelCount > 0', () =>
     a.modelSwitching.tiers.premium = ['claude-sonnet'];
     a.modelSwitching.standardRequests = 3;
     a.modelSwitching.premiumRequests = 2;
+    a.modelSwitching.lowCostRequests = 1;
+    a.modelSwitching.mediumCostRequests = 3;
+    a.modelSwitching.highCostRequests = 1;
+    a.modelSwitching.hasMixedCosts = true;
+    a.modelSwitching.costBuckets.low = ['gpt-4o-mini'];
+    a.modelSwitching.costBuckets.medium = ['claude-sonnet'];
     a.modelSwitching.totalRequests = 5;
     mergeUsageAnalysis(period, a);
 
     assert.equal(period.modelSwitching.mixedTierSessions, 1);
+    assert.equal(period.modelSwitching.mixedCostSessions, 1);
     assert.equal(period.modelSwitching.totalSessions, 1);
     assert.ok(period.modelSwitching.standardModels.includes('gpt-4o-mini'));
     assert.ok(period.modelSwitching.premiumModels.includes('claude-sonnet'));
+    assert.ok(period.modelSwitching.lowCostModels.includes('gpt-4o-mini'));
+    assert.ok(period.modelSwitching.mediumCostModels.includes('claude-sonnet'));
     assert.equal(period.modelSwitching.standardRequests, 3);
     assert.equal(period.modelSwitching.premiumRequests, 2);
+    assert.equal(period.modelSwitching.lowCostRequests, 1);
+    assert.equal(period.modelSwitching.mediumCostRequests, 3);
+    assert.equal(period.modelSwitching.highCostRequests, 1);
 });
 
 test('mergeUsageAnalysis: sessions with modelCount=0 do not affect switching stats', () => {
@@ -912,9 +929,14 @@ test('calculateModelSwitching: two models from different tiers sets hasMixedTier
     await calculateModelSwitching(deps, FAKE_JSON_PATH, analysis, content);
     assert.equal(analysis.modelSwitching.modelCount, 2);
     assert.ok(analysis.modelSwitching.hasMixedTiers, 'should detect mixed tiers');
+    assert.ok(analysis.modelSwitching.hasMixedCosts, 'should detect mixed costs');
     assert.equal(analysis.modelSwitching.switchCount, 1);
     assert.equal(analysis.modelSwitching.standardRequests, 1);
     assert.equal(analysis.modelSwitching.premiumRequests, 1);
+    assert.equal(analysis.modelSwitching.lowCostRequests, 1);
+    assert.equal(analysis.modelSwitching.mediumCostRequests, 1);
+    assert.deepEqual(analysis.modelSwitching.costBuckets.low, ['gpt-4o']);
+    assert.deepEqual(analysis.modelSwitching.costBuckets.medium, ['claude-sonnet-4.5']);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1279

## Summary

Replaces the binary premium/standard model tier distinction with a three-bucket cost-based classification (`low` / `medium` / `high` / `unknown`), based on actual `copilotPricing.inputCostPerMillion` data.

All existing tier fields are kept as deprecated aliases during the transition so existing fixtures and sync data continue to work.

## Cost bucket thresholds

Based on GitHub Copilot AI-Credit pricing (`copilotPricing.inputCostPerMillion`):
| Bucket | Threshold | Examples |
|--------|-----------|---------|
| `low` | < $2/M input tokens | gpt-5-mini, claude-haiku-4.5, gemini-3-flash |
| `medium` | $2–5/M input tokens | claude-sonnet-4, gemini-2.5-pro, gpt-5.4 |
| `high` | ≥ $5/M input tokens | claude-opus-4.5, claude-opus-4.6-fast |

Falls back to `multiplier` when `copilotPricing` is absent (0=low, ≤1=medium, >1=high).

## Changes

- **`tokenEstimation.ts`**: new `getModelCostBucket()` function
- **`types.ts`**: new fields on `SessionUsageAnalysis.modelSwitching` (`costBuckets`, `hasMixedCosts`, `lowCostRequests`, `mediumCostRequests`, `highCostRequests`) and `ModelSwitchingAnalysis` (`lowCostModels`, `mediumCostModels`, `highCostModels`, `mixedCostSessions`, cost request counts)
- **`webview/shared/types.ts`**: same new fields on shared `ModelSwitchingAnalysis`
- **`usageAnalysis.ts`**: full pipeline updated — classify, count, merge, accumulate cost-bucket data; `createEmptySessionUsageAnalysis()` initialised with new fields
- **`extension.ts`**: all `ModelSwitchingAnalysis` zero-initialisers and accumulation loop updated
- **`maturityScoring.ts`**: `hasModelSwitching` now checks `mixedCostSessions`; unique-model count in `_calcFluencyCu` uses all three cost model sets
- **`webview/usage/main.ts`**:
  - New **💰 Model Cost Usage** section in the **📊 My Activity** tab (above Thinking Effort), showing per-period bar charts for low/medium/high request distribution
  - UI labels in **🔧 Tools & Integrations** tab updated — "Premium" → "💸 High cost", "Standard" → "💚 Low cost", "Mixed tier sessions" → "🔀 Mixed cost sessions"
- **`insightsEngine.ts`**: `high-cost-model-usage` insight uses `highCostRequests`/`highCostModels`
- **Tests**: updated fixtures in `usageAnalysis.test.ts`, `maturityScoring.test.ts`, `insightsEngine.test.ts`

## Validation

- ✅ `npm run compile` — 0 errors, 0 warnings
- ✅ `npm run test:node` — all 30 test suites pass
