### PR TITLE
chore: bump VS Code extension version to 0.11.7

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release: VS Code Extension v0.11.7

Patch version bump from `0.11.6` → `0.11.7`.

### Changes
- Updated `version` in `vscode-extension/package.json`