### PR TITLE
feat: track session.truncation events as a negative signal

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -300,7 +300,7 @@ function _scdlDistributeToDays(
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 57; // Fix output token counting: use tool.execution_complete events
+	private static readonly CACHE_VERSION = 58; // Track session.truncation events as a negative signal
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 
@@ -3127,11 +3127,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return toLocalDayKey(lastActivity);
 	}
 
-	private collectTodaySessionInfo(
-		sessionData: SessionFileCache, sessionFile: string,
-		analysis: SessionUsageAnalysis, interactions: number, mtime: number
-	): TodaySessionSummary {
-		const modelUsage = sessionData.modelUsage || {};
+	private _resolveSessionModelTokens(sessionData: SessionFileCache, modelUsage: ModelUsage): { inputTok: number; outputTok: number; cachedTok: number } {
 		let inputTok = 0, outputTok = 0, cachedTok = 0;
 		for (const usage of Object.values(modelUsage)) {
 			inputTok += usage.inputTokens || 0;
@@ -3141,6 +3137,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (sessionData.debugLogInputTokens !== undefined) { inputTok = sessionData.debugLogInputTokens; }
 		if (sessionData.debugLogOutputTokens !== undefined) { outputTok = sessionData.debugLogOutputTokens; }
 		if (sessionData.cacheReadTokens !== undefined) { cachedTok = sessionData.cacheReadTokens; }
+		return { inputTok, outputTok, cachedTok };
+	}
+
+	private collectTodaySessionInfo(
+		sessionData: SessionFileCache, sessionFile: string,
+		analysis: SessionUsageAnalysis, interactions: number, mtime: number
+	): TodaySessionSummary {
+		const modelUsage = sessionData.modelUsage || {};
+		const { inputTok, outputTok, cachedTok } = this._resolveSessionModelTokens(sessionData, modelUsage);
 		return {
 			title: sessionData.title || null, filePath: sessionFile, interactions,
 			toolCalls: analysis.toolCalls.total, inputTokens: inputTok, outputTokens: outputTok,
@@ -3149,6 +3154,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			estimatedCost: sessionData.copilotExactCostDollars ?? this.calculateEstimatedCost(modelUsage),
 			editor: this.detectEditorSource(sessionFile), models: Object.keys(modelUsage),
 			lastActivity: sessionData.lastInteraction || new Date(mtime).toISOString(),
+			...(sessionData.truncationCount ? { truncationCount: sessionData.truncationCount } : {}),
 		};
 	}
 
@@ -3792,7 +3798,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private buildOptionalSessionFields(
-		tokenResult: { thinkingTokens?: number; copilotNanoAiu?: number },
+		tokenResult: { thinkingTokens?: number; copilotNanoAiu?: number; truncationCount?: number; messagesRemovedByTruncation?: number },
 		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number; copilotNanoAiu?: number } | null | undefined,
 		finalCacheReadTokens: number | undefined,
 		copilotExactCostDollars: number | undefined,
@@ -3808,6 +3814,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(hasDebugLog ? { debugLogInputTokens: debugLogTokens!.inputTokens, debugLogOutputTokens: debugLogTokens!.outputTokens } : {}),
 			dailyRollups: Object.keys(dailyRollups).length > 0 ? dailyRollups : undefined,
 			...(copilotExactCostDollars !== undefined ? { copilotExactCostDollars } : {}),
+			...(tokenResult.truncationCount ? { truncationCount: tokenResult.truncationCount, messagesRemovedByTruncation: tokenResult.messagesRemovedByTruncation } : {}),
 			...(hasEditScope ? {
 				linesAdded: usageAnalysis!.editScope!.linesAdded,
 				linesRemoved: usageAnalysis!.editScope!.linesRemoved ?? 0,
@@ -4571,6 +4578,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(sessionCache?.debugLogInputTokens !== undefined ? { debugLogInputTokens: sessionCache.debugLogInputTokens } : {}),
 			...(sessionCache?.debugLogOutputTokens !== undefined ? { debugLogOutputTokens: sessionCache.debugLogOutputTokens } : {}),
 			...(sessionCache?.modelTurns !== undefined ? { modelTurns: sessionCache.modelTurns } : {}),
+			...(sessionCache?.truncationCount ? { truncationCount: sessionCache.truncationCount, messagesRemovedByTruncation: sessionCache.messagesRemovedByTruncation } : {}),
 		};
 	}
 
@@ -5010,7 +5018,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return 0;
 	}
 
-	private estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number; copilotNanoAiu: number } {
+	private estimateTokensFromJsonlSession(fileContent: string): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number; copilotNanoAiu: number; truncationCount?: number; messagesRemovedByTruncation?: number } {
 		return _estimateTokensFromJsonlSession(fileContent);
 	}
 

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -788,6 +788,29 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		},
 		weight: 42,
 	},
