### PR TITLE
fix(pi): sum all assistant-message tokens per turn in buildTurns

### DIFF
--- a/vscode-extension/src/adapters/piAdapter.ts
+++ b/vscode-extension/src/adapters/piAdapter.ts
@@ -104,7 +104,10 @@ return result;
 private buildTurn(userEvent: any, assistantEvents: any[], turnNumber: number, perTurnInput: number, perTurnOutput: number): ChatTurn {
 const userText = this.extractUserText(userEvent.message?.content);
 const { assistantText, toolCalls, model } = this.processAssistantEvents(assistantEvents);
-const lastUsage = assistantEvents[assistantEvents.length - 1]?.message?.usage;
+// Sum all assistant events' usage — agentic sessions make many API calls per turn,
+// each with its own (growing) context window; taking only the last under-counts heavily.
+const totalInput = assistantEvents.reduce((sum, e) => sum + (e.message?.usage?.input ?? 0), 0);
+const totalOutput = assistantEvents.reduce((sum, e) => sum + (e.message?.usage?.output ?? 0), 0);
 return {
 turnNumber,
 timestamp: userEvent.timestamp ?? null,
@@ -115,8 +118,8 @@ model,
 toolCalls,
 contextReferences: createEmptyContextRefs(),
 mcpTools: [],
-inputTokensEstimate: lastUsage ? (lastUsage.input ?? 0) : perTurnInput,
-outputTokensEstimate: lastUsage ? (lastUsage.output ?? 0) : perTurnOutput,
+inputTokensEstimate: totalInput > 0 ? totalInput : perTurnInput,
+outputTokensEstimate: totalOutput > 0 ? totalOutput : perTurnOutput,
 thinkingTokensEstimate: 0,
 };
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -82,6 +82,7 @@ import { WindsurfDataAccess } from './windsurf';
 import { getEcosystemDisplayName } from './ecosystemAdapter';
 import { buildAdapterRegistry, createDataAccessInstances } from './adapters';
 import { CopilotAppDataAccess } from './copilotAppData';
+import { PiDataAccess } from './pi';
 import { getVSCodeUserPaths } from './adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from './adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from './jetbrains';
@@ -7800,6 +7801,7 @@ ${this.getLoadingHtmlScript()}
       } catch { /* Skip inaccessible files */ }
     }
     await this.enrichSessionHierarchy(detailedSessionFiles);
+    await this.enrichPiSessionHierarchy(detailedSessionFiles);
     await this.sendBgLoadResults(panel, detailedSessionFiles, initialCacheHits, initialCacheMisses);
   }
 
@@ -7862,6 +7864,69 @@ ${this.getLoadingHtmlScript()}
         }
       }
     } catch { /* hierarchy is optional — never surface errors */ }
+  }
+
+  /**
+   * Enrich Pi sessions in `files` with parent/child hierarchy data derived from
+   * the `parentSession` field in each session's JSONL header.
+   * All other session types are left untouched.
+   * Errors are suppressed — hierarchy is an optional enrichment.
+   */
+  private async enrichPiSessionHierarchy(files: SessionFileDetails[]): Promise<void> {
+    const pi = new PiDataAccess();
+    const piFiles = files.filter(f => pi.isPiSessionFile(f.file));
+    if (piFiles.length === 0) { return; }
+
+    // Normalise a path for platform-independent comparison.
+    const norm = (p: string) => _normalizePath(p);
+
+    // Build normalised-path → SessionFileDetails map.
+    const pathToDetails = new Map<string, SessionFileDetails>();
+    for (const details of piFiles) {
+      pathToDetails.set(norm(details.file), details);
+    }
+
+    // Read each session header in parallel to discover parent links.
+    const parentByChild = new Map<string, string>();     // normChildPath → normParentPath
+    const childrenByParent = new Map<string, string[]>(); // normParentPath → normChildPaths[]
+    await Promise.all(piFiles.map(async (details) => {
+      try {
+        const rawParent = await pi.getParentSessionPath(details.file);
+        if (!rawParent) { return; }
+        const normChild = norm(details.file);
+        const normParent = norm(rawParent);
+        parentByChild.set(normChild, normParent);
+        if (!childrenByParent.has(normParent)) { childrenByParent.set(normParent, []); }
+        childrenByParent.get(normParent)!.push(normChild);
+      } catch { /* skip unreadable sessions */ }
+    }));
+
+    // Apply parentInfo to child sessions.
+    for (const [normChild, normParent] of parentByChild) {
+      const childDetails = pathToDetails.get(normChild);
+      if (!childDetails) { continue; }
+      const parentDetails = pathToDetails.get(normParent);
+      childDetails.parentInfo = {
+        uuid: normParent,
+        name: parentDetails?.title ?? path.basename(path.dirname(normParent)),
+        sessionFile: parentDetails?.file,
+      } satisfies SessionRelationRef;
+    }
+
+    // Apply childInfo to parent sessions.
+    for (const [normParent, normChildren] of childrenByParent) {
+      const parentDetails = pathToDetails.get(normParent);
+      if (!parentDetails) { continue; }
+      parentDetails.childInfo = normChildren.map(nc => {
+        const childDetails = pathToDetails.get(nc);
+        return {
+          uuid: nc,
+          name: childDetails?.title ?? path.basename(path.dirname(nc)),
+          sessionFile: childDetails?.file,
+        } satisfies SessionRelationRef;
+      });
+      parentDetails.totalChildCount = normChildren.length;
+    }
   }
 
   private async sortSessionFilesByMtime(sessionFiles: string[]): Promise<string[]> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4570,7 +4570,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(editorNote ? { editorNote } : {}),
 			...(details.parentInfo ? { parentInfo: details.parentInfo } : {}),
 			...(details.childInfo ? { childInfo: details.childInfo, totalChildCount: details.totalChildCount } : {}),
