### PR TITLE
fix: correct file paths and PAT issue in sync workflows

### DIFF
--- a/.github/workflows/check-models.yml
+++ b/.github/workflows/check-models.yml
@@ -6,8 +6,8 @@ on:
     paths:
         - .github/workflows/check-models.yml
         - .github/prompts/sync-models.prompt.md
-        - src/tokenEstimators.json
-        - src/modelPricing.json
+        - vscode-extension/src/tokenEstimators.json
+        - vscode-extension/src/modelPricing.json
         
   schedule:
     - cron: '11 17 * * 1' # Run every Monday at 5:11 PM UTC
@@ -77,8 +77,8 @@ jobs:
           PROMPT=$(cat .github/prompts/sync-models.prompt.md)
           
           # Get the paths to relevant files
-          ESTIMATORS_PATH="${GITHUB_WORKSPACE}/src/tokenEstimators.json"
-          PRICING_PATH="${GITHUB_WORKSPACE}/src/modelPricing.json"
+          ESTIMATORS_PATH="${GITHUB_WORKSPACE}/vscode-extension/src/tokenEstimators.json"
+          PRICING_PATH="${GITHUB_WORKSPACE}/vscode-extension/src/modelPricing.json"
           
           # Create the full prompt with context
           {
@@ -107,12 +107,12 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet src/tokenEstimators.json src/modelPricing.json; then
+          if git diff --quiet vscode-extension/src/tokenEstimators.json vscode-extension/src/modelPricing.json; then
             echo "No changes detected in model data files"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             # Check if the only change is the lastUpdated date in modelPricing.json
-            DIFF_OUTPUT=$(git diff src/modelPricing.json)
+            DIFF_OUTPUT=$(git diff vscode-extension/src/modelPricing.json)
             
             # Count the number of changed lines (lines starting with +/- but not +++ or ---)
             CHANGED_LINES=$(echo "$DIFF_OUTPUT" | grep -cE '^[+-][^+-]' || true)
@@ -122,7 +122,7 @@ jobs:
               # Check if all changed lines contain "lastUpdated"
               if ! echo "$DIFF_OUTPUT" | grep -E '^[+-][^+-]' | grep -qv '"lastUpdated"'; then
                 # Verify no changes to tokenEstimators.json
-                if git diff --quiet src/tokenEstimators.json; then
+                if git diff --quiet vscode-extension/src/tokenEstimators.json; then
                   echo "Only lastUpdated date changed - skipping PR creation"
                   echo "changed=false" >> "$GITHUB_OUTPUT"
                   exit 0
@@ -140,13 +140,13 @@ jobs:
         with:
           branch: sync-copilot-models
           add-paths: |
-            src/tokenEstimators.json
-            src/modelPricing.json
+            vscode-extension/src/tokenEstimators.json
+            vscode-extension/src/modelPricing.json
           commit-message: |
             chore: sync model data with GitHub Copilot documentation
             
-            This commit automatically updates src/tokenEstimators.json and
-            src/modelPricing.json with new models found in the official
+            This commit automatically updates vscode-extension/src/tokenEstimators.json and
+            vscode-extension/src/modelPricing.json with new models found in the official
             GitHub Copilot documentation.
             
             Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models
@@ -156,8 +156,8 @@ jobs:
             found in the [GitHub Copilot documentation](https://docs.github.com/en/copilot/reference/ai-models/supported-models).
             
             **Updated Files:**
-            - `src/tokenEstimators.json` - Character-to-token ratio estimators
-            - `src/modelPricing.json` - Model pricing data
+            - `vscode-extension/src/tokenEstimators.json` - Character-to-token ratio estimators
+            - `vscode-extension/src/modelPricing.json` - Model pricing data
             
             **⚠️ Note:** New pricing entries are set to `0.00` by default and require manual verification.
             Please verify pricing data before merging.

--- a/.github/workflows/sync-toolnames.yml
+++ b/.github/workflows/sync-toolnames.yml
@@ -69,7 +69,6 @@ jobs:
     - name: Check Copilot CLI version
       env:
         GH_TOKEN: ${{ secrets.GH_PAT }}
-        COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         npx @github/copilot --version
         
@@ -78,7 +77,6 @@ jobs:
       working-directory: current-repo
       env:
         GH_TOKEN: ${{ secrets.GH_PAT }}
-        COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         # Read the prompt from the file
         PROMPT=$(cat .github/prompts/sync-toolnames.prompt.md)
@@ -87,7 +85,7 @@ jobs:
         UPSTREAM_PATH="${GITHUB_WORKSPACE}/vscode-copilot-chat"
         
         # Get the path to toolNames.json
-        TOOLNAMES_PATH="${GITHUB_WORKSPACE}/current-repo/src/toolNames.json"
+        TOOLNAMES_PATH="${GITHUB_WORKSPACE}/current-repo/vscode-extension/src/toolNames.json"
         
         # Create the full prompt with context - append context to the base prompt
         {
@@ -119,7 +117,7 @@ jobs:
         npx @github/copilot -p "$COPILOT_PROMPT_TEXT" --silent --allow-all --add-dir "${UPSTREAM_PATH}" --add-dir "${GITHUB_WORKSPACE}/current-repo" --no-ask-user  2>&1 || {
           EXIT_CODE=$?
           echo "Warning: gh copilot command exited with code $EXIT_CODE, but continuing to check output"
-          cat /tmp/copilot-output.txt
+          cat /tmp/copilot-output.txt 2>/dev/null || true
         }
         
     - name: Check for changes
@@ -141,7 +139,7 @@ jobs:
         path: current-repo
         branch: sync-toolnames
         add-paths: |
-          src/toolNames.json
+          vscode-extension/src/toolNames.json
         commit-message: |
           chore: sync toolNames.json with vscode-copilot-chat
           


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI workflow failures that have been broken since at least June 1.

### `check-models.yml` (Sync Copilot Models)

**Root cause:** All path references to `tokenEstimators.json` and `modelPricing.json` used `src/` (repo root) instead of the correct `vscode-extension/src/` location. The `git diff` step failed with `fatal: ambiguous argument 'src/tokenEstimators.json': unknown revision or path not in the working tree.`

**Fix:** Updated all path references to use `vscode-extension/src/`:
- `paths:` trigger filter
- `ESTIMATORS_PATH` / `PRICING_PATH` context variables
- `git diff` commands in the "Check for changes" step
- `add-paths` and commit/PR body in the "Create Pull Request" step

### `sync-toolnames.yml` (Sync Tool Names)

**Root cause 1:** `COPILOT_GITHUB_TOKEN` was set to `secrets.GH_PAT` (a classic `ghp_` PAT). The Copilot CLI explicitly rejects classic PATs with: _"Classic Personal Access Tokens (ghp_) are not supported by Copilot."_

**Fix:** Removed `COPILOT_GITHUB_TOKEN` from the "Check Copilot CLI version" and "Run Copilot CLI with prompt" steps. The Copilot CLI will now use `gh auth` (authenticated via `GH_TOKEN`) as recommended in the error message.

**Root cause 2:** When the Copilot CLI failed, the error handler ran `cat /tmp/copilot-output.txt` but that file didn't exist (the redirect to it was commented out), causing `bash -e` to fail the step with exit code 1.

**Fix:** Changed to `cat /tmp/copilot-output.txt 2>/dev/null || true` so the step remains resilient.

**Root cause 3:** `TOOLNAMES_PATH` and `add-paths` pointed to `src/toolNames.json` instead of the correct `vscode-extension/src/toolNames.json`.

**Fix:** Updated both references.

## Verification

The exact failure lines from the latest runs:
- check-models run [27098100061](https://github.com/rajbos/ai-engineering-fluency/actions/runs/27098100061): `fatal: ambiguous argument 'src/tokenEstimators.json'`
- sync-toolnames run [27098100092](https://github.com/rajbos/ai-engineering-fluency/actions/runs/27098100092): `Error: Classic Personal Access Tokens (ghp_) are not supported by Copilot.`