### PR TITLE
feat(omp-segment): Claude Code CLI statusline scripts and docs

### DIFF
--- a/cli/src/commands/segment.ts
+++ b/cli/src/commands/segment.ts
@@ -20,6 +20,7 @@ interface SegmentCacheFile {
 	updatedAt: string;
 	formatted: string;
 	todayTokens: number;
+	thisMonthTokens: number;
 	last30DaysTokens: number;
 }
 
@@ -34,6 +35,7 @@ function readSegmentCache(ttlMinutes: number): SegmentCacheFile | null {
 			typeof data.formatted !== 'string' ||
 			typeof data.updatedAt !== 'string' ||
 			typeof data.todayTokens !== 'number' ||
+			typeof data.thisMonthTokens !== 'number' ||
 			typeof data.last30DaysTokens !== 'number'
 		) {
 			return null;
@@ -87,11 +89,13 @@ export const segmentCommand = new Command('segment')
 		// (The preAction hook in cli.ts has already loaded the session file cache)
 		const files = await discoverSessionFiles();
 		let todayTokens = 0;
+		let thisMonthTokens = 0;
 		let last30DaysTokens = 0;
 
 		if (files.length > 0) {
 			const stats = await calculateDetailedStats(files);
 			todayTokens = stats.today.tokens;
+			thisMonthTokens = stats.month.tokens;
 			last30DaysTokens = stats.last30Days.tokens;
 		}
 
@@ -100,17 +104,19 @@ export const segmentCommand = new Command('segment')
 				updatedAt: new Date().toISOString(),
 				formatted: '',
 				todayTokens,
+				thisMonthTokens,
 				last30DaysTokens,
 			});
 			return;
 		}
 
-		const formatted = `${formatTokens(todayTokens)} today · ${formatTokens(last30DaysTokens)} 30d`;
+		const formatted = `${formatTokens(todayTokens)} today · ${formatTokens(thisMonthTokens)} month · ${formatTokens(last30DaysTokens)} 30d`;
 
 		writeSegmentCache({
 			updatedAt: new Date().toISOString(),
 			formatted,
 			todayTokens,
+			thisMonthTokens,
 			last30DaysTokens,
 		});
 

--- a/omp-segment/README.md
+++ b/omp-segment/README.md
@@ -412,6 +412,220 @@ $tokenOutput = & ai-engineering-fluency segment --ttl 2 2>$null   # refresh ever
 
 ---
 
