### PR TITLE
fix: insights dismissal drops extra items and toolbar count not updating

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5398,7 +5398,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				}
 				break;
 			case 'insightAction':
-					await this.dispatch('insightAction', () => this.handleInsightAction(message));
+					await this.dispatch(`insightAction:${message.id ?? ''}`, () => this.handleInsightAction(message));
 					break;
 		}
 	}
@@ -5434,14 +5434,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		await this.context.globalState.update('insights.state', this._insightStateBag);
 		// Push refreshed state back to the webview
 		if (this.analysisPanel && this.lastUsageAnalysisStats) {
-			const cadenceDays = vscode.workspace.getConfiguration('aiEngineeringFluency').get<number>('insights.cadenceDays', 2);
-			const ctx = {
-				today: this.lastUsageAnalysisStats.today,
-				last30Days: this.lastUsageAnalysisStats.last30Days,
-				missedPotential: this.lastUsageAnalysisStats.missedPotential ?? [],
-				customizationMatrix: this.lastUsageAnalysisStats.customizationMatrix,
-			};
-			const evaluated = _evaluateInsights(ctx, this._insightStateBag, cadenceDays, this._lastInsightNudgeAt);
+			const evaluated = this.buildCurrentInsights(this.lastUsageAnalysisStats);
 			void this.analysisPanel.webview.postMessage({ command: 'updateInsights', insights: evaluated });
 		}
 	}


### PR DESCRIPTION
## Bug fixes

Two bugs in `handleInsightAction` that caused the Insights panel to misbehave when dismissing/completing an insight.

### Bug 1 — Extra insights disappear on dismiss/done/snooze

`handleInsightAction` was re-evaluating insights with a hand-rolled context object that was missing `todaySessions`. Any insight whose `appliesTo` checks `ctx.todaySessions` (e.g. marathon-session, focus-time, truncation insights) would see `undefined` instead of real data, fail their check, and be silently dropped from the result list sent back to the webview.

**Effect:** Clicking "Done" on one insight could make 1–3 _other_ unrelated insights disappear at the same time. If a stats refresh happened shortly after, those insights would flash back briefly then disappear again.

**Fix:** Use `buildCurrentInsights(this.lastUsageAnalysisStats)` — the same helper already used everywhere else — which correctly includes `todaySessions` in the context.

### Bug 2 — Concurrent insight actions silently dropped / toolbar badge not updating

All insight actions (dismiss, done, snooze, seen) were dispatched with the same key `'insightAction'`. The `dispatch()` helper gates concurrent execution per-key, so when the "seen" batch fires on tab-switch (one message per new insight), only the _first_ gets through — the rest are silently dropped because the first is still in-flight.

**Effect:** The toolbar badge never fully decremented to 0 after visiting the Insights tab. A subsequent dismiss/done action could also be silently dropped if a "seen" was still processing.

**Fix:** Use a per-insight key `'insightAction:<id>'` so each insight's actions are independently gated without blocking one another.