### PR TITLE
fix: discover customization files in multi-root .code-workspace folders

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -155,6 +155,7 @@ import {
   globToRegExp as _globToRegExp,
   resolveExactWorkspacePath as _resolveExactWorkspacePath,
   scanWorkspaceCustomizationFiles as _scanWorkspaceCustomizationFiles,
+  parseCodeWorkspaceFolders as _parseCodeWorkspaceFolders,
   getRepositoryUrl as _getRepositoryUrl,
   getModeType as _getModeType,
   extractCustomAgentName as _extractCustomAgentName,
@@ -3551,6 +3552,28 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private ensureWorkspaceCustomizationCached(norm: string): void {
 		if (this._customizationFilesCache.has(norm)) { return; }
 		try {
+			// Handle multi-root workspace (.code-workspace) files — scan each folder and merge
+			if (norm.endsWith('.code-workspace')) {
+				const folders = _parseCodeWorkspaceFolders(norm);
+				if (folders.length > 0) {
+					const allFiles: CustomizationFileEntry[] = [];
+					const seen = new Set<string>();
+					for (const folder of folders) {
+						try {
+							const files = _scanWorkspaceCustomizationFiles(folder);
+							for (const f of files) {
+								const key = path.normalize(f.path);
+								if (!seen.has(key)) {
+									seen.add(key);
+									allFiles.push(f);
+								}
+							}
+						} catch { /* skip per-folder scan errors */ }
+					}
+					this._customizationFilesCache.set(norm, allFiles);
+					return;
+				}
+			}
 			const files = _scanWorkspaceCustomizationFiles(norm);
 			this._customizationFilesCache.set(norm, files);
 		} catch (e) { /* ignore scan errors per workspace */ }

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -762,6 +762,43 @@ export async function extractRepositoryFromContentReferences(contentReferences: 
 	return undefined;
 }
 
+/**
+ * Parse a `.code-workspace` multi-root workspace file and return the resolved folder paths.
+ * Returns an empty array if the file cannot be read, is invalid JSON, or has no folders.
+ */
+export function parseCodeWorkspaceFolders(codeWorkspacePath: string): string[] {
+	try {
+		if (!codeWorkspacePath || !codeWorkspacePath.endsWith('.code-workspace') || !fs.existsSync(codeWorkspacePath)) {
+			return [];
+		}
+		const raw = fs.readFileSync(codeWorkspacePath, 'utf8');
+		const obj = JSON.parse(raw);
+		if (typeof obj !== 'object' || obj === null || !Array.isArray(obj.folders)) {
+			return [];
+		}
+		const folders: string[] = [];
+		for (const entry of obj.folders) {
+			if (typeof entry !== 'object' || entry === null) { continue; }
+			let folderPath: string | undefined;
+			if (typeof entry.path === 'string') {
+				folderPath = entry.path;
+			} else if (typeof entry.uri === 'string' && entry.uri.startsWith('file://')) {
+				folderPath = resolveFileUri(entry.uri);
+			}
+			if (!folderPath) { continue; }
+			try {
+				const resolved = fs.realpathSync.native(folderPath);
+				folders.push(resolved);
+			} catch {
+				folders.push(folderPath);
+			}
+		}
+		return folders;
+	} catch {
+		return [];
+	}
+}
+
 export function resolveWorkspaceFolderFromSessionPath(sessionFilePath: string, workspaceIdToFolderCache: Map<string, string | undefined>): string | undefined {
 	try {
 		// Normalize and split path into segments

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -1503,3 +1503,94 @@ test('globToRegExp: case-insensitive flag set correctly', () => {
     assert.ok(!reSensitive.flags.includes('i'));
     assert.ok(reInsensitive.flags.includes('i'));
 });
+
+// ---------------------------------------------------------------------------
+// parseCodeWorkspaceFolders
+// ---------------------------------------------------------------------------
+
+import { parseCodeWorkspaceFolders } from '../../src/workspaceHelpers';
+
+test('parseCodeWorkspaceFolders: returns empty array for non-existent path', () => {
+    const result = parseCodeWorkspaceFolders('/does/not/exist/code-workspace');
+    assert.deepEqual(result, []);
+});
+
+test('parseCodeWorkspaceFolders: returns empty array for non-code-workspace path', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pcwf-'));
+    try {
+        const tmpFile = nodePath.join(tmpDir, 'not-a-workspace.json');
+        fs.writeFileSync(tmpFile, '{}', 'utf8');
+        const result = parseCodeWorkspaceFolders(tmpFile);
+        assert.deepEqual(result, []);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('parseCodeWorkspaceFolders: returns folders from valid .code-workspace with path entries', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pcwf-'));
+    try {
+        const folder1 = nodePath.join(tmpDir, 'repo1');
+        const folder2 = nodePath.join(tmpDir, 'repo2');
+        fs.mkdirSync(folder1, { recursive: true });
+        fs.mkdirSync(folder2, { recursive: true });
+        const wsFile = nodePath.join(tmpDir, 'test.code-workspace');
+        fs.writeFileSync(wsFile, JSON.stringify({
+            folders: [
+                { path: folder1 },
+                { path: folder2 },
+            ],
+        }), 'utf8');
+        const result = parseCodeWorkspaceFolders(wsFile);
+        // should resolve both folders via realpathSync.native
+        assert.equal(result.length, 2);
+        assert.ok(result.some(p => nodePath.basename(p) === 'repo1'));
+        assert.ok(result.some(p => nodePath.basename(p) === 'repo2'));
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('parseCodeWorkspaceFolders: handles file:// URI entries', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pcwf-'));
+    try {
+        const folder = nodePath.join(tmpDir, 'my-project');
+        fs.mkdirSync(folder, { recursive: true });
+        const wsFile = nodePath.join(tmpDir, 'test.code-workspace');
+        const fileUri = 'file://' + (process.platform === 'win32' ? '/' + folder.replace(/\\/g, '/') : folder);
+        fs.writeFileSync(wsFile, JSON.stringify({
+            folders: [
+                { uri: fileUri },
+            ],
+        }), 'utf8');
+        const result = parseCodeWorkspaceFolders(wsFile);
+        assert.equal(result.length, 1);
+        assert.ok(result[0].endsWith('my-project'));
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('parseCodeWorkspaceFolders: returns empty array for invalid JSON', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pcwf-'));
+    try {
+        const wsFile = nodePath.join(tmpDir, 'bad.code-workspace');
+        fs.writeFileSync(wsFile, 'not-json', 'utf8');
+        const result = parseCodeWorkspaceFolders(wsFile);
+        assert.deepEqual(result, []);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('parseCodeWorkspaceFolders: returns empty array when folders key is missing', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-pcwf-'));
+    try {
+        const wsFile = nodePath.join(tmpDir, 'no-folders.code-workspace');
+        fs.writeFileSync(wsFile, JSON.stringify({ settings: {} }), 'utf8');
+        const result = parseCodeWorkspaceFolders(wsFile);
+        assert.deepEqual(result, []);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Problem

When a multi-root workspace is opened via a \.code-workspace\ file, \esolveWorkspaceFolderFromSessionPath\ returns the \.code-workspace\ file path instead of the individual workspace folder paths. This causes customization files like \copilot-instructions.md\, \.cursorrules\, etc. inside those folders to never be discovered for session correlation.

Fixes #1461

## Fix

1. **\parseCodeWorkspaceFolders()\** (workspaceHelpers.ts) — new helper that reads a \.code-workspace\ JSON file, extracts \olders[].path\ and \olders[].uri\ entries, resolves them to filesystem paths, and returns the list.

2. **\nsureWorkspaceCustomizationCached\** (extension.ts) — when the path ends with \.code-workspace\, parses the folders, scans customization files from each folder, deduplicates by absolute path, and caches the merged result under the \.code-workspace\ key.

## What still works

- **Session tracking** (counts, interactions, tokens) — these are tracked in \	rackWorkspaceForSession\ before the customization scan call, so usage stats remain correct.
- **Single-folder workspaces** — unaffected (the \.code-workspace\ branch is never entered).
- **Graceful degradation** — if the \.code-workspace\ file doesn't exist, can't be parsed, or has no folders, the function falls back to the standard \scanWorkspaceCustomizationFiles\ behavior (which returns \[]\ for file paths).
- **Existing unit tests** — all 226 tests pass.

## New unit tests

- Returns empty array for non-existent path (no file)
- Returns empty array for non-\.code-workspace\ file
- Returns folders from valid \.code-workspace\ with \path\ entries
- Handles \ile://\ URI entries
- Returns empty array for invalid JSON
- Returns empty array when \olders\ key is missing