### PR TITLE
fix: reduce Windsurf session over-fetching log noise

### DIFF
--- a/vscode-extension/src/windsurf.ts
+++ b/vscode-extension/src/windsurf.ts
@@ -71,6 +71,7 @@ export class WindsurfDataAccess {
 	private readonly extensionUri: vscode.Uri;
 	private log: (msg: string) => void = (msg) => console.log(msg);
 	private sessionCache: { sessions: SessionFileDetails[]; expiresAt: number } | null = null;
+	private _sessionFetchInFlight: Promise<SessionFileDetails[]> | null = null;
 	private static readonly SESSION_CACHE_TTL_MS = 15_000;
 
 	constructor(extensionUri: vscode.Uri, log?: (msg: string) => void) {
@@ -853,15 +854,22 @@ export class WindsurfDataAccess {
 	 * Tries the API first (full token data), falls back to .pb file metadata when API is unavailable.
 	 */
 	async getWindsurfSessions(): Promise<SessionFileDetails[]> {
-		this.log('[Windsurf] getWindsurfSessions() called');
 		const now = Date.now();
 		if (this.sessionCache && this.sessionCache.expiresAt > now) {
-			this.log(`[Windsurf] Returning ${this.sessionCache.sessions.length} cached session(s)`);
 			return this.sessionCache.sessions;
 		}
-		const sessions = await this.discoverWindsurfSessions();
-		this.sessionCache = { sessions, expiresAt: now + WindsurfDataAccess.SESSION_CACHE_TTL_MS };
-		return sessions;
+		// Coalesce concurrent cache-miss calls into a single fetch.
+		if (!this._sessionFetchInFlight) {
+			this.log('[Windsurf] getWindsurfSessions() fetching sessions (cache miss)');
+			this._sessionFetchInFlight = this.discoverWindsurfSessions()
+				.then(sessions => {
+					this.sessionCache = { sessions, expiresAt: Date.now() + WindsurfDataAccess.SESSION_CACHE_TTL_MS };
+					this.log(`[Windsurf] getWindsurfSessions() cached ${sessions.length} session(s)`);
+					return sessions;
+				})
+				.finally(() => { this._sessionFetchInFlight = null; });
+		}
+		return this._sessionFetchInFlight;
 	}
 
 	private async discoverWindsurfSessions(): Promise<SessionFileDetails[]> {


### PR DESCRIPTION
## Problem

During a typical load run, `getWindsurfSessions()` was logged 6+ times in rapid succession — once per Windsurf session file, because `resolveSession()` is called once per file and each call internally invoked `getWindsurfSessions()`.

```
[Windsurf] getWindsurfSessions() called
[Windsurf] Returning 6 cached session(s)
[Windsurf] getWindsurfSessions() called
[Windsurf] Returning 6 cached session(s)
... (×6)
```

## Root cause

`resolveSession(file)` calls `getWindsurfSessions()` to look up a single session. With N Windsurf sessions to process, this means N calls to `getWindsurfSessions()`. The cache handled the repeat lookups, but still logged on every cache hit — creating noisy output. On a cold cache, N parallel fetches would be launched unnecessarily.

## Fix

Two changes to `getWindsurfSessions()` in `windsurf.ts`:

1. **Remove logging on cache hits** — cache hits are now silent (they're the happy path).
2. **In-flight promise coalescing** — if a cache miss occurs and a fetch is already in progress, concurrent callers await the same promise instead of launching duplicate `discoverWindsurfSessions()` calls.

After the fix, logs only appear twice per cache miss cycle:
```
[Windsurf] getWindsurfSessions() fetching sessions (cache miss)
[Windsurf] getWindsurfSessions() cached 6 session(s)
```