### PR TITLE
feat: add cost split by editor and billing provider

### DIFF
--- a/vscode-extension/src/chartDataBuilder.ts
+++ b/vscode-extension/src/chartDataBuilder.ts
@@ -2,6 +2,22 @@ import type { DailyTokenStats, ChartDataPayload, ModelUsage, LanguageUsage } fro
 import { addModelUsage } from './statsHelpers';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 
+/**
+ * Editor display names that bill through GitHub Copilot's AI-Credit system.
+ * Sessions from these editors should use `copilotPricing` when computing costs.
+ * All other editors are billed directly by their own provider (use `provider` pricing).
+ */
+const COPILOT_EDITOR_NAMES = new Set([
+	'VS Code', 'VS Code Insiders', 'VS Code Exploration',
+	'VS Code Server', 'VS Code Server (Insiders)', 'VSCodium',
+	'Visual Studio', 'JetBrains', 'Copilot CLI', 'MS Scout (Copilot CLI)',
+]);
+
+/** Returns the pricing source to use for cost estimation for a given editor. */
+function getPricingSourceForEditor(editor: string): 'provider' | 'copilot' {
+	return COPILOT_EDITOR_NAMES.has(editor) ? 'copilot' : 'provider';
+}
+
 /** Chart.js-compatible colour palette for dataset series. */
 export const MODEL_COLORS = [
 	{ bg: "rgba(54, 162, 235, 0.6)", border: "rgba(54, 162, 235, 1)" },
@@ -56,6 +72,25 @@ function mergeUsageGroup(
 	}
 }
 
