### PR TITLE
chore: bump VS Code extension to v0.12.1

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,32 +4,6 @@ All notable changes to the VS Code extension will be documented in this file.
 
 ## [Unreleased]
 
-### Features
-- Tool Curation tab: analyze tool usage patterns, identify unused or underused tools (#1410)
-- Per-provider budget costs in status bar tooltip (#1412)
-- Cost split by editor and billing provider in analysis views (#1412)
-- Microsoft Scout editor session support (#1391)
-- Cursor editor session support (#1357)
-- Externalized JSON config files from webview bundles for easier customization (#1393)
-- Add 17+ friendly tool names across multiple issues
-
-### Bug Fixes
-- Align total tokens to include cached and thinking tokens (#1460)
-- Fix multi-root .code-workspace folder customization discovery (#1467)
-- Fix session state fields for messageIds and turnStatusCounts (#1462)
-- Fix UI colors for VS Code light mode (#1458)
-- Fix Scout session detection and display name labeling
-- Fix OpenCode SQLite DB session detection and add DeepSeek V4 Flash pricing (#1443)
-- Fix deprecated @vscode/webview-ui-toolkit replacement with @vscode-elements/elements
-- Fix unknown models showing "$0 cost" instead of gpt-4o-mini fallback
-- Fix per-tool suppression and background update stats refresh
-- Fix security vulnerabilities via npm overrides
-
-### Improvements
-- Added comprehensive unit tests improving coverage to 87.60% (#1375, #1406, #1436)
-- Enhanced JetBrains session parsing with turn-level metadata (#1455)
-- Code refactoring and dependency updates
-
 ## [0.11.6] - 2026-06-07
 
 ### Features

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release Preparation

### VS Code Extension v0.12.1
- Patch bump (v0.12.0 was already published last week)
- Includes fixes since v0.12.0: token alignment, multi-root customization, UI fixes, Scout/Cursor editor support, security updates, and more

After merging, trigger **Extensions - Release** workflow from GitHub Actions to publish.