### PR TITLE
feat: Add Cursor editor session support

### DIFF
--- a/vscode-extension/src/adapters/adapterRegistry.ts
+++ b/vscode-extension/src/adapters/adapterRegistry.ts
@@ -24,6 +24,7 @@ import { MistralVibeDataAccess } from '../mistralvibe';
 import { GeminiCliDataAccess } from '../geminicli';
 import { AntigravityDataAccess } from '../antigravity';
 import { PiDataAccess } from '../pi';
+import { CursorDataAccess } from '../cursor';
 
 import { OpenCodeAdapter } from './openCodeAdapter';
 import { CrushAdapter } from './crushAdapter';
@@ -35,6 +36,7 @@ import { MistralVibeAdapter } from './mistralVibeAdapter';
 import { GeminiCliAdapter } from './geminiCliAdapter';
 import { AntigravityAdapter } from './antigravityAdapter';
 import { PiAdapter } from './piAdapter';
+import { CursorAdapter } from './cursorAdapter';
 import { CopilotChatAdapter } from './copilotChatAdapter';
 import { CopilotCliAdapter } from './copilotCliAdapter';
 import { JetBrainsAdapter } from './jetbrainsAdapter';
@@ -51,6 +53,7 @@ mistralVibe: MistralVibeDataAccess;
 geminiCli: GeminiCliDataAccess;
 antigravity: AntigravityDataAccess;
 pi: PiDataAccess;
+cursor: CursorDataAccess;
 /** Estimates token count from raw text for a given model. */
 estimateTokens: (text: string, model?: string) => number;
 /** Returns true when the tool name identifies an MCP server tool. */
@@ -87,6 +90,7 @@ mistralVibe: new MistralVibeDataAccess(),
 geminiCli: new GeminiCliDataAccess(),
 antigravity: new AntigravityDataAccess(),
 pi: new PiDataAccess(),
+cursor: new CursorDataAccess(extensionUri),
 };
 }
 
@@ -116,6 +120,7 @@ new MistralVibeAdapter(deps.mistralVibe),
 new AntigravityAdapter(deps.antigravity, deps.estimateTokens),
 new GeminiCliAdapter(deps.geminiCli),
 new PiAdapter(deps.pi),
+new CursorAdapter(deps.cursor),
 // Copilot Chat / CLI adapters: discovery-only. Their handles() returns
 // false so processSessionFile() falls through to the shared parser path
 // for VS Code Copilot Chat and CLI files. See issue #654.

--- a/vscode-extension/src/adapters/cursorAdapter.ts
+++ b/vscode-extension/src/adapters/cursorAdapter.ts
@@ -66,30 +66,56 @@ export class CursorAdapter implements IEcosystemAdapter, IDiscoverableEcosystem,
 		return [{ path: this.cursor.getCursorDbPath(), source: 'Cursor (state.vscdb)' }];
 	}
 
+	private collectAssistantText(
+		headers: Array<{ type?: number; bubbleId?: string }>,
+		startIndex: number,
+		bubbleMap: Map<string, import('../cursor').CursorBubble>
+	): string {
+		const texts: string[] = [];
+		let j = startIndex;
+		while (j < headers.length && headers[j].type !== 1) {
+			const bid = headers[j].bubbleId;
+			const ab = bid ? bubbleMap.get(bid) : undefined;
+			if (ab?.text) { texts.push(ab.text); }
+			j++;
+		}
+		return texts.join('\n\n');
+	}
+
 	async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
 		const data = await this.cursor.readComposerData(sessionFile);
 		if (!data?.fullConversationHeadersOnly) { return { turns: [] }; }
 
 		const headers = data.fullConversationHeadersOnly;
-		const userHeaders = headers.filter(h => h.type === 1);
-		const numTurns = userHeaders.length;
 		const contextTokens = typeof data.contextTokensUsed === 'number' ? data.contextTokensUsed : 0;
-		const perTurnInput = numTurns > 0 ? Math.round(contextTokens / numTurns) : 0;
+		const model = data.modelConfig?.modelName || null;
 
-		const turns: ChatTurn[] = userHeaders.map((h, idx) => ({
-			turnNumber: idx + 1,
-			timestamp: null,
-			mode: 'agent' as const,
-			userMessage: '',
-			assistantResponse: '',
-			model: data.modelConfig?.modelName || null,
-			toolCalls: [],
-			contextReferences: createEmptyContextRefs(),
-			mcpTools: [],
-			inputTokensEstimate: perTurnInput,
-			outputTokensEstimate: 0,
-			thinkingTokensEstimate: 0,
-		}));
+		const allBubbleIds = headers.map(h => h.bubbleId).filter((id): id is string => !!id);
+		const bubbleMap = await this.cursor.readBubbles(sessionFile, allBubbleIds);
+
+		const turns: ChatTurn[] = [];
+		let turnNumber = 0;
+		for (let i = 0; i < headers.length; i++) {
+			const h = headers[i];
+			if (h.type !== 1) { continue; }
+			turnNumber++;
+
+			const userBubble = h.bubbleId ? bubbleMap.get(h.bubbleId) : undefined;
+			turns.push({
+				turnNumber,
+				timestamp: userBubble?.createdAt ?? null,
+				mode: 'agent' as const,
+				userMessage: userBubble?.text ?? '',
+				assistantResponse: this.collectAssistantText(headers, i + 1, bubbleMap),
+				model,
+				toolCalls: [],
+				contextReferences: createEmptyContextRefs(),
+				mcpTools: [],
+				inputTokensEstimate: 0,
+				outputTokensEstimate: 0,
+				thinkingTokensEstimate: 0,
+			});
+		}
 
 		return { turns, actualTokens: contextTokens };
 	}