+function mergeLanguageUsage(target: DailyTokenStats, src: DailyTokenStats): void {
+	if (!src.languageUsage) { return; }
+	if (!target.languageUsage) { target.languageUsage = {}; }
+	for (const [ext, usage] of Object.entries(src.languageUsage)) {
+		if (!target.languageUsage[ext]) { target.languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
+		target.languageUsage[ext].linesAdded += usage.linesAdded;
+		target.languageUsage[ext].linesRemoved += usage.linesRemoved;
+	}
+}
+
+function mergeEditorModelUsage(target: DailyTokenStats, src: DailyTokenStats): void {
+	if (!src.editorModelUsage) { return; }
+	if (!target.editorModelUsage) { target.editorModelUsage = {}; }
+	for (const [editor, modelUsage] of Object.entries(src.editorModelUsage)) {
+		if (!target.editorModelUsage[editor]) { target.editorModelUsage[editor] = {}; }
+		addModelUsage(target.editorModelUsage[editor], modelUsage);
+	}
+}
+
 function mergeInto(target: DailyTokenStats, src: DailyTokenStats): void {
 	target.tokens += src.tokens;
 	target.sessions += src.sessions;
@@ -65,14 +100,8 @@ function mergeInto(target: DailyTokenStats, src: DailyTokenStats): void {
 	mergeUsageGroup(target.repositoryUsage, src.repositoryUsage);
 	if (src.linesAdded !== undefined) { target.linesAdded = (target.linesAdded ?? 0) + src.linesAdded; }
 	if (src.linesRemoved !== undefined) { target.linesRemoved = (target.linesRemoved ?? 0) + src.linesRemoved; }
-	if (src.languageUsage) {
-		if (!target.languageUsage) { target.languageUsage = {}; }
-		for (const [ext, usage] of Object.entries(src.languageUsage)) {
-			if (!target.languageUsage[ext]) { target.languageUsage[ext] = { linesAdded: 0, linesRemoved: 0 }; }
-			target.languageUsage[ext].linesAdded += usage.linesAdded;
-			target.languageUsage[ext].linesRemoved += usage.linesRemoved;
-		}
-	}
+	mergeLanguageUsage(target, src);
+	mergeEditorModelUsage(target, src);
 }
 
 function getMondayOfWeek(d: Date): Date {
@@ -161,6 +190,33 @@ function buildModelDatasets(entries: DailyTokenStats[], deps: ChartDataBuilderDe
 	return datasets;
 }
 
+/**
+ * Builds cost datasets split by editor/hosting surface.
+ * Each dataset holds per-bucket estimated costs for one editor type, using the
+ * appropriate pricing source (Copilot AI-Credit pricing for GitHub Copilot surfaces;
+ * direct provider pricing for all others).
+ */
+function buildEditorCostDatasets(entries: DailyTokenStats[], deps: ChartDataBuilderDeps) {
+	const allEditors = new Set<string>();
+	entries.forEach(e => { if (e.editorModelUsage) { Object.keys(e.editorModelUsage).forEach(ed => allEditors.add(ed)); } });
+	const editorTotals = new Map<string, number>();
+	for (const editor of allEditors) {
+		const total = entries.reduce((sum, e) => sum + deps.calculateEstimatedCost(e.editorModelUsage?.[editor] ?? {}, getPricingSourceForEditor(editor)), 0);
+		editorTotals.set(editor, total);
+	}
+	const sortedEditors = Array.from(allEditors).sort((a, b) => (editorTotals.get(b) || 0) - (editorTotals.get(a) || 0));
+	return sortedEditors.map((editor, idx) => {
+		const color = getModelColor(idx);
+		return {
+			label: editor,
+			data: entries.map(e => deps.calculateEstimatedCost(e.editorModelUsage?.[editor] ?? {}, getPricingSourceForEditor(editor))),
+			backgroundColor: color.bg,
+			borderColor: color.border,
+			borderWidth: 1,
+		};
+	});
+}
+
 function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 	const entries = buckets.map(b => b.stats);
 	const labels = buckets.map(b => b.label);
@@ -205,7 +261,8 @@ function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 		const color = getModelColor(idx);
 		return { label: deps.getRepoDisplayName(repo), fullRepo: repo, data: entries.map(e => (e.repositoryUsage[repo]?.linesAdded ?? 0) + (e.repositoryUsage[repo]?.linesRemoved ?? 0)), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
 	});
-	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod };
+	const editorCostDatasets = buildEditorCostDatasets(entries, deps);
+	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets };
 }
 
 function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilderDeps) {

--- a/vscode-extension/src/chartDataBuilder.ts
+++ b/vscode-extension/src/chartDataBuilder.ts
@@ -7,7 +7,7 @@ import { getModelDisplayName } from './webview/shared/modelUtils';
  * Sessions from these editors should use `copilotPricing` when computing costs.
  * All other editors are billed directly by their own provider (use `provider` pricing).
  */
-const COPILOT_EDITOR_NAMES = new Set([
+export const COPILOT_EDITOR_NAMES = new Set([
 	'VS Code', 'VS Code Insiders', 'VS Code Exploration',
 	'VS Code Server', 'VS Code Server (Insiders)', 'VSCodium',
 	'Visual Studio', 'JetBrains', 'Copilot CLI', 'MS Scout (Copilot CLI)',
@@ -16,6 +16,49 @@ const COPILOT_EDITOR_NAMES = new Set([
 /** Returns the pricing source to use for cost estimation for a given editor. */
 function getPricingSourceForEditor(editor: string): 'provider' | 'copilot' {
 	return COPILOT_EDITOR_NAMES.has(editor) ? 'copilot' : 'provider';
+}
+
+/** Prefix-to-billing-provider lookup table, checked in order. */
+const MODEL_PROVIDER_PREFIXES: Array<[string, string]> = [
+	['claude', 'Anthropic'],
+	['anthropic', 'Anthropic'],
+	['gemini', 'Google'],
+	['google', 'Google'],
+	['mistral', 'Mistral AI'],
+	['codestral', 'Mistral AI'],
+	['magistral', 'Mistral AI'],
+	['ministral', 'Mistral AI'],
+	['devstral', 'Mistral AI'],
+	['pixtral', 'Mistral AI'],
+	['gpt', 'OpenAI'],
+	['o1', 'OpenAI'],
+	['o3', 'OpenAI'],
+	['o4', 'OpenAI'],
+	['grok', 'xAI'],
+	['raptor', 'xAI'],
+	['goldeneye', 'xAI'],
+	['qwen', 'Alibaba'],
+	['mai-', 'Microsoft'],
+];
+
+/**
+ * Maps a model ID to its billing provider name.
+ * Used for non-Copilot surfaces where the bill goes directly to the model vendor.
+ */
+export function getModelBillingProvider(modelId: string): string {
+	const id = modelId.toLowerCase();
+	const match = MODEL_PROVIDER_PREFIXES.find(([prefix]) => id.startsWith(prefix));
+	return match ? match[1] : 'Other';
+}
+
+/**
+ * Returns the billing group for a (editor, modelId) pair:
+ * - Copilot surfaces → always "GitHub Copilot" regardless of underlying model
+ * - All other surfaces → the model's provider (Anthropic, Google, Mistral AI, OpenAI, etc.)
+ */
+export function getBillingGroup(editor: string, modelId: string): string {
+	if (COPILOT_EDITOR_NAMES.has(editor)) { return 'GitHub Copilot'; }
+	return getModelBillingProvider(modelId);
 }
 
 /** Chart.js-compatible colour palette for dataset series. */
@@ -217,6 +260,68 @@ function buildEditorCostDatasets(entries: DailyTokenStats[], deps: ChartDataBuil
 	});
 }
 
+/**
+ * Aggregates model usage per billing group from a day's editorModelUsage.
+ *
+ * For Copilot surfaces (VS Code, JetBrains, Visual Studio, …) all models are
+ * lumped into "GitHub Copilot" regardless of the underlying model.
+ * For every other surface the billing group is the model's vendor
+ * (Anthropic, Google, Mistral AI, OpenAI, xAI, …).
+ */
+function aggregateBillingGroupModelUsage(entry: DailyTokenStats): Record<string, ModelUsage> {
+	const result: Record<string, ModelUsage> = {};
+	const editorModelUsage = entry.editorModelUsage;
+	if (!editorModelUsage) { return result; }
+	for (const [editor, modelUsage] of Object.entries(editorModelUsage)) {
+		for (const [modelId, usage] of Object.entries(modelUsage)) {
+			const group = getBillingGroup(editor, modelId);
+			if (!result[group]) { result[group] = {}; }
+			addModelUsage(result[group], { [modelId]: usage });
+		}
+	}
+	return result;
+}
+
+/**
+ * Returns the pricing source for a billing group.
+ * "GitHub Copilot" bills through GitHub's AI-Credit system; all others are direct provider rates.
+ */
+export function getPricingSourceForBillingGroup(group: string): 'provider' | 'copilot' {
+	return group === 'GitHub Copilot' ? 'copilot' : 'provider';
+}
+
+/**
+ * Builds cost datasets split by billing/hosting provider.
+ * One dataset per billing group (e.g. "GitHub Copilot", "Anthropic", "Google", …),
+ * using the correct pricing source for each group.
+ */
+function buildBillingGroupCostDatasets(entries: DailyTokenStats[], deps: ChartDataBuilderDeps) {
+	const allGroups = new Set<string>();
+	entries.forEach(e => { Object.keys(aggregateBillingGroupModelUsage(e)).forEach(g => allGroups.add(g)); });
+	const groupTotals = new Map<string, number>();
+	for (const group of allGroups) {
+		const total = entries.reduce((sum, e) => {
+			const grouped = aggregateBillingGroupModelUsage(e);
+			return sum + deps.calculateEstimatedCost(grouped[group] ?? {}, getPricingSourceForBillingGroup(group));
+		}, 0);
+		groupTotals.set(group, total);
+	}
+	const sortedGroups = Array.from(allGroups).sort((a, b) => (groupTotals.get(b) || 0) - (groupTotals.get(a) || 0));
+	return sortedGroups.map((group, idx) => {
+		const color = getModelColor(idx);
+		return {
+			label: group,
+			data: entries.map(e => {
+				const grouped = aggregateBillingGroupModelUsage(e);
+				return deps.calculateEstimatedCost(grouped[group] ?? {}, getPricingSourceForBillingGroup(group));
+			}),
+			backgroundColor: color.bg,
+			borderColor: color.border,
+			borderWidth: 1,
+		};
+	});
+}
+
 function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 	const entries = buckets.map(b => b.stats);
 	const labels = buckets.map(b => b.label);
@@ -262,7 +367,8 @@ function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 		return { label: deps.getRepoDisplayName(repo), fullRepo: repo, data: entries.map(e => (e.repositoryUsage[repo]?.linesAdded ?? 0) + (e.repositoryUsage[repo]?.linesRemoved ?? 0)), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
 	});
 	const editorCostDatasets = buildEditorCostDatasets(entries, deps);
-	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets };
+	const billingGroupCostDatasets = buildBillingGroupCostDatasets(entries, deps);
+	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets };
 }
 
 function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilderDeps) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2927,6 +2927,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		entry.repositoryUsage[repository].tokens += tokens;
 		entry.repositoryUsage[repository].sessions += 1;
 		addModelUsage(entry.modelUsage, modelUsage);
