### PR TITLE
fix: improve VS Code extension UI in light mode (#1457)

### DIFF
--- a/vscode-extension/src/webview/dashboard/styles.css
+++ b/vscode-extension/src/webview/dashboard/styles.css
@@ -242,25 +242,25 @@
 
 .fluency-badge.stage-1 {
 	background-color: rgba(147, 197, 253, 0.15);
-	color: #93c5fd;
+	color: var(--stage-1-color);
 	border: 1px solid rgba(147, 197, 253, 0.4);
 }
 
 .fluency-badge.stage-2 {
 	background-color: rgba(167, 139, 250, 0.15);
-	color: #a78bfa;
+	color: var(--stage-2-color);
 	border: 1px solid rgba(167, 139, 250, 0.4);
 }
 
 .fluency-badge.stage-3 {
 	background-color: rgba(59, 130, 246, 0.15);
-	color: #3b82f6;
+	color: var(--stage-3-color);
 	border: 1px solid rgba(59, 130, 246, 0.4);
 }
 
 .fluency-badge.stage-4 {
 	background-color: rgba(34, 211, 238, 0.15);
-	color: #22d3ee;
+	color: var(--stage-4-color);
 	border: 1px solid rgba(34, 211, 238, 0.4);
 }
 
@@ -384,10 +384,10 @@
 }
 
 /* Re-use matching stage colors for inline badges */
