### PR TITLE
feat: add refresh button to log viewer for on-demand session reload

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -312,6 +312,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// Cache of the last diagnostic report text for copy/issue operations
 	private lastDiagnosticReport: string = '';
 	private logViewerPanel?: vscode.WebviewPanel;
+	private logViewerSessionFilePath: string = '';
+	private logViewerCurrentData?: SessionLogData;
 	public openCode!: OpenCodeDataAccess;
 	public crush!: CrushDataAccess;
 	public visualStudio!: VisualStudioDataAccess;
@@ -5671,31 +5673,50 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 		}
 		if (this.logViewerPanel) { this.logViewerPanel.dispose(); this.logViewerPanel = undefined; }
 		const logData = await this.getSessionLogData(sessionFilePath);
+		this.logViewerSessionFilePath = sessionFilePath;
+		this.logViewerCurrentData = logData;
 		this.logViewerPanel = vscode.window.createWebviewPanel(
 			'copilotLogViewer', `Session: ${logData.title || path.basename(sessionFilePath)}`,
 			{ viewColumn: vscode.ViewColumn.One, preserveFocus: false },
 			{ enableScripts: true, retainContextWhenHidden: false, localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview')] }
 		);
 		this.logViewerPanel.webview.html = this.getLogViewerHtml(this.logViewerPanel.webview, logData);
-		this.logViewerPanel.webview.onDidReceiveMessage(async (message) => { await this.handleLogViewerMessage(message, logData, sessionFilePath); });
+		this.logViewerPanel.webview.onDidReceiveMessage(async (message) => { await this.handleLogViewerMessage(message); });
 		this.logViewerPanel.onDidDispose(() => { this.logViewerPanel = undefined; });
 	}
 
