### PR TITLE
fix: restore gradlew files before create-pull-request to prevent stash conflicts

### DIFF
--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -466,6 +466,10 @@ jobs:
           print(f"✅ Wrote {len(to_add)} new entries to toolNames.json", file=sys.stderr)
           PYEOF
           
+      - name: Restore gradlew files to prevent stash conflicts
+        if: steps.extract.outputs.has_missing == 'true'
+        run: git checkout -- jetbrains-plugin/gradlew.bat jetbrains-plugin/gradlew
+
       - name: Create Pull Request
         if: steps.extract.outputs.has_missing == 'true'
         id: create-pr


### PR DESCRIPTION
## Summary

The \dd-toolnames-with-slm\ job in \check-toolnames.yml\ fails when \peter-evans/create-pull-request\ tries to stash/pop because \jetbrains-plugin/gradlew.bat\ has spurious modifications (line-ending artifacts from \.gitattributes\ \*.bat text eol=crlf\).

## Fix

Added a \git checkout --\ restore step before the \Create Pull Request\ step to discard spurious modifications to \gradlew.bat\ and \gradlew\, so the internal stash/pop cycle doesn't encounter a conflict.

## Related

Fixes the CI failure observed in issue #1445 where the fix process stumbled on \gradlew.bat\ being overwritten.