--- a/vscode-extension/src/adapters/cursorAdapter.ts
+++ b/vscode-extension/src/adapters/cursorAdapter.ts
@@ -1,0 +1,124 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ModelUsage, ChatTurn } from '../types';
+import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
+import { CursorDataAccess } from '../cursor';
+import { createEmptyContextRefs } from '../tokenEstimation';
+import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+
+export class CursorAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
+	readonly id = 'cursor';
+	readonly displayName = 'Cursor';
+
+	constructor(private readonly cursor: CursorDataAccess) {}
+
+	handles(sessionFile: string): boolean {
+		return this.cursor.isCursorSessionFile(sessionFile);
+	}
+
+	getBackingPath(sessionFile: string): string {
+		return this.cursor.getDbPathFromVirtual(sessionFile);
+	}
+
+	async stat(sessionFile: string): Promise<fs.Stats> {
+		return this.cursor.statSessionFile(sessionFile);
+	}
+
+	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+		const result = await this.cursor.getTokens(sessionFile);
+		return { ...result, actualTokens: result.tokens };
+	}
+
+	async countInteractions(sessionFile: string): Promise<number> {
+		return this.cursor.countInteractions(sessionFile);
+	}
+
+	async getModelUsage(sessionFile: string): Promise<ModelUsage> {
+		return this.cursor.getModelUsage(sessionFile);
+	}
+
+	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+		return this.cursor.getSessionMeta(sessionFile);
+	}
+
+	getEditorRoot(sessionFile: string): string {
+		return path.dirname(this.cursor.getDbPathFromVirtual(sessionFile));
+	}
+
+	async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
+		const candidatePaths = this.getCandidatePaths();
+		const dbPath = this.cursor.getCursorDbPath();
+		log(`📁 Checking Cursor DB path: ${dbPath}`);
+		let sessionFiles: string[] = [];
+		try {
+			await fs.promises.access(dbPath);
+			sessionFiles = await this.cursor.discoverSessions();
+			if (sessionFiles.length > 0) {
+				log(`📄 Found ${sessionFiles.length} Cursor session(s)`);
+			}
+		} catch {
+			log(`📁 Cursor DB not found: ${dbPath}`);
+		}
+		return { sessionFiles, candidatePaths };
+	}
+
+	getCandidatePaths(): CandidatePath[] {
+		return [{ path: this.cursor.getCursorDbPath(), source: 'Cursor (state.vscdb)' }];
+	}
+
+	async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
+		const data = await this.cursor.readComposerData(sessionFile);
+		if (!data?.fullConversationHeadersOnly) { return { turns: [] }; }
+
+		const headers = data.fullConversationHeadersOnly;
+		const userHeaders = headers.filter(h => h.type === 1);
+		const numTurns = userHeaders.length;
+		const contextTokens = typeof data.contextTokensUsed === 'number' ? data.contextTokensUsed : 0;
+		const perTurnInput = numTurns > 0 ? Math.round(contextTokens / numTurns) : 0;
+
+		const turns: ChatTurn[] = userHeaders.map((h, idx) => ({
+			turnNumber: idx + 1,
+			timestamp: null,
+			mode: 'agent' as const,
+			userMessage: '',
+			assistantResponse: '',
+			model: data.modelConfig?.modelName || null,
+			toolCalls: [],
+			contextReferences: createEmptyContextRefs(),
+			mcpTools: [],
+			inputTokensEstimate: perTurnInput,
+			outputTokensEstimate: 0,
+			thinkingTokensEstimate: 0,
+		}));
+
+		return { turns, actualTokens: contextTokens };
+	}
+
+	async getSyncData(sessionFile: string): Promise<{ tokens: number; interactions: number; modelUsage: ModelUsage; timestamp: number }> {
+		return this.cursor.getSessionData(sessionFile);
+	}
+
+	async analyzeUsage(sessionFile: string, ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {
+		const analysis = createEmptySessionUsageAnalysis();
+		const data = await this.cursor.readComposerData(sessionFile);
+		if (!data?.fullConversationHeadersOnly) { return analysis; }
+
+		const model = data.modelConfig?.modelName || 'unknown';
+		const headers = data.fullConversationHeadersOnly;
+		const userCount = headers.filter(h => h.type === 1).length;
+		const assistantCount = headers.filter(h => h.type === 2).length;
+
+		analysis.modeUsage.agent += userCount;
+
+		if (assistantCount > 0) {
+			analysis.modelSwitching.uniqueModels = [model];
+			analysis.modelSwitching.modelCount = 1;
+			analysis.modelSwitching.totalRequests = assistantCount;
+			analysis.modelSwitching.switchCount = 0;
+		}
+
+		const models = Array(assistantCount).fill(model) as string[];
+		applyModelTierClassification(ctx.modelPricing, [model], models, analysis);
+		return analysis;
+	}
+}

--- a/vscode-extension/src/cursor.ts
+++ b/vscode-extension/src/cursor.ts
@@ -29,7 +29,7 @@ import { normalizePathForComparison } from './utils/pathUtils';
 type SqlJsStatic = initSqlJs.SqlJsStatic;
 type SqlDatabase = initSqlJs.Database;
 