-.fluency-category-badge.stage-1 { background: rgba(147,197,253,0.15); color: #93c5fd; }
-.fluency-category-badge.stage-2 { background: rgba(167,139,250,0.15); color: #a78bfa; }
-.fluency-category-badge.stage-3 { background: rgba(59,130,246,0.15);  color: #3b82f6; }
-.fluency-category-badge.stage-4 { background: rgba(34,211,238,0.15);  color: #22d3ee; }
+.fluency-category-badge.stage-1 { background: rgba(147,197,253,0.15); color: var(--stage-1-color); }
+.fluency-category-badge.stage-2 { background: rgba(167,139,250,0.15); color: var(--stage-2-color); }
+.fluency-category-badge.stage-3 { background: rgba(59,130,246,0.15);  color: var(--stage-3-color); }
+.fluency-category-badge.stage-4 { background: rgba(34,211,238,0.15);  color: var(--stage-4-color); }
 
 /* Left-border accent matching stage color */
 .stage-border-1 { border-left: 3px solid #93c5fd; }
@@ -405,7 +405,7 @@
 	flex: 1;
 	height: 4px;
 	border-radius: 2px;
-	background: rgba(255,255,255,0.1);
+	background: var(--stage-pip-empty-bg);
 }
 
 .stage-pip.filled.stage-pip-1 { background: #93c5fd; }
@@ -419,47 +419,47 @@
 	flex-direction: column;
 	margin-top: 10px;
 	padding-top: 8px;
-	border-top: 1px solid #2a2a30;
+	border-top: 1px solid var(--border-color);
 }
 
 .fluency-tips-label {
 	font-size: 11px;
 	font-weight: 600;
-	color: #f59e0b;
+	color: var(--warning-fg);
 	margin-bottom: 6px;
 }
 
 .fluency-tip {
-	background: #18181b;
-	border: 1px solid #2a2a30;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-color);
 	border-radius: 6px;
 	padding: 10px 12px;
 	margin-bottom: 8px;
 	font-size: 12px;
-	color: #d0d0d0;
+	color: var(--text-primary);
 	line-height: 1.4;
 	word-break: break-word;
 	overflow-wrap: break-word;
 }
 
 .fluency-tip a {
-	color: #60a5fa;
+	color: var(--link-color);
 	text-decoration: none;
 	border-bottom: 1px solid transparent;
 	transition: border-color 0.2s ease;
 }
 
 .fluency-tip a:hover {
-	border-bottom-color: #60a5fa;
+	border-bottom-color: var(--link-color);
 }
 
 .fluency-achieved {
 	font-size: 11px;
-	color: #10b981;
+	color: var(--success-fg);
 	font-weight: 600;
 	margin-top: 10px;
 	padding-top: 8px;
-	border-top: 1px solid #2a2a30;
+	border-top: 1px solid var(--border-color);
 }
 
 /* Tab navigation (shown when both Azure and Team Server are configured) */

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -288,12 +288,12 @@ body {
 }
 
 .context-ref-filter:hover {
-	background: rgb(79, 195, 247, 0.2);
+	background: var(--list-hover-bg);
 	color: var(--link-color);
 }
 
 .context-ref-filter.active {
-	background: rgb(79, 195, 247, 0.3);
+	background: var(--list-inactive-bg);
 	color: var(--link-color);
 	font-weight: 600;
 }
@@ -371,7 +371,7 @@ body {
 	margin: 8px 0 4px;
 	font-size: 13px;
 	font-weight: 600;
-	color: var(--fg-muted, #ccc);
+	color: var(--fg-muted);
 }
 
 .tool-type-badge {
@@ -385,12 +385,12 @@ body {
 
 .tool-type-badge.built-in {
 	background: rgba(100, 120, 180, 0.25);
-	color: #9bb0d8;
+	color: var(--stage-3-color);
 }
 
 .tool-type-badge.alternative {
 	background: rgba(100, 200, 120, 0.2);
-	color: #7ecf8e;
+	color: var(--success-fg);
 }
 
 .tool-ratio {
@@ -404,22 +404,22 @@ body {
 }
 
 .ratio-better {
-	color: #7ecf8e;
+	color: var(--success-fg);
 }
 
 .ratio-worse {
-	color: #e06c75;
+	color: var(--error-fg);
 }
 
 .ratio-neutral {
-	color: var(--fg-muted, #ccc);
+	color: var(--fg-muted);
 }
 
 .inline-link {
 	background: none;
 	border: none;
 	padding: 0;
-	color: var(--link-color, #4fc1ff);
+	color: var(--link-color);
 	cursor: pointer;
 	font-size: inherit;
 	text-decoration: underline;
@@ -432,7 +432,7 @@ body {
 
 
 .session-table tr:hover {
-	background: rgb(255, 255, 255, 0.03);
+	background: var(--list-hover-bg);
 }
 
 .editor-badge {
@@ -575,19 +575,20 @@ border: 1px solid #1f6feb;
 
 .hierarchy-parent {
 	background: rgba(100, 60, 180, 0.2);
-	color: #b89dff;
+	color: var(--stage-2-color);
 	border: 1px solid rgba(100, 60, 180, 0.4);
 	cursor: pointer;
 }
 
 .hierarchy-parent:hover {
 	background: rgba(100, 60, 180, 0.35);
-	color: #d0b8ff;
+	color: var(--stage-2-color);
+	opacity: 0.85;
 }
 
 .hierarchy-children {
 	background: rgba(30, 120, 80, 0.2);
-	color: #7adbb0;
+	color: var(--success-fg);
 	border: 1px solid rgba(30, 120, 80, 0.4);
 }
 
@@ -611,7 +612,8 @@ border: 1px solid #1f6feb;
 	content: '↳';
 	position: absolute;
 	left: 4px;
-	color: rgba(30, 120, 80, 0.7);
+	color: var(--success-fg);
+	opacity: 0.7;
 	font-size: 11px;
 }
 

--- a/vscode-extension/src/webview/fluency-level-viewer/styles.css
+++ b/vscode-extension/src/webview/fluency-level-viewer/styles.css
@@ -39,7 +39,7 @@
 	display: inline-block;
 	padding: 4px 10px;
 	background: rgba(255, 152, 0, 0.2);
-	color: #ff9800;
+	color: var(--warning-fg);
 	border-radius: 12px;
 	font-size: 11px;
 	font-weight: 600;
@@ -48,8 +48,8 @@
 }
 
 .info-box {
-	background: rgba(3, 102, 214, 0.1);
-	border: 1px solid rgba(3, 102, 214, 0.3);
+	background: color-mix(in srgb, var(--link-color) 10%, transparent);
+	border: 1px solid color-mix(in srgb, var(--link-color) 30%, transparent);
 	border-radius: 6px;
 	padding: 12px 16px;
 	margin-bottom: 20px;
@@ -60,7 +60,7 @@
 .info-box-title {
 	font-weight: 600;
 	margin-bottom: 6px;
-	color: #3b82f6;
+	color: var(--link-color);
 }
 
 .category-selector {

--- a/vscode-extension/src/webview/shared/theme.css
+++ b/vscode-extension/src/webview/shared/theme.css
@@ -51,6 +51,18 @@
 	--error-fg: var(--vscode-errorForeground);
 	--warning-fg: var(--vscode-editorWarning-foreground);
 	--success-fg: var(--vscode-terminal-ansiGreen);
+
+	/* Stage accent colors — dark theme defaults */
+	--stage-1-color: #93c5fd;
+	--stage-2-color: #a78bfa;
+	--stage-3-color: #3b82f6;
+	--stage-4-color: #22d3ee;
+
+	/* Stage progress pip empty fill */
+	--stage-pip-empty-bg: rgba(128, 128, 128, 0.2);
+
+	/* Semantic muted foreground */
+	--fg-muted: var(--vscode-disabledForeground);
 	
 	/* Shadow for cards */
 	--shadow-color: rgb(0, 0, 0, 0.16);
@@ -62,6 +74,12 @@ body[data-vscode-theme-kind="vscode-light"],
 body[data-vscode-theme-kind="vscode-high-contrast-light"] {
 	--shadow-color: rgb(0, 0, 0, 0.08);
 	--shadow-hover-color: rgb(0, 0, 0, 0.12);
+	/* Stage colors darkened for readable contrast on light backgrounds */
+	--stage-1-color: #1d6fa4;
+	--stage-2-color: #7c3aed;
+	--stage-3-color: #2563eb;
+	--stage-4-color: #0891b2;
+	--stage-pip-empty-bg: rgba(0, 0, 0, 0.12);
 }
 
 /* High contrast mode adjustments */

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -294,7 +294,7 @@ body {
 }
 
 .stale-warning {
-	color: #f59e0b;
+	color: var(--warning-fg);
 	font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary

Fixes hardcoded dark-mode colors throughout all webview CSS files so the UI renders correctly in VS Code light and high-contrast-light themes.

Closes #1457

## Root Cause

Several CSS files had hardcoded colors designed for dark backgrounds (e.g. `#18181b`, `#2a2a30`, `rgba(255,255,255,0.1)`, `#93c5fd`, `#d0d0d0`) that became unreadable or invisible in light mode.

## Changes

### `shared/theme.css`
- Added `--stage-1/2/3/4-color` variables (dark theme: pale blue/purple/cyan; light theme: darker accessible equivalents)
- Added `--stage-pip-empty-bg` (dark: white-alpha; light: black-alpha, so empty pips are visible in both modes)
- Added `--fg-muted` variable to replace the `#ccc` fallback used in several files

### `dashboard/styles.css`
- Fluency badges (`.fluency-badge.stage-X`, `.fluency-category-badge.stage-X`): replaced hardcoded colors with `var(--stage-X-color)`
- Stage progress pips: `rgba(255,255,255,0.1)` → `var(--stage-pip-empty-bg)` (was invisible in light mode)
- Tips section (`.fluency-tips`, `.fluency-tip`, `.fluency-tips-label`, `.fluency-achieved`): replaced all hardcoded dark colors (`#18181b`, `#2a2a30`, `#d0d0d0`, `#f59e0b`, `#10b981`) with CSS theme variables

### `diagnostics/styles.css`
- Tool type badges, ratio indicators, hierarchy badges: replaced hardcoded `#9bb0d8`, `#7ecf8e`, `#e06c75`, `#b89dff`, `#7adbb0`, `#ccc` with CSS variables
- Session table row hover: `rgb(255,255,255,0.03)` (invisible) → `var(--list-hover-bg)`
- Context-ref filter hover: replaced hardcoded blue rgba with `var(--list-hover-bg)`
- Child session arrow: replaced hardcoded green rgba with `var(--success-fg)` + opacity

### `usage/styles.css`
- `.stale-warning`: `#f59e0b` → `var(--warning-fg)`

### `fluency-level-viewer/styles.css`
- `.debug-badge`: `#ff9800` → `var(--warning-fg)`
- `.info-box` and `.info-box-title`: replaced hardcoded Microsoft-blue rgba with `color-mix()` + `var(--link-color)` so it adapts to any VS Code theme color