### PR TITLE
Show context references as a readable table in usage analysis

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3785,6 +3785,31 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return { preloadedContent, preloadedParsedJson };
 	}
 
+	private buildOptionalSessionFields(
+		tokenResult: { thinkingTokens?: number; copilotNanoAiu?: number },
+		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number; copilotNanoAiu?: number } | null | undefined,
+		finalCacheReadTokens: number | undefined,
+		copilotExactCostDollars: number | undefined,
+		dailyRollups: { [utcDayKey: string]: DailyRollupEntry },
+		usageAnalysis: SessionUsageAnalysis,
+	): Partial<SessionFileCache> {
+		const hasDebugLog = !!debugLogTokens && (debugLogTokens.inputTokens + debugLogTokens.outputTokens) > 0;
+		const hasEditScope = usageAnalysis?.editScope?.linesAdded !== undefined && usageAnalysis.editScope.linesAdded > 0;
+		return {
+			thinkingTokens: tokenResult.thinkingTokens,
+			...(finalCacheReadTokens ? { cacheReadTokens: finalCacheReadTokens } : {}),
+			...(debugLogTokens?.modelTurns ? { modelTurns: debugLogTokens.modelTurns } : {}),
+			...(hasDebugLog ? { debugLogInputTokens: debugLogTokens!.inputTokens, debugLogOutputTokens: debugLogTokens!.outputTokens } : {}),
+			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
+			...(copilotExactCostDollars !== undefined ? { copilotExactCostDollars } : {}),
+			...(hasEditScope ? {
+				linesAdded: usageAnalysis!.editScope!.linesAdded,
+				linesRemoved: usageAnalysis!.editScope!.linesRemoved ?? 0,
+				...(usageAnalysis!.editScope!.languageUsage ? { languageUsage: usageAnalysis!.editScope!.languageUsage } : {}),
+			} : {}),
+		};
+	}
+
 	private buildSessionDataObject(
 		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; cacheReadTokens?: number; copilotNanoAiu?: number },
 		interactions: number,
@@ -3798,25 +3823,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number; copilotNanoAiu?: number } | null | undefined,
 		dailyRollups: { [utcDayKey: string]: DailyRollupEntry }
 	): SessionFileCache {
-		const hasDebugLog = debugLogTokens && (debugLogTokens.inputTokens + debugLogTokens.outputTokens) > 0;
-		const hasEditScope = usageAnalysis?.editScope?.linesAdded !== undefined && usageAnalysis.editScope.linesAdded > 0;
 		const copilotNanoAiu = debugLogTokens?.copilotNanoAiu ?? tokenResult.copilotNanoAiu ?? 0;
 		const copilotExactCostDollars = copilotNanoAiu > 0 ? copilotNanoAiu * NANO_AIU_TO_DOLLARS : undefined;
+		const optionals = this.buildOptionalSessionFields(tokenResult, debugLogTokens, finalCacheReadTokens, copilotExactCostDollars, dailyRollups, usageAnalysis);
 		return {
 			tokens: tokenResult.tokens, interactions, modelUsage: resolvedModelUsage, mtime, size: fileSize,
 			usageAnalysis, title: sessionMeta.title, firstInteraction: sessionMeta.firstInteraction,
-			lastInteraction: sessionMeta.lastInteraction, thinkingTokens: tokenResult.thinkingTokens,
-			actualTokens: resolvedActualTokens,
-			...(finalCacheReadTokens ? { cacheReadTokens: finalCacheReadTokens } : {}),
-			...(debugLogTokens?.modelTurns ? { modelTurns: debugLogTokens.modelTurns } : {}),
-			...(hasDebugLog ? { debugLogInputTokens: debugLogTokens!.inputTokens, debugLogOutputTokens: debugLogTokens!.outputTokens } : {}),
-			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
-			...(copilotExactCostDollars !== undefined ? { copilotExactCostDollars } : {}),
-			...(hasEditScope ? {
-				linesAdded: usageAnalysis!.editScope!.linesAdded,
-				linesRemoved: usageAnalysis!.editScope!.linesRemoved ?? 0,
-				...(usageAnalysis!.editScope!.languageUsage ? { languageUsage: usageAnalysis!.editScope!.languageUsage } : {}),
-			} : {}),
+			lastInteraction: sessionMeta.lastInteraction, actualTokens: resolvedActualTokens,
+			...optionals,
 		};
 	}
 
@@ -3849,41 +3863,79 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return supplemented;
 	}
 
