### PR TITLE
fix: align total tokens to include cached and thinking tokens

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3541,7 +3541,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			title: sessionData.title || null, filePath: sessionFile, interactions,
 			toolCalls: analysis.toolCalls.total, inputTokens: inputTok, outputTokens: outputTok,
 			thinkingTokens: sessionData.thinkingTokens || 0, cachedTokens: cachedTok,
-			totalTokens: sessionData.actualTokens || sessionData.tokens || 0,
+			totalTokens: inputTok + outputTok + cachedTok + (sessionData.thinkingTokens || 0),
 			estimatedCost: sessionData.copilotExactCostDollars ?? this.calculateEstimatedCost(modelUsage),
 			editor: this.detectEditorSource(sessionFile), models: Object.keys(modelUsage),
 			lastActivity: sessionData.lastInteraction || new Date(mtime).toISOString(),

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -221,7 +221,7 @@ setCompactNumbers(stats.compactNumbers !== false);
 const root = document.getElementById('root');
 if (!root) { return; }
 
-const projectedTokens = Math.round(calculateProjection(stats.last30Days.tokens));
+const projectedTokens = Math.round(calculateProjection(stats.last30Days.tokens + (stats.last30Days.cachedTokens ?? 0) + stats.last30Days.thinkingTokens));
 const projectedSessions = Math.round(calculateProjection(stats.last30Days.sessions));
 const projectedCo2 = calculateProjection(stats.last30Days.co2);
 const projectedWater = calculateProjection(stats.last30Days.waterUsage);
@@ -330,11 +330,9 @@ function outputTokenCell(p: PeriodStats): string {
 
 function totalTokenCell(p: PeriodStats): string {
 	const modelTotal = sumInputTokens(p) + sumOutputTokens(p);
-	// When actual tokens (from debug logs) are available, prefer p.tokens — it
-	// captures every llm_request event including those without model attribution,
-	// matching the value shown in the status bar. Otherwise prefer modelTotal
-	// (per-request API data), then fall back to the text-based estimate.
-	if ((p.actualTokens ?? 0) > 0) { return formatCompact(p.tokens); }
+	if ((p.actualTokens ?? 0) > 0) {
+		return formatCompact(p.tokens + (p.cachedTokens ?? 0) + p.thinkingTokens);
+	}
 	return formatCompact(modelTotal > 0 ? modelTotal : p.tokens);
 }
 


### PR DESCRIPTION
Fixes #1454

The "Total tokens" column in both the Details Panel and Usage Analysis → Today's Sessions table was computed as input+output only, ignoring cached and thinking tokens. This caused Total ≠ Input + Output + Cached, breaking user expectations.

### Changes

**extension.ts** — `collectTodaySessionInfo()`: Changed `totalTokens` from `sessionData.actualTokens || sessionData.tokens` to `inputTok + outputTok + cachedTok + thinkingTokens` (uses already-resolved per-column values).

**details/main.ts** — `totalTokenCell()`: When debug log data is available, adds `p.cachedTokens` and `p.thinkingTokens` to `p.tokens` instead of returning `p.tokens` alone. Also fixes the projection calculation to use the same total.

### Verification
- TypeScript compilation passes cleanly
- No existing tests broken
