### PR TITLE
fix(vscode): replace deprecated @vscode/webview-ui-toolkit with @vscode-elements/elements

### DIFF
--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -99,16 +99,13 @@ async function main() {
 		fs.copyFileSync(wasmSrc, wasmDst);
 	}
 
-	// Copy VS Code Webview UI Toolkit to dist/ for webview usage
+	// Copy vscode-elements bundle to dist/ for webview usage (configPanel loads it at runtime via URI)
 	const toolkitDir = path.join(__dirname, 'dist', 'toolkit');
 	if (!fs.existsSync(toolkitDir)) {
 		fs.mkdirSync(toolkitDir, { recursive: true });
 	}
-	const toolkitSrc = path.join(__dirname, 'node_modules', '@vscode', 'webview-ui-toolkit', 'dist');
-	// Use minified version in production, regular version in development
-	const toolkitFile = production ? 'toolkit.min.js' : 'toolkit.js';
-	const src = path.join(toolkitSrc, toolkitFile);
-	const dst = path.join(toolkitDir, 'toolkit.js'); // Always name it toolkit.js for consistent loading
+	const src = path.join(__dirname, 'node_modules', '@vscode-elements', 'elements', 'dist', 'bundled.js');
+	const dst = path.join(toolkitDir, 'toolkit.js');
 	if (fs.existsSync(src)) {
 		fs.copyFileSync(src, dst);
 	}

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -16,7 +16,7 @@
         "@azure/identity": "^4.13.1",
         "@azure/storage-blob": "^12.31.0",
         "@msgpack/msgpack": "^3.1.3",
-        "@vscode/webview-ui-toolkit": "^1.4.0",
+        "@vscode-elements/elements": "^2.5.1",
         "chart.js": "^4.4.1",
         "html-escape": "^2.0.0",
         "html2canvas": "1.4.1",
@@ -3418,50 +3418,28 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
-    "node_modules/@microsoft/fast-element": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.14.0.tgz",
-      "integrity": "sha512-zXvuSOzvsu8zDTy9eby8ix8VqLop2rwKRgp++ZN2kTCsoB3+QJVoaGD2T/Cyso2ViZQFXNpiNCVKfnmxBvmWkQ==",
-      "license": "MIT"
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
     },
-    "node_modules/@microsoft/fast-foundation": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.50.0.tgz",
-      "integrity": "sha512-8mFYG88Xea1jZf2TI9Lm/jzZ6RWR8x29r24mGuLojNYqIR2Bl8+hnswoV6laApKdCbGMPKnsAL/O68Q0sRxeVg==",
-      "license": "MIT",
+    "node_modules/@lit/context": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@microsoft/fast-element": "^1.14.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
+        "@lit/reactive-element": "^1.6.2 || ^2.1.0"
       }
     },