-	private async handleLogViewerMessage(message: any, logData: SessionLogData, sessionFilePath: string): Promise<void> {
+	private async handleLogViewerMessage(message: any): Promise<void> {
 		if (await this.dispatchSharedCommand(message)) { return; }
+		const logData = this.logViewerCurrentData;
+		const sessionFilePath = this.logViewerSessionFilePath;
 		switch (message.command) {
 			case 'openRawFile':
 				await this.dispatch('openRawFile:logviewer', () => this.logViewerHandleOpenRawFile(sessionFilePath)); break;
 			case 'showToolCallPretty': {
+				if (!logData) { break; }
 				const { turnNumber, toolCallIdx } = message as { turnNumber: number; toolCallIdx: number };
 				try { await this.logViewerShowToolCallPretty(turnNumber, toolCallIdx, logData); }
 				catch (err) { this.error('showToolCallPretty: error', err); vscode.window.showErrorMessage('Could not open formatted tool call.'); }
 				break;
 			}
 			case 'revealToolCallSource': {
+				if (!logData) { break; }
 				const { turnNumber, toolCallIdx } = message as { turnNumber: number; toolCallIdx: number };
 				try { await this.logViewerRevealToolCallSource(turnNumber, toolCallIdx, logData, sessionFilePath); }
 				catch (err) { this.error('revealToolCallSource: error', err); vscode.window.showErrorMessage('Could not reveal tool call in file.'); }
+				break;
+			}
+			case 'refreshSession': {
+				try {
+					const newData = await this.getSessionLogData(sessionFilePath);
+					this.logViewerCurrentData = newData;
+					if (this.logViewerPanel) {
+						this.logViewerPanel.webview.html = this.getLogViewerHtml(this.logViewerPanel.webview, newData);
+					}
+				} catch (err) {
+					this.error('refreshSession: error', err);
+					vscode.window.showErrorMessage('Could not refresh session data.');
+				}
 				break;
 			}
 		}

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -979,27 +979,7 @@ ${hasBreakdown ? `<div class="session-usage-breakdown">
  * Wires up all DOM event handlers after the layout has been injected into
  * `#root`. Must be called once immediately after `root.innerHTML` is set.
  */
-function wireUpEventHandlers(): void {
-document.getElementById('btn-raw')?.addEventListener('click', () => {
-vscode.postMessage({ command: 'openRawFile' });
-});
-document.getElementById('btn-diagnostics')?.addEventListener('click', () => {
-vscode.postMessage({ command: 'showDiagnostics' });
-});
-document.getElementById('btn-usage')?.addEventListener('click', () => {
-vscode.postMessage({ command: 'showUsageAnalysis' });
-});
-document.getElementById('btn-details')?.addEventListener('click', () => {
-vscode.postMessage({ command: 'showDetails' });
-});
-document.getElementById('file-link')?.addEventListener('click', (e) => {
-e.preventDefault();
-vscode.postMessage({ command: 'openRawFile' });
-});
-document.getElementById('open-file-link')?.addEventListener('click', () => {
-vscode.postMessage({ command: 'openRawFile' });
-});
-
+function wireUpToolCallHandlers(): void {
 // Wire tool call clicks after DOM render so listeners bind correctly
 document.querySelectorAll('.tool-call-link').forEach(link => {
 link.addEventListener('click', (e) => {
@@ -1058,6 +1038,33 @@ e.preventDefault();
 }
 });
 });
+}
+
+function wireUpEventHandlers(): void {
+document.getElementById('btn-raw')?.addEventListener('click', () => {
+vscode.postMessage({ command: 'openRawFile' });
+});
+document.getElementById('btn-diagnostics')?.addEventListener('click', () => {
+vscode.postMessage({ command: 'showDiagnostics' });
+});
+document.getElementById('btn-usage')?.addEventListener('click', () => {
+vscode.postMessage({ command: 'showUsageAnalysis' });
+});
+document.getElementById('btn-details')?.addEventListener('click', () => {
+vscode.postMessage({ command: 'showDetails' });
+});
+document.getElementById('btn-refresh-session')?.addEventListener('click', () => {
+vscode.postMessage({ command: 'refreshSession' });
+});
+document.getElementById('file-link')?.addEventListener('click', (e) => {
+e.preventDefault();
+vscode.postMessage({ command: 'openRawFile' });
+});
+document.getElementById('open-file-link')?.addEventListener('click', () => {
+vscode.postMessage({ command: 'openRawFile' });
+});
+
+wireUpToolCallHandlers();
 }
 
 // ── Entry-point renderers (signatures preserved) ─────────────────────────────
@@ -1285,6 +1292,7 @@ ${renderSessionActualUsage(
 <div class="turns-header">
 <span>📝</span>
 <span>Chat Turns (${data.turns.length})${data.title ? ` - ${escapeHtml(data.title)}` : ''}</span>
+<vscode-button id="btn-refresh-session" appearance="secondary" style="margin-left: auto;">🔄 Refresh</vscode-button>
 </div>
 
 <div class="turns-list">


### PR DESCRIPTION
## What

Adds a **🔄 Refresh** button to the Chat Turns header in the log viewer webview. Clicking it immediately reloads the session file from disk, so you can inspect ongoing sessions without waiting for the 5-minute automatic timer.

## Why

When monitoring an active session, users had to wait up to 5 minutes for the background timer to pick up new turns. The refresh button gives instant on-demand updates.

## How

**`webview/logviewer/main.ts`**
- Renders a `<vscode-button id="btn-refresh-session">` in the turns-header, pushed to the right with `margin-left: auto`
- Wires the click to `postMessage({ command: 'refreshSession' })`
- Extracts `wireUpToolCallHandlers()` to keep `wireUpEventHandlers` under the 80-line ESLint limit

**`extension.ts`**
- Adds `logViewerSessionFilePath` and `logViewerCurrentData` as class fields, set when the viewer opens
- Refactors `handleLogViewerMessage` to use these fields instead of closure parameters (so tool-call actions always use the freshest data after a refresh)
- Adds `refreshSession` case: re-reads the session file via `getSessionLogData`, updates the class fields, and re-renders the panel HTML

All 70 unit tests pass; `npm run compile` reports 0 errors, 0 warnings.