### PR TITLE
feat: Add Microsoft Scout editor support

### DIFF
--- a/vscode-extension/src/adapters/copilotCliAdapter.ts
+++ b/vscode-extension/src/adapters/copilotCliAdapter.ts
@@ -24,7 +24,7 @@ import type {
 	CandidatePath,
 	UsageAnalysisAdapterContext,
 } from '../ecosystemAdapter';
-import { CopilotCliStoreAccess } from '../copilotCliStore';
+import { CopilotCliStoreAccess, isMicrosoftScoutCwd } from '../copilotCliStore';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
 import { normalizePath } from '../utils/pathUtils';
@@ -38,9 +38,24 @@ export function getCopilotCliSessionStateDir(): string {
 
 export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'copilotcli';
-	readonly displayName = 'GitHub Copilot CLI';
+	readonly displayName = 'Copilot CLI';
 
 	private readonly store = new CopilotCliStoreAccess();
+	/** UUIDs of sessions discovered to have been created by Microsoft Scout. */
+	private readonly _scoutSessionIds = new Set<string>();
+
+	/**
+	 * Returns the per-session display name.
+	 * Sessions whose cwd is under Documents\Microsoft Scout are shown as
+	 * "MS Scout (Copilot CLI)" to distinguish them from regular CLI sessions.
+	 */
+	getDisplayName(sessionFile: string): string {
+		const sessionId = this.store.getSessionId(sessionFile);
+		if (sessionId && this._scoutSessionIds.has(sessionId)) {
+			return 'MS Scout (Copilot CLI)';
+		}
+		return 'Copilot CLI';
+	}
 
 	/**
 	 * Returns true only for session-store.db virtual paths.
@@ -213,10 +228,15 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 
 		// Also discover DB-only sessions (no matching events.jsonl)
 		try {
-			const dbOnlyIds = await this.store.discoverNewSessions(knownUuids);
-			if (dbOnlyIds.length > 0) {
-				log(`📄 Found ${dbOnlyIds.length} chat-only session(s) in Copilot CLI session-store.db`);
-				sessionFiles.push(...dbOnlyIds.map(id => this.store.virtualPath(id)));
+			const dbOnlySessions = await this.store.discoverNewSessionsWithCwd(knownUuids);
+			if (dbOnlySessions.length > 0) {
+				log(`📄 Found ${dbOnlySessions.length} chat-only session(s) in Copilot CLI session-store.db`);
+				for (const { id, cwd } of dbOnlySessions) {
+					if (isMicrosoftScoutCwd(cwd)) {
+						this._scoutSessionIds.add(id);
+					}
+					sessionFiles.push(this.store.virtualPath(id));
+				}
 			}
 		} catch (e) {
 			log(`Could not read Copilot CLI session-store.db: ${e}`);

--- a/vscode-extension/src/copilotCliStore.ts
+++ b/vscode-extension/src/copilotCliStore.ts
@@ -28,11 +28,21 @@ type SqlDatabase = initSqlJs.Database;
 
 export interface CliStoreSession {
 	id: string;
+	cwd: string | null;
 	repository: string | null;
 	branch: string | null;
 	summary: string | null;
 	created_at: string | null;
 	updated_at: string | null;
+}
+
+/**
+ * Returns true when the session's cwd indicates it was created by Microsoft Scout.
+ * Scout stores sessions under Documents\Microsoft Scout (or Documents/Microsoft Scout).
+ */
+export function isMicrosoftScoutCwd(cwd: string | null | undefined): boolean {
+	if (!cwd) { return false; }
+	return cwd.replace(/\\/g, '/').toLowerCase().includes('/microsoft scout');
 }
 
 export interface CliStoreTurn {
@@ -47,6 +57,7 @@ export function isCliStoreSession(obj: unknown): obj is CliStoreSession {
 	if (typeof obj !== 'object' || obj === null) { return false; }
 	const r = obj as Record<string, unknown>;
 	return typeof r['id'] === 'string'
+		&& (r['cwd'] === null || typeof r['cwd'] === 'string')
 		&& (r['repository'] === null || typeof r['repository'] === 'string')
 		&& (r['branch'] === null || typeof r['branch'] === 'string')
 		&& (r['summary'] === null || typeof r['summary'] === 'string')
@@ -243,6 +254,25 @@ export class CopilotCliStoreAccess {
 		}
 	}
 
+	/**
+	 * Discover all session IDs and their cwd values, excluding `knownUuids`.
+	 * Used to identify Microsoft Scout sessions at discovery time.
+	 */
+	async discoverNewSessionsWithCwd(knownUuids: Set<string>): Promise<{ id: string; cwd: string | null }[]> {
+		const dbPath = this.getDbPath();
+		const db = await this.getDb(dbPath);
+		if (!db) { return []; }
+		try {
+			const result = db.exec('SELECT id, cwd FROM sessions ORDER BY updated_at DESC');
+			if (result.length === 0) { return []; }
+			return result[0].values
+				.filter(row => !knownUuids.has(row[0] as string))
+				.map(row => ({ id: row[0] as string, cwd: (row[1] as string | null) ?? null }));
+		} catch {
+			return [];
+		}
+	}
+
 	/** Read session metadata for a virtual session path. */
 	async readSession(virtualPath: string): Promise<CliStoreSession | null> {
 		const dbPath = this.getDbPathFromVirtual(virtualPath);
@@ -252,7 +282,7 @@ export class CopilotCliStoreAccess {
 		if (!db) { return null; }
 		try {
 			const result = db.exec(
-				'SELECT id, repository, branch, summary, created_at, updated_at FROM sessions WHERE id = ?',
+				'SELECT id, cwd, repository, branch, summary, created_at, updated_at FROM sessions WHERE id = ?',
 				[sessionId],
 			);
 			if (result.length === 0 || result[0].values.length === 0) { return null; }

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -15,6 +15,7 @@ export const EDITOR_ICON_MAP: Record<string, string> = {
 	'VSCodium': '🔷',
 	'Cursor': '🖱️',
 	'Copilot CLI': '🤖',
+	'MS Scout (Copilot CLI)': '🔭',
 	'OpenCode': '🟢',
 	'Visual Studio': '🪟',
 	'Claude Code': '🟠',

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -355,6 +355,10 @@ function getRepoDisplayName(repoUrl: string): string {
 
 function getEditorBadgeClass(editor: string): string {
   const lower = editor.toLowerCase();
+  // MS Scout must be checked before generic 'copilot' to avoid misclassification.
+  if (lower.includes("ms scout") || lower.includes("microsoft scout")) {
+    return "editor-badge editor-badge-ms-scout";
+  }
   if (lower.includes("visual studio")) {
     return "editor-badge editor-badge-vs";
   }

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -444,6 +444,13 @@ body {
 	white-space: nowrap;
 }
 
+/* MS Scout: Microsoft brand blue on dark navy */
+.editor-badge-ms-scout {
+	background: #001a2e;
+	color: #0078d4;
+	border: 1px solid #0078d4;
+}
+
 .editor-badge-crush {
 	background: #3d0a4f;
 	color: #ff3dff;

--- a/vscode-extension/test/unit/copilotCliAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotCliAdapter.test.ts
@@ -23,7 +23,21 @@ const adapter = new CopilotCliAdapter();
 
 test('CopilotCliAdapter: id and displayName are stable', () => {
     assert.equal(adapter.id, 'copilotcli');
-    assert.equal(adapter.displayName, 'GitHub Copilot CLI');
+    assert.equal(adapter.displayName, 'Copilot CLI');
+});
+
+test('CopilotCliAdapter.getDisplayName: returns MS Scout label for tracked Scout sessions', () => {
+    const scoutSessionId = '11111111-1111-1111-1111-111111111111';
+    const scoutVirtualPath = path.join(os.homedir(), '.copilot', `session-store.db#${scoutSessionId}`);
+    const scoutSessionIds = (adapter as unknown as { _scoutSessionIds: Set<string> })._scoutSessionIds;
+
+    scoutSessionIds.add(scoutSessionId);
+    try {
+        assert.equal(adapter.getDisplayName(scoutVirtualPath), 'MS Scout (Copilot CLI)');
+        assert.equal(adapter.getDisplayName(path.join(os.homedir(), '.copilot', 'session-store.db#other-session')), 'Copilot CLI');
+    } finally {
+        scoutSessionIds.delete(scoutSessionId);
+    }
 });
 
 test('CopilotCliAdapter: implements IDiscoverableEcosystem', () => {


### PR DESCRIPTION
## Summary

Detects and labels sessions created by **Microsoft Scout** as `MS Scout (Copilot CLI)` in all panels (session list, log viewer, charts, diagnostics).

## How it works

Scout uses `~/.copilot/session-store.db` for session storage — the same database as Copilot CLI. The key distinguisher is the `cwd` column: Scout sessions have `cwd = '...Documents\Microsoft Scout[...]'`.

At discovery time we query `id + cwd` in one pass, mark matching UUIDs in a `Set`, and override the display name per-session via `IEcosystemAdapter.getDisplayName()`.

## Session data

Scout sessions are DB-only (no `events.jsonl`). The existing `countTurns()` already reads from the DB `turns` table, so real Scout task sessions show correct turn counts. There are no token counts (not stored in `session-store.db` for any CLI session). The `summary` field becomes the session title.

## Changes

| File | Change |
|---|---|
| `copilotCliStore.ts` | Add `cwd` to `CliStoreSession`, add `isMicrosoftScoutCwd()` helper, add `discoverNewSessionsWithCwd()` |
| `copilotCliAdapter.ts` | Track `_scoutSessionIds` Set during `discover()`; implement `getDisplayName()` returning `'MS Scout (Copilot CLI)'` for matches |
| `editorIcons.ts` | Add 🔭 icon for `'MS Scout (Copilot CLI)'` |
| `diagnostics/main.ts` | Add badge class lookup for `ms-scout` |
| `diagnostics/styles.css` | Add `.editor-badge-ms-scout` with Microsoft blue (`#0078d4`) |