+
+	// ── Context-window health ─────────────────────────────────────────────────
+	{
+		id: 'session-context-truncated',
+		category: 'context',
+		severity: 'opportunity',
+		title: '⚠️ Context window was truncated in a session today',
+		buildBody: (ctx) => {
+			const truncated = (ctx.todaySessions ?? []).filter(s => (s.truncationCount ?? 0) > 0);
+			const count = truncated.length;
+			const totalRemoved = truncated.reduce((sum, s) => sum + (s.truncationCount ?? 0), 0);
+			const sessionWord = count === 1 ? 'session' : 'sessions';
+			const truncationWord = totalRemoved === 1 ? 'truncation event' : 'truncation events';
+			return `${count} of your ${sessionWord} today had ${totalRemoved} ${truncationWord} where the AI dropped earlier messages to fit within the context window. ` +
+				`This breaks the prompt cache (increasing latency and cost) and may have caused responses to lose track of earlier context. ` +
+				`To avoid truncation: start a new session when switching tasks, use /compact before the context fills, or break large tasks into smaller focused sessions.`;
+		},
+		appliesTo: (ctx) => {
+			return (ctx.todaySessions ?? []).some(s => (s.truncationCount ?? 0) > 0);
+		},
+		weight: 75,
+		allowToast: true,
+	},
 ];
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/tokenEstimation.ts
+++ b/vscode-extension/src/tokenEstimation.ts
@@ -277,6 +277,10 @@ export type TokenEstimationResult = {
 	dailyActualTokens: Record<string, number>;
 	/** Exact GitHub Copilot billing amount in nano-AI-units (0 when unavailable). Divide by 1e11 for USD. */
 	copilotNanoAiu: number;
+	/** Number of session.truncation events where at least one message was removed (breaking prompt cache). */
+	truncationCount?: number;
+	/** Total messages removed across all truncation events in this session. */
+	messagesRemovedByTruncation?: number;
 };
 
 /**
@@ -462,6 +466,10 @@ interface EjtsState {
 	dailyActualTokens: Record<string, number>;
 	/** Sum of totalNanoAiu from all session.shutdown events (exact Copilot billing). */
 	cliTotalNanoAiu: number;
+	/** Count of session.truncation events where at least one message was removed. */
+	truncationCount: number;
+	/** Total messages removed across all session.truncation events. */
+	messagesRemovedByTruncation: number;
 }
 
 /** Accumulate one model's metrics from a session.shutdown event into state. Returns the total tokens added. */
@@ -504,6 +512,16 @@ function _ejtsHandleShutdown(event: Record<string, unknown>, state: EjtsState): 
 		if (dayKey && dayKey !== 'Inval') {
 			state.dailyActualTokens[dayKey] = (state.dailyActualTokens[dayKey] || 0) + shutdownTotal;
 		}
+	}
+}
+
+/** Handle a session.truncation event — count events where messages were removed (prompt cache break). */
+function _ejtsHandleTruncation(event: Record<string, unknown>, state: EjtsState): void {
+	const data = event.data as Record<string, unknown> | undefined;
+	const removed = typeof data?.messagesRemovedDuringTruncation === 'number' ? data.messagesRemovedDuringTruncation : 0;
+	if (removed > 0) {
+		state.truncationCount++;
+		state.messagesRemovedByTruncation += removed;
 	}
 }
 
