### PR TITLE
fix: remove Edit mode references from tips and fluency level data

### DIFF
--- a/vscode-extension/src/fluencyLevelData.json
+++ b/vscode-extension/src/fluencyLevelData.json
@@ -135,7 +135,7 @@
         "thresholds": [
           "Zero agent-mode interactions",
           "No tool calls executed",
-          "Not using edit mode or multi-file capabilities"
+          "Not using multi-file or agentic capabilities"
         ],
         "tips": [
           "Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) — it can run terminal commands, edit files, and explore your codebase autonomously — [▶ Agent Mode video](https://tech.hub.ms/github-copilot/videos/agent-mode)",
@@ -148,12 +148,11 @@
         "description": "Beginning to explore agent mode",
         "thresholds": [
           "At least 1 agent-mode interaction OR",
-          "Using edit mode OR",
           "At least 1 multi-file edit session"
         ],
         "tips": [
           "Use [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-step tasks; let it chain tools like file search, terminal, and code edits — [▶ Agent Mode video](https://tech.hub.ms/github-copilot/videos/agent-mode)",
-          "Try edit mode for focused code changes"
+          "Use agent mode for focused, multi-step code changes"
         ]
       },
       {

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -348,10 +348,7 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 			const sessions = ctx.last30Days.sessions;
 			const m = ctx.last30Days.modeUsage;
 			if ((m.ask ?? 0) > 0.85 * sessions) {
-				return 'You mostly use Ask mode. Try Edit mode for making code changes directly.';
-			}
-			if ((m.edit ?? 0) > 0.85 * sessions) {
-				return 'You mostly use Edit mode. Ask mode is great for questions and exploration.';
+				return 'You mostly use Ask mode. Try Agent mode for making code changes directly — it can edit files, run terminal commands, and iterate across your whole codebase autonomously.';
 			}
 			return 'You haven\'t tried Agent mode yet. It handles multi-step tasks autonomously — great for refactoring, adding tests, or implementing features.';
 		},
@@ -359,8 +356,8 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 			const sessions = ctx.last30Days.sessions;
 			if (sessions < 10) { return false; }
 			const m = ctx.last30Days.modeUsage;
+			if ((m.agent ?? 0) > 0.85 * sessions) { return false; }
 			return (m.ask ?? 0) > 0.85 * sessions
-				|| (m.edit ?? 0) > 0.85 * sessions
 				|| ((m.agent ?? 0) === 0 && sessions >= 15);
 		},
 		weight: 50,
@@ -778,7 +775,7 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		buildBody: (ctx) => {
 			const es = ctx.last30Days.editScope;
 			return `You've made ${es.singleFileEdits} edit-mode sessions over the last 30 days, all touching a single file. ` +
-				`For refactors that span multiple files — renaming a type, extracting a module, updating API contracts — switch to Agent mode (or Edit mode with multiple files selected). ` +
+				`For refactors that span multiple files — renaming a type, extracting a module, updating API contracts — switch to Agent mode. ` +
 				`It can make changes consistently across your whole codebase without you opening each file manually.`;
 		},
 		appliesTo: (ctx) => {


### PR DESCRIPTION
Fixes #1407

Edit mode was removed from VS Code Copilot. This PR cleans up all references to it in tips and fluency level descriptions, replacing them with Agent mode guidance.

## Changes

**`insightsEngine.ts`**
- `mode-diversity-low` tip: Replace *"Try Edit mode for making code changes directly"* with an Agent mode suggestion when user mostly uses Ask mode
- Drop the *"You mostly use Edit mode"* branch entirely (the mode no longer exists)
- Guard the `mode-diversity-low` tip so it does **not** fire for users who already use Agent mode heavily (> 85% of sessions)
- `single-file-edits-only` tip: Remove the *"(or Edit mode with multiple files selected)"* parenthetical

**`fluencyLevelData.json`**
- Stage 1 threshold: *"Not using edit mode or multi-file capabilities"* → *"Not using multi-file or agentic capabilities"*
- Stage 2 threshold: Remove *"Using edit mode OR"*
- Stage 2 tip: *"Try edit mode for focused code changes"* → *"Use agent mode for focused, multi-step code changes"*