+	private buildDailyRollupEntry(
+		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
+		fraction: number,
+		interactions: number,
+		modelUsage: ModelUsage,
+		totalNanoAiu: number,
+	): DailyRollupEntry {
+		const dayModelUsage = this.scaledModelUsage(modelUsage, fraction);
+		const dayExactCost = totalNanoAiu > 0 ? totalNanoAiu * NANO_AIU_TO_DOLLARS * fraction : undefined;
+		return {
+			tokens: Math.round(tokenResult.tokens * fraction),
+			actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction),
+			thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction),
+			cachedReadTokens: 0,
+			interactions,
+			modelUsage: dayModelUsage,
+			...(dayExactCost !== undefined ? { copilotExactCostDollars: dayExactCost } : {}),
+		};
+	}
+
+	private computeRollupsFromFractions(
+		fractions: Record<string, number>,
+		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
+		modelUsage: ModelUsage,
+		interactions: number,
+		totalNanoAiu: number,
+	): { dailyRollups: { [localDayKey: string]: DailyRollupEntry }; totalInteractions: number } {
+		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
+		const totalFracInteractions = Math.max(1, interactions);
+		for (const [dayKey, fraction] of Object.entries(fractions)) {
+			const dayInteractions = Math.max(1, Math.round(totalFracInteractions * fraction));
+			dailyRollups[dayKey] = this.buildDailyRollupEntry(tokenResult, fraction, dayInteractions, modelUsage, totalNanoAiu);
+		}
+		return { dailyRollups, totalInteractions: totalFracInteractions };
+	}
+
+	private computeRollupsFromInteractionCounts(
+		interactionMap: { [localDayKey: string]: number },
+		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
+		modelUsage: ModelUsage,
+		totalNanoAiu: number,
+	): { dailyRollups: { [localDayKey: string]: DailyRollupEntry }; totalInteractions: number } {
+		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
+		const totalInteractions = Object.values(interactionMap).reduce((a, b) => a + b, 0);
+		for (const [dayKey, dayInteractionCount] of Object.entries(interactionMap)) {
+			const fraction = dayInteractionCount / totalInteractions;
+			dailyRollups[dayKey] = this.buildDailyRollupEntry(tokenResult, fraction, dayInteractionCount, modelUsage, totalNanoAiu);
+		}
+		return { dailyRollups, totalInteractions };
+	}
+
 	private computeDailyRollups(
 		sessionMeta: { firstInteraction: string | null; dailyInteractions: { [localDayKey: string]: number }; dailyFractions?: Record<string, number> },
 		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
 		modelUsage: ModelUsage,
 		interactions: number
 	): { dailyRollups: { [localDayKey: string]: DailyRollupEntry }; totalInteractions: number } {
-		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
 		const totalNanoAiu = tokenResult.copilotNanoAiu ?? 0;
 
 		// Prefer pre-computed fractions from ecosystem adapters (e.g. getDailyFractions()),
 		// which have accurate per-request timestamps. Fall back to dailyInteractions counts.
 		if (sessionMeta.dailyFractions && Object.keys(sessionMeta.dailyFractions).length > 0) {
-			const totalFracInteractions = Math.max(1, interactions);
-			for (const [dayKey, fraction] of Object.entries(sessionMeta.dailyFractions)) {
-				const dayModelUsage = this.scaledModelUsage(modelUsage, fraction);
-				const dayInteractions = Math.max(1, Math.round(totalFracInteractions * fraction));
-				const dayExactCost = totalNanoAiu > 0 ? totalNanoAiu * NANO_AIU_TO_DOLLARS * fraction : undefined;
-				dailyRollups[dayKey] = { tokens: Math.round(tokenResult.tokens * fraction), actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction), thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction), cachedReadTokens: 0, interactions: dayInteractions, modelUsage: dayModelUsage, ...(dayExactCost !== undefined ? { copilotExactCostDollars: dayExactCost } : {}) };
-			}
-			return { dailyRollups, totalInteractions: totalFracInteractions };
+			return this.computeRollupsFromFractions(sessionMeta.dailyFractions, tokenResult, modelUsage, interactions, totalNanoAiu);
 		}
 
 		const dailyInteractionMap = sessionMeta.dailyInteractions;
 		const totalInteractions = Object.values(dailyInteractionMap).reduce((a, b) => a + b, 0);