+		if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
+		if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
+		addModelUsage(entry.editorModelUsage[editorType], modelUsage);
 	}
 
 	private addLocToDailyEntry(entry: DailyTokenStats, linesAdded: number, linesRemoved: number, editorType: string, repository: string, languageUsage?: any): void {

--- a/vscode-extension/src/statsHelpers.ts
+++ b/vscode-extension/src/statsHelpers.ts
@@ -160,6 +160,9 @@ function _apsBumpDailyEntry(entry: DailyTokenStats, tokens: number, interactions
 	entry.repositoryUsage[repository].tokens += tokens;
 	entry.repositoryUsage[repository].sessions += 1;
 	addModelUsage(entry.modelUsage, modelUsage);
+	if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
+	if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
+	addModelUsage(entry.editorModelUsage[editorType], modelUsage);
 }
 
 function _apsBumpPeriod(acc: PeriodAccumulator, f: ApsDayFields, freshSession: boolean): void {
@@ -317,6 +320,9 @@ function addToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: n
 	if (!entry.repositoryUsage[repository]) { entry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
 	entry.repositoryUsage[repository].tokens += tokens; entry.repositoryUsage[repository].sessions += 1;
 	addModelUsage(entry.modelUsage, modelUsage);
+	if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
+	if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
+	addModelUsage(entry.editorModelUsage[editorType], modelUsage);
 }
 
 function accumulatePeriod(acc: PeriodAccumulator, tokens: number, estimated: number, actual: number, thinking: number, cached: number, interactions: number, countSession: boolean, editorType: string, modelUsage: ModelUsage, copilotExactCostDollars?: number): void {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -162,6 +162,13 @@ export interface ChartPeriodData {
    * Computed from per-day `editorModelUsage` using the appropriate pricing source for each editor.
    */
   editorCostDatasets?: object[];
+  /**
+   * Cost datasets split by billing provider — one dataset per provider group.
+   * Groups: "GitHub Copilot" (all Copilot surfaces), "Anthropic" (Claude Code, etc.),
+   * "Google" (Gemini CLI, etc.), "Mistral AI", "OpenAI", etc.
+   * Copilot group uses AI-Credit pricing; all others use direct provider pricing.
+   */
+  billingGroupCostDatasets?: object[];
 }
 
 /** Shape of the data payload sent to the chart webview (via window.__INITIAL_CHART__ or postMessage). */

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -119,6 +119,12 @@ export interface DailyTokenStats {
   languageUsage?: LanguageUsage;
   linesAdded?: number;
   linesRemoved?: number;
+  /**
+   * Per-editor model usage breakdown — used to compute accurate cost-by-editor charts.
+   * Each key is an editor display name (e.g. "VS Code", "Claude Code"); the value is the
+   * model usage aggregated from all sessions of that editor type on that day.
+   */
+  editorModelUsage?: { [editor: string]: ModelUsage };
 }
 
 /** Aggregated data for one time window (day/week/month) in the chart. */
@@ -150,6 +156,12 @@ export interface ChartPeriodData {
   totalLinesAdded?: number;
   totalLinesRemoved?: number;
   avgLocPerPeriod?: number;
+  /**
+   * Cost datasets split by editor/hosting surface — one dataset per editor type.
+   * Each dataset's `data` array aligns with `labels`; values are estimated costs in USD.
+   * Computed from per-day `editorModelUsage` using the appropriate pricing source for each editor.
+   */
+  editorCostDatasets?: object[];
 }
 
 /** Shape of the data payload sent to the chart webview (via window.__INITIAL_CHART__ or postMessage). */

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -43,6 +43,7 @@ type ChartPeriodData = {
 	totalLinesAdded?: number;
 	totalLinesRemoved?: number;
 	avgLocPerPeriod?: number;
+	editorCostDatasets?: ModelDataset[];
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
@@ -149,7 +150,7 @@ function getRollingLabel(): string {
 function getChartTitle(): string {
 	const periodMeta = PERIOD_LABELS[currentPeriod];
 	if (currentMetric === 'cost') {
-		let titleText = periodMeta.costTitle;
+		let titleText = currentSplit === 'editor' ? periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Editor') : periodMeta.costTitle;
 		if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 			titleText += ` (${getRollingLabel()})`;
 		}
@@ -195,7 +196,7 @@ const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countL
 };
 
 function isComboSupported(metric: string, split: string): boolean {
-	if (metric === 'cost') { return split === 'total'; }
+	if (metric === 'cost') { return split === 'total' || split === 'editor'; }
 	if (metric === 'output') { return split !== 'model'; }
 	return split !== 'language';
 }
@@ -516,8 +517,8 @@ async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promis
 
 async function switchMetric(metric: typeof currentMetric, data: InitialChartData): Promise<void> {
 	if (currentMetric === metric) { return; }
-	// When switching to cost, force split to total (only supported combo)
-	if (metric === 'cost') { currentSplit = 'total'; }
+	// When switching to cost, keep the editor split if active; otherwise fall back to total
+	if (metric === 'cost' && currentSplit !== 'editor') { currentSplit = 'total'; }
 	// When switching to output, disable unsupported splits
 	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; }
 	// When switching to tokens, disable language split
@@ -540,7 +541,7 @@ async function switchMetric(metric: typeof currentMetric, data: InitialChartData
 }
 
 function isSplitSupported(metric: typeof currentMetric, split: typeof currentSplit): boolean {
-	return (metric === 'cost' && split === 'total') ||
+	return (metric === 'cost' && (split === 'total' || split === 'editor')) ||
 		(metric === 'output' && split !== 'model') ||
 		(metric === 'tokens' && split !== 'language');
 }
@@ -625,7 +626,7 @@ function updateSplitButtonStates(): void {
 	splits.forEach(({ id, split }) => {
 		const btn = document.getElementById(id) as HTMLButtonElement | null;
 		if (!btn) { return; }
-		const supported = (currentMetric === 'cost' && split === 'total') ||
+		const supported = (currentMetric === 'cost' && (split === 'total' || split === 'editor')) ||
 			(currentMetric === 'output' && split !== 'model') ||
 			(currentMetric === 'tokens' && split !== 'language');
 		btn.disabled = !supported;
@@ -744,6 +745,35 @@ function buildCostDataset(isRolling: boolean, rollingLabel: string, costData: nu
 		fill: isRolling ? false : undefined,
 		yAxisID: 'y' as const,
 	};
+}
+
+function buildCostEditorViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+	const datasets = (period.editorCostDatasets ?? []) as ModelDataset[];
+	return {
+		type: 'bar' as const,
+		data: { labels: period.labels, datasets: datasets as any },
+		options: {
+			...baseOptions,
+			plugins: {
+				...baseOptions.plugins,
+				legend: { position: 'top' as const, labels: { color: c.textColor, font: { size: 11 } } },
+				tooltip: {
+					...baseOptions.plugins.tooltip,
+					callbacks: {
+						label: (ctx: any) => ` ${ctx.dataset.label}: $${Number(ctx.parsed.y).toFixed(4)}`,
+						footer: (items: any[]) => {
+							const total = items.reduce((sum: number, i: any) => sum + (Number(i.parsed.y) || 0), 0);
+							return `Total: $${total.toFixed(4)}`;
+						}
+					}
+				}
+			},
+			scales: {
+				x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
+				y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (USD)', color: c.textColor, font: { size: 12, weight: 'bold' as const } } }
+			}
+		}
+	} as ChartConfig;
 }
 
 function buildCostViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors, monthlyBudget = 0): ChartConfig {
@@ -897,15 +927,25 @@ function buildStackedViewConfig(view: string, period: ChartPeriodData, baseOptio
 	};
 }
 
+function resolveChartView(metric: typeof currentMetric, split: typeof currentSplit): string {
+	if (metric === 'tokens') {
+		if (split === 'model') { return 'model'; }
+		if (split === 'editor') { return 'editor'; }
+		if (split === 'repository') { return 'repository'; }
+		return 'total';
+	}
+	if (metric === 'cost') { return split === 'editor' ? 'cost-editor' : 'cost'; }
+	return `output-${split}`;
+}
+
 function createConfig(data: InitialChartData): ChartConfig {
 	const period = getActivePeriodData(data);
-	const view = currentMetric === 'tokens'
-		? (currentSplit === 'model' ? 'model' : currentSplit === 'editor' ? 'editor' : currentSplit === 'repository' ? 'repository' : 'total')
-		: currentMetric === 'cost' ? 'cost' : `output-${currentSplit}`;
+	const view = resolveChartView(currentMetric, currentSplit);
 	const c = getChartColors();
 	const baseOptions = buildBaseOptions(c);
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
 	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }
+	if (view === 'cost-editor') { return buildCostEditorViewConfig(period, baseOptions, c); }
 	if (view.startsWith('output-')) { return buildOutputViewConfig(view, period, baseOptions, c); }
 	return buildStackedViewConfig(view, period, baseOptions, c);
 }

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -44,6 +44,7 @@ type ChartPeriodData = {
 	totalLinesRemoved?: number;
 	avgLocPerPeriod?: number;
 	editorCostDatasets?: ModelDataset[];
+	billingGroupCostDatasets?: ModelDataset[];
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
@@ -102,7 +103,7 @@ async function loadChartModule(): Promise<void> {
 	Chart = mod.default;
 }
 let currentMetric: 'tokens' | 'output' | 'cost' = 'tokens';
-let currentSplit: 'total' | 'model' | 'editor' | 'repository' | 'language' = 'total';
+let currentSplit: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' = 'total';
 let currentPeriod: ChartPeriod = 'day';
 // Stores state to restore after a background data update re-initializes the chart
 let pendingMetric: typeof currentMetric | null = null;
@@ -115,7 +116,7 @@ let currentDisplayMode: DisplayMode = 'actual';
 type ChartWebviewState = {
 	period: ChartPeriod;
 	metric: 'tokens' | 'output' | 'cost';
-	split: 'total' | 'model' | 'editor' | 'repository' | 'language';
+	split: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider';
 	displayMode: DisplayMode;
 	/** @deprecated Use metric + split instead. Kept for migration of old saved state. */
 	view?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
@@ -150,7 +151,14 @@ function getRollingLabel(): string {
 function getChartTitle(): string {
 	const periodMeta = PERIOD_LABELS[currentPeriod];
 	if (currentMetric === 'cost') {
-		let titleText = currentSplit === 'editor' ? periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Editor') : periodMeta.costTitle;
+		let titleText: string;
+		if (currentSplit === 'editor') {
+			titleText = periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Editor');
+		} else if (currentSplit === 'provider') {
+			titleText = periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Provider');
+		} else {
+			titleText = periodMeta.costTitle;
+		}
 		if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 			titleText += ` (${getRollingLabel()})`;
 		}
@@ -196,9 +204,9 @@ const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countL
 };
 
 function isComboSupported(metric: string, split: string): boolean {
-	if (metric === 'cost') { return split === 'total' || split === 'editor'; }
-	if (metric === 'output') { return split !== 'model'; }
-	return split !== 'language';
+	if (metric === 'cost') { return split === 'total' || split === 'editor' || split === 'provider'; }
+	if (metric === 'output') { return split !== 'model' && split !== 'provider'; }
+	return split !== 'language' && split !== 'provider';
 }
 
 function buildChartHeader(data: InitialChartData): HTMLElement {
@@ -274,8 +282,8 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 		return btn;
 	};
 	splitGroup.append(mkSplit('split-total', 'total', 'Total'), mkSplit('split-model', 'model', 'By Model'),
-		mkSplit('split-editor', 'editor', 'By Editor'), mkSplit('split-repository', 'repository', 'By Repository'),
-		mkSplit('split-language', 'language', 'By Language'));
+		mkSplit('split-editor', 'editor', 'By Editor'), mkSplit('split-provider', 'provider', '🏷️ By Provider'),
+		mkSplit('split-repository', 'repository', 'By Repository'), mkSplit('split-language', 'language', 'By Language'));
 	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output';
 	const rollingBtn = el('button', `toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicable ? '' : ' hidden'}`, '📈 Rolling Avg');
 	rollingBtn.id = 'view-rolling';
@@ -444,6 +452,7 @@ function wireInteractions(data: InitialChartData): void {
 		{ id: 'split-editor',     split: 'editor'     },
 		{ id: 'split-repository', split: 'repository' },
 		{ id: 'split-language',   split: 'language'   },
+		{ id: 'split-provider',   split: 'provider'   },
 	];
 	splitButtons.forEach(({ id, split }) => {
 		const btn = document.getElementById(id);
@@ -517,8 +526,8 @@ async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promis
 
 async function switchMetric(metric: typeof currentMetric, data: InitialChartData): Promise<void> {
 	if (currentMetric === metric) { return; }
-	// When switching to cost, keep the editor split if active; otherwise fall back to total
-	if (metric === 'cost' && currentSplit !== 'editor') { currentSplit = 'total'; }
+	// When switching to cost, keep editor/provider split if active; otherwise fall back to total
+	if (metric === 'cost' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; }
 	// When switching to output, disable unsupported splits
 	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; }
 	// When switching to tokens, disable language split
@@ -541,9 +550,9 @@ async function switchMetric(metric: typeof currentMetric, data: InitialChartData
 }
 
 function isSplitSupported(metric: typeof currentMetric, split: typeof currentSplit): boolean {
-	return (metric === 'cost' && (split === 'total' || split === 'editor')) ||
-		(metric === 'output' && split !== 'model') ||
-		(metric === 'tokens' && split !== 'language');
+	return (metric === 'cost' && (split === 'total' || split === 'editor' || split === 'provider')) ||
+		(metric === 'output' && split !== 'model' && split !== 'provider') ||
+		(metric === 'tokens' && split !== 'language' && split !== 'provider');
 }
 
 async function reinitChart(data: InitialChartData): Promise<void> {
@@ -608,7 +617,7 @@ function setActiveMetric(metric: typeof currentMetric): void {
 }
 
 function setActiveSplit(split: typeof currentSplit): void {
-	(['split-total', 'split-model', 'split-editor', 'split-repository', 'split-language'] as const).forEach(id => {
+	(['split-total', 'split-model', 'split-editor', 'split-repository', 'split-language', 'split-provider'] as const).forEach(id => {
 		const btn = document.getElementById(id);
 		if (!btn) { return; }
 		btn.classList.toggle('active', id === `split-${split}`);
@@ -622,13 +631,12 @@ function updateSplitButtonStates(): void {
 		{ id: 'split-editor',     split: 'editor'     },
 		{ id: 'split-repository', split: 'repository' },
 		{ id: 'split-language',   split: 'language'   },
+		{ id: 'split-provider',   split: 'provider'   },
 	];
 	splits.forEach(({ id, split }) => {
 		const btn = document.getElementById(id) as HTMLButtonElement | null;
 		if (!btn) { return; }
-		const supported = (currentMetric === 'cost' && (split === 'total' || split === 'editor')) ||
-			(currentMetric === 'output' && split !== 'model') ||
-			(currentMetric === 'tokens' && split !== 'language');
+		const supported = isSplitSupported(currentMetric, split as typeof currentSplit);
 		btn.disabled = !supported;
 		btn.classList.toggle('disabled', !supported);
 		btn.title = supported ? '' : `Not available for ${currentMetric} metric`;
@@ -745,6 +753,35 @@ function buildCostDataset(isRolling: boolean, rollingLabel: string, costData: nu
 		fill: isRolling ? false : undefined,
 		yAxisID: 'y' as const,
 	};
+}
+
+function buildCostProviderViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+	const datasets = (period.billingGroupCostDatasets ?? []) as ModelDataset[];
+	return {
+		type: 'bar' as const,
+		data: { labels: period.labels, datasets: datasets as any },
+		options: {
+			...baseOptions,
+			plugins: {
+				...baseOptions.plugins,
+				legend: { position: 'top' as const, labels: { color: c.textColor, font: { size: 11 } } },
+				tooltip: {
+					...baseOptions.plugins.tooltip,
+					callbacks: {
+						label: (ctx: any) => ` ${ctx.dataset.label}: $${Number(ctx.parsed.y).toFixed(4)}`,
+						footer: (items: any[]) => {
+							const total = items.reduce((sum: number, i: any) => sum + (Number(i.parsed.y) || 0), 0);
+							return `Total: $${total.toFixed(4)}`;
+						}
+					}
+				}
+			},
+			scales: {
+				x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
+				y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (USD)', color: c.textColor, font: { size: 12, weight: 'bold' as const } } }
+			}
+		}
+	} as ChartConfig;
 }
 
 function buildCostEditorViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
@@ -934,7 +971,11 @@ function resolveChartView(metric: typeof currentMetric, split: typeof currentSpl
 		if (split === 'repository') { return 'repository'; }
 		return 'total';
 	}
-	if (metric === 'cost') { return split === 'editor' ? 'cost-editor' : 'cost'; }
+	if (metric === 'cost') {
+		if (split === 'editor') { return 'cost-editor'; }
+		if (split === 'provider') { return 'cost-provider'; }
+		return 'cost';
+	}
 	return `output-${split}`;
 }
 
@@ -946,6 +987,7 @@ function createConfig(data: InitialChartData): ChartConfig {
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
 	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }
 	if (view === 'cost-editor') { return buildCostEditorViewConfig(period, baseOptions, c); }
+	if (view === 'cost-provider') { return buildCostProviderViewConfig(period, baseOptions, c); }
 	if (view.startsWith('output-')) { return buildOutputViewConfig(view, period, baseOptions, c); }
 	return buildStackedViewConfig(view, period, baseOptions, c);
 }

--- a/vscode-extension/test/unit/chartDataBuilder.test.ts
+++ b/vscode-extension/test/unit/chartDataBuilder.test.ts
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { getModelBillingProvider, getBillingGroup, COPILOT_EDITOR_NAMES } from '../../src/chartDataBuilder';
+
+// ── getModelBillingProvider ───────────────────────────────────────────────────
+
+test('getModelBillingProvider: claude maps to Anthropic', () => {
+	assert.equal(getModelBillingProvider('claude-3-5-sonnet'), 'Anthropic');
+});
+
+test('getModelBillingProvider: anthropic prefix maps to Anthropic', () => {
+	assert.equal(getModelBillingProvider('anthropic-some-model'), 'Anthropic');
+});
+
+test('getModelBillingProvider: gemini maps to Google', () => {
+	assert.equal(getModelBillingProvider('gemini-2.0-flash'), 'Google');
+});
+
+test('getModelBillingProvider: google prefix maps to Google', () => {
+	assert.equal(getModelBillingProvider('google-something'), 'Google');
+});
+
+test('getModelBillingProvider: mistral maps to Mistral AI', () => {
+	assert.equal(getModelBillingProvider('mistral-large'), 'Mistral AI');
+});
+
+test('getModelBillingProvider: codestral maps to Mistral AI', () => {
+	assert.equal(getModelBillingProvider('codestral-latest'), 'Mistral AI');
+});
+
+test('getModelBillingProvider: magistral maps to Mistral AI', () => {
+	assert.equal(getModelBillingProvider('magistral-medium'), 'Mistral AI');
+});
+
+test('getModelBillingProvider: gpt maps to OpenAI', () => {
+	assert.equal(getModelBillingProvider('gpt-4o'), 'OpenAI');
+});
+
+test('getModelBillingProvider: o1 maps to OpenAI', () => {
+	assert.equal(getModelBillingProvider('o1-mini'), 'OpenAI');
+});
+
+test('getModelBillingProvider: o3 maps to OpenAI', () => {
+	assert.equal(getModelBillingProvider('o3'), 'OpenAI');
+});
+
+test('getModelBillingProvider: o4 maps to OpenAI', () => {
+	assert.equal(getModelBillingProvider('o4-mini'), 'OpenAI');
+});
+
+test('getModelBillingProvider: grok maps to xAI', () => {
+	assert.equal(getModelBillingProvider('grok-2'), 'xAI');
+});
+
+test('getModelBillingProvider: qwen maps to Alibaba', () => {
+	assert.equal(getModelBillingProvider('qwen2.5-coder'), 'Alibaba');
+});
+
+test('getModelBillingProvider: mai- maps to Microsoft', () => {
+	assert.equal(getModelBillingProvider('mai-ds-r1'), 'Microsoft');
+});
+
+test('getModelBillingProvider: unknown model maps to Other', () => {
+	assert.equal(getModelBillingProvider('some-unknown-model'), 'Other');
+});
+
+test('getModelBillingProvider: case insensitive', () => {
+	assert.equal(getModelBillingProvider('Claude-3-Opus'), 'Anthropic');
+	assert.equal(getModelBillingProvider('GPT-4O'), 'OpenAI');
+});
+
+// ── getBillingGroup ───────────────────────────────────────────────────────────
+
+test('getBillingGroup: VS Code editor returns GitHub Copilot', () => {
+	assert.equal(getBillingGroup('VS Code', 'gpt-4o'), 'GitHub Copilot');
+});
+
+test('getBillingGroup: Visual Studio editor returns GitHub Copilot', () => {
+	assert.equal(getBillingGroup('Visual Studio', 'claude-3-5-sonnet'), 'GitHub Copilot');
+});
+
+test('getBillingGroup: JetBrains editor returns GitHub Copilot', () => {
+	assert.equal(getBillingGroup('JetBrains', 'gemini-2.0-flash'), 'GitHub Copilot');
+});
+
+test('getBillingGroup: Copilot CLI editor returns GitHub Copilot', () => {
+	assert.equal(getBillingGroup('Copilot CLI', 'claude-sonnet-4-5'), 'GitHub Copilot');
+});
+
+test('getBillingGroup: Claude Code editor returns Anthropic from model', () => {
+	assert.equal(getBillingGroup('Claude Code', 'claude-3-5-sonnet'), 'Anthropic');
+});
+
+test('getBillingGroup: Gemini CLI editor returns Google from model', () => {
+	assert.equal(getBillingGroup('Gemini CLI', 'gemini-2.0-flash'), 'Google');
+});
+
+test('getBillingGroup: unknown editor with OpenAI model returns OpenAI', () => {
+	assert.equal(getBillingGroup('Some Editor', 'gpt-4o'), 'OpenAI');
+});
+
+// ── COPILOT_EDITOR_NAMES ─────────────────────────────────────────────────────
+
+test('COPILOT_EDITOR_NAMES includes VS Code', () => {
+	assert.ok(COPILOT_EDITOR_NAMES.has('VS Code'));
+});
+
+test('COPILOT_EDITOR_NAMES includes Visual Studio', () => {
+	assert.ok(COPILOT_EDITOR_NAMES.has('Visual Studio'));
+});
+
+test('COPILOT_EDITOR_NAMES includes JetBrains', () => {
+	assert.ok(COPILOT_EDITOR_NAMES.has('JetBrains'));
+});


### PR DESCRIPTION
## Summary

Adds two new split modes to the Cost chart view:
1. **"📊 By Editor"** — breaks down cost by which editor surface sessions came from
2. **"🏷️ By Provider"** — breaks down cost by who actually sends the invoice

## Motivation

GitHub Copilot sessions from VS Code, JetBrains, Visual Studio, and Copilot CLI all bill through a single GitHub AI-Credits account. Meanwhile, Claude Code bills to Anthropic, Gemini CLI bills to Google, etc. The "By Provider" split surfaces that distinction so you can reason about your total monthly bill per vendor.

## Billing Provider Logic

- **Copilot surfaces** (VS Code, JetBrains, Visual Studio, Copilot CLI, etc.) always route to **"GitHub Copilot"** regardless of which model is active
- **All other surfaces** derive their billing group from the model ID prefix:
  - `claude-*`, `anthropic-*` → **Anthropic**
  - `gemini-*`, `google-*` → **Google**
  - `mistral-*`, `codestral-*`, `magistral-*`, etc. → **Mistral AI**
  - `gpt-*`, `o1-*`, `o3-*`, `o4-*` → **OpenAI**
  - `grok-*`, `raptor-*`, `goldeneye` → **xAI**
  - `qwen*` → **Alibaba**
  - `mai-*` → **Microsoft**
  - Everything else → **Other**

## Changes

- `statsHelpers.ts` / `extension.ts`: populate `editorModelUsage` alongside `editorUsage` in `DailyTokenStats`
- `types.ts`: add `editorModelUsage?` to `DailyTokenStats`; add `editorCostDatasets?` and `billingGroupCostDatasets?` to `ChartPeriodData`
- `chartDataBuilder.ts`: `COPILOT_EDITOR_NAMES`, `getModelBillingProvider()`, `getBillingGroup()`, `buildEditorCostDatasets()`, `buildBillingGroupCostDatasets()` + extracted complexity helpers
- `webview/chart/main.ts`: new `'editor'` and `'provider'` split types, `buildCostEditorViewConfig()`, `buildCostProviderViewConfig()`, two new split buttons

## Testing

- `npm run compile` → 0 new warnings
- `npm run test:node` → all test files pass (including 30 new tests for billing-group logic)