### PR TITLE
chore: bump VS Code extension version to 0.12.0

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep: VS Code extension v0.12.0

Bumps version from `0.11.7` → `0.12.0` to prepare a new release.

### Changes since v0.11.7

**Features:**
- feat: add cost split by editor and billing provider (#1412)
- Add Tool Curation feature for analyzing tool usage (#1410)
- Add high-prompt-bloat insight for tool curation savings (#1420)
- feat: add friendly names (#1419, #1404, #1400, #1397, #1388)
- feat: Add Microsoft Scout editor support (#1391)
- fix: align details view total tokens with status bar (#1401)
- fix: add buildTurns() to ClaudeCodeAdapter (#1402)
- fix: remove Edit mode references from tips and fluency data (#1408)
- rename: CopilotTokenTracker → AIEngineeringFluency in VS extension (#1394)
- feat: externalize JSON config files from webview bundles (#1393)
- Bring Visual Studio extension to parity with VS Code extension (#1392)

**Fixes & chores:**
- fix: address dependabot security alerts via npm overrides (#1422)
- Various dependency bumps

### After merging

Run the **VS Code Extension Release** GitHub Actions workflow to publish to the marketplace.