### PR TITLE
Add high-prompt-bloat insight for tool curation savings > 2.5k tokens

### DIFF
--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -856,6 +856,26 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		weight: 70,
 	},
 	{
+		id: 'high-prompt-bloat',
+		category: 'tools',
+		severity: 'opportunity',
+		title: '💡 Unused tools are adding significant prompt overhead',
+		buildBody: (ctx) => {
+			const tokens = ctx.curationAnalysis?.estimatedPromptBloat.totalTokens ?? 0;
+			const unusedCount = ctx.curationAnalysis?.unusedTools.length ?? 0;
+			return `Your unused tools are adding an estimated ~${tokens.toLocaleString()} extra tokens to every prompt. ` +
+				`${unusedCount} tool${unusedCount !== 1 ? 's' : ''} (MCP servers and/or skills) ${unusedCount !== 1 ? 'were' : 'was'} not used in the last ${ctx.curationAnalysis?.windowDays ?? 30} days but ${unusedCount !== 1 ? 'are' : 'is'} still injected into each interaction. ` +
+				`Removing or disabling them can meaningfully reduce your prompt size, lower latency, and cut costs.`;
+		},
+		actionLabel: 'View Tool Curation',
+		actionCommand: 'aiEngineeringFluency.openToolsTab',
+		appliesTo: (ctx) => {
+			if (!ctx.curationAnalysis) { return false; }
+			return ctx.curationAnalysis.estimatedPromptBloat.totalTokens > 2500;
+		},
+		weight: 65,
+	},
+	{
 		id: 'stale-skills',
 		category: 'customization',
 		severity: 'tip',

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import * as assert from 'node:assert/strict';
 import { INSIGHT_CATALOG, evaluateInsights } from '../../src/insightsEngine';
 import type { InsightContext } from '../../src/insightsEngine';
-import type { UsageAnalysisPeriod } from '../../src/types';
+import type { ToolCurationAnalysis, UsageAnalysisPeriod } from '../../src/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -122,4 +122,71 @@ test('auto-compaction-pattern: body mentions /compact and /new', () => {
 	assert.ok(insight);
 	assert.ok(insight!.body.includes('/compact'), 'body should mention /compact');
 	assert.ok(insight!.body.includes('/new'), 'body should mention /new');
+});
+
+// ---------------------------------------------------------------------------
+// high-prompt-bloat insight tests
+// ---------------------------------------------------------------------------
+
+const HIGH_PROMPT_BLOAT_ID = 'high-prompt-bloat';
+
+function makeCurationAnalysis(totalTokens: number, unusedToolCount: number): ToolCurationAnalysis {
+	return {
+		windowDays: 30,
+		availableTools: [],
+		usedTools: [],
+		unusedTools: Array.from({ length: unusedToolCount }, (_, i) => ({
+			name: `tool-${i}`,
+			description: 'test tool',
+			source: 'mcp' as const,
+		})),
+		underusedMcpServers: [],
+		estimatedPromptBloat: { totalTokens, byServer: {} },
+		recommendations: [],
+	};
+}
+
+test('high-prompt-bloat: insight exists in INSIGHT_CATALOG', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === HIGH_PROMPT_BLOAT_ID);
+	assert.ok(def, 'high-prompt-bloat should be in INSIGHT_CATALOG');
+});
+
+test('high-prompt-bloat: does NOT fire when curationAnalysis is absent', () => {
+	const ctx = makeCtx();
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === HIGH_PROMPT_BLOAT_ID);
+	assert.equal(insight, undefined);
+});
+
+test('high-prompt-bloat: does NOT fire when totalTokens <= 2500', () => {
+	const ctx: InsightContext = { ...makeCtx(), curationAnalysis: makeCurationAnalysis(2500, 3) };
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === HIGH_PROMPT_BLOAT_ID);
+	assert.equal(insight, undefined);
+});
+
+test('high-prompt-bloat: fires when totalTokens > 2500', () => {
+	const ctx: InsightContext = { ...makeCtx(), curationAnalysis: makeCurationAnalysis(2501, 3) };
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === HIGH_PROMPT_BLOAT_ID);
+	assert.ok(insight, 'insight should fire when totalTokens > 2500');
+});
+
+test('high-prompt-bloat: body includes token count', () => {
+	const ctx: InsightContext = { ...makeCtx(), curationAnalysis: makeCurationAnalysis(5000, 2) };
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === HIGH_PROMPT_BLOAT_ID);
+	assert.ok(insight);
+	assert.ok(insight!.body.includes('5'), 'body should mention the token count (5000)');
+	assert.ok(/extra tokens/.test(insight!.body), 'body should mention extra tokens');
+});
+
+test('high-prompt-bloat: has severity=opportunity', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === HIGH_PROMPT_BLOAT_ID);
+	assert.equal(def?.severity, 'opportunity');
+});
+
+test('high-prompt-bloat: has category=tools', () => {
+	const def = INSIGHT_CATALOG.find(d => d.id === HIGH_PROMPT_BLOAT_ID);
+	assert.equal(def?.category, 'tools');
 });


### PR DESCRIPTION
## Summary

Adds a new `high-prompt-bloat` insight to the Insights Engine that fires when unused tools (MCP servers and/or skills) are estimated to contribute **more than 2,500 extra context tokens per prompt**.

## Details

The insight:
- **Category**: `tools`
- **Severity**: `opportunity`  
- **Weight**: 65 (surfaces prominently alongside the existing `unused-mcp-servers` insight at 70)
- **Action**: "View Tool Curation" → `aiEngineeringFluency.openToolsTab` (the new view from #1410)

**Trigger condition**: `curationAnalysis.estimatedPromptBloat.totalTokens > 2500`

The body message explains how many unused tools and how many estimated tokens are being added to every prompt, and encourages the user to open the Tool Curation tab to review and remove them.

## Tests

7 new unit tests in `insightsEngine.test.ts` covering:
- Exists in catalog
- Does not fire without curation analysis
- Does not fire at or below 2,500 tokens
- Fires above 2,500 tokens  
- Body includes token count
- Correct severity and category