### PR TITLE
fix: add credentials check to sharing server cleanup workflow

### DIFF
--- a/.github/workflows/sharing-server-cleanup.yml
+++ b/.github/workflows/sharing-server-cleanup.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Check Azure credentials
+        id: prereqs
+        run: |
+          if [[ -z "$ARM_CLIENT_ID" ]]; then
+            echo "⚠️ Azure credentials not configured for 'testing' environment — skipping cleanup." >> "$GITHUB_STEP_SUMMARY"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Reproduce the exact same slug+hash logic used by the deploy workflow
       # so the state key resolves to the same tfstate file.
       - name: Compute state key for branch
@@ -60,9 +70,11 @@ jobs:
           echo "state_key=sharing-server/test-${SLUG_TRUNC}${HASH}.tfstate"    >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
+        if: steps.prereqs.outputs.configured == 'true'
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Terraform init
+        if: steps.prereqs.outputs.configured == 'true'
         id: init
         working-directory: sharing-server/infra
         run: |
@@ -77,9 +89,11 @@ jobs:
       # binding still references the cert (400 CertificateInUse), which breaks
       # terraform destroy. We must unbind all hostnames and delete all certs first.
       - name: Azure CLI login
+        if: steps.prereqs.outputs.configured == 'true'
         run: az login --service-principal -u "$ARM_CLIENT_ID" -p "$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID" --output none
 
       - name: Pre-destroy - unbind custom domains and delete managed certs
+        if: steps.prereqs.outputs.configured == 'true'
         env:
           APP_NAME: ${{ steps.env.outputs.app_name }}
           RG:       ${{ vars.AZURE_RESOURCE_GROUP }}
@@ -118,6 +132,7 @@ jobs:
           fi
 
       - name: Destroy resources (if any exist)
+        if: steps.prereqs.outputs.configured == 'true'
         working-directory: sharing-server/infra
         env:
           # Variables are required by Terraform even for destroy; use safe placeholders


### PR DESCRIPTION
## Problem

The **Cleanup Sharing Server** workflow was failing on every branch deletion (including branches that never had a sharing-server test environment). The root cause: unlike the deploy workflow, the cleanup had no credentials check — so when `ARM_CLIENT_ID` is not configured in the `testing` environment, `terraform init` fails hard instead of skipping gracefully.

## Fix

Added a `Check Azure credentials` prereqs step to the cleanup workflow, mirroring the exact same pattern already present in `sharing-server-deploy.yml`. All Terraform/Azure CLI steps are now conditioned on `steps.prereqs.outputs.configured == 'true'`.

## What's already correct

The **Deploy** workflow already has `paths:` filtering:
```yaml
paths:
  - "sharing-server/**"
  - ".github/workflows/sharing-server-deploy.yml"
```
So it only runs when sharing-server code actually changes — no changes needed there.

> **Note:** `paths:` filters are not available on `delete` events (GitHub limitation), so the cleanup workflow will still _trigger_ for every branch deletion but will now exit cleanly (with a summary note) when credentials aren't configured, instead of failing.