### PR TITLE
fix: include todaySessions in background updateStats message

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5451,6 +5451,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					missedPotential: analysisStats.missedPotential || [], lastUpdated: analysisStats.lastUpdated.toISOString(),
 					backendConfigured: this.isBackendConfigured(),
 					currentWorkspacePaths: vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [],
+					todaySessions: analysisStats.todaySessions || [],
 					insights: this.buildCurrentInsights(analysisStats),
 				},
 			});


### PR DESCRIPTION
## Root Cause

`loadAnalysisStatsInBackground` sends an `updateStats` message to the webview after the initial background data load, but was **missing `todaySessions`** in the payload.

When the webview's `sanitizeStats()` processes a message without `todaySessions`, the field is simply not set on the sanitized object (`undefined`). `renderLayout` then renders the sessions table as `stats.todaySessions || []` — an empty array — showing **"No sessions recorded today yet."**

This only affects the *background* refresh (the one that fires automatically after opening the panel). A manual refresh (`refreshAnalysisPanel`) rebuilds the entire HTML and correctly includes `todaySessions`, so the user would see sessions again after clicking Refresh.

## Fix

Add `todaySessions: analysisStats.todaySessions || []` to the `updateStats` data payload in `loadAnalysisStatsInBackground`, matching the fields already sent during initial page load in `getUsageAnalysisHtml`.