### PR TITLE
chore: prepare releases for VS Code extension v0.12.0 and CLI v0.2.10

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the CLI (@rajbos/ai-engineering-fluency) will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+- Fix update sync-host-views skill paths after CopilotTokenTracker rename (#1398)
+- Fix modelSwitching cost model array initialization
+
+### Maintenance
+- Added unit tests for error handling and CLI utilities (#1375)
+- Bumped `@types/node` to 26.0.0
+- Bumped `esbuild` to 0.28.1
+
 ## [0.2.9] - 2026-06-07
 
 ### Features

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the VS Code extension will be documented in this file.
 
+## [Unreleased]
+
+### Features
+- Tool Curation tab: analyze tool usage patterns, identify unused or underused tools (#1410)
+- Per-provider budget costs in status bar tooltip (#1412)
+- Cost split by editor and billing provider in analysis views (#1412)
+- Microsoft Scout editor session support (#1391)
+- Cursor editor session support (#1357)
+- Externalized JSON config files from webview bundles for easier customization (#1393)
+- Add 17+ friendly tool names across multiple issues
+
+### Bug Fixes
+- Align total tokens to include cached and thinking tokens (#1460)
+- Fix multi-root .code-workspace folder customization discovery (#1467)
+- Fix session state fields for messageIds and turnStatusCounts (#1462)
+- Fix UI colors for VS Code light mode (#1458)
+- Fix Scout session detection and display name labeling
+- Fix OpenCode SQLite DB session detection and add DeepSeek V4 Flash pricing (#1443)
+- Fix deprecated @vscode/webview-ui-toolkit replacement with @vscode-elements/elements
+- Fix unknown models showing "$0 cost" instead of gpt-4o-mini fallback
+- Fix per-tool suppression and background update stats refresh
+- Fix security vulnerabilities via npm overrides
+
+### Improvements
+- Added comprehensive unit tests improving coverage to 87.60% (#1375, #1406, #1436)
+- Enhanced JetBrains session parsing with turn-level metadata (#1455)
+- Code refactoring and dependency updates
+
 ## [0.11.6] - 2026-06-07
 
 ### Features


### PR DESCRIPTION
## Release Preparation

### VS Code Extension v0.12.0
- Version already bumped in \package.json\
- New features: Tool Curation tab, per-provider budget costs, Scout/Cursor editor support, 17+ friendly tool names
- Bug fixes: multi-root workspace support, token alignment, UI fixes, security updates
- Tests: coverage improved to 87.60%

### CLI v0.2.10
- Patch bump from 0.2.9
- Bug fixes and dependency updates

After merging, trigger the release workflows:
1. **Extensions - Release** → Run workflow (extension will publish to VS Code Marketplace + Open VSX)
2. **CLI - Publish to npm and GitHub** → Run workflow (CLI will publish to npm + create GitHub release)