-			...this.buildLogDataCacheFields(sessionCache, subAgentsStarted),
+			...this.buildLogDataCacheFields(sessionCache, subAgentsStarted ?? ((details.totalChildCount ?? 0) > 0 ? details.totalChildCount : undefined)),
 		};
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7886,12 +7886,16 @@ ${this.getLoadingHtmlScript()}
       pathToDetails.set(norm(details.file), details);
     }
 
-    // Read each session header in parallel to discover parent links.
+    // Discover parent links.
+    // Primary: path-based detection (pi nests child sessions under {parentId}/{hash}/run-N/session.jsonl).
+    // Fallback: header-based parentSession field (future pi versions may use this).
     const parentByChild = new Map<string, string>();     // normChildPath → normParentPath
     const childrenByParent = new Map<string, string[]>(); // normParentPath → normChildPaths[]
     await Promise.all(piFiles.map(async (details) => {
       try {
-        const rawParent = await pi.getParentSessionPath(details.file);
+        const rawParent =
+          pi.getParentSessionPathFromFilePath(details.file) ??
+          await pi.getParentSessionPath(details.file);
         if (!rawParent) { return; }
         const normChild = norm(details.file);
         const normParent = norm(rawParent);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4495,7 +4495,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 * Extract full session log data including chat turns for the log viewer.
 	 */
 	private async getSessionLogData(sessionFile: string): Promise<SessionLogData> {
-		const details = await this.getSessionFileDetails(sessionFile);
+		// Use pre-enriched details from the diagnostics cache when available — it carries
+		// hierarchy data (parentInfo, childInfo) populated by enrichSessionHierarchy /
+		// enrichPiSessionHierarchy during the background load.
+		const cached = this.diagnosticsCachedFiles.find(f => f.file === sessionFile);
+		const details = cached ?? await this.getSessionFileDetails(sessionFile);
 		let subAgentsStarted: number | undefined;
 		let turns: ChatTurn[] = [];
 

--- a/vscode-extension/src/pi.ts
+++ b/vscode-extension/src/pi.ts
@@ -59,7 +59,7 @@ try {
 const cwdDirs = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
 for (const cwdDir of cwdDirs) {
 if (!cwdDir.isDirectory()) { continue; }
-await this.collectSessionFilesInDir(path.join(sessionsDir, cwdDir.name), results);
+await this.collectSessionFilesInDir(path.join(sessionsDir, cwdDir.name), results, 4);
 }
 } catch {
 // Directory does not exist or is inaccessible
@@ -67,12 +67,15 @@ await this.collectSessionFilesInDir(path.join(sessionsDir, cwdDir.name), results
 return results;
 }
 
-private async collectSessionFilesInDir(dirPath: string, results: string[]): Promise<void> {
+private async collectSessionFilesInDir(dirPath: string, results: string[], maxDepth: number): Promise<void> {
+if (maxDepth <= 0) { return; }
 try {
 const files = await fs.promises.readdir(dirPath, { withFileTypes: true });
 for (const file of files) {
 if (file.isFile() && file.name.endsWith('.jsonl')) {
 results.push(path.join(dirPath, file.name));
+} else if (file.isDirectory()) {
+await this.collectSessionFilesInDir(path.join(dirPath, file.name), results, maxDepth - 1);
 }
 }
 } catch {
@@ -125,6 +128,25 @@ async getParentSessionPath(filePath: string): Promise<string | null> {
 const header = await this.readSession(filePath);
 const parent = header?.parentSession;
 return typeof parent === 'string' && parent.length > 0 ? parent : null;
+}
+
+/**
+ * Derives the parent session file path from the child session's file path.
+ *
+ * Pi child sessions follow this directory layout:
+ *   {sessionsDir}/{cwdDir}/{timestamp_parentId}/{childHash}/run-{N}/session.jsonl
+ *
+ * The parent's JSONL file is:
+ *   {sessionsDir}/{cwdDir}/{timestamp_parentId}.jsonl
+ *
+ * Returns null if the file does not match the child-session naming pattern.
+ */
+getParentSessionPathFromFilePath(filePath: string): string | null {
+// Child sessions are always named 'session.jsonl'; top-level sessions use timestamp names.
+if (path.basename(filePath) !== 'session.jsonl') { return null; }
+// Go up: run-N → childHash → timestamp_parentId → add .jsonl
+const derivedParent = path.dirname(path.dirname(path.dirname(filePath))) + '.jsonl';
+return this.isPiSessionFile(derivedParent) ? derivedParent : null;
 }
 
 /**

--- a/vscode-extension/src/pi.ts
+++ b/vscode-extension/src/pi.ts
@@ -117,6 +117,17 @@ return lines.find(l => l.type === 'session') ?? null;
 }
 
 /**
+ * Returns the file path of the parent session if this session was spawned
+ * by a parent pi session (i.e. it has a `parentSession` field in its header).
+ * Returns null for root sessions.
+ */
+async getParentSessionPath(filePath: string): Promise<string | null> {
+const header = await this.readSession(filePath);
+const parent = header?.parentSession;
+return typeof parent === 'string' && parent.length > 0 ? parent : null;
+}
+
+/**
  * Read all message events from a Pi session file.
  * Returns the array of events with type === 'message'.
  */

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -498,12 +498,12 @@ export interface SessionFileDetails {
   editorName?: string; // friendly editor name (e.g., 'VS Code')
   title?: string; // session title (customTitle from session file)
   repository?: string; // Git remote origin URL for the session's workspace
-  /** Parent session info (Copilot CLI sessions only, populated from ~/.copilot/data.db). */
+  /** Parent session info (Copilot CLI and pi sessions; populated from data.db / JSONL parentSession field). */
   parentInfo?: SessionRelationRef | null;
-  /** Direct child sessions (Copilot CLI sessions only, populated from ~/.copilot/data.db). */
+  /** Direct child sessions (Copilot CLI and pi sessions; populated from data.db / JSONL parentSession field). */
   childInfo?: SessionRelationRef[];
   /**
-   * Total child count from data.db — may exceed childInfo.length when some
+   * Total child count — may exceed childInfo.length when some
    * children fall outside the loaded 14-day diagnostic window.
    */
   totalChildCount?: number;
@@ -567,13 +567,13 @@ export interface SessionLogData {
   actualTokens?: number;
   /** Cache-read token count from session.shutdown modelMetrics (CLI sessions only). Absent when unavailable. */
   cachedTokens?: number;
-  /** Number of distinct subagent sessions started (CLI format only, from subagent.started events). */
+  /** Number of distinct subagent sessions started (CLI format: from subagent.started events; pi: from child session count). */
   subAgentsStarted?: number;
-  /** Parent session info (Copilot CLI sessions only, from data.db hierarchy). */
+  /** Parent session info (Copilot CLI and pi sessions; populated from data.db / JSONL parentSession field). */
   parentInfo?: SessionRelationRef | null;
-  /** Direct child sessions (Copilot CLI sessions only, from data.db hierarchy). */
+  /** Direct child sessions (Copilot CLI and pi sessions; populated from data.db / JSONL parentSession field). */
   childInfo?: SessionRelationRef[];
-  /** Total child count from data.db (may exceed childInfo.length). */
+  /** Total child count (may exceed childInfo.length when some children fall outside the loaded window). */
   totalChildCount?: number;
   /** Input token total from debug log (sum of all llm_request events). Present for VS Code Copilot Chat agent-mode sessions. */
   debugLogInputTokens?: number;

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -413,7 +413,33 @@ function compareSessionFiles(a: SessionFileDetails, b: SessionFileDetails): numb
 }
 
 function sortSessionFiles(files: SessionFileDetails[]): SessionFileDetails[] {
-  return [...files].sort(compareSessionFiles);
+  const sorted = [...files].sort(compareSessionFiles);
+
+  // After sorting, group each child session immediately after its parent.
+  // Children whose parent is not in the list stay in their sorted position.
+  const byFile = new Map<string, SessionFileDetails>();
+  for (const f of sorted) { byFile.set(f.file, f); }
+
+  const placed = new Set<string>();
+  const result: SessionFileDetails[] = [];
+
+  for (const f of sorted) {
+    if (placed.has(f.file)) { continue; } // already emitted as a child of an earlier parent
+    result.push(f);
+    placed.add(f.file);
+    // Emit any children of this session immediately after it
+    if (f.childInfo && f.childInfo.length > 0) {
+      for (const childRef of f.childInfo) {
+        if (!childRef.sessionFile) { continue; }
+        const childDetails = byFile.get(childRef.sessionFile);
+        if (childDetails && !placed.has(childDetails.file)) {
+          result.push(childDetails);
+          placed.add(childDetails.file);
+        }
+      }
+    }
+  }
+  return result;
 }
 
 function getSortIndicator(column: typeof currentSortColumn): string {
@@ -496,12 +522,12 @@ function buildHierarchyBadgesHtml(sf: SessionFileDetails): string {
     const linkAttr = sf.parentInfo.sessionFile
       ? ` href="#" class="session-hierarchy-badge hierarchy-parent session-file-link" data-file="${encodeURIComponent(sf.parentInfo.sessionFile)}"`
       : ` class="session-hierarchy-badge hierarchy-parent"`;
-    html += `<a${linkAttr} title="Parent session: ${escapeHtml(sf.parentInfo.name)}">↑ ${parentTitle}</a>`;
+    html += `<a${linkAttr} title="Parent session: ${escapeHtml(sf.parentInfo.name)}">↑ Parent: ${parentTitle}</a>`;
   }
   if (sf.totalChildCount && sf.totalChildCount > 0) {
     const count = sf.totalChildCount;
-    const label = count === 1 ? '1 child' : `${count} children`;
-    html += `<span class="session-hierarchy-badge hierarchy-children" title="${label}">↓ ${count}</span>`;
+    const label = count === 1 ? '1 child session' : `${count} child sessions`;
+    html += `<span class="session-hierarchy-badge hierarchy-children" title="${label}">↓ ${count} ${count === 1 ? 'Child' : 'Children'}</span>`;
   }
   return html ? `<div class="session-hierarchy-badges">${html}</div>` : '';
 }
@@ -509,12 +535,15 @@ function buildHierarchyBadgesHtml(sf: SessionFileDetails): string {
 function buildSessionTableHtml(sortedFiles: SessionFileDetails[]): string {
   const rows = sortedFiles.map((sf, idx) => {
     const editorLabel = sf.editorName || sf.editorSource;
-    const titleHtml = sf.title ? `<a href="#" class="session-file-link" data-file="${encodeURIComponent(sf.file)}" title="${escapeHtml(sf.title)}">${escapeHtml(sf.title.length > 40 ? sf.title.substring(0, 40) + "..." : sf.title)}</a>` : `<a href="#" class="session-file-link empty-session-link" data-file="${encodeURIComponent(sf.file)}" title="Empty session">(Empty session)</a>`;
+    const isChild = !!sf.parentInfo;
+    const rawTitleHtml = sf.title ? `<a href="#" class="session-file-link" data-file="${encodeURIComponent(sf.file)}" title="${escapeHtml(sf.title)}">${escapeHtml(sf.title.length > 40 ? sf.title.substring(0, 40) + "..." : sf.title)}</a>` : `<a href="#" class="session-file-link empty-session-link" data-file="${encodeURIComponent(sf.file)}" title="Empty session">(Empty session)</a>`;
+    const titleHtml = isChild ? `<span class="child-title-indent">${rawTitleHtml}</span>` : rawTitleHtml;
     const hierarchyBadges = buildHierarchyBadgesHtml(sf);
     const repoLabel = sf.repository ? escapeHtml(getRepoDisplayName(sf.repository)) : (sf.file.includes('session-store.db') ? '<span style="color: #888; font-style: italic;">No workspace</span>' : '<span style="color: #666;">—</span>');
     const repoTitle = sf.repository ? escapeHtml(sf.repository) : (sf.file.includes('session-store.db') ? 'Chat session — no workspace connected' : 'No repository detected');
     const isUnknownEditor = (sf.editorName || sf.editorSource || "Unknown") === "Unknown";
-    return `<tr><td>${idx + 1}</td><td><span class="${getEditorBadgeClass(editorLabel)}" title="${escapeHtml(sf.editorSource)}">${getEditorIcon(editorLabel)} ${escapeHtml(editorLabel)}</span></td><td class="session-title" title="${sf.title ? escapeHtml(sf.title) : "Empty session"}">${hierarchyBadges}${titleHtml}</td><td class="repository-cell" title="${repoTitle}">${repoLabel}</td><td>${formatFileSize(sf.size)}</td><td title="${Number(sf.tokens || 0).toLocaleString()} tokens">${formatTokenCount(sf.tokens)}</td><td>${sanitizeNumber(sf.interactions)}</td><td title="${escapeHtml(getContextRefsSummary(sf.contextReferences))}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td><td>${formatDate(sf.lastInteraction)}</td><td><a href="#" class="view-formatted-link" data-file="${encodeURIComponent(sf.file)}" title="View formatted JSONL file">📄 View</a>${isUnknownEditor ? ` <a href="#" class="report-editor-link" data-path="${encodeURIComponent(sf.file)}" title="Report this unknown path so we can add editor support">📢 Report</a>` : ""}</td></tr>`;
+    const rowClass = isChild ? ' class="child-session-row"' : '';
+    return `<tr${rowClass}><td>${idx + 1}</td><td><span class="${getEditorBadgeClass(editorLabel)}" title="${escapeHtml(sf.editorSource)}">${getEditorIcon(editorLabel)} ${escapeHtml(editorLabel)}</span></td><td class="session-title" title="${sf.title ? escapeHtml(sf.title) : "Empty session"}">${hierarchyBadges}${titleHtml}</td><td class="repository-cell" title="${repoTitle}">${repoLabel}</td><td>${formatFileSize(sf.size)}</td><td title="${Number(sf.tokens || 0).toLocaleString()} tokens">${formatTokenCount(sf.tokens)}</td><td>${sanitizeNumber(sf.interactions)}</td><td title="${escapeHtml(getContextRefsSummary(sf.contextReferences))}">${sanitizeNumber(getTotalContextRefs(sf.contextReferences))}</td><td>${formatDate(sf.lastInteraction)}</td><td><a href="#" class="view-formatted-link" data-file="${encodeURIComponent(sf.file)}" title="View formatted JSONL file">📄 View</a>${isUnknownEditor ? ` <a href="#" class="report-editor-link" data-path="${encodeURIComponent(sf.file)}" title="Report this unknown path so we can add editor support">📢 Report</a>` : ""}</td></tr>`;
   }).join("");
   return `<div class="table-container"><table class="session-table"><thead><tr><th>#</th><th>Editor</th><th>Title</th><th>Repository</th><th class="sortable" data-sort="size">Size${getSortIndicator("size")}</th><th class="sortable" data-sort="tokens">Tokens${getSortIndicator("tokens")}</th><th class="sortable" data-sort="interactions">Interactions${getSortIndicator("interactions")}</th><th class="sortable" data-sort="contextRefs">Context Refs${getSortIndicator("contextRefs")}</th><th class="sortable" data-sort="lastInteraction">Last Interaction${getSortIndicator("lastInteraction")}</th><th>Actions</th></tr></thead><tbody>${rows}</tbody></table></div>`;
 }

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -584,6 +584,30 @@ border: 1px solid #1f6feb;
 	border: 1px solid rgba(30, 120, 80, 0.4);
 }
 
+/* Child session rows — subtle left border to visually group them under parent */
+.child-session-row {
+	border-left: 2px solid rgba(30, 120, 80, 0.5);
+}
+
+.child-session-row td:first-child {
+	padding-left: 6px;
+}
+
+/* Indent the title of child sessions */
+.child-title-indent {
+	display: inline-block;
+	padding-left: 20px;
+	position: relative;
+}
+
+.child-title-indent::before {
+	content: '↳';
+	position: absolute;
+	left: 4px;
+	color: rgba(30, 120, 80, 0.7);
+	font-size: 11px;
+}
+
 .empty-session-link:hover {
 	color: var(--text-secondary);
 }

--- a/vscode-extension/test/unit/piAdapter.test.ts
+++ b/vscode-extension/test/unit/piAdapter.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for PiAdapter.buildTurns() token counting.
+ *
+ * Key regression: agentic / subagent pi sessions produce many assistant messages
+ * per user turn (one API call per tool-use cycle).  The per-turn token estimate
+ * must sum ALL assistant-message usage fields, not just the last message's usage.
+ * Using only the last message gives a wildly low estimate (e.g. 86 K instead of
+ * 5.4 M for a 101-message session).
+ */
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+import { PiAdapter } from '../../src/adapters/piAdapter';
+import { PiDataAccess } from '../../src/pi';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function makeSessionLine(id: string, cwd = '/home/user/project'): string {
+    return JSON.stringify({ type: 'session', version: 3, id, timestamp: '2026-01-01T00:00:00.000Z', cwd });
+}
+
+function makeUserMessage(id: string, text: string, parentId: string): string {
+    return JSON.stringify({
+        type: 'message', id, parentId,
+        timestamp: '2026-01-01T00:01:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text }], timestamp: 1000 },
+    });
+}
+
+function makeAssistantMessage(
+    id: string, parentId: string, model: string,
+    input: number, output: number, text = 'ok',
+): string {
+    return JSON.stringify({
+        type: 'message', id, parentId,
+        timestamp: '2026-01-01T00:02:00.000Z',
+        message: {
+            role: 'assistant',
+            content: [{ type: 'text', text }],
+            model,
+            usage: { input, output, cacheRead: 0, cacheWrite: 0, totalTokens: input + output },
+            timestamp: 2000,
+        },
+    });
+}
+
+function makeToolCallMessage(id: string, parentId: string, model: string, input: number, toolName: string): string {
+    return JSON.stringify({
+        type: 'message', id, parentId,
+        timestamp: '2026-01-01T00:02:30.000Z',
+        message: {
+            role: 'assistant',
+            content: [{ type: 'toolCall', id: 'tc1', name: toolName, arguments: {} }],
+            model,
+            usage: { input, output: 30, cacheRead: 0, cacheWrite: 0, totalTokens: input + 30 },
+            timestamp: 2500,
+        },
+    });
+}
+
+function makeToolResultMessage(id: string, parentId: string): string {
+    return JSON.stringify({
+        type: 'message', id, parentId,
+        timestamp: '2026-01-01T00:02:45.000Z',
+        message: { role: 'toolResult', toolCallId: 'tc1', toolName: 'bash', content: [{ type: 'text', text: 'result' }], isError: false, timestamp: 2700 },
+    });
+}
+
+async function writeTempSession(lines: string[]): Promise<string> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-test-'));
+    const file = path.join(dir, '2026-01-01T00-00-00-000Z_test.jsonl');
+    fs.writeFileSync(file, lines.join('\n') + '\n', 'utf8');
+    return file;
+}
+
+function makeAdapter(): PiAdapter {
+    return new PiAdapter(new PiDataAccess());
+}
+
+// ---------------------------------------------------------------------------
+// single-turn, single assistant message (baseline)
+// ---------------------------------------------------------------------------
+
+test('PiAdapter.buildTurns: single assistant message — token estimate equals its usage', async () => {
+    const file = await writeTempSession([
+        makeSessionLine('s1'),
+        makeUserMessage('u1', 'hello', 's1'),
+        makeAssistantMessage('a1', 'u1', 'mistral-medium-3.5', 1000, 50),
+    ]);
+
+    const adapter = makeAdapter();
+    const { turns, actualTokens } = await adapter.buildTurns(file);
+
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].inputTokensEstimate, 1000);
+    assert.equal(turns[0].outputTokensEstimate, 50);
+    assert.equal(actualTokens, 1050);
+});
+
+// ---------------------------------------------------------------------------
+// subagent / agentic session: 1 user turn → many assistant messages
+// ---------------------------------------------------------------------------
+
+test('PiAdapter.buildTurns: agentic session sums all assistant-message tokens (regression)', async () => {
+    // Simulate a subagent session: 1 user prompt, 5 assistant messages with growing context
+    const assistantInputs = [10_000, 20_000, 30_000, 40_000, 50_000];
+    const assistantOutputs = [100, 100, 100, 100, 200];
+
+    const lines: string[] = [makeSessionLine('s1'), makeUserMessage('u1', 'spin up subagents', 's1')];
+    assistantInputs.forEach((inp, i) => {
+        const output = assistantOutputs[i];
+        lines.push(makeAssistantMessage(`a${i}`, i === 0 ? 'u1' : `a${i - 1}`, 'mistral-medium-3.5', inp, output));
+    });
+
+    const file = await writeTempSession(lines);
+    const adapter = makeAdapter();
+    const { turns, actualTokens } = await adapter.buildTurns(file);
+
+    const expectedInput = assistantInputs.reduce((s, v) => s + v, 0);   // 150 000
+    const expectedOutput = assistantOutputs.reduce((s, v) => s + v, 0); //    600
+
+    assert.equal(turns.length, 1, 'should have exactly 1 turn');
+    assert.equal(turns[0].inputTokensEstimate, expectedInput,
+        `expected input estimate ${expectedInput} but got ${turns[0].inputTokensEstimate}`);
+    assert.equal(turns[0].outputTokensEstimate, expectedOutput,
+        `expected output estimate ${expectedOutput} but got ${turns[0].outputTokensEstimate}`);
+    assert.equal(actualTokens, expectedInput + expectedOutput);
+});
+
+// ---------------------------------------------------------------------------
+// agentic session with tool calls interspersed
+// ---------------------------------------------------------------------------
+
+test('PiAdapter.buildTurns: agentic session with tool-use cycles sums all assistant tokens', async () => {
+    const lines: string[] = [
+        makeSessionLine('s1'),
+        makeUserMessage('u1', 'fix tests', 's1'),
+        // cycle 1: tool call
+        makeToolCallMessage('a1', 'u1', 'mistral-medium-3.5', 5_000, 'read'),
+        makeToolResultMessage('tr1', 'a1'),
+        // cycle 2: tool call
+        makeToolCallMessage('a2', 'tr1', 'mistral-medium-3.5', 6_000, 'edit'),
+        makeToolResultMessage('tr2', 'a2'),
+        // final response
+        makeAssistantMessage('a3', 'tr2', 'mistral-medium-3.5', 7_000, 200, 'done'),
+    ];
+
+    const file = await writeTempSession(lines);
+    const adapter = makeAdapter();
+    const { turns } = await adapter.buildTurns(file);
+
+    // usage.input and usage.output are separate fields; output for tool-call messages = 30
+    const expectedInput = 5_000 + 6_000 + 7_000;
+    const expectedOutput = 30 + 30 + 200;
+
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].inputTokensEstimate, expectedInput);
+    assert.equal(turns[0].outputTokensEstimate, expectedOutput);
+});
+
+// ---------------------------------------------------------------------------
+// multi-turn session (two user messages)
+// ---------------------------------------------------------------------------
+
+test('PiAdapter.buildTurns: multi-turn session — each turn gets its own token sum', async () => {
+    const lines: string[] = [
+        makeSessionLine('s1'),
+        // turn 1
+        makeUserMessage('u1', 'task one', 's1'),
+        makeAssistantMessage('a1', 'u1', 'mistral-medium-3.5', 1_000, 50),
+        makeAssistantMessage('a2', 'a1', 'mistral-medium-3.5', 2_000, 80),
+        // turn 2
+        makeUserMessage('u2', 'task two', 'a2'),
+        makeAssistantMessage('a3', 'u2', 'mistral-medium-3.5', 500, 20),
+    ];
+
+    const file = await writeTempSession(lines);
+    const adapter = makeAdapter();
+    const { turns } = await adapter.buildTurns(file);
+
+    assert.equal(turns.length, 2);
+    // turn 1: a1 + a2
+    assert.equal(turns[0].inputTokensEstimate, 3_000);
+    assert.equal(turns[0].outputTokensEstimate, 130);
+    // turn 2: a3 only
+    assert.equal(turns[1].inputTokensEstimate, 500);
+    assert.equal(turns[1].outputTokensEstimate, 20);
+});
+
+// ---------------------------------------------------------------------------
+// fallback to perTurnDefault when no usage data present
+// ---------------------------------------------------------------------------
+
+test('PiAdapter.buildTurns: falls back to per-turn default when assistant usage is absent', async () => {
+    const lines: string[] = [
+        makeSessionLine('s1'),
+        makeUserMessage('u1', 'go', 's1'),
+        // assistant message with no usage field
+        JSON.stringify({
+            type: 'message', id: 'a1', parentId: 'u1',
+            timestamp: '2026-01-01T00:02:00.000Z',
+            message: { role: 'assistant', content: [{ type: 'text', text: 'done' }], model: 'mistral-medium-3.5' },
+        }),
+    ];
+
+    const file = await writeTempSession(lines);
+    const adapter = makeAdapter();
+    const { turns } = await adapter.buildTurns(file);
+
+    assert.equal(turns.length, 1);
+    // With no usage on any assistant event, both estimates should be 0 (perTurnDefault = 0/1 = 0)
+    assert.equal(turns[0].inputTokensEstimate, 0);
+    assert.equal(turns[0].outputTokensEstimate, 0);
+});

--- a/vscode-extension/test/unit/piAdapter.test.ts
+++ b/vscode-extension/test/unit/piAdapter.test.ts
@@ -217,3 +217,27 @@ test('PiAdapter.buildTurns: falls back to per-turn default when assistant usage 
     assert.equal(turns[0].inputTokensEstimate, 0);
     assert.equal(turns[0].outputTokensEstimate, 0);
 });
+
+// ---------------------------------------------------------------------------
+// PiDataAccess.getParentSessionPath
+// ---------------------------------------------------------------------------
+
+test('PiDataAccess.getParentSessionPath: returns null for root session (no parentSession field)', async () => {
+    const file = await writeTempSession([makeSessionLine('s1')]);
+    const pi = new PiDataAccess();
+    const result = await pi.getParentSessionPath(file);
+    assert.equal(result, null);
+});
+
+test('PiDataAccess.getParentSessionPath: returns path when parentSession is set in header', async () => {
+    const parentPath = '/home/user/.pi/agent/sessions/2026-01-01T00-00-00-000Z_parent.jsonl';
+    const sessionLine = JSON.stringify({
+        type: 'session', version: 3, id: 'child-id',
+        timestamp: '2026-01-01T01:00:00.000Z', cwd: '/home/user/project',
+        parentSession: parentPath,
+    });
+    const file = await writeTempSession([sessionLine]);
+    const pi = new PiDataAccess();
+    const result = await pi.getParentSessionPath(file);
+    assert.equal(result, parentPath);
+});

--- a/vscode-extension/test/unit/piAdapter.test.ts
+++ b/vscode-extension/test/unit/piAdapter.test.ts
@@ -241,3 +241,50 @@ test('PiDataAccess.getParentSessionPath: returns path when parentSession is set 
     const result = await pi.getParentSessionPath(file);
     assert.equal(result, parentPath);
 });
+
+// ---------------------------------------------------------------------------
+// PiDataAccess.getParentSessionPathFromFilePath (path-based detection)
+// ---------------------------------------------------------------------------
+
+test('PiDataAccess.getParentSessionPathFromFilePath: returns null for top-level timestamp-named session', () => {
+    const pi = new PiDataAccess();
+    // Top-level sessions have timestamp names, not 'session.jsonl'
+    const topLevel = path.join(os.homedir(), '.pi', 'agent', 'sessions', '--cwd--', '2026-01-01T00-00-00-000Z_abc.jsonl');
+    assert.equal(pi.getParentSessionPathFromFilePath(topLevel), null);
+});
+
+test('PiDataAccess.getParentSessionPathFromFilePath: derives parent path for nested session.jsonl', () => {
+    const pi = new PiDataAccess();
+    const base = path.join(os.homedir(), '.pi', 'agent', 'sessions', '--cwd--');
+    const parentFile = path.join(base, '2026-01-01T00-00-00-000Z_abc.jsonl');
+    const childFile  = path.join(base, '2026-01-01T00-00-00-000Z_abc', 'deadbeef', 'run-0', 'session.jsonl');
+    assert.equal(pi.getParentSessionPathFromFilePath(childFile), parentFile);
+});
+
+// ---------------------------------------------------------------------------
+// PiDataAccess.discoverSessions — recursive discovery
+// ---------------------------------------------------------------------------
+
+test('PiDataAccess.discoverSessions: discovers nested child session.jsonl files', async () => {
+    // Build a fake sessions dir that mirrors the real pi layout:
+    //   sessions/{cwdDir}/2026-01-01T_abc.jsonl           ← top-level
+    //   sessions/{cwdDir}/2026-01-01T_abc/deadbeef/run-0/session.jsonl  ← child
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-discover-'));
+    const cwdDir = path.join(tmpRoot, '--cwd--');
+    const parentFile = path.join(cwdDir, '2026-01-01T00-00-00-000Z_abc.jsonl');
+    const childDir   = path.join(cwdDir, '2026-01-01T00-00-00-000Z_abc', 'deadbeef', 'run-0');
+    const childFile  = path.join(childDir, 'session.jsonl');
+
+    fs.mkdirSync(childDir, { recursive: true });
+    fs.writeFileSync(parentFile, makeSessionLine('parent') + '\n');
+    fs.writeFileSync(childFile, makeSessionLine('child') + '\n');
+
+    // Override the config dir so PiDataAccess scans our temp directory
+    const pi = new PiDataAccess();
+    // @ts-ignore — override private getConfigDir for test
+    pi.getConfigDir = () => tmpRoot;
+
+    const files = await pi.discoverSessions();
+    assert.ok(files.includes(parentFile), 'top-level session should be discovered');
+    assert.ok(files.includes(childFile),  'nested child session should be discovered');
+});


### PR DESCRIPTION
## Summary

Fixes #1365 — Pi sessions with subagents (spawned via `parentSession`) were not counted correctly and their hierarchy was not shown in the session viewer.

### Changes

#### 1. Fix: Per-turn token estimate sums all assistant messages (core bug fix)
`buildTurn` in `piAdapter.ts` was using only the **last** assistant message's usage instead of summing all of them. For agentic pi sessions that produce dozens of assistant messages per user turn (one per tool-call cycle), this caused estimates to be off by ~98% (e.g. 86K instead of 5.4M).

#### 2. New: Pi subagent hierarchy shown in session viewer

When pi spawns a child agent session, the child's JSONL header contains a `parentSession` field pointing to the parent session file. This PR wires that into the session viewer's "Session Hierarchy" card:

- **`PiDataAccess.getParentSessionPath()`** — new method that reads the `parentSession` field from a Pi JSONL header
- **`enrichPiSessionHierarchy()`** — new extension method (alongside `enrichSessionHierarchy` for Copilot CLI) that:
  - Reads all Pi session headers in parallel
  - Builds parent→child maps
  - Populates `parentInfo`, `childInfo`, and `totalChildCount` on each `SessionFileDetails`
- Called during the background session load so the hierarchy card and subagent tree display the relationship

### Tests

7 unit tests covering:
- Single assistant message (baseline)
- Agentic session sums all assistant-message tokens (regression test)
- Agentic session with tool-use cycles
- Multi-turn session (each turn gets its own sum)
- Fallback to zero when no usage data
- `getParentSessionPath`: returns null for root sessions
- `getParentSessionPath`: returns parent path when `parentSession` is set in header