+## Claude Code CLI Statusline
+
+Claude Code CLI has a native `statusLine` feature that pipes session JSON to a local command and renders its output at the bottom of the Claude Code terminal UI. This folder includes ready-to-use scripts that combine Claude Code session data (model name, context tokens, cost, duration, line changes) with your total daily / 30-day token usage from `ai-engineering-fluency`.
+
+Two variants are available — pick the one that fits your setup:
+
+| Variant | Files | Requirement |
+|---|---|---|
+| **Plain PowerShell** | `statusline-claude-plain.*` | None beyond `pwsh` |
+| **oh-my-posh** | `statusline-claude.*` | oh-my-posh on PATH |
+
+### JSON Fields from Claude Code
+
+Claude Code pipes this structure to stdin on each status refresh:
+
+| Field | Description |
+|---|---|
+| `model.display_name` | Current model name (e.g. `claude-sonnet-4-6`) |
+| `context_window.total_input_tokens` | Current input tokens used |
+| `context_window.context_window_size` | Max context window (default 200 000) |
+| `context_window.used_percentage` | Pre-calculated percentage used |
+| `cost.total_cost_usd` | Estimated session cost in USD |
+| `cost.total_duration_ms` | Total wall-clock time since session start |
+| `cost.total_lines_added` / `total_lines_removed` | Code changes this session |
+| `rate_limits.five_hour.used_percentage` | 5-hour rolling window usage (Claude.ai plans only) |
+| `rate_limits.five_hour.resets_at` | Unix timestamp when the 5-hour window resets |
+| `rate_limits.seven_day.used_percentage` | 7-day rolling window usage (Claude.ai plans only) |
+| `rate_limits.seven_day.resets_at` | Unix timestamp when the 7-day window resets |
+
+---
+
+### Option A: Plain PowerShell (no oh-my-posh)
+
+> **Credit:** Approach inspired by [Andrew Connell's guide](https://www.voitanos.io/blog/claude-code-cli-statusline/).
+
+No external tools required — pure PowerShell with ANSI truecolor output. Renders two lines:
+
+```
+claude-sonnet-4-6  ██████░░░░ 123.5k/200.0k 62%  00:12:34  +42/-8  $0.42
+███░░░░░ 38% 5h resets 2h59m  |  ███████░░ 72% 7d resets 3d0h  |  12.9M today · 1.4B 30d
+```
+
+- **Line 1:** model name · color-coded context bar (green → yellow → red) · token counts · duration · line changes · cost
+- **Line 2:** 5-hour and 7-day rate limit bars with reset countdowns · `ai-engineering-fluency` daily totals
+
+Rate limit bars only appear when Claude Code provides that data (Claude.ai Pro/Max plans).
+
+#### Files
+
+| File | Purpose |
+|---|---|
+| [`statusline-claude-plain.cmd`](./statusline-claude-plain.cmd) | Windows wrapper |
+| [`statusline-claude-plain.ps1`](./statusline-claude-plain.ps1) | Pure-PowerShell renderer — no oh-my-posh dependency |
+
+#### Requirements
+
+- **Claude Code CLI** — `npm install -g @anthropic-ai/claude-code`
+- **PowerShell 7+** (`pwsh`) — included with Windows 11; `pwsh --version` to confirm
+
+#### Setup
+
+Add the `statusLine` key to `%USERPROFILE%\.claude\settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "C:\\Users\\YOURUSER\\path\\to\\ai-engineering-fluency\\omp-segment\\statusline-claude-plain.cmd"
+  }
+}
+```
+
+Restart Claude Code (or run `/reload`) to activate.
+
+#### Test Without Claude Code
+
+```powershell
+@'
+{
+  "model": { "id": "claude-sonnet-4-6", "display_name": "claude-sonnet-4-6" },
+  "cwd": "C:\\src\\my-repo",
+  "context_window": {
+    "total_input_tokens": 123456,
+    "context_window_size": 200000,
+    "used_percentage": 61.7
+  },
+  "cost": {
+    "total_cost_usd": 0.42,
+    "total_duration_ms": 754000,
+    "total_lines_added": 42,
+    "total_lines_removed": 8
+  },
+  "rate_limits": {
+    "five_hour":  { "used_percentage": 38, "resets_at": 1749340800 },
+    "seven_day":  { "used_percentage": 72, "resets_at": 1749600000 }
+  }
+}
+'@ | & "path\to\ai-engineering-fluency\omp-segment\statusline-claude-plain.cmd"
+```
+
+#### Customising
+
+Open `statusline-claude-plain.ps1` to adjust:
+
+- **Bar width** — change the `$Width = 10` default in `New-Bar`
+- **Color thresholds** — the `if ($bounded -lt 60)` / `if ($bounded -lt 80)` breakpoints in `New-Bar`
+- **Line layout** — edit the `Write-Host` calls at the bottom of the script
+
+---
+
+### Option B: oh-my-posh (rich theme)
+
+Uses oh-my-posh's powerline rendering for a styled, multi-segment bar. Falls back to the same plain-text output as Option A when oh-my-posh is not found.
+
+Example output (with Nerd Font):
+
+```
+claude-sonnet-4-6 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > $0.42 > 12.9M today · 1.4B 30d
+```
+
+#### Files
+
+| File | Purpose |
+|---|---|
+| [`statusline-claude.cmd`](./statusline-claude.cmd) | Windows wrapper |
+| [`statusline-claude.ps1`](./statusline-claude.ps1) | Sets env vars, calls `ai-engineering-fluency segment`, renders via oh-my-posh |
+| [`statusline-claude.omp.json`](./statusline-claude.omp.json) | Compact oh-my-posh theme — model name, context gauge, duration, changes, cost, token totals |
+
+#### Requirements
+
+In addition to the [prerequisites above](#prerequisites):
+
+- **Claude Code CLI** — `npm install -g @anthropic-ai/claude-code`
+- **oh-my-posh** available on `PATH` (`oh-my-posh version` should return output)
+
+#### Setup
+
+Add the `statusLine` key to `%USERPROFILE%\.claude\settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "C:\\Users\\YOURUSER\\path\\to\\ai-engineering-fluency\\omp-segment\\statusline-claude.cmd"
+  }
+}
+```
+
+Restart Claude Code (or run `/reload`) to activate.
+
+#### Test Without Claude Code
+
+```powershell
+@'
+{
+  "model": {
+    "id": "claude-sonnet-4-6",
+    "display_name": "claude-sonnet-4-6"
+  },
+  "cwd": "C:\\src\\my-repo",
+  "context_window": {
+    "total_input_tokens": 123456,
+    "context_window_size": 200000,
+    "used_percentage": 61.7
+  },
+  "cost": {
+    "total_cost_usd": 0.42,
+    "total_duration_ms": 754000,
+    "total_lines_added": 42,
+    "total_lines_removed": 8
+  }
+}
+'@ | & "path\to\ai-engineering-fluency\omp-segment\statusline-claude.cmd"
+```
+
+#### Environment Variables Set by the Script
+
+| Variable | Value | Example |
+|---|---|---|
+| `CLAUDE_STATUS_MODEL` | Model display name | `claude-sonnet-4-6` |
+| `CLAUDE_STATUS_CONTEXT` | `used/limit` formatted | `123.5k/200.0k` |
+| `CLAUDE_STATUS_GAUGE` | 10-char ASCII gauge | `######....` |
+| `CLAUDE_STATUS_DURATION` | `HH:MM:SS` | `00:12:34` |
+| `CLAUDE_STATUS_CHANGES` | `+added/-removed` or empty | `+42/-8` |
+| `CLAUDE_STATUS_COST` | Cost in USD or empty | `$0.42` |
+| `COPILOT_TOKEN_USAGE` | Output of `ai-engineering-fluency segment` | `12.9M today · 1.4B 30d` |
+
+#### Customising the Theme
+
+Open `statusline-claude.omp.json` to adjust colours, icons, or segments.
+
+To use Nerd Font glyphs instead of plain ASCII separators, replace the diamond and powerline values:
+
+```json
+"leading_diamond": "",
+"trailing_diamond": "",
+"powerline_symbol": ""
+```
+
+---
+
+### Differences vs Copilot CLI Statusline
+
+| Aspect | Copilot CLI | Claude Code |
+|---|---|---|
+| Context tokens field | `context_window.current_context_tokens` | `context_window.total_input_tokens` |
+| Context limit field | `context_window.displayed_context_limit` | `context_window.context_window_size` |
+| Percentage field | `context_window.current_context_used_percentage` | `context_window.used_percentage` |
+| Extra fields | git info via oh-my-posh | `model.display_name`, `cost.total_cost_usd` |
+| Settings file | `%USERPROFILE%\.copilot\settings.json` | `%USERPROFILE%\.claude\settings.json` |
+| Feature flag needed | Yes (`STATUS_LINE`) | No — `statusLine` is stable |
+
+---
+
 ## Related
 
 - [AI Engineering Fluency CLI docs](../docs/cli/README.md)

--- a/omp-segment/README.md
+++ b/omp-segment/README.md
@@ -5,7 +5,7 @@ Display your AI token usage (today and last 30 days) directly in your terminal p
 Example output in your prompt:
 
 ```
- 󱊤 1.2K today · 45.3K 30d 
+ 󱊤 1.2K today · 4.5K month · 45.3K 30d 
 ```
 
 The segment reads **local session files** on your machine — no internet connection or API token required. It tracks tokens from VS Code Copilot Chat, Claude Code, Gemini CLI, OpenCode, and [all other supported editors](../cli/README.md).
@@ -42,7 +42,7 @@ Verify it works:
 
 ```powershell
 ai-engineering-fluency segment
-# e.g.: 1.2K today · 45.3K 30d
+# e.g.: 1.2K today · 4.5K month · 45.3K 30d
 ```
 
 > **Note:** If you use `npx` instead of a global install, replace `"ai-engineering-fluency"` with `"npx"` and add `"-y"`, `"@rajbos/ai-engineering-fluency"` as additional arguments in the `cmd` call below. `npx` is significantly slower due to package resolution on first run.
@@ -134,11 +134,11 @@ Save the file.
   "trailing_diamond": "\ue0b4",
   "foreground": "#ffffff",
   "background": "#005ca5",
-  "template": " \uec1e {{ .Env.COPILOT_TOKENS_TODAY }} today · {{ .Env.COPILOT_TOKENS_30D }} 30d "
+  "template": " \uec1e {{ .Env.COPILOT_TOKENS_TODAY }} today · {{ .Env.COPILOT_TOKENS_MONTH }} month · {{ .Env.COPILOT_TOKENS_30D }} 30d "
 }
 ```
 
-The hook updates `$env:COPILOT_TOKENS_TODAY` and `$env:COPILOT_TOKENS_30D` at most once every 5 minutes.
+The hook updates `$env:COPILOT_TOKENS_TODAY`, `$env:COPILOT_TOKENS_MONTH`, and `$env:COPILOT_TOKENS_30D` at most once every 5 minutes.
 
 ---
 
@@ -268,9 +268,9 @@ oh-my-posh init pwsh --config "$env:TEMP\test.omp.json" | Invoke-Expression
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Command not found: `ai-engineering-fluency` | CLI not installed globally | `npm install -g @rajbos/ai-engineering-fluency` |
-| Segment shows `0 today · 0 30d` | No session files found | Run `ai-engineering-fluency diagnostics` to check paths |
+| Segment shows `0 today · 0 month · 0 30d` | No session files found | Run `ai-engineering-fluency diagnostics` to check paths |
 | Segment shows `invalid template text` | `{{ cmd }}` not supported in your OMP version | Switch to [Method 2](#method-2-powershell-pre-prompt-hook--recommended) |
-| Segment shows `today · 30d` without values | `Set-PoshContext` not called before first render | Add `Set-PoshContext` call at end of `$PROFILE` after the function definition |
+| Segment shows `today · month · 30d` without values | `Set-PoshContext` not called before first render | Add `Set-PoshContext` call at end of `$PROFILE` after the function definition |
 | Segment never updates | OMP cache too long | Set `cache.duration` to `"1m"` or use `--hide-zero` |
 | Stale numbers | CLI cache still valid | Run `ai-engineering-fluency segment --refresh` |
 | Prompt shows stale data even after refresh | OMP `cache` block on a Method 2 env var segment | **Remove** the `"cache"` block from the env var segment — OMP caches the rendered string, bypassing env var updates from `Set-PoshContext` |
@@ -296,7 +296,7 @@ GitHub Copilot CLI has an experimental `STATUS_LINE` feature that calls a local 
 Example statusline:
 
 ```
-main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 1443.5M 30d
+main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 45.3M month · 1443.5M 30d
 ```
 
 ### Files
@@ -380,7 +380,7 @@ Pipe a sample JSON payload directly to the command to verify output before wirin
 Expected output (appearance depends on your Nerd Font):
 
 ```
-main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 1443.5M 30d
+main +2/-1 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > 12.9M today · 45.3M month · 1443.5M 30d
 ```
 
 ### Customising the Theme
@@ -450,12 +450,12 @@ Claude Code pipes this structure to stdin on each status refresh:
 No external tools required — pure PowerShell with ANSI truecolor output. Renders two lines:
 
 ```
-claude-sonnet-4-6  ██████░░░░ 123.5k/200.0k 62%  00:12:34  +42/-8  $0.42
-███░░░░░ 38% 5h resets 2h59m  |  ███████░░ 72% 7d resets 3d0h  |  12.9M today · 1.4B 30d
+claude-sonnet-4-6  ██████░░░░ ctx: 123.5k/200.0k 62%  time: 00:12:34  lines: +42/-8  cost: $0.42
+5h-limit: ███░░░░░ 38% resets 2h59m  |  7d-limit: ███████░░ 72% resets 3d0h  |  tokens: 12.9M today · 45.3M month · 1.4B 30d
 ```
 
-- **Line 1:** model name · color-coded context bar (green → yellow → red) · token counts · duration · line changes · cost
-- **Line 2:** 5-hour and 7-day rate limit bars with reset countdowns · `ai-engineering-fluency` daily totals
+- **Line 1:** model name · color-coded context bar (green → yellow → red) · `ctx:` token counts · `time:` session duration · `lines:` code changes · `cost:` session cost
+- **Line 2:** `5h-limit:` and `7d-limit:` rate limit bars with reset countdowns · `tokens:` `ai-engineering-fluency` daily totals
 
 Rate limit bars only appear when Claude Code provides that data (Claude.ai Pro/Max plans).
 
@@ -529,7 +529,7 @@ Uses oh-my-posh's powerline rendering for a styled, multi-segment bar. Falls bac
 Example output (with Nerd Font):
 
 ```
-claude-sonnet-4-6 > ctx 123.5k/200.0k > ######.... > 00:12:34 > +42/-8 > $0.42 > 12.9M today · 1.4B 30d
+claude-sonnet-4-6 > ctx: 123.5k/200.0k > ######.... > time: 00:12:34 > lines: +42/-8 > cost: $0.42 > tokens: 12.9M today · 45.3M month · 1.4B 30d
 ```
 
 #### Files
@@ -597,7 +597,7 @@ Restart Claude Code (or run `/reload`) to activate.
 | `CLAUDE_STATUS_DURATION` | `HH:MM:SS` | `00:12:34` |
 | `CLAUDE_STATUS_CHANGES` | `+added/-removed` or empty | `+42/-8` |
 | `CLAUDE_STATUS_COST` | Cost in USD or empty | `$0.42` |
-| `COPILOT_TOKEN_USAGE` | Output of `ai-engineering-fluency segment` | `12.9M today · 1.4B 30d` |
+| `COPILOT_TOKEN_USAGE` | Output of `ai-engineering-fluency segment` | `12.9M today · 45.3M month · 1.4B 30d` |
 
 #### Customising the Theme
 

--- a/omp-segment/posh-hook.ps1
+++ b/omp-segment/posh-hook.ps1
@@ -30,6 +30,7 @@ function Set-PoshContext {
     try {
         $data   = ai-engineering-fluency usage --json | ConvertFrom-Json
         $today  = [int]$data.today.tokens
+        $month  = [int]$data.month.tokens
         $days30 = [int]$data.last30Days.tokens
 
         function Format-Tokens([long]$n) {
@@ -40,11 +41,13 @@ function Set-PoshContext {
         }
 
         $env:COPILOT_TOKENS_TODAY   = Format-Tokens $today
+        $env:COPILOT_TOKENS_MONTH   = Format-Tokens $month
         $env:COPILOT_TOKENS_30D     = Format-Tokens $days30
         $env:COPILOT_TOKEN_LAST_RUN = [DateTime]::UtcNow.ToString("o")
     }
     catch {
         $env:COPILOT_TOKENS_TODAY = "?"
+        $env:COPILOT_TOKENS_MONTH = "?"
         $env:COPILOT_TOKENS_30D   = "?"
     }
 }

--- a/omp-segment/statusline-claude-plain.cmd
+++ b/omp-segment/statusline-claude-plain.cmd
@@ -1,0 +1,2 @@
+@echo off
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0statusline-claude-plain.ps1"

--- a/omp-segment/statusline-claude-plain.ps1
+++ b/omp-segment/statusline-claude-plain.ps1
@@ -1,0 +1,98 @@
+# Pure PowerShell — no oh-my-posh required.
+# Claude Code pipes JSON to stdin; this script outputs ANSI-colored lines.
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+function fg { param([int]$r,[int]$g,[int]$b,[string]$t) "`e[38;2;${r};${g};${b}m${t}`e[0m" }
+function bold { param([string]$t) "`e[1m${t}`e[22m" }
+
+function Format-TokenCount {
+    param([Nullable[double]]$Value)
+    if ($null -eq $Value) { return '?' }
+    if ($Value -ge 1000000000) { return ('{0:0.0}b' -f ($Value / 1000000000)) }
+    if ($Value -ge 1000000)    { return ('{0:0.0}m' -f ($Value / 1000000)) }
+    if ($Value -ge 1000)       { return ('{0:0.0}k' -f ($Value / 1000)) }
+    return ([int]$Value).ToString()
+}
+
+function Format-Duration {
+    param([Nullable[double]]$Milliseconds)
+    if ($null -eq $Milliseconds -or $Milliseconds -le 0) { return '00:00:00' }
+    $d = [TimeSpan]::FromMilliseconds($Milliseconds)
+    return '{0:00}:{1:00}:{2:00}' -f [int]$d.TotalHours, $d.Minutes, $d.Seconds
+}
+
+function Format-Countdown {
+    param([Nullable[double]]$UnixEpoch)
+    if ($null -eq $UnixEpoch) { return '' }
+    $remaining = [DateTimeOffset]::FromUnixTimeSeconds([long]$UnixEpoch) - [DateTimeOffset]::UtcNow
+    if ($remaining.TotalSeconds -le 0) { return 'now' }
+    if ($remaining.TotalHours -ge 1) { return ('{0:0}h{1:00}m' -f [int]$remaining.TotalHours, $remaining.Minutes) }
+    return ('{0:0}m' -f [Math]::Ceiling($remaining.TotalMinutes))
+}
+
+function New-Bar {
+    param([Nullable[double]]$Percent, [int]$Width = 10)
+    if ($null -eq $Percent) { return '░' * $Width }
+    $bounded = [Math]::Max(0, [Math]::Min(100, $Percent))
+    $filled  = [int][Math]::Floor($bounded / 100 * $Width)
+    $bar     = ('█' * $filled) + ('░' * ($Width - $filled))
+    if ($bounded -lt 60) { return fg 108 163  94 $bar }
+    if ($bounded -lt 80) { return fg 255 165   0 $bar }
+    return fg 217 87 87 $bar
+}
+
+$payload = [Console]::In.ReadToEnd()
+try   { $json = $payload | ConvertFrom-Json }
+catch { Write-Host -NoNewline 'Claude status unavailable'; exit 0 }
+
+$ctx  = $json.context_window
+$cost = $json.cost
+$rl   = $json.rate_limits
+
+$pct      = if ($null -ne $ctx.used_percentage)      { [double]$ctx.used_percentage }      else { $null }
+$tokens   = if ($null -ne $ctx.total_input_tokens)   { [double]$ctx.total_input_tokens }   else { $null }
+$limit    = if ($null -ne $ctx.context_window_size)   { [double]$ctx.context_window_size }   else { $null }
+$model    = if ($null -ne $json.model.display_name)  { [string]$json.model.display_name }  else { '?' }
+$duration = $cost.total_duration_ms
+$added    = if ($null -ne $cost.total_lines_added)   { [int]$cost.total_lines_added }   else { 0 }
+$removed  = if ($null -ne $cost.total_lines_removed) { [int]$cost.total_lines_removed } else { 0 }
+$costUsd  = if ($null -ne $cost.total_cost_usd)      { '${0:F2}' -f [double]$cost.total_cost_usd } else { '' }
+
+$fivePct  = if ($null -ne $rl.five_hour.used_percentage) { [double]$rl.five_hour.used_percentage } else { $null }
+$fiveReset = $rl.five_hour.resets_at
+$sevenPct  = if ($null -ne $rl.seven_day.used_percentage) { [double]$rl.seven_day.used_percentage } else { $null }
+$sevenReset = $rl.seven_day.resets_at
+
+# ── Line 1: model · context ──────────────────────────────────────────────────
+$modelStr   = bold (fg 217 119 87 $model)
+$ctxStr     = "$(Format-TokenCount $tokens)/$(Format-TokenCount $limit)"
+$pctStr     = if ($null -ne $pct) { " $(fg 180 180 180 ('{0:0}%' -f $pct))" } else { '' }
+$bar        = New-Bar $pct
+$durationStr = fg 100 160 220 (Format-Duration $duration)
+$changes    = if ($added -or $removed) { "  $(fg 160 200 120 "+$added")$(fg 220 100 100 "/-$removed")" } else { '' }
+$costStr    = if ($costUsd) { "  $(fg 200 180 100 $costUsd)" } else { '' }
+
+Write-Host "$modelStr  $bar $ctxStr$pctStr  $durationStr$changes$costStr"
+
+# ── Line 2: rate limits (only when data present) ─────────────────────────────
+$parts = @()
+if ($null -ne $fivePct) {
+    $reset5 = Format-Countdown $fiveReset
+    $label  = if ($reset5) { "5h $(fg 140 140 140 "resets $reset5")" } else { '5h' }
+    $parts += "$(New-Bar $fivePct 8) $(fg 180 180 180 ('{0:0}%' -f $fivePct)) $label"
+}
+if ($null -ne $sevenPct) {
+    $reset7 = Format-Countdown $sevenReset
+    $label  = if ($reset7) { "7d $(fg 140 140 140 "resets $reset7")" } else { '7d' }
+    $parts += "$(New-Bar $sevenPct 8) $(fg 180 180 180 ('{0:0}%' -f $sevenPct)) $label"
+}
+
+# ── Token totals from ai-engineering-fluency ──────────────────────────────────
+try {
+    $tok = & ai-engineering-fluency segment 2>$null
+    if ($tok) { $parts += fg 100 150 210 $tok.Trim() }
+} catch {}
+
+if ($parts.Count) { Write-Host ($parts -join "  $(fg 80 80 80 '|')  ") }

--- a/omp-segment/statusline-claude-plain.ps1
+++ b/omp-segment/statusline-claude-plain.ps1
@@ -66,13 +66,15 @@ $sevenPct  = if ($null -ne $rl.seven_day.used_percentage) { [double]$rl.seven_da
 $sevenReset = $rl.seven_day.resets_at
 
 # ── Line 1: model · context ──────────────────────────────────────────────────
+$dim        = { param($t) fg 140 140 140 $t }
+
 $modelStr   = bold (fg 217 119 87 $model)
-$ctxStr     = "$(Format-TokenCount $tokens)/$(Format-TokenCount $limit)"
+$ctxStr     = "$(& $dim 'ctx:') $(Format-TokenCount $tokens)/$(Format-TokenCount $limit)"
 $pctStr     = if ($null -ne $pct) { " $(fg 180 180 180 ('{0:0}%' -f $pct))" } else { '' }
 $bar        = New-Bar $pct
-$durationStr = fg 100 160 220 (Format-Duration $duration)
-$changes    = if ($added -or $removed) { "  $(fg 160 200 120 "+$added")$(fg 220 100 100 "/-$removed")" } else { '' }
-$costStr    = if ($costUsd) { "  $(fg 200 180 100 $costUsd)" } else { '' }
+$durationStr = "$(& $dim 'time:') $(fg 100 160 220 (Format-Duration $duration))"
+$changes    = if ($added -or $removed) { "  $(& $dim 'lines:') $(fg 160 200 120 "+$added")$(fg 220 100 100 "/-$removed")" } else { '' }
+$costStr    = if ($costUsd) { "  $(& $dim 'cost:') $(fg 200 180 100 $costUsd)" } else { '' }
 
 Write-Host "$modelStr  $bar $ctxStr$pctStr  $durationStr$changes$costStr"
 
@@ -80,19 +82,19 @@ Write-Host "$modelStr  $bar $ctxStr$pctStr  $durationStr$changes$costStr"
 $parts = @()
 if ($null -ne $fivePct) {
     $reset5 = Format-Countdown $fiveReset
-    $label  = if ($reset5) { "5h $(fg 140 140 140 "resets $reset5")" } else { '5h' }
-    $parts += "$(New-Bar $fivePct 8) $(fg 180 180 180 ('{0:0}%' -f $fivePct)) $label"
+    $label  = if ($reset5) { "$(& $dim "resets $reset5")" } else { '' }
+    $parts += "$(& $dim '5h-limit:') $(New-Bar $fivePct 8) $(fg 180 180 180 ('{0:0}%' -f $fivePct)) $label"
 }
 if ($null -ne $sevenPct) {
     $reset7 = Format-Countdown $sevenReset
-    $label  = if ($reset7) { "7d $(fg 140 140 140 "resets $reset7")" } else { '7d' }
-    $parts += "$(New-Bar $sevenPct 8) $(fg 180 180 180 ('{0:0}%' -f $sevenPct)) $label"
+    $label  = if ($reset7) { "$(& $dim "resets $reset7")" } else { '' }
+    $parts += "$(& $dim '7d-limit:') $(New-Bar $sevenPct 8) $(fg 180 180 180 ('{0:0}%' -f $sevenPct)) $label"
 }
 
 # ── Token totals from ai-engineering-fluency ──────────────────────────────────
 try {
     $tok = & ai-engineering-fluency segment 2>$null
-    if ($tok) { $parts += fg 100 150 210 $tok.Trim() }
+    if ($tok) { $parts += "$(& $dim 'tokens:') $(fg 100 150 210 $tok.Trim())" }
 } catch {}
 
 if ($parts.Count) { Write-Host ($parts -join "  $(fg 80 80 80 '|')  ") }

--- a/omp-segment/statusline-claude.cmd
+++ b/omp-segment/statusline-claude.cmd
@@ -1,0 +1,2 @@
+@echo off
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0statusline-claude.ps1"

--- a/omp-segment/statusline-claude.omp.json
+++ b/omp-segment/statusline-claude.omp.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "version": 3,
+  "final_space": false,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "text",
+          "style": "diamond",
+          "leading_diamond": "<",
+          "trailing_diamond": ">",
+          "foreground": "#1A1A2E",
+          "background": "#D97757",
+          "template": " {{ .Env.CLAUDE_STATUS_MODEL }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#193549",
+          "background": "#FFA500",
+          "template": " ctx {{ .Env.CLAUDE_STATUS_CONTEXT }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#6CA35E",
+          "template": " {{ .Env.CLAUDE_STATUS_GAUGE }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#0184bc",
+          "template": " {{ .Env.CLAUDE_STATUS_DURATION }} "
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#a1108c",
+          "template": "{{ if .Env.CLAUDE_STATUS_CHANGES }} {{ .Env.CLAUDE_STATUS_CHANGES }} {{ end }}"
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "powerline_symbol": ">",
+          "foreground": "#ffffff",
+          "background": "#7B2D8B",
+          "template": "{{ if .Env.CLAUDE_STATUS_COST }} {{ .Env.CLAUDE_STATUS_COST }} {{ end }}"
+        },
+        {
+          "type": "text",
+          "style": "diamond",
+          "trailing_diamond": ">",
+          "foreground": "#ffffff",
+          "background": "#005ca5",
+          "template": "{{ if .Env.COPILOT_TOKEN_USAGE }}  {{ .Env.COPILOT_TOKEN_USAGE }} {{ end }}"
+        }
+      ]
+    }
+  ]
+}

--- a/omp-segment/statusline-claude.ps1
+++ b/omp-segment/statusline-claude.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+function Format-TokenCount {
+    param([Nullable[double]]$Value)
+    if ($null -eq $Value) { return '?' }
+    if ($Value -ge 1000000000) { return ('{0:0.0}b' -f ($Value / 1000000000)) }
+    if ($Value -ge 1000000) { return ('{0:0.0}m' -f ($Value / 1000000)) }
+    if ($Value -ge 1000) { return ('{0:0.0}k' -f ($Value / 1000)) }
+    return ([int]$Value).ToString()
+}
+
+function Format-Duration {
+    param([Nullable[double]]$Milliseconds)
+    if ($null -eq $Milliseconds -or $Milliseconds -le 0) { return '00:00:00' }
+    $duration = [TimeSpan]::FromMilliseconds($Milliseconds)
+    return '{0:00}:{1:00}:{2:00}' -f [int]$duration.TotalHours, $duration.Minutes, $duration.Seconds
+}
+
+function New-Gauge {
+    param([Nullable[double]]$Percent)
+    if ($null -eq $Percent) { return '..........' }
+    $bounded = [Math]::Max(0, [Math]::Min(100, [Math]::Round($Percent)))
+    $filled = [int][Math]::Floor($bounded / 10)
+    return ('#' * $filled) + ('.' * (10 - $filled))
+}
+
+$payload = [Console]::In.ReadToEnd()
+
+try {
+    $json = $payload | ConvertFrom-Json
+} catch {
+    Write-Host -NoNewline 'Claude status unavailable'
+    exit 0
+}
+
+$context = $json.context_window
+$cost    = $json.cost
+$model   = $json.model
+
+$currentTokens  = if ($null -ne $context.total_input_tokens)  { [double]$context.total_input_tokens }  else { $null }
+$contextLimit   = if ($null -ne $context.context_window_size)  { [double]$context.context_window_size }  else { $null }
+$contextPercent = if ($null -ne $context.used_percentage)      { [double]$context.used_percentage }      else { $null }
+
+$linesAdded   = if ($null -ne $cost.total_lines_added)   { [int]$cost.total_lines_added }   else { 0 }
+$linesRemoved = if ($null -ne $cost.total_lines_removed) { [int]$cost.total_lines_removed } else { 0 }
+
+$costUsd   = if ($null -ne $cost.total_cost_usd) { '${0:F2}' -f [double]$cost.total_cost_usd } else { '' }
+$modelName = if ($null -ne $model.display_name)  { [string]$model.display_name }              else { '' }
+
+$env:CLAUDE_STATUS_MODEL    = $modelName
+$env:CLAUDE_STATUS_CONTEXT  = "$(Format-TokenCount $currentTokens)/$(Format-TokenCount $contextLimit)"
+$env:CLAUDE_STATUS_GAUGE    = New-Gauge $contextPercent
+$env:CLAUDE_STATUS_DURATION = Format-Duration $cost.total_duration_ms
+$env:CLAUDE_STATUS_CHANGES  = if ($linesAdded -or $linesRemoved) { "+$linesAdded/-$linesRemoved" } else { '' }
+$env:CLAUDE_STATUS_COST     = $costUsd
+
+try {
+    $tokenOutput = & ai-engineering-fluency segment 2>$null
+    $env:COPILOT_TOKEN_USAGE = if ($tokenOutput) { $tokenOutput.Trim() } else { '' }
+} catch {
+    $env:COPILOT_TOKEN_USAGE = ''
+}
+
+$theme = Join-Path $PSScriptRoot 'statusline-claude.omp.json'
+$cwd   = if ($json.cwd) { [string]$json.cwd } else { (Get-Location).Path }
+
+try {
+    $output = & oh-my-posh print primary --config $theme --pwd $cwd --force --escape=false 2>$null
+    if ([string]::IsNullOrWhiteSpace($output)) { throw 'Oh My Posh returned no output.' }
+    Write-Host -NoNewline $output.TrimEnd()
+} catch {
+    $changes = if ($env:CLAUDE_STATUS_CHANGES) { " | $($env:CLAUDE_STATUS_CHANGES)" } else { '' }
+    $tokens  = if ($env:COPILOT_TOKEN_USAGE)   { " | $($env:COPILOT_TOKEN_USAGE)" }   else { '' }
+    $costStr = if ($env:CLAUDE_STATUS_COST)    { " | $($env:CLAUDE_STATUS_COST)" }    else { '' }
+    Write-Host -NoNewline "[$($env:CLAUDE_STATUS_MODEL)] ctx $($env:CLAUDE_STATUS_CONTEXT) $($env:CLAUDE_STATUS_GAUGE) | $($env:CLAUDE_STATUS_DURATION)$changes$costStr$tokens"
+}


### PR DESCRIPTION
## Summary

- Adds two statusline variants for Claude Code CLI's native `statusLine` feature, mirroring the existing GitHub Copilot CLI statusline pattern in `omp-segment/`:
  - **Option A — Plain PowerShell** (`statusline-claude-plain.*`): no external dependencies, pure PowerShell with ANSI truecolor. Two-line output: model/context bar/cost on line 1; rate-limit bars with reset countdowns + `ai-engineering-fluency` daily totals on line 2. All values are labelled (`ctx:`, `time:`, `lines:`, `cost:`, `5h-limit:`, `7d-limit:`, `tokens:`) for readability.
  - **Option B — oh-my-posh** (`statusline-claude.*` + `statusline-claude.omp.json`): powerline-style theme using Claude's orange brand colour; falls back to plain text when oh-my-posh is not on PATH.
- `segment` command now outputs `X today · Y month · Z 30d` — adds the current calendar month alongside the existing rolling 30-day window.
- `posh-hook.ps1` exports `$env:COPILOT_TOKENS_MONTH`; Method 2 OMP template updated to include it.
- `README.md` restructured: variant picker table, full JSON field reference (including `rate_limits`), test payloads, customisation notes, and all examples updated to the new output format.

## Test plan

- [ ] Pipe sample JSON to `statusline-claude-plain.cmd` and verify two-line labelled output renders correctly
- [ ] Pipe sample JSON to `statusline-claude.cmd` and verify oh-my-posh or plain-text fallback renders correctly
- [ ] Run `ai-engineering-fluency segment --refresh` and confirm output includes `today · month · 30d`
- [ ] Add `statusLine` config to `~/.claude/settings.json` pointing at `statusline-claude-plain.cmd` and confirm bar appears at bottom of Claude Code UI after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)