@@ -593,6 +611,8 @@ export class EventJsonlTokenStrategy implements TokenEstimationStrategy {
 			totalEstToolCalls: 0,
 			dailyActualTokens: {},
 			cliTotalNanoAiu: 0,
+			truncationCount: 0,
+			messagesRemovedByTruncation: 0,
 		};
 
 		for (const line of lines) {
@@ -600,6 +620,7 @@ export class EventJsonlTokenStrategy implements TokenEstimationStrategy {
 			try {
 				const event = JSON.parse(line) as Record<string, unknown>;
 				if (event.type === 'session.shutdown') { _ejtsHandleShutdown(event, state); }
+				else if (event.type === 'session.truncation') { _ejtsHandleTruncation(event, state); }
 				_ejtsHandleEventType(event, state);
 			} catch { /* skip invalid lines */ }
 		}
@@ -615,6 +636,7 @@ export class EventJsonlTokenStrategy implements TokenEstimationStrategy {
 			modelUsage: state.cliShutdownModelUsage ?? {},
 			dailyActualTokens: state.dailyActualTokens,
 			copilotNanoAiu: state.cliTotalNanoAiu,
+			...(state.truncationCount > 0 ? { truncationCount: state.truncationCount, messagesRemovedByTruncation: state.messagesRemovedByTruncation } : {}),
 		};
 	}
 }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -216,6 +216,10 @@ export interface SessionFileCache {
   debugLogChecked?: boolean; // Sentinel: true means we already looked for a debug log and found none
   /** Exact GitHub Copilot billing for this session in USD (from session.shutdown.totalNanoAiu or debug log copilotUsageNanoAiu). */
   copilotExactCostDollars?: number;
+  /** Number of session.truncation events where messages were removed (breaking prompt cache). 0 or absent means no truncation. */
+  truncationCount?: number;
+  /** Total messages removed across all truncation events. Absent when truncationCount is 0 or unavailable. */
+  messagesRemovedByTruncation?: number;
   /** Per-UTC-day token/interaction breakdown (keyed by YYYY-MM-DD UTC). Used for consistent daily stats. */
   dailyRollups?: { [utcDayKey: string]: DailyRollupEntry };
   linesAdded?: number;
@@ -407,6 +411,8 @@ export interface TodaySessionSummary {
   editor: string;
   models: string[];
   lastActivity: string;
+  /** Number of truncation events where messages were removed in this session. 0 or absent means no truncation. */
+  truncationCount?: number;
 }
 
 export interface UsageAnalysisStats {
@@ -575,6 +581,10 @@ export interface SessionLogData {
   debugLogOutputTokens?: number;
   /** Number of LLM API calls made during the session (from debug log). >1 means agent-mode multi-call session. */
   modelTurns?: number;
+  /** Number of session.truncation events where messages were removed (breaking prompt cache). 0 or absent means no truncation. */
+  truncationCount?: number;
+  /** Total messages removed across all truncation events. Absent when truncationCount is 0. */
+  messagesRemovedByTruncation?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -90,6 +90,10 @@ debugLogInputTokens?: number;
 debugLogOutputTokens?: number;
 /** Number of LLM API calls made during the session (from debug log). >1 means agent-mode multi-call session. */
 modelTurns?: number;
+/** Number of session.truncation events where messages were removed (breaking prompt cache). */
+truncationCount?: number;
+/** Total messages removed across all truncation events. */
+messagesRemovedByTruncation?: number;
 compactNumbers?: boolean;
 };
 
@@ -821,6 +825,19 @@ function buildSubAgentsCard(data: SessionLogData, stats: SummaryStats): string {
 </div>`;
 }
 
+function buildTruncationCard(data: SessionLogData): string {
+	if ((data.truncationCount ?? 0) <= 0) { return ''; }
+	const removed = data.messagesRemovedByTruncation ?? 0;
+	const sub = removed > 0
+		? `${removed} message${removed !== 1 ? 's' : ''} dropped — prompt cache broken`
+		: 'Context window truncated';
+	return `<div class="summary-card summary-card--warning" title="The AI dropped earlier messages to fit within the context window. This breaks prompt cache efficiency and may affect response quality.">
+<div class="summary-label">⚠️ Context Truncated</div>
+<div class="summary-value">${data.truncationCount}</div>
+<div class="summary-sub">${sub}</div>
+</div>`;
+}
+
 function buildFileNameCard(data: SessionLogData): string {
 	const isOpenCode = data.file.includes('opencode.db#ses_');
 	const displayName = escapeHtml(truncateText(getFileName(data.file), 30));
@@ -858,6 +875,7 @@ ${buildCachedTokensCard(data)}
 ${buildThinkingTokensCard(data, stats)}
 ${buildEffortCard(stats)}
 ${buildSubAgentsCard(data, stats)}
+${buildTruncationCard(data)}
 ${buildHierarchyCard(data)}
 <div class="summary-card">
 <div class="summary-label">🔧 Tool Calls</div>

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -115,6 +115,16 @@ body {
 	box-shadow: 0 6px 16px rgb(0, 0, 0, 0.4), 0 2px 4px rgb(0, 0, 0, 0.2);
 }
 
+.summary-card--warning {
+	border-color: var(--vscode-editorWarning-foreground, #d7a73b);
+	background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #d7a73b) 8%, var(--bg-secondary));
+}
+
+.summary-card--warning .summary-label,
+.summary-card--warning .summary-value {
+	color: var(--vscode-editorWarning-foreground, #d7a73b);
+}
+
 .filename-link {
 	cursor: pointer;
 	color: var(--link-color);

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -1707,3 +1707,96 @@ test('reconstructJsonlStateAsync: skips invalid JSON lines without throwing', as
         const state = sessionState as Record<string, unknown>;
         assert.equal(state.x, 2);
 });
+
+// ── EventJsonlTokenStrategy: session.truncation event parsing ─────────────
+
+test('estimateTokensFromJsonlSession: session.truncation with removed messages increments truncationCount', () => {
+	const events = [
+		JSON.stringify({ type: 'user.message', data: { content: 'hello' } }),
+		JSON.stringify({
+			type: 'session.truncation',
+			data: {
+				tokenLimit: 128000,
+				preTruncationTokensInMessages: 13863,
+				preTruncationMessagesLength: 9,
+				postTruncationTokensInMessages: 8000,
+				postTruncationMessagesLength: 5,
+				tokensRemovedDuringTruncation: 5863,
+				messagesRemovedDuringTruncation: 4,
+				performedBy: 'BasicTruncator',
+			},
+		}),
+	].join('\n');
+	const result = estimateTokensFromJsonlSession(events);
+	assert.equal(result.truncationCount, 1, 'should count one truncation event');
+	assert.equal(result.messagesRemovedByTruncation, 4, 'should track messages removed');
+});
+
+test('estimateTokensFromJsonlSession: session.truncation with zero removed messages does not increment truncationCount', () => {
+	const events = [
+		JSON.stringify({
+			type: 'session.truncation',
+			data: {
+				tokenLimit: 128000,
+				preTruncationTokensInMessages: 13863,
+				preTruncationMessagesLength: 9,
+				postTruncationTokensInMessages: 13863,
+				postTruncationMessagesLength: 9,
+				tokensRemovedDuringTruncation: 0,
+				messagesRemovedDuringTruncation: 0,
+				performedBy: 'BasicTruncator',
+			},
+		}),
+	].join('\n');
+	const result = estimateTokensFromJsonlSession(events);
+	assert.equal(result.truncationCount, undefined, 'should not count truncation when no messages removed');
+	assert.equal(result.messagesRemovedByTruncation, undefined, 'should not track messages when none removed');
+});
+
+test('estimateTokensFromJsonlSession: multiple session.truncation events accumulate correctly', () => {
+	const makeTruncation = (removed: number) => JSON.stringify({
+		type: 'session.truncation',
+		data: { messagesRemovedDuringTruncation: removed, tokensRemovedDuringTruncation: removed * 100 },
+	});
+	const events = [
+		makeTruncation(3),  // should count
+		makeTruncation(0),  // should not count (no messages removed)
+		makeTruncation(2),  // should count
+	].join('\n');
+	const result = estimateTokensFromJsonlSession(events);
+	assert.equal(result.truncationCount, 2, 'should count only events where messages were removed');
+	assert.equal(result.messagesRemovedByTruncation, 5, 'should sum all removed messages');
+});
+
+test('estimateTokensFromJsonlSession: session.truncation missing data does not count', () => {
+	const events = [
+		JSON.stringify({ type: 'session.truncation' }),
+	].join('\n');
+	const result = estimateTokensFromJsonlSession(events);
+	assert.equal(result.truncationCount, undefined, 'missing data should not count as truncation');
+});
+
+test('estimateTokensFromJsonlSession: session.truncation with non-numeric messagesRemoved does not count', () => {
+	const events = [
+		JSON.stringify({
+			type: 'session.truncation',
+			data: { messagesRemovedDuringTruncation: 'lots' },
+		}),
+	].join('\n');
+	const result = estimateTokensFromJsonlSession(events);
+	assert.equal(result.truncationCount, undefined, 'non-numeric messagesRemoved should not count');
+});
+
+test('estimateTokensFromJsonlSession: truncation events do not affect token counts', () => {
+	const userOnly = JSON.stringify({ type: 'user.message', data: { content: 'hello world' } });
+	const withTruncation = [
+		JSON.stringify({ type: 'user.message', data: { content: 'hello world' } }),
+		JSON.stringify({
+			type: 'session.truncation',
+			data: { messagesRemovedDuringTruncation: 5 },
+		}),
+	].join('\n');
+	const resultA = estimateTokensFromJsonlSession(userOnly);
+	const resultB = estimateTokensFromJsonlSession(withTruncation);
+	assert.equal(resultA.tokens, resultB.tokens, 'truncation events should not affect estimated token counts');
+});


### PR DESCRIPTION
## Summary

Tracks `session.truncation` events emitted by Copilot CLI JSONL sessions, surfacing them as a negative signal in the insights engine and log viewer.

### What changed

#### Parsing (`tokenEstimation.ts`)
- Added `truncationCount` and `messagesRemovedByTruncation` to `TokenEstimationResult`
- Added `_ejtsHandleTruncation` handler in `EventJsonlTokenStrategy` — only counts events where `messagesRemovedDuringTruncation > 0` (actual context loss)
- Bumped `CACHE_VERSION` to `58`

#### Data model (`types.ts`)
- Added `truncationCount?: number` and `messagesRemovedByTruncation?: number` to `SessionFileCache` and `SessionLogData`
- Added `truncationCount?: number` to `TodaySessionSummary`

#### Extension plumbing (`extension.ts`)
- `buildOptionalSessionFields` — stores truncation data in the cache
- `buildLogDataCacheFields` — passes truncation data to the log viewer
- `collectTodaySessionInfo` — includes `truncationCount` in today-session summaries
- Extracted `_resolveSessionModelTokens` helper to keep `collectTodaySessionInfo` within complexity limits

#### Insights (`insightsEngine.ts`)
- New `session-context-truncated` insight (category: `context`, severity: `opportunity`, weight: 75, allowToast)
- Fires when any session today had truncation events where messages were removed
- Message explains that this breaks prompt cache efficiency and suggests mitigation

#### Log viewer (`webview/logviewer/main.ts` + `styles.css`)
- New `buildTruncationCard()` renders a `⚠️ Context Truncated` summary card
- `summary-card--warning` CSS class uses the VS Code warning token color with tinted background

#### Tests (`test/unit/tokenEstimation.test.ts`)
- 6 new tests covering: truncation counting, zero-removal no-count, multiple events accumulation, missing data, non-numeric values, no effect on token counts

### Research note
Other host formats (Claude Code JSONL, JetBrains JSONL, Gemini CLI, Antigravity, VS Code delta JSONL) do not emit equivalent `session.truncation` events — this feature is Copilot CLI specific.