-    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.25.tgz",
-      "integrity": "sha512-jKzmk2xJV93RL/jEFXEZgBvXlKIY4N4kXy3qrjmBfFpqNi3VjY+oUTWyMnHRMC5EUhIFxD+Y1VD4u9uIPX3jQw==",
-      "license": "MIT",
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@microsoft/fast-element": "^1.14.0",
-        "@microsoft/fast-foundation": "^2.50.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "license": "MIT",
-      "dependencies": {
-        "exenv-es6": "^1.1.1"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@msgpack/msgpack": {
@@ -4412,8 +4390,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.110.0",
@@ -4668,6 +4645,26 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@vscode-elements/elements": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-2.5.1.tgz",
+      "integrity": "sha512-HiKgIj9GwlfYkw1LrxG7dM5bMQUr8/GkOqG1HU1+npGHd51nRKCF6ZZ9FtnfoC2wujNN0lc+m0emH/wMpAseYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lit/context": "^1.1.3",
+        "lit": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@vscode/codicons": ">=0.0.40"
+      }
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
+      "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/@vscode/vsce": {
       "version": "3.9.2",
@@ -4957,22 +4954,6 @@
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
-      }
-    },
-    "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "deprecated": "This package has been deprecated, https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
       }
     },
     "node_modules/acorn": {
@@ -6917,13 +6898,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
-    },
-    "node_modules/exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
@@ -9011,6 +8985,37 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -10529,16 +10534,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -11916,12 +11911,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "license": "MIT"
-    },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
       "license": "MIT"
     },
     "node_modules/table": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -385,7 +385,11 @@
         "aiEngineeringFluency.curation.timeWindowDays": {
           "type": "number",
           "default": 30,
-          "enum": [7, 30, 90],
+          "enum": [
+            7,
+            30,
+            90
+          ],
           "enumDescriptions": [
             "Look back 7 days when determining which tools are unused",
             "Look back 30 days when determining which tools are unused (default)",
@@ -532,7 +536,7 @@
     "@azure/identity": "^4.13.1",
     "@azure/storage-blob": "^12.31.0",
     "@msgpack/msgpack": "^3.1.3",
-    "@vscode/webview-ui-toolkit": "^1.4.0",
+    "@vscode-elements/elements": "^2.5.1",
     "chart.js": "^4.4.1",
     "html-escape": "^2.0.0",
     "html2canvas": "1.4.1",

--- a/vscode-extension/src/backend/configPanel.ts
+++ b/vscode-extension/src/backend/configPanel.ts
@@ -383,12 +383,11 @@ function buildProfileDetailsHtml(): string {
 
 function buildToolkitScriptTag(nonce: string, toolkitUri: string): string {
 	return `	<script type="module" nonce="${nonce}">
-		// Register toolkit components before main script runs
+		// Import vscode-elements bundle — components auto-register on import
 		try {
-			const { provideVSCodeDesignSystem, vsCodeButton, vsCodeBadge } = await import(${safeJsonForInlineScript(toolkitUri)});
-			provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeBadge());
+			await import(${safeJsonForInlineScript(toolkitUri)});
 		} catch (error) {
-			console.warn('Failed to load VS Code Webview UI Toolkit:', error);
+			console.warn('Failed to load vscode-elements toolkit:', error);
 		}
 		// Signal that toolkit registration is complete (or has failed)
 		window.__toolkitReady = true;

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -1028,8 +1028,7 @@ function restoreChartState(initialData: InitialChartData): void {
 }
 
 async function bootstrap(): Promise<void> {
-	const { provideVSCodeDesignSystem, vsCodeButton } = await import('@vscode/webview-ui-toolkit');
-	provideVSCodeDesignSystem().register(vsCodeButton());
+	await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
 	if (!initialData) {
 		const root = document.getElementById('root');

--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -675,9 +675,7 @@ window.addEventListener("message", (event) => {
 
 async function bootstrap(): Promise<void> {
   console.log("[CopilotTokenTracker] dashboard bootstrap called");
-  const { provideVSCodeDesignSystem, vsCodeButton } =
-    await import("@vscode/webview-ui-toolkit");
-  provideVSCodeDesignSystem().register(vsCodeButton());
+  await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
   currentConfig = window.__DASHBOARD_CONFIG__ ?? null;
 

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -848,8 +848,8 @@ wireExtensionPointButtons(vscode as { postMessage: (message: unknown) => void })
 
 async function bootstrap(): Promise<void> {
 console.log('[CopilotTokenTracker] bootstrap called');
-const { provideVSCodeDesignSystem, vsCodeButton, vsCodeBadge } = await import('@vscode/webview-ui-toolkit');
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeBadge());
+await import('@vscode-elements/elements/dist/vscode-button/index.js');
+await import('@vscode-elements/elements/dist/vscode-badge/index.js');
 
 if (initialData) {
 console.log('[CopilotTokenTracker] Rendering details with initialData:', initialData);

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -2382,9 +2382,7 @@ function renderLayout(data: DiagnosticsData): void {
   }
 }
 async function bootstrap(): Promise<void> {
-  const { provideVSCodeDesignSystem, vsCodeButton } =
-    await import("@vscode/webview-ui-toolkit");
-  provideVSCodeDesignSystem().register(vsCodeButton());
+  await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
   if (!initialData) {
     const root = document.getElementById("root");

--- a/vscode-extension/src/webview/environmental/main.ts
+++ b/vscode-extension/src/webview/environmental/main.ts
@@ -302,8 +302,7 @@ registerMessageHandler<{ command: string; data?: EnvironmentalStats }>((message)
 });
 
 async function bootstrap(): Promise<void> {
-	const { provideVSCodeDesignSystem, vsCodeButton } = await import('@vscode/webview-ui-toolkit');
-	provideVSCodeDesignSystem().register(vsCodeButton());
+	await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
 	if (initialData) {
 		render(initialData);

--- a/vscode-extension/src/webview/fluency-level-viewer/main.ts
+++ b/vscode-extension/src/webview/fluency-level-viewer/main.ts
@@ -152,8 +152,7 @@ function renderLayout(data: FluencyLevelData): void {
 }
 
 async function bootstrap(): Promise<void> {
-	const { provideVSCodeDesignSystem, vsCodeButton } = await import('@vscode/webview-ui-toolkit');
-	provideVSCodeDesignSystem().register(vsCodeButton());
+	await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
 	if (!initialData) {
 		const root = document.getElementById('root');

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1364,8 +1364,7 @@ ${data.turns.length > 0
 }
 
 async function bootstrap(): Promise<void> {
-const { provideVSCodeDesignSystem, vsCodeButton } = await import('@vscode/webview-ui-toolkit');
-provideVSCodeDesignSystem().register(vsCodeButton());
+await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
 if (!initialData) {
 const root = document.getElementById('root');

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -591,8 +591,7 @@ function renderLayout(data: MaturityData): void {
 }
 
 async function bootstrap(): Promise<void> {
-	const { provideVSCodeDesignSystem, vsCodeButton } = await import('@vscode/webview-ui-toolkit');
-	provideVSCodeDesignSystem().register(vsCodeButton());
+	await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
 	if (!initialData) {
 		const root = document.getElementById('root');

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -3503,8 +3503,7 @@ function handleBatchAnalysisComplete(): void {
 }
 
 async function bootstrap(): Promise<void> {
-	const { provideVSCodeDesignSystem, vsCodeButton } = await import('@vscode/webview-ui-toolkit');
-	provideVSCodeDesignSystem().register(vsCodeButton());
+	await import('@vscode-elements/elements/dist/vscode-button/index.js');
 
 	// TOOL_NAME_MAP is imported at build-time from src/toolNames.json
 


### PR DESCRIPTION
## Summary

- Replaces the deprecated `@vscode/webview-ui-toolkit@1.4.0` with `@vscode-elements/elements@^2.5.1` (the community-maintained successor)
- Updates `esbuild.js` to copy the new package's `dist/bundled.js` instead of the old toolkit file
- Removes all `provideVSCodeDesignSystem().register()` calls — the new package auto-registers components on import
- Affected files: `configPanel.ts` (backend) + 9 webview `main.ts` files

## Test plan

- [ ] Build passes with no errors (`npm run compile`)
- [ ] `<vscode-button>` renders correctly in all webviews (usage, chart, dashboard, logviewer, maturity, environmental, fluency-level-viewer, diagnostics, details)
- [ ] `<vscode-badge>` renders correctly in the details webview and config panel
- [ ] Config panel loads and registers components correctly via runtime URI import
- [ ] No `npm warn deprecated` warning for `@vscode/webview-ui-toolkit` during install

🤖 Generated with [Claude Code](https://claude.com/claude-code)