-type CursorDbCacheEntry = { db: SqlDatabase; mtimeMs: number; size: number };
+type CursorDbCacheEntry = { db: SqlDatabase; mtimeMs: number; size: number; walMtimeMs: number };
 
 interface CursorComposerData {
 	composerId: string;
@@ -142,6 +142,10 @@ export class CursorDataAccess {
 
 	// ── DB caching ────────────────────────────────────────────────────────────
 
+	private getWalMtimeMs(dbPath: string): number {
+		try { return fs.statSync(dbPath + '-wal').mtimeMs; } catch { return 0; }
+	}
+
 	private statDb(dbPath: string): fs.Stats | null {
 		try {
 			return fs.statSync(dbPath);
@@ -157,14 +161,48 @@ export class CursorDataAccess {
 
 	private isCachedDbCurrent(dbPath: string, stats: fs.Stats): boolean {
 		const entry = this._dbCache.get(dbPath);
-		return !!entry && entry.mtimeMs === stats.mtimeMs && entry.size === stats.size;
+		return !!entry && entry.mtimeMs === stats.mtimeMs && entry.size === stats.size
+			&& entry.walMtimeMs === this.getWalMtimeMs(dbPath);
+	}
+
+	/**
+	 * When an active WAL file is present, sql.js cannot see uncommitted WAL frames.
+	 * Copies the DB + WAL to a temp location, uses node:sqlite to checkpoint the WAL,
+	 * and returns the merged buffer for sql.js. Falls back to null if unavailable.
+	 */
+	private async tryReadDbWithWal(dbPath: string): Promise<Buffer | null> {
+		const walPath = dbPath + '-wal';
+		let walSize: number;
+		try { walSize = fs.statSync(walPath).size; } catch { return null; }
+		if (walSize === 0) { return null; }
+		try {
+			const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+			const tmpDir = os.tmpdir();
+			const tmpDb = path.join(tmpDir, `cursor-wal-${Date.now()}.db`);
+			const tmpWal = tmpDb + '-wal';
+			const tmpShm = tmpDb + '-shm';
+			const shmPath = dbPath + '-shm';
+			fs.copyFileSync(dbPath, tmpDb);
+			fs.copyFileSync(walPath, tmpWal);
+			if (fs.existsSync(shmPath)) { fs.copyFileSync(shmPath, tmpShm); }
+			const nativeDb = new DatabaseSync(tmpDb);
+			nativeDb.exec('PRAGMA wal_checkpoint(TRUNCATE);');
+			nativeDb.close();
+			const buffer = fs.readFileSync(tmpDb);
+			for (const f of [tmpDb, tmpWal, tmpShm]) { try { fs.unlinkSync(f); } catch { /* ignore */ } }
+			return buffer;
+		} catch {
+			return null;
+		}
 	}
 
 	private async refreshDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
+		const walMtimeMs = this.getWalMtimeMs(dbPath);
 		let db: SqlDatabase;
 		try {
 			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
+			const walBuffer = await this.tryReadDbWithWal(dbPath);
+			const buffer = walBuffer ?? fs.readFileSync(dbPath);
 			db = new SQL.Database(buffer);
 		} catch {
 			return this._dbCache.get(dbPath)?.db ?? null;
@@ -178,7 +216,7 @@ export class CursorDataAccess {
 
 		const existing = this._dbCache.get(dbPath);
 		if (existing) { try { existing.db.close(); } catch { /* ignore */ } }
-		this._dbCache.set(dbPath, { db, mtimeMs: stats.mtimeMs, size: stats.size });
+		this._dbCache.set(dbPath, { db, mtimeMs: stats.mtimeMs, size: stats.size, walMtimeMs });
 		return db;
 	}
 
@@ -188,7 +226,7 @@ export class CursorDataAccess {
 		if (this.isCachedDbCurrent(dbPath, stats)) {
 			return this._dbCache.get(dbPath)!.db;
 		}
-		const cacheKey = `${dbPath}:${stats.mtimeMs}:${stats.size}`;
+		const cacheKey = `${dbPath}:${stats.mtimeMs}:${stats.size}:wal${this.getWalMtimeMs(dbPath)}`;
 		const inflight = this._dbCacheInflight.get(cacheKey);
 		if (inflight) { return inflight; }
 		const promise = this.refreshDb(dbPath, stats);

--- a/vscode-extension/src/cursor.ts
+++ b/vscode-extension/src/cursor.ts
@@ -1,0 +1,364 @@
+/**
+ * Cursor data access layer.
+ * Handles reading session data from Cursor's global SQLite database.
+ *
+ * Cursor stores all composer (chat) sessions in a single global SQLite database:
+ *   Windows: %APPDATA%\Cursor\User\globalStorage\state.vscdb
+ *   macOS:   ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
+ *   Linux:   ~/.config/Cursor/User/globalStorage/state.vscdb
+ *
+ * Sessions are stored as JSON blobs in the `cursorDiskKV` table, keyed by
+ * `composerData:<composerId>`. Each session blob contains metadata, model config,
+ * context token usage, and a header list of conversation turns.
+ *
+ * Virtual path scheme: `<dbPath>#<composerId>`
+ * Example: `C:\Users\...\globalStorage\state.vscdb#f1ff4e72-3ad1-449c-8027-6750ac80dbca`
+ *
+ * Token data available: `contextTokensUsed` (current prompt context size, input only).
+ * Per-turn output tokens are not stored by Cursor in the SQLite DB.
+ */
+/// <reference types="sql.js" />
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import initSqlJs from 'sql.js';
+import type { ModelUsage } from './types';
+import type { UriLike } from './opencode';
+import { normalizePath } from './utils/pathUtils';
+
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+type SqlDatabase = initSqlJs.Database;
+
+type CursorDbCacheEntry = { db: SqlDatabase; mtimeMs: number; size: number };
+
+interface CursorComposerData {
+	composerId: string;
+	name?: string;
+	modelConfig?: { modelName?: string };
+	contextTokensUsed?: number;
+	createdAt?: number;
+	lastUpdatedAt?: number;
+	status?: string;
+	trackedGitRepos?: Array<{ repoPath?: string }>;
+	originalFileStates?: { [uri: string]: unknown };
+	fullConversationHeadersOnly?: Array<{ type?: number; bubbleId?: string }>;
+}
+
+export class CursorDataAccess {
+	private _sqlJsModule: SqlJsStatic | null = null;
+	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
+	private _dbCache: Map<string, CursorDbCacheEntry> = new Map();
+	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
+	private readonly extensionUri: UriLike;
+
+	constructor(extensionUri: UriLike) {
+		this.extensionUri = extensionUri;
+	}
+
+	dispose(): void {
+		for (const entry of this._dbCache.values()) {
+			try { entry.db.close(); } catch { /* ignore */ }
+		}
+		this._dbCache.clear();
+		this._dbCacheInflight.clear();
+		this._sqlJsInitPromise = null;
+	}
+
+	// ── Path helpers ──────────────────────────────────────────────────────────
+
+	/**
+	 * Get the Cursor global storage directory (OS-aware).
+	 *   Windows: %APPDATA%\Cursor\User\globalStorage
+	 *   macOS:   ~/Library/Application Support/Cursor/User/globalStorage
+	 *   Linux:   ~/.config/Cursor/User/globalStorage
+	 */
+	getCursorGlobalStorageDir(): string {
+		const platform = os.platform();
+		if (platform === 'win32') {
+			const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+			return path.join(appData, 'Cursor', 'User', 'globalStorage');
+		}
+		if (platform === 'darwin') {
+			return path.join(os.homedir(), 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage');
+		}
+		const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+		return path.join(xdgConfig, 'Cursor', 'User', 'globalStorage');
+	}
+
+	/** Full path to Cursor's global state.vscdb SQLite file. */
+	getCursorDbPath(): string {
+		return path.join(this.getCursorGlobalStorageDir(), 'state.vscdb');
+	}
+
+	/**
+	 * Returns true when the given path is a Cursor virtual session path.
+	 * Virtual paths contain `state.vscdb#` with a UUID composer ID.
+	 */
+	isCursorSessionFile(filePath: string): boolean {
+		const normalized = normalizePath(filePath);
+		return normalized.includes('/cursor/user/globalstorage/state.vscdb#');
+	}
+
+	/**
+	 * Extract the absolute path to `state.vscdb` from a virtual session path.
+	 * e.g. `C:\...\globalStorage\state.vscdb#<uuid>` → `C:\...\globalStorage\state.vscdb`
+	 */
+	getDbPathFromVirtual(virtualPath: string): string {
+		const idx = virtualPath.indexOf('state.vscdb#');
+		if (idx === -1) { return virtualPath; }
+		return virtualPath.substring(0, idx + 'state.vscdb'.length);
+	}
+
+	/**
+	 * Extract the composer UUID from a virtual session path.
+	 */
+	getComposerIdFromVirtual(virtualPath: string): string | null {
+		const idx = virtualPath.indexOf('state.vscdb#');
+		if (idx === -1) { return null; }
+		return virtualPath.substring(idx + 'state.vscdb#'.length);
+	}
+
+	// ── sql.js init ───────────────────────────────────────────────────────────
+
+	async initSqlJs(): Promise<SqlJsStatic> {
+		if (this._sqlJsModule) { return this._sqlJsModule; }
+		if (!this._sqlJsInitPromise) {
+			this._sqlJsInitPromise = (async () => {
+				const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+				let wasmBinary: Uint8Array | undefined;
+				if (fs.existsSync(wasmPath)) {
+					wasmBinary = fs.readFileSync(wasmPath);
+				}
+				const module = await initSqlJs(wasmBinary ? { wasmBinary: wasmBinary.buffer as ArrayBuffer } : undefined);
+				this._sqlJsModule = module;
+				return module;
+			})().catch(err => {
+				this._sqlJsInitPromise = null;
+				throw err;
+			});
+		}
+		return this._sqlJsInitPromise;
+	}
+
+	// ── DB caching ────────────────────────────────────────────────────────────
+
+	private statDb(dbPath: string): fs.Stats | null {
+		try {
+			return fs.statSync(dbPath);
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException)?.code;
+			if ((code === 'ENOENT' || code === 'ENOTDIR') && this._dbCache.has(dbPath)) {
+				try { this._dbCache.get(dbPath)!.db.close(); } catch { /* ignore */ }
+				this._dbCache.delete(dbPath);
+			}
+			return null;
+		}
+	}
+
+	private isCachedDbCurrent(dbPath: string, stats: fs.Stats): boolean {
+		const entry = this._dbCache.get(dbPath);
+		return !!entry && entry.mtimeMs === stats.mtimeMs && entry.size === stats.size;
+	}
+
+	private async refreshDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
+		let db: SqlDatabase;
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = fs.readFileSync(dbPath);
+			db = new SQL.Database(buffer);
+		} catch {
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+
+		const currentStats = this.statDb(dbPath);
+		if (!currentStats || currentStats.mtimeMs !== stats.mtimeMs || currentStats.size !== stats.size) {
+			try { db.close(); } catch { /* ignore */ }
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+
+		const existing = this._dbCache.get(dbPath);
+		if (existing) { try { existing.db.close(); } catch { /* ignore */ } }
+		this._dbCache.set(dbPath, { db, mtimeMs: stats.mtimeMs, size: stats.size });
+		return db;
+	}
+
+	private async getDb(dbPath: string): Promise<SqlDatabase | null> {
+		const stats = this.statDb(dbPath);
+		if (!stats) { return this._dbCache.get(dbPath)?.db ?? null; }
+		if (this.isCachedDbCurrent(dbPath, stats)) {
+			return this._dbCache.get(dbPath)!.db;
+		}
+		const cacheKey = `${dbPath}:${stats.mtimeMs}:${stats.size}`;
+		const inflight = this._dbCacheInflight.get(cacheKey);
+		if (inflight) { return inflight; }
+		const promise = this.refreshDb(dbPath, stats);
+		this._dbCacheInflight.set(cacheKey, promise);
+		try {
+			return await promise;
+		} finally {
+			if (this._dbCacheInflight.get(cacheKey) === promise) {
+				this._dbCacheInflight.delete(cacheKey);
+			}
+		}
+	}
+
+	// ── Data access ───────────────────────────────────────────────────────────
+
+	/**
+	 * Read and parse the composer data blob for a session.
+	 */
+	async readComposerData(virtualPath: string): Promise<CursorComposerData | null> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const composerId = this.getComposerIdFromVirtual(virtualPath);
+		if (!composerId) { return null; }
+		const db = await this.getDb(dbPath);
+		if (!db) { return null; }
+		try {
+			const result = db.exec(
+				"SELECT value FROM cursorDiskKV WHERE key = ?",
+				[`composerData:${composerId}`]
+			);
+			if (result.length === 0 || result[0].values.length === 0) { return null; }
+			const raw = result[0].values[0][0] as string;
+			return JSON.parse(raw) as CursorComposerData;
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Discover all composer session IDs in the global state.vscdb.
+	 * Returns virtual paths in the form `<dbPath>#<composerId>`.
+	 */
+	async discoverSessions(): Promise<string[]> {
+		const dbPath = this.getCursorDbPath();
+		const db = await this.getDb(dbPath);
+		if (!db) { return []; }
+		try {
+			// Keys are `composerData:<uuid>` — exclude sub-keys like `composerData:<uuid>:<other>`
+			const result = db.exec(
+				"SELECT key FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND (length(key) - length(replace(key, ':', ''))) = 1"
+			);
+			if (result.length === 0) { return []; }
+			return result[0].values.map((row: unknown[]) => {
+				const composerId = (row[0] as string).replace('composerData:', '');
+				return `${dbPath}#${composerId}`;
+			});
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * Stat the underlying `state.vscdb` file for a virtual session path.
+	 */
+	async statSessionFile(virtualPath: string): Promise<fs.Stats> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		return fs.promises.stat(dbPath);
+	}
+
+	/**
+	 * Get token counts for a session.
+	 * Cursor only stores `contextTokensUsed` (current prompt context size, input tokens).
+	 * Output tokens are not tracked in the SQLite DB.
+	 */
+	async getTokens(virtualPath: string): Promise<{ tokens: number; thinkingTokens: number }> {
+		const data = await this.readComposerData(virtualPath);
+		if (!data) { return { tokens: 0, thinkingTokens: 0 }; }
+		const contextTokens = typeof data.contextTokensUsed === 'number' ? data.contextTokensUsed : 0;
+		return { tokens: contextTokens, thinkingTokens: 0 };
+	}
+
+	/**
+	 * Count user interactions (type === 1 entries in fullConversationHeadersOnly).
+	 */
+	async countInteractions(virtualPath: string): Promise<number> {
+		const data = await this.readComposerData(virtualPath);
+		if (!data?.fullConversationHeadersOnly) { return 0; }
+		return data.fullConversationHeadersOnly.filter(h => h.type === 1).length;
+	}
+
+	/**
+	 * Build per-model token usage for a session.
+	 * Cursor only has context window (input) tokens; output tokens are unavailable.
+	 * All tokens are attributed to the session's configured model.
+	 */
+	async getModelUsage(virtualPath: string): Promise<ModelUsage> {
+		const data = await this.readComposerData(virtualPath);
+		if (!data) { return {}; }
+		const contextTokens = typeof data.contextTokensUsed === 'number' ? data.contextTokensUsed : 0;
+		if (contextTokens === 0) { return {}; }
+		const model = data.modelConfig?.modelName || 'unknown';
+		return {
+			[model]: { inputTokens: contextTokens, outputTokens: 0 }
+		};
+	}
+
+	/**
+	 * Extract session metadata: title, timestamps, workspace path.
+	 * Timestamps are already in milliseconds in Cursor's storage.
+	 */
+	async getSessionMeta(virtualPath: string): Promise<{
+		title: string | undefined;
+		firstInteraction: string | null;
+		lastInteraction: string | null;
+		workspacePath: string | undefined;
+	}> {
+		const data = await this.readComposerData(virtualPath);
+		if (!data) {
+			return { title: undefined, firstInteraction: null, lastInteraction: null, workspacePath: undefined };
+		}
+		const title = data.name && data.name.trim() ? data.name.trim() : undefined;
+		const createdAt = typeof data.createdAt === 'number' ? data.createdAt : null;
+		const lastUpdatedAt = typeof data.lastUpdatedAt === 'number' ? data.lastUpdatedAt : null;
+		const firstInteraction = createdAt ? new Date(createdAt).toISOString() : null;
+		const lastInteraction = lastUpdatedAt ? new Date(lastUpdatedAt) : createdAt ? new Date(createdAt) : null;
+		const workspacePath = this.extractWorkspacePath(data);
+		return {
+			title,
+			firstInteraction,
+			lastInteraction: lastInteraction ? lastInteraction.toISOString() : null,
+			workspacePath,
+		};
+	}
+
+	private extractWorkspacePath(data: CursorComposerData): string | undefined {
+		if (data.trackedGitRepos && data.trackedGitRepos.length > 0) {
+			return data.trackedGitRepos[0].repoPath;
+		}
+		return this.extractWorkspaceFromFileStates(data.originalFileStates);
+	}
+
+	private extractWorkspaceFromFileStates(fileStates: { [uri: string]: unknown } | undefined): string | undefined {
+		if (!fileStates) { return undefined; }
+		const uris = Object.keys(fileStates);
+		if (uris.length === 0) { return undefined; }
+		// URI format: file:///c%3A/Users/.../repo/file.ts → c:\Users\...\repo
+		try {
+			return decodeURIComponent(uris[0].replace('file:///', '').replace('file://', ''))
+				.replace(/^\/([A-Za-z]):/, '$1:')  // Windows: /c:/... → c:/...
+				.split(/[/\\]/).slice(0, -1).join(path.sep);
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Returns a unified session data object for backend sync.
+	 */
+	async getSessionData(virtualPath: string): Promise<{
+		tokens: number;
+		interactions: number;
+		modelUsage: ModelUsage;
+		timestamp: number;
+	}> {
+		const [{ tokens }, interactions, modelUsage, meta] = await Promise.all([
+			this.getTokens(virtualPath),
+			this.countInteractions(virtualPath),
+			this.getModelUsage(virtualPath),
+			this.getSessionMeta(virtualPath),
+		]);
+		const timestamp = meta.firstInteraction ? new Date(meta.firstInteraction).getTime() : Date.now();
+		return { tokens, interactions, modelUsage, timestamp };
+	}
+}

--- a/vscode-extension/src/cursor.ts
+++ b/vscode-extension/src/cursor.ts
@@ -24,7 +24,7 @@ import * as os from 'os';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import type { UriLike } from './opencode';
-import { normalizePath } from './utils/pathUtils';
+import { normalizePathForComparison } from './utils/pathUtils';
 
 type SqlJsStatic = initSqlJs.SqlJsStatic;
 type SqlDatabase = initSqlJs.Database;
@@ -95,7 +95,7 @@ export class CursorDataAccess {
 	 * Virtual paths contain `state.vscdb#` with a UUID composer ID.
 	 */
 	isCursorSessionFile(filePath: string): boolean {
-		const normalized = normalizePath(filePath);
+		const normalized = normalizePathForComparison(filePath);
 		return normalized.includes('/cursor/user/globalstorage/state.vscdb#');
 	}
 

--- a/vscode-extension/src/cursor.ts
+++ b/vscode-extension/src/cursor.ts
@@ -44,6 +44,14 @@ interface CursorComposerData {
 	fullConversationHeadersOnly?: Array<{ type?: number; bubbleId?: string }>;
 }
 
+export interface CursorBubble {
+	bubbleId: string;
+	type: number; // 1 = user, 2 = assistant
+	text?: string;
+	createdAt?: string;
+	capabilityType?: number;
+}
+
 export class CursorDataAccess {
 	private _sqlJsModule: SqlJsStatic | null = null;
 	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
@@ -262,6 +270,39 @@ export class CursorDataAccess {
 		} catch {
 			return null;
 		}
+	}
+
+	/**
+	 * Read bubble data for a set of bubble IDs within a session.
+	 * Each bubble holds the actual message text (user or assistant).
+	 */
+	async readBubbles(virtualPath: string, bubbleIds: string[]): Promise<Map<string, CursorBubble>> {
+		if (bubbleIds.length === 0) { return new Map(); }
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const composerId = this.getComposerIdFromVirtual(virtualPath);
+		if (!composerId) { return new Map(); }
+		const db = await this.getDb(dbPath);
+		if (!db) { return new Map(); }
+		const map = new Map<string, CursorBubble>();
+		try {
+			const placeholders = bubbleIds.map(() => '?').join(',');
+			const keys = bubbleIds.map(id => `bubbleId:${composerId}:${id}`);
+			const result = db.exec(
+				`SELECT key, value FROM cursorDiskKV WHERE key IN (${placeholders})`,
+				keys
+			);
+			if (result.length === 0) { return map; }
+			for (const row of result[0].values) {
+				const key = row[0] as string;
+				const raw = row[1] as string;
+				const bubbleId = key.replace(`bubbleId:${composerId}:`, '');
+				try {
+					const bubble = JSON.parse(raw) as CursorBubble;
+					map.set(bubbleId, bubble);
+				} catch { /* ignore malformed entries */ }
+			}
+		} catch { /* ignore DB errors */ }
+		return map;
 	}
 
 	/**

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for editor display-name → emoji icon mappings.
+ *
+ * Imported by both the extension host (extension.ts) and the webview bundles
+ * (webview/shared/formatUtils.ts, webview/diagnostics/main.ts) so there is
+ * exactly one place to add or change an icon.
+ */
+
+export const EDITOR_ICON_MAP: Record<string, string> = {
+	'VS Code': '💙',
+	'VS Code Insiders': '💚',
+	'VS Code Exploration': '🧪',
+	'VS Code Server': '☁️',
+	'VS Code Server (Insiders)': '☁️',
+	'VSCodium': '🔷',
+	'Cursor': '🖱️',
+	'Copilot CLI': '🤖',
+	'OpenCode': '🟢',
+	'Visual Studio': '🪟',
+	'Claude Code': '🟠',
+	'Claude Desktop Cowork': '🟠',
+	'Mistral Vibe': '🔥',
+	'Gemini CLI': '💎',
+	'Antigravity': '🚀',
+	'JetBrains': '🧩',
+	'Crush': '🦾',
+	'Windsurf': '🏄',
+	'Continue': '▶️',
+	'Pi': 'π',
+	'Unknown': '❓',
+};
+
+/** Returns the emoji icon for a known editor display name. Falls back to '📝'. */
+export function getEditorIconByName(editor: string): string {
+	return EDITOR_ICON_MAP[editor] ?? '📝';
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4560,11 +4560,20 @@ class CopilotTokenTracker implements vscode.Disposable {
 	): SessionLogData {
 		const editorName = details.editorName || (eco && sessionFile ? getEcosystemDisplayName(eco, sessionFile) : details.editorSource);
 		const actualTokens = ecoActualTokens ?? sessionCache?.actualTokens ?? 0;
+		const editorNote = editorName === 'Cursor' ? {
+			items: [
+				'Token counts reflect the context window size at the last request (contextTokensUsed), not cumulative per-turn billing.',
+				'Output tokens are not stored locally — Cursor proxies all AI calls through its backend.',
+				'Per-turn input/output token breakdown is unavailable (shown as 0).',
+				'For accurate billing data, check the Cursor dashboard at cursor.com/settings.',
+			],
+		} : undefined;
 		return {
 			file: details.file, title: details.title || null, editorSource: details.editorSource,
 			editorName, size: details.size, modified: details.modified, interactions: details.interactions,
 			contextReferences: details.contextReferences, firstInteraction: details.firstInteraction,
 			lastInteraction: details.lastInteraction, turns, usageAnalysis, actualTokens,
+			...(editorNote ? { editorNote } : {}),
 			...(details.parentInfo ? { parentInfo: details.parentInfo } : {}),
 			...(details.childInfo ? { childInfo: details.childInfo, totalChildCount: details.totalChildCount } : {}),
 			...this.buildLogDataCacheFields(sessionCache, subAgentsStarted),

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -13,6 +13,7 @@ import customizationPatternsData from './customizationPatterns.json';
 import copilotPlansData from './copilotPlans.json';
 import * as packageJson from '../package.json';
 import { getToolFamilies, DEFAULT_TOOL_FAMILIES } from './toolFamilies';
+import { getEditorIconByName } from './editorIcons';
 
 // --- Core types ---
 import type {
@@ -2126,15 +2127,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	/** Maps known editor display names to emoji icons for the loader animation. */
 	private getEditorIconForLoader(editorName: string): string {
-		const map: Record<string, string> = {
-			'VS Code': '💙', 'VS Code Insiders': '💚', 'VS Code Exploration': '🧪',
-			'VS Code Server': '☁️', 'VS Code Server (Insiders)': '☁️', 'VSCodium': '🔷',
-			'Cursor': '🖱️', 'Copilot CLI': '🤖', 'OpenCode': '🟢', 'Visual Studio': '🪟',
-			'Claude Code': '🟠', 'Claude Desktop Cowork': '🟠', 'Mistral Vibe': '🔥',
-			'Gemini CLI': '💎', 'Antigravity': '🚀', 'JetBrains': '🧩',
-			'Crush': '🦾', 'Continue': '▶️', 'Pi': 'π',
-		};
-		return map[editorName] ?? '📝';
+		return getEditorIconByName(editorName);
 	}
 
 	private mergeIntoFullDailyStats(dailyStats: DailyTokenStats[]): void {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2129,7 +2129,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const map: Record<string, string> = {
 			'VS Code': '💙', 'VS Code Insiders': '💚', 'VS Code Exploration': '🧪',
 			'VS Code Server': '☁️', 'VS Code Server (Insiders)': '☁️', 'VSCodium': '🔷',
-			'Cursor': '⚡', 'Copilot CLI': '🤖', 'OpenCode': '🟢', 'Visual Studio': '🪟',
+			'Cursor': '🖱️', 'Copilot CLI': '🤖', 'OpenCode': '🟢', 'Visual Studio': '🪟',
 			'Claude Code': '🟠', 'Claude Desktop Cowork': '🟠', 'Mistral Vibe': '🔥',
 			'Gemini CLI': '💎', 'Antigravity': '🚀', 'JetBrains': '🧩',
 			'Crush': '🦾', 'Continue': '▶️', 'Pi': 'π',

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -585,6 +585,12 @@ export interface SessionLogData {
   truncationCount?: number;
   /** Total messages removed across all truncation events. Absent when truncationCount is 0. */
   messagesRemovedByTruncation?: number;
+  /**
+   * Optional editor-specific note injected by the adapter/backend.
+   * When present the log viewer renders an info panel at the top of the page
+   * listing the items as bullet points alongside the editor name and icon.
+   */
+  editorNote?: { items: string[] };
 }
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -435,11 +435,12 @@ function buildEditorRow(item: EditorItem, totals: { today: number; last30Days: n
 	const tr = document.createElement('tr');
 	if (editor === 'JetBrains') { tr.title = 'JetBrains: only user messages + assistant text are persisted, so token counts here are estimates of those alone. Actual API counts and thinking tokens are not available.'; }
 	if (editor === 'Antigravity') { tr.title = 'Antigravity: token counts are estimated from transcript content. Actual API counts are not stored locally.'; }
+	if (editor === 'Cursor') { tr.title = 'Cursor: token counts reflect the context window size at the last request (contextTokensUsed). Output tokens are not stored locally.'; }
 	const labelTd = document.createElement('td');
 	const labelWrapper = document.createElement('span');
 	labelWrapper.className = 'metric-label';
 	labelWrapper.textContent = `${getEditorIcon(editor)} ${editor}`;
-	if (editor === 'JetBrains' || editor === 'Antigravity') { labelWrapper.textContent = `${labelWrapper.textContent} ⓘ`; }
+	if (editor === 'JetBrains' || editor === 'Antigravity' || editor === 'Cursor') { labelWrapper.textContent = `${labelWrapper.textContent} ⓘ`; }
 	labelTd.append(labelWrapper);
 	tr.append(labelTd,
 		buildValueCell(formatCompact(todayUsage.tokens), `${formatPercent(todayPct)} · ${todayUsage.sessions} sessions`),

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -749,7 +749,7 @@ const toolsList = document.createElement('ul');
 toolsList.className = 'empty-state-steps';
 const toolsTexts = [
 '�� VS Code / VS Code Insiders / VSCodium — GitHub Copilot Chat extension',
-'⚡ Cursor, 🌊 Windsurf — built-in AI chat',
+'🖱️ Cursor, 🌊 Windsurf — built-in AI chat',
 '🖥️ Visual Studio 2022+ — GitHub Copilot Chat extension',
 '🟢 OpenCode, 🦀 Crush — terminal-based coding agents',
 '🤖 Claude Code — Anthropic\'s CLI coding agent',

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -374,6 +374,9 @@ function getEditorBadgeClass(editor: string): string {
   if (lower.includes("crush")) {
     return "editor-badge editor-badge-crush";
   }
+  if (lower.includes("cursor")) {
+    return "editor-badge editor-badge-cursor";
+  }
   // Exact match required: 'copilot' contains the substring 'pi' and would false-positive.
   if (lower === 'pi') {
     return "editor-badge editor-badge-pi";

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1,7 +1,7 @@
 // Diagnostics Report webview with tabbed interface
 import { buttonHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
-import { escapeHtml, formatFileSize, getTimeSince } from "../shared/formatUtils";
+import { escapeHtml, formatFileSize, getTimeSince, getEditorIcon } from "../shared/formatUtils";
 import { createViewStateManager } from "../shared/viewState";
 // CSS imported as text via esbuild
 import themeStyles from "../shared/theme.css";
@@ -384,20 +384,6 @@ function getEditorBadgeClass(editor: string): string {
   return "editor-badge";
 }
 
-function getEditorIcon(editor: string): string {
-  const lower = editor.toLowerCase();
-  const ICONS: [string, string][] = [
-    ['jetbrains', '🟣'], ['rider', '🟣'], ['intellij', '🟣'],
-    ['visual studio', '🪟'], ['mistral', '🔥'], ['antigravity', '🚀'],
-    ['gemini', '💎'], ['crush', '🩷'], ['opencode', '🟢'],
-    ['cursor', '🖱️'], ['insiders', '💚'], ['vscodium', '🔵'],
-    ['windsurf', '🏄'], ['copilot', '🤖'], ['vs code', '💙'], ['vscode', '💙'],
-    ['pi', 'π'],
-  ];
-  // 'copilot' contains the substring 'pi', so use exact match for Pi.
-  if (lower === 'pi') { return 'π'; }
-  return ICONS.find(([key]) => lower.includes(key))?.[1] ?? '📝';
-}
 
 function getSortValue(file: SessionFileDetails, column: typeof currentSortColumn): number {
   switch (column) {

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -496,6 +496,13 @@ color: #58a6ff;
 border: 1px solid #1f6feb;
 }
 
+/* Cursor: dark theme matching Cursor's brand (charcoal + bright white) */
+.editor-badge-cursor {
+	background: #1a1a2e;
+	color: #ffffff;
+	border: 1px solid #4a4a8a;
+}
+
 .session-folders-table {
 	margin-top: 16px;
 	margin-bottom: 16px;

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,6 +1,6 @@
 // Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
-import { escapeHtml, formatCompact, formatFileSize, setCompactNumbers } from '../shared/formatUtils';
+import { escapeHtml, formatCompact, formatFileSize, setCompactNumbers, getEditorIcon } from '../shared/formatUtils';
 import { getModelDisplayName } from '../shared/modelUtils';
 import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
@@ -94,6 +94,8 @@ modelTurns?: number;
 truncationCount?: number;
 /** Total messages removed across all truncation events. */
 messagesRemovedByTruncation?: number;
+/** Optional editor-specific note. When present, an info panel is rendered at the top of the viewer. */
+editorNote?: { items: string[] };
 compactNumbers?: boolean;
 };
 
@@ -694,12 +696,16 @@ function buildEditorModeCard(data: SessionLogData, stats: SummaryStats): string 
 function buildEstimatedTokensCard(data: SessionLogData, stats: SummaryStats): string {
 	const isJetBrains = data.editorName === 'JetBrains';
 	const isAntigravity = data.editorName === 'Antigravity';
+	const isCursor = data.editorName === 'Cursor';
 	const titleAttr = isJetBrains
 		? ` title="JetBrains: only user messages + assistant text are persisted in the session log, so this is an estimate of those alone. Actual API token counts and thinking tokens are not available."`
-		: isAntigravity ? ` title="Antigravity: token counts are estimated from transcript content. Actual API counts are not stored locally."` : '';
-	const suffix = (isJetBrains || isAntigravity) ? ' ⓘ' : '';
+		: isAntigravity ? ` title="Antigravity: token counts are estimated from transcript content. Actual API counts are not stored locally."`
+		: isCursor ? ` title="Cursor: shows the context window size at the last request (contextTokensUsed). This is a snapshot, not cumulative per-turn billing. Output tokens are not stored locally."` : '';
+	const suffix = (isJetBrains || isAntigravity || isCursor) ? ' ⓘ' : '';
 	const sub = isJetBrains ? 'User + assistant text only (no API counts, no thinking)'
-		: isAntigravity ? 'Estimated from transcript content' : 'Input + Output estimated from text';
+		: isAntigravity ? 'Estimated from transcript content'
+		: isCursor ? 'Context window at last request (snapshot, not cumulative)'
+		: 'Input + Output estimated from text';
 	return `<div class="summary-card"${titleAttr}>
 <div class="summary-label">📊 Estimated Tokens${suffix}</div>
 <div class="summary-value">${formatCompact(stats.totalTokens)}</div>
@@ -850,6 +856,25 @@ function buildFileNameCard(data: SessionLogData): string {
 <div class="summary-label">📁 File Name</div>
 <div class="summary-value" style="font-size: 16px;">${valueHtml}</div>
 <div class="summary-sub">${sub}</div>
+</div>`;
+}
+
+/**
+ * Renders the optional editor info panel at the very top of the log viewer.
+ * Only shown when `data.editorNote` is present (injected by the adapter/backend
+ * to communicate data-availability limitations or editor-specific notes).
+ */
+function renderEditorInfoPanel(data: SessionLogData): string {
+	if (!data.editorNote?.items?.length) { return ''; }
+	const icon = getEditorIcon(data.editorName);
+	const items = data.editorNote.items.map(i => `<li>${escapeHtml(i)}</li>`).join('');
+	return `<div class="editor-info-panel">
+<div class="editor-info-header">
+<span class="editor-info-icon">${icon}</span>
+<span class="editor-info-name">${escapeHtml(data.editorName)}</span>
+<span class="editor-info-badge">ℹ️ Data Availability</span>
+</div>
+<ul class="editor-info-list">${items}</ul>
 </div>`;
 }
 
@@ -1087,7 +1112,14 @@ wireUpToolCallHandlers();
 
 // ── Entry-point renderers (signatures preserved) ─────────────────────────────
 
-function renderTurnCard(turn: ChatTurn, isJetBrains = false, isAntigravity = false): string {
+function getTurnTokenAttrs(isJetBrains: boolean, isAntigravity: boolean, isCursor: boolean): { tooltip: string; suffix: string } {
+if (isJetBrains) { return { tooltip: ` title="JetBrains: estimated from user message + assistant text only. Actual API counts and thinking tokens are not available."`, suffix: ' ⓘ' }; }
+if (isAntigravity) { return { tooltip: ` title="Antigravity: estimated from transcript content. Actual API counts are not stored locally."`, suffix: ' ⓘ' }; }
+if (isCursor) { return { tooltip: ` title="Cursor: per-turn token counts are not stored locally. Output tokens are unavailable and input tokens require the full context window."`, suffix: ' ⓘ' }; }
+return { tooltip: '', suffix: '' };
+}
+
+function renderTurnCard(turn: ChatTurn, isJetBrains = false, isAntigravity = false, isCursor = false): string {
 const totalTokens    = turn.inputTokensEstimate + turn.outputTokensEstimate + turn.thinkingTokensEstimate;
 const hasThinking    = turn.thinkingTokensEstimate > 0;
 const hasActualUsage = !!turn.actualUsage;
@@ -1109,6 +1141,8 @@ ${turn.mcpTools.map(mcp => `
 </div>
 ` : '';
 
+const { tooltip: tokenTooltip, suffix: tokenSuffix } = getTurnTokenAttrs(isJetBrains, isAntigravity, isCursor);
+
 return `
 <div class="turn-card" data-turn="${turn.turnNumber}">
 <div class="turn-header">
@@ -1117,7 +1151,7 @@ return `
 <span class="turn-mode" style="background: ${getModeColor(turn.mode)};">${getModeIcon(turn.mode)} ${turn.mode}</span>
 ${turn.model ? renderTurnModelBadge(turn.model) : ''}
 ${turn.thinkingEffort ? `<span class="turn-effort">💡 ${escapeHtml(getEffortDisplayName(turn.thinkingEffort))}</span>` : ''}
-${totalTokens > 0 ? `<span class="turn-tokens"${isJetBrains ? ` title="JetBrains: estimated from user message + assistant text only. Actual API counts and thinking tokens are not available."` : isAntigravity ? ` title="Antigravity: estimated from transcript content. Actual API counts are not stored locally."` : ''}>📊 ${formatCompact(totalTokens)} tokens (↑${turn.inputTokensEstimate} ↓${turn.outputTokensEstimate})${(isJetBrains || isAntigravity) ? ' ⓘ' : ''}</span>` : ''}
+${totalTokens > 0 ? `<span class="turn-tokens"${tokenTooltip}>📊 ${formatCompact(totalTokens)} tokens (↑${turn.inputTokensEstimate} ↓${turn.outputTokensEstimate})${tokenSuffix}</span>` : ''}
 ${hasThinking ? `<span class="turn-tokens" style="color: #a78bfa;">🧠 ${formatCompact(turn.thinkingTokensEstimate)} thinking</span>` : ''}
 ${hasActualUsage ? `<span class="turn-tokens" style="color: #22c55e;">✓ ${formatCompact(turn.actualUsage!.promptTokens + turn.actualUsage!.completionTokens)} actual</span>` : ''}
 ${contextHeaderHtml}
@@ -1299,6 +1333,8 @@ function renderLayout(data: SessionLogData): void {
 <style>${styles}</style>
 
 <div class="container">
+${renderEditorInfoPanel(data)}
+
 ${renderSummaryCards(data, summaryStats)}
 
 ${renderSessionActualUsage(
@@ -1315,7 +1351,7 @@ ${renderSessionActualUsage(
 
 <div class="turns-list">
 ${data.turns.length > 0 
-? data.turns.map(turn => renderTurnCard(turn, data.editorName === 'JetBrains', data.editorName === 'Antigravity')).join('')
+? data.turns.map(turn => renderTurnCard(turn, data.editorName === 'JetBrains', data.editorName === 'Antigravity', data.editorName === 'Cursor')).join('')
 : '<div class="empty-state">No chat turns found in this session.</div>'
 }
 </div>

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -18,6 +18,69 @@ body {
 	margin: 0 auto;
 }
 
+/* ── Editor info panel ────────────────────────────────────────────────────── */
+.editor-info-panel {
+	background: color-mix(in srgb, var(--vscode-editorInfo-foreground, #3794ff) 8%, var(--bg-secondary));
+	border: 1px solid color-mix(in srgb, var(--vscode-editorInfo-foreground, #3794ff) 40%, transparent);
+	border-left: 4px solid var(--vscode-editorInfo-foreground, #3794ff);
+	border-radius: 8px;
+	padding: 14px 18px;
+	margin-bottom: 20px;
+}
+
+.editor-info-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 10px;
+	font-weight: 600;
+	font-size: 14px;
+}
+
+.editor-info-icon {
+	font-size: 18px;
+}
+
+.editor-info-name {
+	color: var(--text-primary);
+}
+
+.editor-info-badge {
+	margin-left: auto;
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--vscode-editorInfo-foreground, #3794ff);
+	background: color-mix(in srgb, var(--vscode-editorInfo-foreground, #3794ff) 15%, transparent);
+	border: 1px solid color-mix(in srgb, var(--vscode-editorInfo-foreground, #3794ff) 30%, transparent);
+	border-radius: 4px;
+	padding: 2px 8px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.editor-info-list {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.editor-info-list li {
+	font-size: 13px;
+	color: var(--text-secondary);
+	padding-left: 1em;
+	position: relative;
+}
+
+.editor-info-list li::before {
+	content: '⚠';
+	position: absolute;
+	left: 0;
+	color: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 80%, transparent);
+	font-size: 10px;
+	top: 3px;
+}
+
 /* Mode/model bar improvements */
 .mode-bar-group {
 	background: var(--bg-secondary);

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import tokenEstimatorsJson from '../../tokenEstimators.json';
 import type { TokenEstimator } from '../../types';
+import { EDITOR_ICON_MAP as _EDITOR_ICON_MAP, getEditorIconByName } from '../../editorIcons';
 
 const tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsJson.estimators;
 let currentLocale: string | undefined;
@@ -23,63 +24,21 @@ export function setCompactNumbers(enabled: boolean): void {
 }
 
 /** Union of all known editor display names that have explicit icon mappings. */
-export type EditorName =
-	| 'VS Code'
-	| 'VS Code Insiders'
-	| 'VS Code Exploration'
-	| 'VS Code Server'
-	| 'VS Code Server (Insiders)'
-	| 'VSCodium'
-	| 'Cursor'
-	| 'Copilot CLI'
-	| 'OpenCode'
-	| 'Visual Studio'
-	| 'Claude Code'
-	| 'Claude Desktop Cowork'
-	| 'Mistral Vibe'
-	| 'Gemini CLI'
-	| 'Antigravity'
-	| 'JetBrains'
-	| 'Crush'
-	| 'Continue'
-	| 'Pi'
-	| 'Unknown';
+export type EditorName = keyof typeof _EDITOR_ICON_MAP;
 
 /**
- * Maps known editor display names to their representative emoji icons.
- *
- * Icon format: a single Unicode emoji character (e.g. '💙', '⚡').
- * Editors not present in this map fall back to '📝' in {@link getEditorIcon}.
+ * Re-export canonical map for callers that need the full record.
+ * The authoritative source is `src/editorIcons.ts`.
  */
-export const EDITOR_ICON_MAP: Record<EditorName, string> = {
-	'VS Code': '💙',
-	'VS Code Insiders': '💚',
-	'VS Code Exploration': '🧪',
-	'VS Code Server': '☁️',
-	'VS Code Server (Insiders)': '☁️',
-	'VSCodium': '🔷',
-	'Cursor': '🖱️',
-	'Copilot CLI': '🤖',
-	'OpenCode': '🟢',
-	'Visual Studio': '🪟',
-	'Claude Code': '🟠',
-	'Claude Desktop Cowork': '🟠',
-	'Mistral Vibe': '🔥',
-	'Gemini CLI': '💎',
-	'Antigravity': '🚀',
-	'JetBrains': '🧩',
-	'Crush': '🦾',
-	'Continue': '▶️',
-	'Pi': 'π',
-	'Unknown': '❓'
-};
+export const EDITOR_ICON_MAP: Record<string, string> = _EDITOR_ICON_MAP;
 
 /**
  * Returns an icon for a given editor name.
- * Falls back to '📝' for editors not present in {@link EDITOR_ICON_MAP}.
+ * Falls back to '📝' for editors not present in the map.
+ * Delegates to the canonical {@link getEditorIconByName} in `src/editorIcons.ts`.
  */
 export function getEditorIcon(editor: string): string {
-	return EDITOR_ICON_MAP[editor as EditorName] || '📝';
+	return getEditorIconByName(editor);
 }
 
 /**

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -58,7 +58,7 @@ export const EDITOR_ICON_MAP: Record<EditorName, string> = {
 	'VS Code Server': '☁️',
 	'VS Code Server (Insiders)': '☁️',
 	'VSCodium': '🔷',
-	'Cursor': '⚡',
+	'Cursor': '🖱️',
 	'Copilot CLI': '🤖',
 	'OpenCode': '🟢',
 	'Visual Studio': '🪟',

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -888,6 +888,8 @@ function detectToolEditorFromPath(
 	if (lowerPath.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
 	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
+	// Cursor virtual paths must be checked before the generic /cursor/ match in detectVSCodeVariantFromPath.
+	if (lowerPath.includes('/cursor/user/globalstorage/state.vscdb#')) { return 'Cursor'; }
 	if (lowerPath.includes('/.pi/agent/sessions/')) { return 'Pi'; }
 	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }
 	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -46,7 +46,7 @@ test('getModelDisplayName: returns raw ID when URI decoding fails (malformed per
 
 test('getEditorIcon: returns correct icons for known editors', () => {
 	assert.equal(getEditorIcon('VS Code'), '💙');
-	assert.equal(getEditorIcon('Cursor'), '⚡');
+	assert.equal(getEditorIcon('Cursor'), '🖱️');
 	assert.equal(getEditorIcon('OpenCode'), '🟢');
 	assert.equal(getEditorIcon('Gemini CLI'), '💎');
 	assert.equal(getEditorIcon('Unknown'), '❓');


### PR DESCRIPTION
## Summary

Integrates Cursor's global SQLite database (`state.vscdb`) as a new editor source so Cursor composer sessions appear in the session list, log viewer, charts, usage analysis, and diagnostics panels.

## Changes

| File | Change |
|---|---|
| `src/cursor.ts` | New `CursorDataAccess` class — reads sessions from the single global SQLite DB |
| `src/adapters/cursorAdapter.ts` | New `CursorAdapter` — discovery, token, turn, usage analysis |
| `src/adapters/adapterRegistry.ts` | Register `CursorAdapter` in the shared registry |
| `src/workspaceHelpers.ts` | Add specific path check for Cursor virtual paths before generic `/cursor/` match |
| `src/webview/diagnostics/main.ts` | Add Cursor badge class |
| `src/webview/diagnostics/styles.css` | Add `.editor-badge-cursor` brand colours |

## Data source

- **DB**: `%APPDATA%\Cursor\User\globalStorage\state.vscdb` (Windows) — single global file for all workspaces
- **Virtual path**: `<state.vscdb>#<composerId>` (same `db#id` pattern as Crush/OpenCode)
- **Session data**: JSON blobs in the `cursorDiskKV` table, key = `composerData:<uuid>`

## Available data

| Field | Available |
|---|---|
| Session title | ✅ (`name` field — often blank for short sessions) |
| Timestamps | ✅ already in milliseconds |
| Model | ✅ `modelConfig.modelName` |
| User turn count | ✅ type=1 entries in `fullConversationHeadersOnly` |
| Context tokens (input) | ✅ `contextTokensUsed` |
| Output tokens | ❌ not stored in SQLite by Cursor |
| Workspace path | ✅ from `trackedGitRepos[0].repoPath` or inferred from `originalFileStates` |