-
 		if (totalInteractions > 0) {
-			for (const [dayKey, dayInteractionCount] of Object.entries(dailyInteractionMap)) {
-				const fraction = dayInteractionCount / totalInteractions;
-				const dayModelUsage = this.scaledModelUsage(modelUsage, fraction);
-				const dayExactCost = totalNanoAiu > 0 ? totalNanoAiu * NANO_AIU_TO_DOLLARS * fraction : undefined;
-				dailyRollups[dayKey] = { tokens: Math.round(tokenResult.tokens * fraction), actualTokens: Math.round((tokenResult.actualTokens || 0) * fraction), thinkingTokens: Math.round((tokenResult.thinkingTokens || 0) * fraction), cachedReadTokens: 0, interactions: dayInteractionCount, modelUsage: dayModelUsage, ...(dayExactCost !== undefined ? { copilotExactCostDollars: dayExactCost } : {}) };
-			}
-		} else {
-			this.computeFallbackDailyRollup(dailyRollups, sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
+			return this.computeRollupsFromInteractionCounts(dailyInteractionMap, tokenResult, modelUsage, totalNanoAiu);
 		}
+
+		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
+		this.computeFallbackDailyRollup(dailyRollups, sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
 		return { dailyRollups, totalInteractions };
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2358,7 +2358,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			void this.analysisPanel.webview.postMessage({
 				command: 'updateStats',
 				data: {
-					today: analysisStats.today, last30Days: analysisStats.last30Days, month: analysisStats.month,
+					today: analysisStats.today, last30Days: analysisStats.last30Days, month: analysisStats.month, lastMonth: analysisStats.lastMonth,
 					locale: analysisStats.locale, customizationMatrix: analysisStats.customizationMatrix || null,
 					missedPotential: analysisStats.missedPotential || [],
 					lastUpdated: analysisStats.lastUpdated.toISOString(), backendConfigured: this.isBackendConfigured(),
@@ -2971,7 +2971,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return this.lastUsageAnalysisStats;
 		}
 		const now = new Date();
-		const { todayUtcKey, last30DaysUtcStartKey, monthUtcStartKey, last30DaysStartMs, lastMonthStartMs } = computeUtcDateRanges(now);
+		const { todayUtcKey, last30DaysUtcStartKey, monthUtcStartKey, lastMonthUtcStartKey, lastMonthUtcEndKey, last30DaysStartMs, lastMonthStartMs } = computeUtcDateRanges(now);
 		const cutoffMs = Math.min(last30DaysStartMs, lastMonthStartMs);
 		this.log('🔍 [Usage Analysis] Starting calculation...');
 		this._cacheHits = 0;
@@ -2979,6 +2979,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const todayStats = this.createEmptyUsagePeriod();
 		const last30DaysStats = this.createEmptyUsagePeriod();
 		const monthStats = this.createEmptyUsagePeriod();
+		const lastMonthStats = this.createEmptyUsagePeriod();
 		const todaySessionsList: TodaySessionSummary[] = [];
 		const workspaceSessionCounts = new Map<string, number>();
 		const workspaceInteractionCounts = new Map<string, number>();
@@ -2988,7 +2989,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this._customizationFilesCache.clear();
 		try {
 			const { results: usageResults, totalFiles } = await this.loadUsageSessionFiles(preloaded, cutoffMs);
-			const periods = { todayStats, last30DaysStats, monthStats, todayUtcKey, last30DaysUtcStartKey, monthUtcStartKey };
+			const periods = { todayStats, last30DaysStats, monthStats, lastMonthStats, todayUtcKey, last30DaysUtcStartKey, monthUtcStartKey, lastMonthUtcStartKey, lastMonthUtcEndKey };
 			const wsMaps = { workspaceSessionCounts, workspaceInteractionCounts, unresolvedWorkspaceIds, unresolvedWorkspaceInteractionCounts };
 			this.aggregateUsageFileResults(usageResults, periods, wsMaps, todaySessionsList, totalFiles);
 			this.deduplicateWorkspacePaths(workspaceSessionCounts, workspaceInteractionCounts);
@@ -3002,6 +3003,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			today: todayStats,
 			last30Days: last30DaysStats,
 			month: monthStats,
+			lastMonth: lastMonthStats,
 			locale: Intl.DateTimeFormat().resolvedOptions().locale,
 			lastUpdated: now,
 			customizationMatrix: this._lastCustomizationMatrix,
@@ -3179,7 +3181,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private aggregateSessionFileIntoStats(
 		r: { sessionFile: string; sessionData: SessionFileCache; mtime: number },
-		periods: { todayStats: UsageAnalysisPeriod; last30DaysStats: UsageAnalysisPeriod; monthStats: UsageAnalysisPeriod; todayUtcKey: string; last30DaysUtcStartKey: string; monthUtcStartKey: string },
+		periods: { todayStats: UsageAnalysisPeriod; last30DaysStats: UsageAnalysisPeriod; monthStats: UsageAnalysisPeriod; lastMonthStats: UsageAnalysisPeriod; todayUtcKey: string; last30DaysUtcStartKey: string; monthUtcStartKey: string; lastMonthUtcStartKey: string; lastMonthUtcEndKey: string },
 		wsMaps: { workspaceSessionCounts: Map<string, number>; workspaceInteractionCounts: Map<string, number>; unresolvedWorkspaceIds: Set<string>; unresolvedWorkspaceInteractionCounts: Map<string, number> },
 		todaySessionsList: TodaySessionSummary[]
 	): void {
@@ -3188,15 +3190,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (interactions === 0) { return; }
 		const analysis = sessionData.usageAnalysis || this.buildDefaultSessionAnalysis();
 		const lastActivityUtcKey = this.computeLastActivityKey(sessionData, mtime);
-		if (lastActivityUtcKey < periods.last30DaysUtcStartKey) { return; }
-		periods.last30DaysStats.sessions++;
-		this.mergeUsageAnalysis(periods.last30DaysStats, analysis);
-		this.trackWorkspaceForSession(sessionFile, interactions,
-			wsMaps.workspaceSessionCounts, wsMaps.workspaceInteractionCounts,
-			wsMaps.unresolvedWorkspaceIds, wsMaps.unresolvedWorkspaceInteractionCounts);
+		const inLast30Days = lastActivityUtcKey >= periods.last30DaysUtcStartKey;
+		const inLastMonth = lastActivityUtcKey >= periods.lastMonthUtcStartKey && lastActivityUtcKey <= periods.lastMonthUtcEndKey;
+		// month-to-date is always a subset of last 30 days, so this guard also covers it.
+		if (!inLast30Days && !inLastMonth) { return; }
+		if (inLast30Days) {
+			periods.last30DaysStats.sessions++;
+			this.mergeUsageAnalysis(periods.last30DaysStats, analysis);
+			this.trackWorkspaceForSession(sessionFile, interactions,
+				wsMaps.workspaceSessionCounts, wsMaps.workspaceInteractionCounts,
+				wsMaps.unresolvedWorkspaceIds, wsMaps.unresolvedWorkspaceInteractionCounts);
+		}
 		if (lastActivityUtcKey >= periods.monthUtcStartKey) {
 			periods.monthStats.sessions++;
 			this.mergeUsageAnalysis(periods.monthStats, analysis);
+		}
+		if (inLastMonth) {
+			periods.lastMonthStats.sessions++;
+			this.mergeUsageAnalysis(periods.lastMonthStats, analysis);
 		}
 		if (lastActivityUtcKey === periods.todayUtcKey) {
 			periods.todayStats.sessions++;
@@ -3207,7 +3218,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private aggregateUsageFileResults(
 		usageResults: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
-		periods: { todayStats: UsageAnalysisPeriod; last30DaysStats: UsageAnalysisPeriod; monthStats: UsageAnalysisPeriod; todayUtcKey: string; last30DaysUtcStartKey: string; monthUtcStartKey: string },
+		periods: { todayStats: UsageAnalysisPeriod; last30DaysStats: UsageAnalysisPeriod; monthStats: UsageAnalysisPeriod; lastMonthStats: UsageAnalysisPeriod; todayUtcKey: string; last30DaysUtcStartKey: string; monthUtcStartKey: string; lastMonthUtcStartKey: string; lastMonthUtcEndKey: string },
 		wsMaps: { workspaceSessionCounts: Map<string, number>; workspaceInteractionCounts: Map<string, number>; unresolvedWorkspaceIds: Set<string>; unresolvedWorkspaceInteractionCounts: Map<string, number> },
 		todaySessionsList: TodaySessionSummary[], totalFiles: number
 	): void {
@@ -5356,7 +5367,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			void this.analysisPanel.webview.postMessage({
 				command: 'updateStats',
 				data: {
-					today: analysisStats.today, last30Days: analysisStats.last30Days, month: analysisStats.month,
+					today: analysisStats.today, last30Days: analysisStats.last30Days, month: analysisStats.month, lastMonth: analysisStats.lastMonth,
 					locale: analysisStats.locale, customizationMatrix: analysisStats.customizationMatrix || null,
 					missedPotential: analysisStats.missedPotential || [], lastUpdated: analysisStats.lastUpdated.toISOString(),
 					backendConfigured: this.isBackendConfigured(),
@@ -8053,6 +8064,7 @@ ${this.getLoadingHtmlScript()}
       today: stats.today,
       last30Days: stats.last30Days,
       month: stats.month,
+      lastMonth: stats.lastMonth,
       locale: detectedLocale,
       customizationMatrix: stats.customizationMatrix || null,
       missedPotential: stats.missedPotential || [],

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -400,7 +400,10 @@ export interface TodaySessionSummary {
 export interface UsageAnalysisStats {
 today: UsageAnalysisPeriod;
 last30Days: UsageAnalysisPeriod;
+/** Current calendar month-to-date. */
 month: UsageAnalysisPeriod;
+/** Previous calendar month (full month). */
+lastMonth: UsageAnalysisPeriod;
 locale?: string;
 lastUpdated: Date;
 customizationMatrix?: WorkspaceCustomizationMatrix;

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1827,7 +1827,7 @@ function renderContextRefTable(
 						<th class="ctx-ref-num">This Month</th>
 						<th class="ctx-ref-num">Last Month</th>
 						<th class="ctx-ref-num">Last 30 Days</th>
-						<th class="ctx-ref-spark">Trend</th>
+						<th class="ctx-ref-spark" title="Trend: Last Month → This Month → Today">Trend</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -70,6 +70,7 @@ type UsageAnalysisStats = {
 	today: UsageAnalysisPeriod;
 	last30Days: UsageAnalysisPeriod;
 	month: UsageAnalysisPeriod;
+	lastMonth: UsageAnalysisPeriod;
 	locale?: string;
 	lastUpdated: string;
 	customizationMatrix?: WorkspaceCustomizationMatrix | null;
@@ -847,6 +848,7 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 			today: sanitizePeriod(raw.today),
 			last30Days: sanitizePeriod(raw.last30Days),
 			month: sanitizePeriod(raw.month),
+			lastMonth: sanitizePeriod(raw.lastMonth),
 			lastUpdated: typeof raw.lastUpdated === 'string' ? raw.lastUpdated : '',
 			backendConfigured: !!raw.backendConfigured,
 			locale: typeof raw.locale === 'string' ? raw.locale : undefined,
@@ -1763,26 +1765,37 @@ function buildActivityTabPanelHtml(
 		</div>`;
 }
 
+interface ContextRefDescriptor {
+	label: string;
+	title?: string;
+	get: (cr: ContextReferenceUsage) => number;
+}
+
 interface ContextRefRow {
 	label: string;
 	title?: string;
 	last30: number;
+	month: number;
+	lastMonth: number;
 	today: number;
 }
 
-function renderContextRefTable(rows: ContextRefRow[], totalLast30: number, totalToday: number): string {
+function numCell(value: number, extraClass = ''): string {
+	const zeroClass = value > 0 ? '' : ' ctx-ref-zero';
+	const cls = `ctx-ref-num${extraClass ? ' ' + extraClass : ''}${zeroClass}`;
+	return `<td class="${cls}">${value}</td>`;
+}
+
+function renderContextRefTable(
+	rows: ContextRefRow[],
+	totals: { last30: number; month: number; lastMonth: number; today: number },
+): string {
 	const bodyRows = rows
 		.slice()
 		.sort((a, b) => b.last30 - a.last30)
 		.map((row) => {
 			const titleAttr = row.title ? ` title="${escapeHtml(row.title)}"` : '';
-			const todayCell = row.today > 0
-				? `<td class="ctx-ref-num ctx-ref-today-active">${row.today}</td>`
-				: `<td class="ctx-ref-num ctx-ref-zero">${row.today}</td>`;
-			const last30Cell = row.last30 > 0
-				? `<td class="ctx-ref-num">${row.last30}</td>`
-				: `<td class="ctx-ref-num ctx-ref-zero">${row.last30}</td>`;
-			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${last30Cell}${todayCell}</tr>`;
+			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.last30)}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.today, row.today > 0 ? 'ctx-ref-today-active' : '')}</tr>`;
 		})
 		.join('');
 	return `
@@ -1792,6 +1805,8 @@ function renderContextRefTable(rows: ContextRefRow[], totalLast30: number, total
 					<tr>
 						<th class="ctx-ref-name">Reference</th>
 						<th class="ctx-ref-num">Last 30 Days</th>
+						<th class="ctx-ref-num">This Month</th>
+						<th class="ctx-ref-num">Last Month</th>
 						<th class="ctx-ref-num">Today</th>
 					</tr>
 				</thead>
@@ -1801,8 +1816,10 @@ function renderContextRefTable(rows: ContextRefRow[], totalLast30: number, total
 				<tfoot>
 					<tr class="ctx-ref-total">
 						<td class="ctx-ref-name">📊 Total References</td>
-						<td class="ctx-ref-num">${totalLast30}</td>
-						<td class="ctx-ref-num">${totalToday}</td>
+						<td class="ctx-ref-num">${totals.last30}</td>
+						<td class="ctx-ref-num">${totals.month}</td>
+						<td class="ctx-ref-num">${totals.lastMonth}</td>
+						<td class="ctx-ref-num">${totals.today}</td>
 					</tr>
 				</tfoot>
 			</table>
@@ -1810,33 +1827,48 @@ function renderContextRefTable(rows: ContextRefRow[], totalLast30: number, total
 }
 
 function buildContextRefCardsHtml(stats: UsageAnalysisStats, todayTotalRefs: number, last30DaysTotalRefs: number): string {
-	const r = stats.last30Days.contextReferences;
-	const t = stats.today.contextReferences;
 	const c = (v: number | undefined): number => v || 0;
-	const rows: ContextRefRow[] = [
-		{ label: '📄 #file', last30: r.file, today: t.file },
-		{ label: '✂️ #selection', last30: r.selection, today: t.selection },
-		{ label: '✨ Implicit Selection', title: 'Text selected in your editor providing passive context to Copilot', last30: r.implicitSelection, today: t.implicitSelection },
-		{ label: '🔤 #symbol', last30: r.symbol, today: t.symbol },
-		{ label: '🗂️ #codebase', last30: r.codebase, today: t.codebase },
-		{ label: '📁 @workspace', last30: r.workspace, today: t.workspace },
-		{ label: '💻 @terminal', last30: r.terminal, today: t.terminal },
-		{ label: '🔧 @vscode', last30: r.vscode, today: t.vscode },
-		{ label: '⌨️ #terminalLastCommand', title: 'Last command run in the terminal', last30: c(r.terminalLastCommand), today: c(t.terminalLastCommand) },
-		{ label: '🖱️ #terminalSelection', title: 'Selected terminal output', last30: c(r.terminalSelection), today: c(t.terminalSelection) },
-		{ label: '📋 #clipboard', title: 'Clipboard contents', last30: c(r.clipboard), today: c(t.clipboard) },
-		{ label: '📝 #changes', title: 'Uncommitted git changes', last30: c(r.changes), today: c(t.changes) },
-		{ label: '📤 #outputPanel', title: 'Output panel contents', last30: c(r.outputPanel), today: c(t.outputPanel) },
-		{ label: '⚠️ #problemsPanel', title: 'Problems panel contents', last30: c(r.problemsPanel), today: c(t.problemsPanel) },
-		{ label: '🔀 #pr', title: 'Pull request context references (#pr / #pullRequest) — Copilot PR chat understanding, review, and summary', last30: c(r.pullRequest), today: c(t.pullRequest) },
-		{ label: '📷 Images', title: 'Pasted images and vision context detected in session logs', last30: c(r.byKind['copilot.image']), today: c(t.byKind['copilot.image']) },
-		{ label: '📋 Prompt Files', title: '.github/prompts/ prompt file uses detected in session logs', last30: c(r.byKind['promptFile']), today: c(t.byKind['promptFile']) },
-		{ label: '📐 Code Lines', title: 'Total lines of code referenced via #file: range selections', last30: c(r.codeContextLines), today: c(t.codeContextLines) },
-		{ label: '🎯 Custom Prompts', title: 'Custom /command prompt uses detected in session logs', last30: c(r.byKind['prompt']), today: c(t.byKind['prompt']) },
-		{ label: '📋 Copilot Instructions', title: 'copilot-instructions.md file references detected in session logs', last30: r.copilotInstructions, today: t.copilotInstructions },
-		{ label: '🤖 Agents.md', title: 'agents.md file references detected in session logs', last30: r.agentsMd, today: t.agentsMd },
+	const descriptors: ContextRefDescriptor[] = [
+		{ label: '📄 #file', get: (cr) => cr.file },
+		{ label: '✂️ #selection', get: (cr) => cr.selection },
+		{ label: '✨ Implicit Selection', title: 'Text selected in your editor providing passive context to Copilot', get: (cr) => cr.implicitSelection },
+		{ label: '🔤 #symbol', get: (cr) => cr.symbol },
+		{ label: '🗂️ #codebase', get: (cr) => cr.codebase },
+		{ label: '📁 @workspace', get: (cr) => cr.workspace },
+		{ label: '💻 @terminal', get: (cr) => cr.terminal },
+		{ label: '🔧 @vscode', get: (cr) => cr.vscode },
+		{ label: '⌨️ #terminalLastCommand', title: 'Last command run in the terminal', get: (cr) => c(cr.terminalLastCommand) },
+		{ label: '🖱️ #terminalSelection', title: 'Selected terminal output', get: (cr) => c(cr.terminalSelection) },
+		{ label: '📋 #clipboard', title: 'Clipboard contents', get: (cr) => c(cr.clipboard) },
+		{ label: '📝 #changes', title: 'Uncommitted git changes', get: (cr) => c(cr.changes) },
+		{ label: '📤 #outputPanel', title: 'Output panel contents', get: (cr) => c(cr.outputPanel) },
+		{ label: '⚠️ #problemsPanel', title: 'Problems panel contents', get: (cr) => c(cr.problemsPanel) },
+		{ label: '🔀 #pr', title: 'Pull request context references (#pr / #pullRequest) — Copilot PR chat understanding, review, and summary', get: (cr) => c(cr.pullRequest) },
+		{ label: '📷 Images', title: 'Pasted images and vision context detected in session logs', get: (cr) => c(cr.byKind['copilot.image']) },
+		{ label: '📋 Prompt Files', title: '.github/prompts/ prompt file uses detected in session logs', get: (cr) => c(cr.byKind['promptFile']) },
+		{ label: '📐 Code Lines', title: 'Total lines of code referenced via #file: range selections', get: (cr) => c(cr.codeContextLines) },
+		{ label: '🎯 Custom Prompts', title: 'Custom /command prompt uses detected in session logs', get: (cr) => c(cr.byKind['prompt']) },
+		{ label: '📋 Copilot Instructions', title: 'copilot-instructions.md file references detected in session logs', get: (cr) => cr.copilotInstructions },
+		{ label: '🤖 Agents.md', title: 'agents.md file references detected in session logs', get: (cr) => cr.agentsMd },
 	];
-	return renderContextRefTable(rows, last30DaysTotalRefs, todayTotalRefs);
+	const r = stats.last30Days.contextReferences;
+	const m = stats.month.contextReferences;
+	const lm = stats.lastMonth.contextReferences;
+	const t = stats.today.contextReferences;
+	const rows: ContextRefRow[] = descriptors.map((d) => ({
+		label: d.label,
+		title: d.title,
+		last30: d.get(r),
+		month: d.get(m),
+		lastMonth: d.get(lm),
+		today: d.get(t),
+	}));
+	return renderContextRefTable(rows, {
+		last30: last30DaysTotalRefs,
+		month: getTotalContextRefs(m),
+		lastMonth: getTotalContextRefs(lm),
+		today: todayTotalRefs,
+	});
 }
 
 function buildContextRefsHtml(stats: UsageAnalysisStats, todayTotalRefs: number, last30DaysTotalRefs: number): string {
@@ -1989,7 +2021,8 @@ function renderLayout(stats: UsageAnalysisStats): void {
 			<div class="stats-grid">
 				<div class="stat-card"><div class="stat-label">📅 Today Sessions</div><div class="stat-value">${formatNumber(stats.today.sessions)}</div></div>
 				<div class="stat-card"><div class="stat-label">📆 Last 30 Days Sessions</div><div class="stat-value">${formatNumber(stats.last30Days.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">📅 Previous Month Sessions</div><div class="stat-value">${formatNumber(stats.month.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">📅 This Month Sessions</div><div class="stat-value">${formatNumber(stats.month.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">📅 Last Month Sessions</div><div class="stat-value">${formatNumber(stats.lastMonth.sessions)}</div></div>
 			</div>
 		</div>`;
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1786,6 +1786,25 @@ function numCell(value: number, extraClass = ''): string {
 	return `<td class="${cls}">${value}</td>`;
 }
 
+function sparklineCell(lastMonth: number, month: number, today: number): string {
+	const W = 60, H = 20, PAD = 2;
+	const values = [lastMonth, month, today];
+	const max = Math.max(...values);
+	// Flat line at the bottom when all zeros
+	const points = values.map((v, i) => {
+		const x = PAD + i * ((W - PAD * 2) / (values.length - 1));
+		const y = max === 0 ? H - PAD : PAD + (1 - v / max) * (H - PAD * 2);
+		return `${x.toFixed(1)},${y.toFixed(1)}`;
+	}).join(' ');
+	const isFlat = max === 0;
+	const color = isFlat ? 'var(--text-muted)' : today >= month && month >= lastMonth ? 'var(--link-color)' : today <= month && month <= lastMonth ? '#f87171' : 'var(--text-secondary)';
+	return `<td class="ctx-ref-spark"><svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" aria-hidden="true"><polyline points="${points}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>${values.map((v, i) => {
+		const x = PAD + i * ((W - PAD * 2) / (values.length - 1));
+		const y = max === 0 ? H - PAD : PAD + (1 - v / max) * (H - PAD * 2);
+		return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2" fill="${color}"/>`;
+	}).join('')}</svg></td>`;
+}
+
 function renderContextRefTable(
 	rows: ContextRefRow[],
 	totals: { last30: number; month: number; lastMonth: number; today: number },
@@ -1795,7 +1814,7 @@ function renderContextRefTable(
 		.sort((a, b) => b.last30 - a.last30)
 		.map((row) => {
 			const titleAttr = row.title ? ` title="${escapeHtml(row.title)}"` : '';
-			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.today, row.today > 0 ? 'ctx-ref-today-active' : '')}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.last30)}</tr>`;
+			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.today, row.today > 0 ? 'ctx-ref-today-active' : '')}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.last30)}${sparklineCell(row.lastMonth, row.month, row.today)}</tr>`;
 		})
 		.join('');
 	return `
@@ -1808,6 +1827,7 @@ function renderContextRefTable(
 						<th class="ctx-ref-num">This Month</th>
 						<th class="ctx-ref-num">Last Month</th>
 						<th class="ctx-ref-num">Last 30 Days</th>
+						<th class="ctx-ref-spark">Trend</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -1820,6 +1840,7 @@ function renderContextRefTable(
 						<td class="ctx-ref-num">${totals.month}</td>
 						<td class="ctx-ref-num">${totals.lastMonth}</td>
 						<td class="ctx-ref-num">${totals.last30}</td>
+						<td class="ctx-ref-spark">${sparklineCell(totals.lastMonth, totals.month, totals.today).replace(/^<td[^>]*>/, '').replace(/<\/td>$/, '')}</td>
 					</tr>
 				</tfoot>
 			</table>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1763,35 +1763,80 @@ function buildActivityTabPanelHtml(
 		</div>`;
 }
 
+interface ContextRefRow {
+	label: string;
+	title?: string;
+	last30: number;
+	today: number;
+}
+
+function renderContextRefTable(rows: ContextRefRow[], totalLast30: number, totalToday: number): string {
+	const bodyRows = rows
+		.slice()
+		.sort((a, b) => b.last30 - a.last30)
+		.map((row) => {
+			const titleAttr = row.title ? ` title="${escapeHtml(row.title)}"` : '';
+			const todayCell = row.today > 0
+				? `<td class="ctx-ref-num ctx-ref-today-active">${row.today}</td>`
+				: `<td class="ctx-ref-num ctx-ref-zero">${row.today}</td>`;
+			const last30Cell = row.last30 > 0
+				? `<td class="ctx-ref-num">${row.last30}</td>`
+				: `<td class="ctx-ref-num ctx-ref-zero">${row.last30}</td>`;
+			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${last30Cell}${todayCell}</tr>`;
+		})
+		.join('');
+	return `
+		<div class="ctx-ref-table-wrap">
+			<table class="ctx-ref-table">
+				<thead>
+					<tr>
+						<th class="ctx-ref-name">Reference</th>
+						<th class="ctx-ref-num">Last 30 Days</th>
+						<th class="ctx-ref-num">Today</th>
+					</tr>
+				</thead>
+				<tbody>
+					${bodyRows}
+				</tbody>
+				<tfoot>
+					<tr class="ctx-ref-total">
+						<td class="ctx-ref-name">📊 Total References</td>
+						<td class="ctx-ref-num">${totalLast30}</td>
+						<td class="ctx-ref-num">${totalToday}</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>`;
+}
+
 function buildContextRefCardsHtml(stats: UsageAnalysisStats, todayTotalRefs: number, last30DaysTotalRefs: number): string {
 	const r = stats.last30Days.contextReferences;
 	const t = stats.today.contextReferences;
 	const c = (v: number | undefined): number => v || 0;
-	return `
-		<div class="stats-grid">
-			<div class="stat-card"><div class="stat-label">📄 #file</div><div class="stat-value">${r.file}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.file}</div></div>
-			<div class="stat-card"><div class="stat-label">✂️ #selection</div><div class="stat-value">${r.selection}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.selection}</div></div>
-			<div class="stat-card" title="Text selected in your editor providing passive context to Copilot"><div class="stat-label">✨ Implicit Selection</div><div class="stat-value">${r.implicitSelection}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.implicitSelection}</div></div>
-			<div class="stat-card"><div class="stat-label">🔤 #symbol</div><div class="stat-value">${r.symbol}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.symbol}</div></div>
-			<div class="stat-card"><div class="stat-label">🗂️ #codebase</div><div class="stat-value">${r.codebase}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.codebase}</div></div>
-			<div class="stat-card"><div class="stat-label">📁 @workspace</div><div class="stat-value">${r.workspace}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.workspace}</div></div>
-			<div class="stat-card"><div class="stat-label">💻 @terminal</div><div class="stat-value">${r.terminal}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.terminal}</div></div>
-			<div class="stat-card"><div class="stat-label">🔧 @vscode</div><div class="stat-value">${r.vscode}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.vscode}</div></div>
-			<div class="stat-card" title="Last command run in the terminal"><div class="stat-label">⌨️ #terminalLastCommand</div><div class="stat-value">${c(r.terminalLastCommand)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.terminalLastCommand)}</div></div>
-			<div class="stat-card" title="Selected terminal output"><div class="stat-label">🖱️ #terminalSelection</div><div class="stat-value">${c(r.terminalSelection)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.terminalSelection)}</div></div>
-			<div class="stat-card" title="Clipboard contents"><div class="stat-label">📋 #clipboard</div><div class="stat-value">${c(r.clipboard)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.clipboard)}</div></div>
-			<div class="stat-card" title="Uncommitted git changes"><div class="stat-label">📝 #changes</div><div class="stat-value">${c(r.changes)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.changes)}</div></div>
-			<div class="stat-card" title="Output panel contents"><div class="stat-label">📤 #outputPanel</div><div class="stat-value">${c(r.outputPanel)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.outputPanel)}</div></div>
-			<div class="stat-card" title="Problems panel contents"><div class="stat-label">⚠️ #problemsPanel</div><div class="stat-value">${c(r.problemsPanel)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.problemsPanel)}</div></div>
-			<div class="stat-card" title="Pull request context references (#pr / #pullRequest) — Copilot PR chat understanding, review, and summary"><div class="stat-label">🔀 #pr</div><div class="stat-value">${c(r.pullRequest)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.pullRequest)}</div></div>
-			<div class="stat-card" title="Pasted images and vision context detected in session logs"><div class="stat-label">📷 Images</div><div class="stat-value">${c(r.byKind['copilot.image'])}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.byKind['copilot.image'])}</div></div>
-			<div class="stat-card" title=".github/prompts/ prompt file uses detected in session logs"><div class="stat-label">📋 Prompt Files</div><div class="stat-value">${c(r.byKind['promptFile'])}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.byKind['promptFile'])}</div></div>
-			<div class="stat-card" title="Total lines of code referenced via #file: range selections"><div class="stat-label">📐 Code Lines</div><div class="stat-value">${c(r.codeContextLines)}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.codeContextLines)}</div></div>
-			<div class="stat-card" title="Custom /command prompt uses detected in session logs"><div class="stat-label">🎯 Custom Prompts</div><div class="stat-value">${c(r.byKind['prompt'])}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${c(t.byKind['prompt'])}</div></div>
-			<div class="stat-card" title="copilot-instructions.md file references detected in session logs"><div class="stat-label">📋 Copilot Instructions</div><div class="stat-value">${r.copilotInstructions}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.copilotInstructions}</div></div>
-			<div class="stat-card" title="agents.md file references detected in session logs"><div class="stat-label">🤖 Agents.md</div><div class="stat-value">${r.agentsMd}</div><div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Today: ${t.agentsMd}</div></div>
-			<div class="stat-card" style="background: var(--list-active-bg); border: 2px solid var(--border-color); color: var(--list-active-fg);"><div class="stat-label" style="color: var(--list-active-fg); opacity: 0.85;">📊 Total References</div><div class="stat-value" style="color: var(--list-active-fg);">${last30DaysTotalRefs}</div><div style="font-size: 10px; color: var(--list-active-fg); opacity: 0.75; margin-top: 4px;">Today: ${todayTotalRefs}</div></div>
-		</div>`;
+	const rows: ContextRefRow[] = [
+		{ label: '📄 #file', last30: r.file, today: t.file },
+		{ label: '✂️ #selection', last30: r.selection, today: t.selection },
+		{ label: '✨ Implicit Selection', title: 'Text selected in your editor providing passive context to Copilot', last30: r.implicitSelection, today: t.implicitSelection },
+		{ label: '🔤 #symbol', last30: r.symbol, today: t.symbol },
+		{ label: '🗂️ #codebase', last30: r.codebase, today: t.codebase },
+		{ label: '📁 @workspace', last30: r.workspace, today: t.workspace },
+		{ label: '💻 @terminal', last30: r.terminal, today: t.terminal },
+		{ label: '🔧 @vscode', last30: r.vscode, today: t.vscode },
+		{ label: '⌨️ #terminalLastCommand', title: 'Last command run in the terminal', last30: c(r.terminalLastCommand), today: c(t.terminalLastCommand) },
+		{ label: '🖱️ #terminalSelection', title: 'Selected terminal output', last30: c(r.terminalSelection), today: c(t.terminalSelection) },
+		{ label: '📋 #clipboard', title: 'Clipboard contents', last30: c(r.clipboard), today: c(t.clipboard) },
+		{ label: '📝 #changes', title: 'Uncommitted git changes', last30: c(r.changes), today: c(t.changes) },
+		{ label: '📤 #outputPanel', title: 'Output panel contents', last30: c(r.outputPanel), today: c(t.outputPanel) },
+		{ label: '⚠️ #problemsPanel', title: 'Problems panel contents', last30: c(r.problemsPanel), today: c(t.problemsPanel) },
+		{ label: '🔀 #pr', title: 'Pull request context references (#pr / #pullRequest) — Copilot PR chat understanding, review, and summary', last30: c(r.pullRequest), today: c(t.pullRequest) },
+		{ label: '📷 Images', title: 'Pasted images and vision context detected in session logs', last30: c(r.byKind['copilot.image']), today: c(t.byKind['copilot.image']) },
+		{ label: '📋 Prompt Files', title: '.github/prompts/ prompt file uses detected in session logs', last30: c(r.byKind['promptFile']), today: c(t.byKind['promptFile']) },
+		{ label: '📐 Code Lines', title: 'Total lines of code referenced via #file: range selections', last30: c(r.codeContextLines), today: c(t.codeContextLines) },
+		{ label: '🎯 Custom Prompts', title: 'Custom /command prompt uses detected in session logs', last30: c(r.byKind['prompt']), today: c(t.byKind['prompt']) },
+		{ label: '📋 Copilot Instructions', title: 'copilot-instructions.md file references detected in session logs', last30: r.copilotInstructions, today: t.copilotInstructions },
+		{ label: '🤖 Agents.md', title: 'agents.md file references detected in session logs', last30: r.agentsMd, today: t.agentsMd },
+	];
+	return renderContextRefTable(rows, last30DaysTotalRefs, todayTotalRefs);
 }
 
 function buildContextRefsHtml(stats: UsageAnalysisStats, todayTotalRefs: number, last30DaysTotalRefs: number): string {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1795,7 +1795,7 @@ function renderContextRefTable(
 		.sort((a, b) => b.last30 - a.last30)
 		.map((row) => {
 			const titleAttr = row.title ? ` title="${escapeHtml(row.title)}"` : '';
-			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.last30)}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.today, row.today > 0 ? 'ctx-ref-today-active' : '')}</tr>`;
+			return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.today, row.today > 0 ? 'ctx-ref-today-active' : '')}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.last30)}</tr>`;
 		})
 		.join('');
 	return `
@@ -1804,10 +1804,10 @@ function renderContextRefTable(
 				<thead>
 					<tr>
 						<th class="ctx-ref-name">Reference</th>
-						<th class="ctx-ref-num">Last 30 Days</th>
+						<th class="ctx-ref-num">Today</th>
 						<th class="ctx-ref-num">This Month</th>
 						<th class="ctx-ref-num">Last Month</th>
-						<th class="ctx-ref-num">Today</th>
+						<th class="ctx-ref-num">Last 30 Days</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -1816,10 +1816,10 @@ function renderContextRefTable(
 				<tfoot>
 					<tr class="ctx-ref-total">
 						<td class="ctx-ref-name">📊 Total References</td>
-						<td class="ctx-ref-num">${totals.last30}</td>
+						<td class="ctx-ref-num">${totals.today}</td>
 						<td class="ctx-ref-num">${totals.month}</td>
 						<td class="ctx-ref-num">${totals.lastMonth}</td>
-						<td class="ctx-ref-num">${totals.today}</td>
+						<td class="ctx-ref-num">${totals.last30}</td>
 					</tr>
 				</tfoot>
 			</table>

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -137,15 +137,84 @@ body {
 	color: var(--text-primary);
 }
 
+.ctx-ref-table-wrap {
+	margin-bottom: 16px;
+	overflow-x: auto;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	box-shadow: 0 2px 4px var(--shadow-color);
+}
+
+.ctx-ref-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 13px;
+}
+
+.ctx-ref-table th,
+.ctx-ref-table td {
+	padding: 8px 14px;
+	text-align: left;
+	border-bottom: 1px solid var(--border-subtle);
+}
+
+.ctx-ref-table thead th {
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	position: sticky;
+	top: 0;
+}
+
+.ctx-ref-table tbody tr:hover {
+	background: var(--list-hover-bg);
+}
+
+.ctx-ref-table .ctx-ref-name {
+	color: var(--text-primary);
+	white-space: nowrap;
+}
+
+.ctx-ref-table .ctx-ref-num {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+	font-weight: 600;
+	color: var(--text-primary);
+	width: 110px;
+}
+
+.ctx-ref-table .ctx-ref-zero {
+	color: var(--text-muted);
+	font-weight: 400;
+}
+
+.ctx-ref-table .ctx-ref-today-active {
+	color: var(--link-color);
+}
+
+.ctx-ref-table tfoot .ctx-ref-total td {
+	background: var(--list-active-bg);
+	color: var(--list-active-fg);
+	font-weight: 700;
+	border-bottom: none;
+	border-top: 2px solid var(--border-color);
+}
+
+.ctx-ref-table tfoot .ctx-ref-total .ctx-ref-num {
+	color: var(--list-active-fg);
+}
+
+
 .bar-chart {
 	background: var(--list-hover-bg);
 	border: 1px solid var(--border-color);
 	border-radius: 6px;
 	padding: 12px;
 	margin-bottom: 12px;
-}
-
-.bar-item {
+}.bar-item {
 	margin-bottom: 8px;
 }
 

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -207,6 +207,22 @@ body {
 	color: var(--list-active-fg);
 }
 
+.ctx-ref-table .ctx-ref-spark {
+	width: 68px;
+	text-align: center;
+	padding: 4px 8px;
+	vertical-align: middle;
+}
+
+.ctx-ref-table thead .ctx-ref-spark {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	color: var(--text-secondary);
+	text-align: center;
+}
+
 
 .bar-chart {
 	background: var(--list-hover-bg);

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -212,6 +212,7 @@ body {
 	text-align: center;
 	padding: 4px 8px;
 	vertical-align: middle;
+	color: var(--text-primary);
 }
 
 

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -214,15 +214,6 @@ body {
 	vertical-align: middle;
 }
 
-.ctx-ref-table thead .ctx-ref-spark {
-	font-size: 11px;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.4px;
-	color: var(--text-secondary);
-	text-align: center;
-}
-
 
 .bar-chart {
 	background: var(--list-hover-bg);

--- a/vscode-extension/test/unit/maturityScoring.test.ts
+++ b/vscode-extension/test/unit/maturityScoring.test.ts
@@ -61,7 +61,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
 }
 
 function emptyStats(): UsageAnalysisStats {
-    return { today: emptyPeriod(), last30Days: emptyPeriod(), month: emptyPeriod(), lastUpdated: new Date() };
+    return { today: emptyPeriod(), last30Days: emptyPeriod(), month: emptyPeriod(), lastMonth: emptyPeriod(), lastUpdated: new Date() };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Improves the **Context References** section of the usage analysis screen.

1. Replaces the dense grid of stat-card panels with a compact, readable **table** with clear column headers.
2. Adds **This Month** and **Last Month** columns alongside **Last 30 Days** and **Today**.

## Why

In the original layout (see issue screenshot):
- The big number on each card was the **30-day total** but was unlabeled, so its meaning was ambiguous.
- The **`Today:` value** was tiny muted text that was hard to read.
- Only two time windows were shown; there was no calendar-month view.

## How

**Readability**
- Table with explicit `Last 30 Days`, `This Month`, `Last Month`, `Today` headers.
- Rows **sorted by 30-day usage** so the most-referenced types surface first.
- Today's **non-zero** counts highlighted; zeros de-emphasized. Tooltips preserved. `📊 Total References` moved to a highlighted footer row.

**New periods**
- Added a `lastMonth` (previous calendar month) `UsageAnalysisPeriod` to `UsageAnalysisStats`, computed in `calculateUsageAnalysisStats`.
- Fixed the session-aggregation guard that early-returned for sessions outside the rolling 30-day window — it would have dropped last-month-only sessions. It now also keeps sessions whose last activity falls in the previous calendar month. Month-to-date remains a subset of the last 30 days.
- Workspace/customization-matrix tracking stays scoped to the last 30 days (no behavior change there).
- Threaded `lastMonth` through all 3 webview serialization sites + the webview type/sanitizer.

**Label fix**
- The Sessions Summary "Previous Month" card actually showed month-to-date; corrected to "This Month" and added a "Last Month" card for consistency.

## Testing

- `npm run compile` clean (only pre-existing unrelated lint warnings).
- `npm run test:node` — all 35 unit suites pass (incl. `usageAnalysis`, `maturityScoring`, `statsHelpers`).