### PR TITLE
feat: externalize JSON config files from webview bundles

### DIFF
--- a/visualstudio-extension/src/CopilotTokenTracker/CopilotTokenTracker.csproj
+++ b/visualstudio-extension/src/CopilotTokenTracker/CopilotTokenTracker.csproj
@@ -149,6 +149,10 @@
       <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\diagnostics.js" />
       <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\environmental.js" />
       <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\maturity.js" />
+      <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\tokenEstimators.json" />
+      <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\modelPricing.json" />
+      <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\toolNames.json" />
+      <_WebviewBundle Include="..\..\..\vscode-extension\dist\webview\automaticTools.json" />
     </ItemGroup>
     <MakeDir Directories="$(MSBuildProjectDirectory)\webview" />
     <Copy SourceFiles="@(_WebviewBundle)" DestinationFolder="$(MSBuildProjectDirectory)\webview\" SkipUnchangedFiles="true" ContinueOnError="true" />
@@ -157,6 +161,11 @@
   <!-- Include copied webview JS files inside the VSIX package -->
   <ItemGroup>
     <Content Include="webview\*.js" Condition="Exists('$(MSBuildProjectDirectory)\webview')">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>webview\</VSIXSubPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="webview\*.json" Condition="Exists('$(MSBuildProjectDirectory)\webview')">
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>webview\</VSIXSubPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/visualstudio-extension/src/CopilotTokenTracker/WebBridge/ThemedHtmlBuilder.cs
+++ b/visualstudio-extension/src/CopilotTokenTracker/WebBridge/ThemedHtmlBuilder.cs
@@ -32,8 +32,9 @@ namespace CopilotTokenTracker.WebBridge
             string themeCss;
             try   { themeCss = BuildThemeCss(); }
             catch { themeCss = BuildFallbackThemeCss(); }
-            var globalKey = ViewToGlobalKey(view);
-            var vsHideJs  = BuildVsHideScript(view);
+            var globalKey  = ViewToGlobalKey(view);
+            var vsHideJs   = BuildVsHideScript(view);
+            var jsonGlobals = BuildJsonGlobalsScript();
 
             // Prevent </script> injection in the JSON payload (OWASP XSS defence)
             var safeJson = statsJson.Replace("<", "\\u003c").Replace(">", "\\u003e");
@@ -68,6 +69,7 @@ html, body {{ margin: 0; padding: 0; height: 100%; overflow: auto; }}
 <script>
 window.{globalKey} = {safeJson};
 </script>
+{jsonGlobals}
 </head>
 <body>
 <div id=""root""></div>
@@ -281,6 +283,47 @@ html, body {{
                 "maturity"      => "__INITIAL_MATURITY__",
                 _               => "__INITIAL_DETAILS__",
             };
+
+        /// <summary>
+        /// Reads the JSON config sidecar files from the installed webview directory and
+        /// returns an inline &lt;script&gt; block that sets the corresponding window globals.
+        /// The webview bundles read these globals instead of bundling the JSON inline.
+        /// Falls back gracefully if any file is missing (e.g. first run before build).
+        /// </summary>
+        private static string BuildJsonGlobalsScript()
+        {
+            try
+            {
+                var webviewDir = Path.Combine(
+                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+                    "webview");
+
+                var entries = new (string file, string key)[]
+                {
+                    ("tokenEstimators.json", "__TOKEN_ESTIMATORS__"),
+                    ("modelPricing.json",    "__MODEL_PRICING__"),
+                    ("toolNames.json",       "__TOOL_NAMES__"),
+                    ("automaticTools.json",  "__AUTOMATIC_TOOLS__"),
+                };
+
+                var sb = new System.Text.StringBuilder("<script>\n");
+                foreach (var (file, key) in entries)
+                {
+                    var filePath = Path.Combine(webviewDir, file);
+                    if (!File.Exists(filePath)) { continue; }
+                    var content = File.ReadAllText(filePath)
+                        .Replace("<", "\\u003c")
+                        .Replace(">", "\\u003e");
+                    sb.AppendLine($"window.{key} = {content};");
+                }
+                sb.Append("</script>");
+                return sb.ToString();
+            }
+            catch
+            {
+                return "<!-- JSON config globals unavailable -->";
+            }
+        }
 
         private static string LoadShim()
         {

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -74,6 +74,18 @@ async function main() {
 		await webviewCtx.dispose();
 	}
 
+	// Copy JSON config files to dist/webview/ so the VS extension can read them as runtime sidecars
+	const jsonConfigFiles = ['tokenEstimators.json', 'modelPricing.json', 'toolNames.json', 'automaticTools.json'];
+	const webviewDistDir = path.join(__dirname, 'dist', 'webview');
+	fs.mkdirSync(webviewDistDir, { recursive: true });
+	for (const file of jsonConfigFiles) {
+		const jsonSrc = path.join(__dirname, 'src', file);
+		const jsonDst = path.join(webviewDistDir, file);
+		if (fs.existsSync(jsonSrc)) {
+			fs.copyFileSync(jsonSrc, jsonDst);
+		}
+	}
+
 	// Copy sql.js WASM file to dist/ for OpenCode SQLite support
 	const wasmSrc = path.join(__dirname, 'node_modules', 'sql.js', 'dist', 'sql-wasm.wasm');
 	const wasmDst = path.join(__dirname, 'dist', 'sql-wasm.wasm');

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9,6 +9,7 @@ import * as childProcess from 'child_process';
 import tokenEstimatorsData from './tokenEstimators.json';
 import modelPricingData from './modelPricing.json';
 import toolNamesData from './toolNames.json';
+import automaticToolsData from './automaticTools.json';
 import customizationPatternsData from './customizationPatterns.json';
 import copilotPlansData from './copilotPlans.json';
 import * as packageJson from '../package.json';
@@ -677,6 +678,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private getLocalViewRegressionProbeScript(viewId: string, nonce: string): string {
 		return createViewRegressionProbeScript(nonce, this.consumeLocalViewRegressionProbe(viewId));
+	}
+
+	/**
+	 * Returns a <script> block that injects the JSON config files as window globals,
+	 * so the webview bundles no longer need to bundle them inline.
+	 * All views receive all four globals; the small extra payload is negligible.
+	 */
+	private getJsonConfigScript(nonce: string): string {
+		const estimators = JSON.stringify(tokenEstimatorsData).replace(/</g, '\\u003c');
+		const pricing    = JSON.stringify(modelPricingData).replace(/</g, '\\u003c');
+		const tools      = JSON.stringify(toolNamesData).replace(/</g, '\\u003c');
+		const autoTools  = JSON.stringify(automaticToolsData).replace(/</g, '\\u003c');
+		return `<script nonce="${nonce}">` +
+			`window.__TOKEN_ESTIMATORS__=${estimators};` +
+			`window.__MODEL_PRICING__=${pricing};` +
+			`window.__TOOL_NAMES__=${tools};` +
+			`window.__AUTOMATIC_TOOLS__=${autoTools};` +
+			`</script>`;
 	}
 
 	private handleLocalViewRegressionMessage(message: any): boolean {
@@ -5249,6 +5268,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_ENVIRONMENTAL__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			${this.getLocalViewRegressionProbeScript('environmental', nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -5961,6 +5981,7 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_LOGDATA__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
 		</body>
@@ -6443,6 +6464,7 @@ ${hashtag}`;
 	<body>
 		<div id="root"></div>
 		<script nonce="${nonce}">window.__INITIAL_FLUENCY_LEVEL_DATA__ = ${initialData};</script>
+		${this.getJsonConfigScript(nonce)}
 		${this.extensionPointButtonsScript(nonce)}
 		${this.getLocalViewRegressionProbeScript('fluency-level-viewer', nonce)}
 		<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -6504,6 +6526,7 @@ ${hashtag}`;
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_MATURITY__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			${this.getLocalViewRegressionProbeScript('maturity', nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -7014,6 +7037,7 @@ ${hashtag}`;
 			<div id="root"></div>
 			${configScript}
 			${initialDataScript}
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
 		</body>
@@ -7278,6 +7302,7 @@ ${this.getLoadingHtmlScript()}
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_DETAILS__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			${this.getLocalViewRegressionProbeScript('details', nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -8113,6 +8138,7 @@ ${this.getLoadingHtmlScript()}
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_DIAGNOSTICS__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			${this.getLocalViewRegressionProbeScript('diagnostics', nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -8199,6 +8225,7 @@ ${this.getLoadingHtmlScript()}
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_CHART__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			${this.getLocalViewRegressionProbeScript('chart', nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>
@@ -8265,6 +8292,7 @@ ${this.getLoadingHtmlScript()}
 		<body>
 			<div id="root"></div>
 			<script nonce="${nonce}">window.__INITIAL_USAGE__ = ${initialData};</script>
+			${this.getJsonConfigScript(nonce)}
 			${this.extensionPointButtonsScript(nonce)}
 			${this.getLocalViewRegressionProbeScript('usage', nonce)}
 			<script nonce="${nonce}" src="${scriptUri}"></script>

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -4,9 +4,6 @@ import { getEditorIcon, getCharsPerToken, formatFixed, formatPercent, formatNumb
 import { el, createButton } from '../shared/domUtils';
 import { BUTTONS } from '../shared/buttonConfig';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
-// Token estimators loaded from JSON
-// @ts-ignore
-import tokenEstimatorsJson from '../../tokenEstimators.json';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -163,10 +163,10 @@ interface Window { __INITIAL_LOGDATA__?: SessionLogData; }
 const vscode = acquireVsCodeApi();
 const initialData = getWindowData<SessionLogData>('__INITIAL_LOGDATA__');
 
-import toolNames from '../../toolNames.json';
 import { resolveGuidMcpToolName } from '../../utils/toolUtils';
 
-let TOOL_NAME_MAP: { [key: string]: string } | null = toolNames || null;
+// Tool name map is injected by the extension host as window.__TOOL_NAMES__
+const TOOL_NAME_MAP: { [key: string]: string } | null = getWindowData<Record<string, string>>('__TOOL_NAMES__') ?? null;
 
 // ── Module-level constants ────────────────────────────────────────────────────
 

--- a/vscode-extension/src/webview/shared/dataLoader.ts
+++ b/vscode-extension/src/webview/shared/dataLoader.ts
@@ -6,5 +6,6 @@
  *   const data = getWindowData<MyType>('__INITIAL_MY_KEY__');
  */
 export function getWindowData<T>(key: string): T | undefined {
+	if (typeof window === 'undefined') { return undefined; }
 	return (window as unknown as Record<string, T | undefined>)[key];
 }

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
-import tokenEstimatorsJson from '../../tokenEstimators.json';
 import type { TokenEstimator } from '../../types';
 import { EDITOR_ICON_MAP as _EDITOR_ICON_MAP, getEditorIconByName } from '../../editorIcons';
+import { getWindowData } from './dataLoader';
 
-const tokenEstimators: Record<string, TokenEstimator> = tokenEstimatorsJson.estimators;
+const _estimatorsData = getWindowData<{ estimators: Record<string, number> }>('__TOKEN_ESTIMATORS__');
+const tokenEstimators: Record<string, TokenEstimator> = _estimatorsData?.estimators ?? {};
 let currentLocale: string | undefined;
 let compactNumbersEnabled = true;
 

--- a/vscode-extension/src/webview/shared/modelUtils.ts
+++ b/vscode-extension/src/webview/shared/modelUtils.ts
@@ -1,12 +1,12 @@
-// @ts-ignore — resolved by esbuild at bundle time
-import modelPricingJson from '../../modelPricing.json';
+import { getWindowData } from './dataLoader';
 
 type PricingEntry = { displayNames?: string[] };
 
-// Build display name map from pricing JSON (first displayName = canonical friendly name).
+// Build display name map from pricing JSON injected by the extension host as window.__MODEL_PRICING__.
 // This is the single source of truth so it stays in sync with the nightly JSON refresh.
+const _pricingData = getWindowData<{ pricing: Record<string, PricingEntry> }>('__MODEL_PRICING__');
 const _modelNames: Record<string, string> = {};
-for (const [modelId, pricing] of Object.entries(modelPricingJson.pricing as Record<string, PricingEntry>)) {
+for (const [modelId, pricing] of Object.entries((_pricingData?.pricing ?? {}) as Record<string, PricingEntry>)) {
     if (pricing.displayNames && pricing.displayNames.length > 0) {
         _modelNames[modelId] = pricing.displayNames[0];
     }

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -293,12 +293,12 @@ function getEffortDisplayName(level: string): string {
 	return EFFORT_DISPLAY_NAMES[level] ?? level;
 }
 
-import toolNames from '../../toolNames.json';
-import automaticToolIds from '../../automaticTools.json';
 import { resolveGuidMcpToolName, isGuidMcpTool } from '../../utils/toolUtils';
 
-let TOOL_NAME_MAP: { [key: string]: string } | null = toolNames || null;
-const AUTOMATIC_TOOL_SET_WV = new Set<string>((automaticToolIds as string[]).map(id => id.toLowerCase()));
+// Tool name maps are injected by the extension host as window.__TOOL_NAMES__ and window.__AUTOMATIC_TOOLS__
+const TOOL_NAME_MAP: { [key: string]: string } | null = getWindowData<Record<string, string>>('__TOOL_NAMES__') ?? null;
+const _automaticToolIds = getWindowData<string[]>('__AUTOMATIC_TOOLS__') ?? [];
+const AUTOMATIC_TOOL_SET_WV = new Set<string>(_automaticToolIds.map(id => id.toLowerCase()));
 
 function lookupToolName(id: string): string {
 	if (!TOOL_NAME_MAP) {

--- a/vscode-extension/test/unit/vscode-shim-register.ts
+++ b/vscode-extension/test/unit/vscode-shim-register.ts
@@ -323,3 +323,13 @@ try {
 // imported extension code) prevent the process from exiting after tests.
 // The timer is unref()'d so it won't keep the process alive on its own.
 setTimeout(() => process.exit(process.exitCode ?? 0), 30_000).unref();
+
+// Set up a minimal browser-like `window` global so webview utilities that
+// call getWindowData() (modelUtils, formatUtils, etc.) work in Node.js tests.
+// We populate the JSON config globals so tests that exercise model/estimator
+// lookups get the real data rather than empty fallbacks.
+(global as any).window = (global as any).window ?? {};
+(global as any).window.__TOKEN_ESTIMATORS__ = require('../../src/tokenEstimators.json');
+(global as any).window.__MODEL_PRICING__    = require('../../src/modelPricing.json');
+(global as any).window.__TOOL_NAMES__       = require('../../src/toolNames.json');
+(global as any).window.__AUTOMATIC_TOOLS__  = require('../../src/automaticTools.json');


### PR DESCRIPTION
## Summary

Removes `tokenEstimators.json`, `modelPricing.json`, `toolNames.json`, and `automaticTools.json` from being bundled inline into the webview JS files. Instead they are kept as sidecar files read at runtime by both the VS Code extension host and the Visual Studio extension.

## Problem

Previously, updating any of these JSON files (e.g. `modelPricing.json` after a nightly model refresh) required rebuilding and redistributing the full ~750KB–1.2MB webview JS bundles. The JSON data was embedded inline at build time.

## Solution: Sidecar files + host-side injection

The single source of truth is still `vscode-extension/src/*.json`. The data flows:

```
vscode-extension/src/modelPricing.json   ← single source
        ↓ (esbuild copies to dist/webview/)
vscode-extension/dist/webview/modelPricing.json
        ↓ (CopyWebviewBundles MSBuild target)
visualstudio-extension/.../webview/modelPricing.json  (in VSIX)
```

Both extension hosts inject the data as `window.__MODEL_PRICING__` etc. globals **before** the bundle script runs, so no async loading or CSP changes are needed.

## Changes

| File | Change |
|---|---|
| `vscode-extension/esbuild.js` | Copies 4 JSON sidecars to `dist/webview/` after each build |
| `vscode-extension/src/extension.ts` | Adds `getJsonConfigScript()` helper; injects globals in all 9 HTML builders |
| `vscode-extension/src/webview/shared/modelUtils.ts` | Reads `__MODEL_PRICING__` via `getWindowData()` instead of static import |
| `vscode-extension/src/webview/shared/formatUtils.ts` | Reads `__TOKEN_ESTIMATORS__` via `getWindowData()` |
| `vscode-extension/src/webview/usage/main.ts` | Reads `__TOOL_NAMES__` / `__AUTOMATIC_TOOLS__` via `getWindowData()` |
| `vscode-extension/src/webview/logviewer/main.ts` | Reads `__TOOL_NAMES__` via `getWindowData()` |
| `vscode-extension/src/webview/details/main.ts` | Removes now-unused `tokenEstimators.json` import |
| `vscode-extension/src/webview/shared/dataLoader.ts` | Guards `window` access for Node.js environments |
| `vscode-extension/test/unit/vscode-shim-register.ts` | Populates `global.window` JSON globals for unit tests |
| `visualstudio-extension/.../ThemedHtmlBuilder.cs` | Reads JSON sidecars at runtime and injects them as globals |
| `visualstudio-extension/.../CopilotTokenTracker.csproj` | Includes `webview\*.json` in VSIX; copies JSON from vscode-extension build |

## Verification

- `npm run compile` — 0 errors (1 pre-existing warning in diagnostics unrelated to this change)
- `npm run test:node` — all tests pass
- Confirmed `dist/webview/details.js` no longer contains inline pricing data