### PR TITLE
refactor: resolve all 29 lint complexity warnings

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -719,45 +719,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					void vscode.window.showTextDocument(vscode.Uri.file(message.path));
 				}
 			},
-			openToolPicker:         async () => {
-				this.log('🔧 openToolPicker: handler invoked');
-				const allCommands = await vscode.commands.getCommands(true);
-				const configureToolsId = 'workbench.action.chat.configureTools';
-				const hasConfigure = allCommands.includes(configureToolsId);
-				this.log(`🔧 openToolPicker: '${configureToolsId}' registered = ${hasConfigure}`);
-
-				if (!hasConfigure) {
-					// Fallback for older VS Code: open chat panel + notify user
-					this.log('🔧 openToolPicker: command not registered, opening chat panel + notifying user');
-					await vscode.commands.executeCommand('workbench.action.chat.open');
-					void vscode.window.showInformationMessage(
-						'To manage tools, click the Tools (⚙) button in the GitHub Copilot Chat input area.'
-					);
-					return;
-				}
-
-				// ConfigureToolsAction requires:
-				//   1. chat in Agent mode (precondition)
-				//   2. a focused chat widget (chatWidgetService.lastFocusedWidget)
-				// Open + focus chat in agent mode first, then invoke the picker.
-				try {
-					this.log('🔧 openToolPicker: opening chat in agent mode');
-					await vscode.commands.executeCommand('workbench.action.chat.open', { mode: 'agent' });
-				} catch (err) {
-					this.log(`🔧 openToolPicker: chat.open failed: ${err instanceof Error ? err.message : String(err)}`);
-				}
-
-				try {
-					this.log(`🔧 openToolPicker: executing '${configureToolsId}'`);
-					await vscode.commands.executeCommand(configureToolsId);
-					this.log('🔧 openToolPicker: command executed successfully');
-				} catch (err) {
-					this.log(`🔧 openToolPicker: command failed: ${err instanceof Error ? err.message : String(err)}`);
-					void vscode.window.showErrorMessage(
-						`Could not open tool picker: ${err instanceof Error ? err.message : String(err)}`
-					);
-				}
-			},
+			openToolPicker:         async () => this._handleOpenToolPickerCommand(),
 			openFileFromList:       async () => {
 				const paths: unknown = message.paths;
 				if (!Array.isArray(paths) || paths.length === 0) { return; }
@@ -806,6 +768,39 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 		await this.dispatch(message.command, handler);
 		return true;
+	}
+
+	private async _handleOpenToolPickerCommand(): Promise<void> {
+		this.log('🔧 openToolPicker: handler invoked');
+		const allCommands = await vscode.commands.getCommands(true);
+		const configureToolsId = 'workbench.action.chat.configureTools';
+		const hasConfigure = allCommands.includes(configureToolsId);
+		this.log(`🔧 openToolPicker: '${configureToolsId}' registered = ${hasConfigure}`);
+		if (!hasConfigure) {
+			this.log('🔧 openToolPicker: command not registered, opening chat panel + notifying user');
+			await vscode.commands.executeCommand('workbench.action.chat.open');
+			void vscode.window.showInformationMessage(
+				'To manage tools, click the Tools (⚙) button in the GitHub Copilot Chat input area.'
+			);
+			return;
+		}
+		// ConfigureToolsAction requires: (1) chat in Agent mode, (2) a focused chat widget.
+		try {
+			this.log('🔧 openToolPicker: opening chat in agent mode');
+			await vscode.commands.executeCommand('workbench.action.chat.open', { mode: 'agent' });
+		} catch (err) {
+			this.log(`🔧 openToolPicker: chat.open failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+		try {
+			this.log(`🔧 openToolPicker: executing '${configureToolsId}'`);
+			await vscode.commands.executeCommand(configureToolsId);
+			this.log('🔧 openToolPicker: command executed successfully');
+		} catch (err) {
+			this.log(`🔧 openToolPicker: command failed: ${err instanceof Error ? err.message : String(err)}`);
+			void vscode.window.showErrorMessage(
+				`Could not open tool picker: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
 	}
 
 	private consumeLocalViewRegressionProbe(viewId: string): ViewRegressionProbeConfig | undefined {
@@ -3552,33 +3547,29 @@ class CopilotTokenTracker implements vscode.Disposable {
 		};
 	}
 
+	private _mergeCodeWorkspaceCustomizationFiles(norm: string): CustomizationFileEntry[] {
+		const folders = _parseCodeWorkspaceFolders(norm);
+		const allFiles: CustomizationFileEntry[] = [];
+		const seen = new Set<string>();
+		for (const folder of folders) {
+			try {
+				for (const f of _scanWorkspaceCustomizationFiles(folder)) {
+					const key = path.normalize(f.path);
+					if (!seen.has(key)) { seen.add(key); allFiles.push(f); }
+				}
+			} catch { /* skip per-folder scan errors */ }
+		}
+		return allFiles;
+	}
+
 	private ensureWorkspaceCustomizationCached(norm: string): void {
 		if (this._customizationFilesCache.has(norm)) { return; }
 		try {
-			// Handle multi-root workspace (.code-workspace) files — scan each folder and merge
 			if (norm.endsWith('.code-workspace')) {
-				const folders = _parseCodeWorkspaceFolders(norm);
-				if (folders.length > 0) {
-					const allFiles: CustomizationFileEntry[] = [];
-					const seen = new Set<string>();
-					for (const folder of folders) {
-						try {
-							const files = _scanWorkspaceCustomizationFiles(folder);
-							for (const f of files) {
-								const key = path.normalize(f.path);
-								if (!seen.has(key)) {
-									seen.add(key);
-									allFiles.push(f);
-								}
-							}
-						} catch { /* skip per-folder scan errors */ }
-					}
-					this._customizationFilesCache.set(norm, allFiles);
-					return;
-				}
+				const merged = this._mergeCodeWorkspaceCustomizationFiles(norm);
+				if (merged.length > 0) { this._customizationFilesCache.set(norm, merged); return; }
 			}
-			const files = _scanWorkspaceCustomizationFiles(norm);
-			this._customizationFilesCache.set(norm, files);
+			this._customizationFilesCache.set(norm, _scanWorkspaceCustomizationFiles(norm));
 		} catch (e) { /* ignore scan errors per workspace */ }
 	}
 
@@ -5777,6 +5768,25 @@ class CopilotTokenTracker implements vscode.Disposable {
 		void this.analysisPanel?.webview.postMessage({ command: 'switchTab', tab: 'tools', anchor: 'section-tool-curation' });
 	}
 
+	private async _handleSuppressUnknownTool(toolName: string): Promise<void> {
+		this.analysisPanel?.webview.postMessage({ command: 'toolSuppressed', toolName });
+		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
+		const current = config.get<string[]>('suppressedUnknownTools', []);
+		if (!current.includes(toolName)) {
+			await config.update('suppressedUnknownTools', [...current, toolName], vscode.ConfigurationTarget.Global);
+			this.log(`🔇 Suppressed unknown tool: ${toolName}`);
+		}
+	}
+
+	private _logTraceCuration(message: any): void {
+		const stage = typeof message.stage === 'string' ? message.stage : 'unknown';
+		let details = '{}';
+		if (message.details && typeof message.details === 'object') {
+			try { details = JSON.stringify(message.details); } catch { details = '[circular or non-serializable]'; }
+		}
+		this.log(`🧭 [Tool Curation Trace] ${stage} ${details}`);
+	}
+
 	private async handleAnalysisMessage(message: any): Promise<void> {
 		switch (message.command) {
 			case 'refresh':
@@ -5795,16 +5805,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				break;
 			case 'suppressUnknownTool': {
 				const toolName = message.toolName as string;
-				if (toolName) {
-					// Acknowledge immediately so the webview can remove the item without waiting for the disk write.
-					this.analysisPanel?.webview.postMessage({ command: 'toolSuppressed', toolName });
-					const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
-					const current = config.get<string[]>('suppressedUnknownTools', []);
-					if (!current.includes(toolName)) {
-						await config.update('suppressedUnknownTools', [...current, toolName], vscode.ConfigurationTarget.Global);
-						this.log(`🔇 Suppressed unknown tool: ${toolName}`);
-					}
-				}
+				if (toolName) { await this._handleSuppressUnknownTool(toolName); }
 				break;
 			}
 			case 'loadRepoPrStats':
@@ -5824,19 +5825,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			case 'insightAction':
 					await this.dispatch(`insightAction:${message.id ?? ''}`, () => this.handleInsightAction(message));
 					break;
-			case 'traceUsageCuration': {
-				const stage = typeof message.stage === 'string' ? message.stage : 'unknown';
-				let details = '{}';
-				if (message.details && typeof message.details === 'object') {
-					try {
-						details = JSON.stringify(message.details);
-					} catch {
-						details = '[circular or non-serializable]';
-					}
-				}
-				this.log(`🧭 [Tool Curation Trace] ${stage} ${details}`);
+			case 'traceUsageCuration':
+				this._logTraceCuration(message);
 				break;
-			}
 		}
 	}
 
@@ -5876,6 +5867,23 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 	}
 
+	private _buildAnalysisUpdateData(analysisStats: Awaited<ReturnType<typeof this.calculateUsageAnalysisStats>>): object {
+		const workspacePaths = vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [];
+		return {
+			today: analysisStats.today, last30Days: analysisStats.last30Days,
+			month: analysisStats.month, lastMonth: analysisStats.lastMonth,
+			locale: analysisStats.locale,
+			customizationMatrix: analysisStats.customizationMatrix || null,
+			missedPotential: analysisStats.missedPotential || [],
+			lastUpdated: analysisStats.lastUpdated.toISOString(),
+			backendConfigured: this.isBackendConfigured(),
+			currentWorkspacePaths: workspacePaths,
+			todaySessions: analysisStats.todaySessions || [],
+			insights: this.buildCurrentInsights(analysisStats),
+			curationAnalysis: analysisStats.curationAnalysis ?? null,
+		};
+	}
+
 	private async loadAnalysisStatsInBackground(panel: vscode.WebviewPanel): Promise<void> {
 		try {
 			this.postUsageLoadingProgress('start');
@@ -5885,24 +5893,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 				availableTools: analysisStats.curationAnalysis?.availableTools.length ?? 0,
 				unusedTools: analysisStats.curationAnalysis?.unusedTools.length ?? 0,
 			});
-			void this.analysisPanel.webview.postMessage({
-				command: 'updateStats',
-				data: {
-					today: analysisStats.today, last30Days: analysisStats.last30Days, month: analysisStats.month, lastMonth: analysisStats.lastMonth,
-					locale: analysisStats.locale, customizationMatrix: analysisStats.customizationMatrix || null,
-					missedPotential: analysisStats.missedPotential || [], lastUpdated: analysisStats.lastUpdated.toISOString(),
-					backendConfigured: this.isBackendConfigured(),
-					currentWorkspacePaths: vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [],
-					todaySessions: analysisStats.todaySessions || [],
-					insights: this.buildCurrentInsights(analysisStats),
-					curationAnalysis: analysisStats.curationAnalysis ?? null,
-				},
-			});
+			void this.analysisPanel.webview.postMessage({ command: 'updateStats', data: this._buildAnalysisUpdateData(analysisStats) });
 		} catch (err) {
 			this.error(`Failed to load usage analysis stats: ${err}`);
-			this.postUsageLoadingProgress('error', {
-				error: String(err),
-			});
+			this.postUsageLoadingProgress('error', { error: String(err) });
 			if (this.analysisPanel && this.analysisPanel === panel) {
 				void this.analysisPanel.webview.postMessage({ command: 'updateStatsError', error: String(err) });
 			}

--- a/vscode-extension/src/jetbrains.ts
+++ b/vscode-extension/src/jetbrains.ts
@@ -215,129 +215,140 @@ function _jbpHandleUserMessage(event: any, state: JbpState): void {
 	}
 }
 
- 
+function _jbpUpdateCurrentTurn(state: JbpState, updater: (turn: JetBrainsTurn) => void): void {
+	if (!state.currentTurnId) { return; }
+	const turn = state.turnById.get(state.currentTurnId);
+	if (turn) { updater(turn); }
+}
+
+
+function _jbpGetMessageText(data: any): string | null {
+	if (typeof data?.text === 'string' && data.text) { return data.text; }
+	if (typeof data?.content === 'string' && data.content) { return data.content; }
+	return null;
+}
+
 function _jbpHandleAssistantMessage(event: any, state: JbpState): void {
-	// Extract message content - try both 'text' and 'content' fields
-	const messageText = typeof event.data?.text === 'string' && event.data.text 
-		? event.data.text 
-		: (typeof event.data?.content === 'string' && event.data.content 
-			? event.data.content 
-			: null);
-	
-	if (messageText) { 
-		state.outputTokens += estimateTokensFromText(messageText); 
-	}
-	
+	const messageText = _jbpGetMessageText(event.data);
+	if (messageText) { state.outputTokens += estimateTokensFromText(messageText); }
+
 	// Extract thinking content
 	const thinking = event.data?.thinking?.text;
-	if (typeof thinking === 'string' && thinking) { 
+	if (typeof thinking === 'string' && thinking) {
 		state.result.thinkingTokens += estimateTokensFromText(thinking);
 		state.hasThinking = true;
-		// Mark current turn as having thinking
-		if (state.currentTurnId && state.turnById.has(state.currentTurnId)) {
-			const turn = state.turnById.get(state.currentTurnId)!;
-			turn.hasThinking = true;
-		}
+		_jbpUpdateCurrentTurn(state, t => { t.hasThinking = true; });
 	}
-	
+
 	// Track message metadata
 	if (typeof event.data?.messageId === 'string') {
 		state.currentMessageId = event.data.messageId;
 		state.messageIds.push(event.data.messageId);
-		// Associate with current turn
-		if (state.currentTurnId && state.turnById.has(state.currentTurnId)) {
-			const turn = state.turnById.get(state.currentTurnId)!;
-			turn.messageId = event.data.messageId;
-		}
+		_jbpUpdateCurrentTurn(state, t => { t.messageId = event.data.messageId; });
 	}
-	
+
 	if (typeof event.data?.iterationNumber === 'number') {
 		state.currentIterationNumber = event.data.iterationNumber;
-		// Associate with current turn
-		if (state.currentTurnId && state.turnById.has(state.currentTurnId)) {
-			const turn = state.turnById.get(state.currentTurnId)!;
-			turn.iterationNumber = event.data.iterationNumber;
-		}
+		_jbpUpdateCurrentTurn(state, t => { t.iterationNumber = event.data.iterationNumber; });
 	}
-	
-	if (typeof event.timestamp === 'string') { 
-		state.lastTurnTs = event.timestamp; 
-		// Update turn end timestamp if we're still in the same turn
-		if (state.currentTurnId && state.turnById.has(state.currentTurnId)) {
-			const turn = state.turnById.get(state.currentTurnId)!;
-			if (!turn.endTimestamp) {
-				turn.endTimestamp = event.timestamp;
-			}
-		}
+
+	if (typeof event.timestamp === 'string') {
+		state.lastTurnTs = event.timestamp;
+		_jbpUpdateCurrentTurn(state, t => { if (!t.endTimestamp) { t.endTimestamp = event.timestamp; } });
 	}
 }
 
- 
+
+function _jbpRegisterToolCallForTurn(callId: string | undefined, state: JbpState, tc: JetBrainsToolCall): void {
+	if (!state.currentTurnId) { return; }
+	tc.turnId = state.currentTurnId;
+	if (!state.toolCallByTurnId.has(state.currentTurnId)) {
+		state.toolCallByTurnId.set(state.currentTurnId, []);
+	}
+	state.toolCallByTurnId.get(state.currentTurnId)!.push(callId || '');
+	_jbpUpdateCurrentTurn(state, t => { t.toolCallCount++; });
+}
+
 function _jbpHandleToolExecutionStart(event: any, state: JbpState): void {
 	state.sawToolCall = true;
+	const d = event.data;
+	const callId: string | undefined = d?.toolCallId;
 	if (!state.modelFromToolCallId) {
-		const hint = modelHintFromToolCallId(event.data?.toolCallId);
+		const hint = modelHintFromToolCallId(callId);
 		if (hint) { state.modelFromToolCallId = hint; }
 	}
-	const toolName = typeof event.data?.toolName === 'string' ? event.data.toolName : 'unknown';
+	const toolName = typeof d?.toolName === 'string' ? d.toolName : 'unknown';
 	const tc: JetBrainsToolCall = { toolName };
-	
-	// Capture turn ID association
-	if (state.currentTurnId) {
-		tc.turnId = state.currentTurnId;
-		// Track tool calls by turn
-		if (!state.toolCallByTurnId.has(state.currentTurnId)) {
-			state.toolCallByTurnId.set(state.currentTurnId, []);
-		}
-		state.toolCallByTurnId.get(state.currentTurnId)!.push(event.data?.toolCallId || '');
-		
-		// Increment tool call count for this turn
-		if (state.turnById.has(state.currentTurnId)) {
-			const turn = state.turnById.get(state.currentTurnId)!;
-			turn.toolCallCount++;
-		}
-	}
-	
-	// Store tool call ID
-	if (event.data?.toolCallId) {
-		tc.toolCallId = event.data.toolCallId;
-	}
-	
-	if (event.data?.arguments !== undefined) {
-		try { tc.arguments = JSON.stringify(event.data.arguments); } catch { /* ignore */ }
+	_jbpRegisterToolCallForTurn(callId, state, tc);
+	if (callId) { tc.toolCallId = callId; }
+	if (d?.arguments !== undefined) {
+		try { tc.arguments = JSON.stringify(d.arguments); } catch { /* ignore */ }
 	}
 	state.result.toolCalls.push(tc);
 	state.result.toolCounts[toolName] = (state.result.toolCounts[toolName] || 0) + 1;
-	const callId = event.data?.toolCallId;
 	if (typeof callId === 'string') { state.toolCallById.set(callId, tc); }
 }
 
- 
-function _jbpHandleToolExecutionComplete(event: any, state: JbpState): void {
-	const blocks = event.data?.result?.result;
-	let resultText = '';
-	if (Array.isArray(blocks)) {
-		for (const block of blocks) {
-			if (block && typeof block.value === 'string') {
-				state.outputTokens += estimateTokensFromText(block.value);
-				resultText += (resultText ? '\n' : '') + block.value;
-			}
+
+function _jbpExtractBlockText(blocks: unknown[], state: JbpState): string {
+	let text = '';
+	for (const block of blocks) {
+		const b = block as { value?: unknown } | null;
+		if (b && typeof b.value === 'string') {
+			state.outputTokens += estimateTokensFromText(b.value);
+			text += (text ? '\n' : '') + b.value;
 		}
 	}
+	return text;
+}
+
+function _jbpHandleToolExecutionComplete(event: any, state: JbpState): void {
+	const blocks = event.data?.result?.result;
+	const resultText = Array.isArray(blocks) ? _jbpExtractBlockText(blocks, state) : '';
 	const callId = event.data?.toolCallId;
 	if (typeof callId !== 'string') { return; }
 	const tc = state.toolCallById.get(callId);
 	if (!tc) { return; }
 	if (typeof event.data?.success === 'boolean') { tc.success = event.data.success; }
 	if (resultText) { tc.result = resultText; }
-	
-	// Capture progress message
-	if (typeof event.data?.progressMessage === 'string') {
-		tc.progressMessage = event.data.progressMessage;
+	if (typeof event.data?.progressMessage === 'string') { tc.progressMessage = event.data.progressMessage; }
+}
+
+
+function _jbpHandleTurnStart(event: any, state: JbpState): void {
+	if (typeof event.data?.model === 'string' && !state.modelFromTurnStart) { state.modelFromTurnStart = event.data.model; }
+	if (typeof event.data?.turnId !== 'string') { return; }
+	state.currentTurnId = event.data.turnId;
+	state.currentMessageId = null;
+	state.currentIterationNumber = null;
+	if (!state.turnById.has(event.data.turnId)) {
+		state.turnById.set(event.data.turnId, {
+			turnId: event.data.turnId,
+			startTimestamp: typeof event.timestamp === 'string' ? event.timestamp : null,
+			endTimestamp: null, status: null, turnStatus: null,
+			messageId: null, iterationNumber: null, hasThinking: false, toolCallCount: 0,
+		});
 	}
 }
 
- 
+function _jbpHandleTurnEnd(event: any, state: JbpState): void {
+	if (typeof event.timestamp === 'string') { state.lastTurnTs = event.timestamp; }
+	if (typeof event.data?.turnId !== 'string') { return; }
+	const turn = state.turnById.get(event.data.turnId);
+	if (!turn) { return; }
+	if (typeof event.timestamp === 'string') { turn.endTimestamp = event.timestamp; }
+	const status = typeof event.data?.status === 'string' ? event.data.status : null;
+	turn.turnStatus = typeof event.data?.turnStatus === 'string' ? event.data.turnStatus : null;
+	if (!status) { return; }
+	turn.status = status;
+	switch (status.toLowerCase()) {
+		case 'success': state.turnStatusCounts.success++; break;
+		case 'cancelled': state.turnStatusCounts.cancelled++; break;
+		case 'failed': state.turnStatusCounts.failed++; break;
+		default: state.turnStatusCounts.unknown++; break;
+	}
+}
+
 function _jbpDispatchEvent(event: any, state: JbpState): void {
 	switch (event.type) {
 		case 'partition.created': _jbpHandlePartitionCreated(event, state.result); break;
@@ -345,67 +356,11 @@ function _jbpDispatchEvent(event: any, state: JbpState): void {
 		case 'user.message_rendered':
 			if (typeof event.data?.renderedMessage === 'string') { state.inputTokens += estimateTokensFromText(event.data.renderedMessage); }
 			break;
-		case 'assistant.turn_start':
-			if (typeof event.data?.model === 'string' && !state.modelFromTurnStart) { state.modelFromTurnStart = event.data.model; }
-			// Track turn start
-			if (typeof event.data?.turnId === 'string') {
-				state.currentTurnId = event.data.turnId;
-				state.currentMessageId = null;
-				state.currentIterationNumber = null;
-				// Initialize turn tracking if not already exists
-				if (!state.turnById.has(event.data.turnId)) {
-					state.turnById.set(event.data.turnId, {
-						turnId: event.data.turnId,
-						startTimestamp: typeof event.timestamp === 'string' ? event.timestamp : null,
-						endTimestamp: null,
-						status: null,
-						turnStatus: null,
-						messageId: null,
-						iterationNumber: null,
-						hasThinking: false,
-						toolCallCount: 0
-					});
-				}
-			}
-			break;
+		case 'assistant.turn_start': _jbpHandleTurnStart(event, state); break;
 		case 'assistant.message': _jbpHandleAssistantMessage(event, state); break;
 		case 'tool.execution_start': _jbpHandleToolExecutionStart(event, state); break;
 		case 'tool.execution_complete': _jbpHandleToolExecutionComplete(event, state); break;
-		case 'assistant.turn_end':
-			if (typeof event.timestamp === 'string') { state.lastTurnTs = event.timestamp; }
-			// Update turn end information
-			if (typeof event.data?.turnId === 'string') {
-				const turnId = event.data.turnId;
-				if (state.turnById.has(turnId)) {
-					const turn = state.turnById.get(turnId)!;
-					turn.endTimestamp = typeof event.timestamp === 'string' ? event.timestamp : turn.endTimestamp;
-					
-					// Update status counts
-					const status = typeof event.data?.status === 'string' ? event.data.status : null;
-					const turnStatus = typeof event.data?.turnStatus === 'string' ? event.data.turnStatus : null;
-					
-					if (status) {
-						turn.status = status;
-						switch (status.toLowerCase()) {
-							case 'success':
-								state.turnStatusCounts.success++;
-								break;
-							case 'cancelled':
-								state.turnStatusCounts.cancelled++;
-								break;
-							case 'failed':
-								state.turnStatusCounts.failed++;
-								break;
-							default:
-								state.turnStatusCounts.unknown++;
-								break;
-						}
-					}
-					
-					turn.turnStatus = turnStatus;
-				}
-			}
-			break;
+		case 'assistant.turn_end': _jbpHandleTurnEnd(event, state); break;
 	}
 }
 

--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -171,21 +171,29 @@ function _peQualifiesForStage4(totalInteractions: number, hasAgentMode: boolean,
 	const T = STAGE_THRESHOLDS.promptEngineering;
 	return totalInteractions >= T.stage4MinInteractions && hasAgentMode && (hasModelSwitching || usedSlashCommands.length >= T.stage4MinSlashCommands);
 }
+function _buildPeTipsForStage3(hasAgentMode: boolean, usedSlashCommands: string[], T: { stage3MinSlashCommands: number }): string[] {
+	const tips: string[] = [];
+	if (!hasAgentMode) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-file changes'); }
+	if (usedSlashCommands.length < T.stage3MinSlashCommands) { tips.push('Use [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /fix, or /tests to give structured prompts'); }
+	return tips;
+}
+
+function _buildPeTipsForStage4(hasAgentMode: boolean, hasModelSwitching: boolean, usedSlashCommands: string[], autoUsageRatio: number, T: { stage4MinSlashCommands: number }): string[] {
+	const tips: string[] = [];
+	if (!hasAgentMode) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for autonomous, multi-step coding tasks'); }
+	if (!hasModelSwitching) { tips.push('Experiment with [different models](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_choose-a-language-model) for different tasks - use fast models for simple queries and reasoning models for complex problems'); }
+	if (autoUsageRatio === 0) { tips.push('Try the Auto model for cost-sensitive tasks so Copilot can pick the most efficient model for you'); }
+	else if (autoUsageRatio < 0.5) { tips.push('Use the Auto model more often when you want Copilot to balance quality and cost for you'); }
+	if (usedSlashCommands.length < T.stage4MinSlashCommands && hasAgentMode && hasModelSwitching) { tips.push('Explore more [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /tests, or /doc to diversify your prompting'); }
+	return tips;
+}
+
 function _buildPeTips(stage: Stage, hasAgentMode: boolean, hasModelSwitching: boolean, usedSlashCommands: string[], autoUsageRatio: number): string[] {
 	const T = STAGE_THRESHOLDS.promptEngineering;
 	const tips: string[] = [];
 	if (stage < 2) { tips.push('Try asking Copilot a question using the Chat panel'); }
-	if (stage < 3) {
-		if (!hasAgentMode) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for multi-file changes'); }
-		if (usedSlashCommands.length < T.stage3MinSlashCommands) { tips.push('Use [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /fix, or /tests to give structured prompts'); }
-	}
-	if (stage < 4) {
-		if (!hasAgentMode) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) for autonomous, multi-step coding tasks'); }
-		if (!hasModelSwitching) { tips.push('Experiment with [different models](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_choose-a-language-model) for different tasks - use fast models for simple queries and reasoning models for complex problems'); }
-		if (autoUsageRatio === 0) { tips.push('Try the Auto model for cost-sensitive tasks so Copilot can pick the most efficient model for you'); }
-		else if (autoUsageRatio < 0.5) { tips.push('Use the Auto model more often when you want Copilot to balance quality and cost for you'); }
-		if (usedSlashCommands.length < T.stage4MinSlashCommands && hasAgentMode && hasModelSwitching) { tips.push('Explore more [slash commands](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-context-to-your-prompts) like /explain, /tests, or /doc to diversify your prompting'); }
-	}
+	if (stage < 3) { tips.push(..._buildPeTipsForStage3(hasAgentMode, usedSlashCommands, T)); }
+	if (stage < 4) { tips.push(..._buildPeTipsForStage4(hasAgentMode, hasModelSwitching, usedSlashCommands, autoUsageRatio, T)); }
 	return tips;
 }
 function _applyPeConversationStage(p: UsageAnalysisPeriod, evidence: string[], stage: Stage): Stage {
@@ -1009,16 +1017,19 @@ function _calcFluencyAg(fd: FluencyInputData, cv: FluencyVars): FluencyStageResu
 	return { stage, tips };
 }
 
-function _calcFluencyTu(fd: FluencyInputData, cv: FluencyVars, isMCPEnabled?: boolean): FluencyStageResult {
+function _calcFluencyTuStage(fd: FluencyInputData, cv: FluencyVars, isMCPEnabled: boolean | undefined): Stage {
 	const T = STAGE_THRESHOLDS.toolUsage;
-	let stage: Stage = 1;
-	if (cv.nonAutoToolCount > 0) { stage = 2; }
-	if (fd.workspaceAgentCount > 0) { stage = promoteStage(stage, 3); }
 	const advancedToolIds = ["github_pull_request", "github_repo", "run_in_terminal", "editFiles", "listFiles"];
 	const usedAdvancedCount = advancedToolIds.filter(t => (fd.toolCallsByTool[t] ?? 0) > 0).length;
+	let stage: Stage = cv.nonAutoToolCount > 0 ? 2 : 1;
+	if (fd.workspaceAgentCount > 0) { stage = promoteStage(stage, 3); }
 	if (usedAdvancedCount >= T.stage3MinAdvancedTools) { stage = promoteStage(stage, 3); }
 	if (isMCPEnabled !== false && fd.mcpTotal > 0) { stage = promoteStage(stage, 3); }
 	if (isMCPEnabled !== false && Object.keys(fd.mcpByServer).length >= T.stage4MinMcpServers) { stage = 4; }
+	return stage;
+}
+
+function _calcFluencyTuTips(fd: FluencyInputData, stage: Stage, isMCPEnabled: boolean | undefined): string[] {
 	const tips: string[] = [];
 	if (stage < 2) { tips.push("Try agent mode to let Copilot use built-in tools for file operations and terminal commands"); }
 	if (stage < 3) {
@@ -1030,7 +1041,12 @@ function _calcFluencyTu(fd: FluencyInputData, cv: FluencyVars, isMCPEnabled?: bo
 		else if (fd.mcpTotal === 0 && isMCPEnabled !== false) { tips.push("Explore MCP servers for tools that integrate with your workflow"); }
 		else if (fd.mcpTotal > 0) { tips.push("Keep exploring advanced tool combinations"); }
 	}
-	return { stage, tips };
+	return tips;
+}
+
+function _calcFluencyTu(fd: FluencyInputData, cv: FluencyVars, isMCPEnabled?: boolean): FluencyStageResult {
+	const stage = _calcFluencyTuStage(fd, cv, isMCPEnabled);
+	return { stage, tips: _calcFluencyTuTips(fd, stage, isMCPEnabled) };
 }
 
 function _calcFluencyCu(fd: FluencyInputData, cv: FluencyVars): FluencyStageResult {

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -197,29 +197,43 @@ function _cmsGetSelectedModelCandidate(event: CmsEvent): SelectedModelMetadataRa
 	return v?.selectedModel ?? v?.inputState?.selectedModel;
 }
 
+function _cmsIsAutoModel(normalizedId: string, family: string): boolean {
+	return normalizedId === 'auto' || family === 'auto' || family.includes('auto') || normalizedId.includes('/auto');
+}
+
+function _cmsIsFoundryModel(normalizedId: string, vendor: string, family: string, extension: string, category: string): boolean {
+	const looksFoundry = family.includes('foundry') || family.includes('local') || extension.includes('foundry') || extension.includes('windows') || category.includes('foundry') || category.includes('windows') || normalizedId.includes('foundry');
+	const looksFoundryById = normalizedId.includes('foundry') && (normalizedId.includes('microsoft') || normalizedId.includes('aitk'));
+	return looksFoundryById || (vendor.includes('microsoft') && looksFoundry);
+}
+
+interface CmsModelMetaFields { family: string; vendor: string; extension: string; category: string; rawExtension: string | undefined }
+
+function _cmsExtractModelMetaFields(modelInfo: SelectedModelMetadataRaw | undefined): CmsModelMetaFields {
+	const meta = modelInfo?.metadata;
+	const ext = meta?.extension;
+	return {
+		family: _cmsNormalizeText(meta?.family),
+		vendor: _cmsNormalizeText(meta?.vendor),
+		extension: _cmsNormalizeText(ext?.value),
+		category: _cmsNormalizeText(meta?.modelPickerCategory?.label),
+		rawExtension: ext?.value,
+	};
+}
+
 function _cmsTrackModelSelectionSignals(modelId: string | undefined, modelInfo: SelectedModelMetadataRaw | undefined, analysis: SessionUsageAnalysis): void {
 	const normalizedId = (modelId ?? '').replace(/^copilot\//, '');
 	if (!normalizedId) { return; }
-	const family = _cmsNormalizeText(modelInfo?.metadata?.family);
-	const vendor = _cmsNormalizeText(modelInfo?.metadata?.vendor);
-	const extension = _cmsNormalizeText(modelInfo?.metadata?.extension?.value);
-	const category = _cmsNormalizeText(modelInfo?.metadata?.modelPickerCategory?.label);
-	if (normalizedId === 'auto' || family === 'auto' || family.includes('auto') || normalizedId.includes('/auto')) {
-		analysis.modelSwitching.autoSessions = 1;
-	}
-	const looksFoundry = family.includes('foundry') || family.includes('local') || extension.includes('foundry') || extension.includes('windows') || category.includes('foundry') || category.includes('windows') || normalizedId.includes('foundry');
-	const looksFoundryById = normalizedId.includes('foundry') && (normalizedId.includes('microsoft') || normalizedId.includes('aitk'));
-	if (looksFoundryById || (vendor.includes('microsoft') && looksFoundry)) {
-		analysis.modelSwitching.foundryWindowsSessions = 1;
-	}
+	const { family, vendor, extension, category, rawExtension } = _cmsExtractModelMetaFields(modelInfo);
+	if (_cmsIsAutoModel(normalizedId, family)) { analysis.modelSwitching.autoSessions = 1; }
+	if (_cmsIsFoundryModel(normalizedId, vendor, family, extension, category)) { analysis.modelSwitching.foundryWindowsSessions = 1; }
 	const provider = getModelBillingProvider(normalizedId);
 	if (provider === 'Other') {
 		analysis.modelSwitching.unknownProviderSessions = 1;
 		if (!analysis.modelSwitching.unknownProviderModels.includes(normalizedId)) { analysis.modelSwitching.unknownProviderModels.push(normalizedId); }
 	}
-	const selectedExtension = modelInfo?.metadata?.extension?.value;
-	if (selectedExtension && !analysis.modelSwitching.selectedModelExtensions.includes(selectedExtension)) {
-		analysis.modelSwitching.selectedModelExtensions.push(selectedExtension);
+	if (rawExtension && !analysis.modelSwitching.selectedModelExtensions.includes(rawExtension)) {
+		analysis.modelSwitching.selectedModelExtensions.push(rawExtension);
 	}
 }
 
@@ -586,6 +600,12 @@ function _pdsaCountModelSwitches(models: string[]): number {
 	return count;
 }
 
+function _pdsaGetSessionDefaultModel(sessionState: DeltaSessionState): string {
+	const sm = sessionState.selectedModel;
+	const ism = sessionState.inputState?.selectedModel;
+	return (sm?.identifier || sm?.metadata?.id || ism?.identifier || ism?.metadata?.id || 'gpt-4o').replace(/^copilot\//, '');
+}
+
 /** Extract model switching statistics from a reconstructed delta session state. */
 function _pdsaExtractModelSwitching(
 	deps: Pick<UsageAnalysisDeps, 'modelPricing'>,
@@ -593,26 +613,18 @@ function _pdsaExtractModelSwitching(
 	requests: SessionRequestRaw[],
 	analysis: SessionUsageAnalysis
 ): void {
-	const sessionDefaultModel = (
-		sessionState.selectedModel?.identifier ||
-		sessionState.selectedModel?.metadata?.id ||
-		sessionState.inputState?.selectedModel?.identifier ||
-		sessionState.inputState?.selectedModel?.metadata?.id ||
-		'gpt-4o'
-	).replace(/^copilot\//, '');
+	const sessionDefaultModel = _pdsaGetSessionDefaultModel(sessionState);
 
-	// Detect Auto model from the session-level selected model
-	const sessionSelectedId = (sessionState.selectedModel?.identifier || sessionState.inputState?.selectedModel?.identifier || '').replace(/^copilot\//, '');
-	if (sessionSelectedId === 'auto') {
-		analysis.modelSwitching.autoSessions = 1;
-	}
+	const sm = sessionState.selectedModel;
+	const ism = sessionState.inputState?.selectedModel;
+	const sessionSelectedId = (sm?.identifier || ism?.identifier || '').replace(/^copilot\//, '');
+	if (sessionSelectedId === 'auto') { analysis.modelSwitching.autoSessions = 1; }
 
 	const models: string[] = [];
 	for (const req of requests) {
 		if (!req || !req.requestId) { continue; }
 		const reqModel = _pdsaGetReqModel(req, sessionDefaultModel, deps.modelPricing);
 		models.push(reqModel);
-		// Detect Foundry models from per-request modelId
 		const reqModelLower = reqModel.toLowerCase();
 		if (reqModelLower.includes('foundry') && (reqModelLower.includes('microsoft') || reqModelLower.includes('aitk'))) {
 			analysis.modelSwitching.foundryWindowsSessions = 1;
@@ -1458,7 +1470,10 @@ type CmsEvent = JsonlEventRaw & { type?: string; data?: { selectedModel?: string
 function _cmsGetKind0ModelId(event: CmsEvent): string | null {
 	if (event.kind !== 0) { return null; }
 	const v = event.v as { selectedModel?: { identifier?: string; metadata?: { id?: string } }; inputState?: { selectedModel?: { identifier?: string; metadata?: { id?: string } } } } | undefined;
-	const id = v?.selectedModel?.identifier || v?.selectedModel?.metadata?.id || v?.inputState?.selectedModel?.identifier || v?.inputState?.selectedModel?.metadata?.id;
+	if (!v) { return null; }
+	const sm = v.selectedModel;
+	const ism = v.inputState?.selectedModel;
+	const id = sm?.identifier || sm?.metadata?.id || ism?.identifier || ism?.metadata?.id;
 	if (!id) { return null; }
 	return id.replace(/^copilot\//, '');
 }

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1104,6 +1104,23 @@ function sanitizeInsights(rawInsights: any[]): EvaluatedInsight[] {
 		}));
 }
 
+function _sanitizeCurationAnalysis(rawCa: unknown): ToolCurationAnalysis | null {
+	if (!rawCa || typeof rawCa !== 'object') { return null; }
+	const ca = rawCa as Partial<ToolCurationAnalysis>;
+	return {
+		windowDays: typeof ca.windowDays === 'number' ? ca.windowDays : 30,
+		availableTools: Array.isArray(ca.availableTools) ? ca.availableTools : [],
+		usedTools: Array.isArray(ca.usedTools) ? ca.usedTools : [],
+		unusedTools: Array.isArray(ca.unusedTools) ? ca.unusedTools : [],
+		underusedMcpServers: Array.isArray(ca.underusedMcpServers) ? ca.underusedMcpServers : [],
+		underusedAgentPlugins: Array.isArray(ca.underusedAgentPlugins) ? ca.underusedAgentPlugins : [],
+		estimatedPromptBloat: ca.estimatedPromptBloat && typeof ca.estimatedPromptBloat === 'object'
+			? ca.estimatedPromptBloat
+			: { totalTokens: 0, byServer: {} },
+		recommendations: Array.isArray(ca.recommendations) ? ca.recommendations : [],
+	};
+}
+
 function sanitizeStats(raw: any): UsageAnalysisStats | null {
 	if (!raw || typeof raw !== 'object') {
 		traceCurationOnce('sanitize-invalid-root', 'sanitizeStats.invalidRoot');
@@ -1156,24 +1173,13 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 
 		// Pass through curationAnalysis (already structured server-side).
 		// Normalize required array/object fields so rendering paths don't throw on partial payloads.
-		if (raw.curationAnalysis && typeof raw.curationAnalysis === 'object') {
-			const ca = raw.curationAnalysis as Partial<ToolCurationAnalysis>;
-			sanitized.curationAnalysis = {
-				windowDays: typeof ca.windowDays === 'number' ? ca.windowDays : 30,
-				availableTools: Array.isArray(ca.availableTools) ? ca.availableTools : [],
-				usedTools: Array.isArray(ca.usedTools) ? ca.usedTools : [],
-				unusedTools: Array.isArray(ca.unusedTools) ? ca.unusedTools : [],
-				underusedMcpServers: Array.isArray(ca.underusedMcpServers) ? ca.underusedMcpServers : [],
-				underusedAgentPlugins: Array.isArray(ca.underusedAgentPlugins) ? ca.underusedAgentPlugins : [],
-				estimatedPromptBloat: ca.estimatedPromptBloat && typeof ca.estimatedPromptBloat === 'object'
-					? ca.estimatedPromptBloat
-					: { totalTokens: 0, byServer: {} },
-				recommendations: Array.isArray(ca.recommendations) ? ca.recommendations : [],
-			};
+		const curationAnalysis = _sanitizeCurationAnalysis(raw.curationAnalysis);
+		if (curationAnalysis) {
+			sanitized.curationAnalysis = curationAnalysis;
 			traceCuration('sanitizeStats.curation.present', {
-				availableTools: sanitized.curationAnalysis.availableTools.length,
-				unusedTools: sanitized.curationAnalysis.unusedTools.length,
-				unusedServers: sanitized.curationAnalysis.underusedMcpServers.filter(s => s && s.usedToolCount === 0).length,
+				availableTools: curationAnalysis.availableTools.length,
+				unusedTools: curationAnalysis.unusedTools.length,
+				unusedServers: curationAnalysis.underusedMcpServers.filter(s => s && s.usedToolCount === 0).length,
 			});
 		} else {
 			traceCurationOnce('sanitize-no-curation', 'sanitizeStats.curation.missing');
@@ -1861,85 +1867,86 @@ function buildCurationSummaryHtml(availableTools: AvailableToolEntry[], unusedTo
 	</div>`;
 }
 
+type McpServerEntry = ToolCurationAnalysis['underusedMcpServers'][number];
+
+function _mcpSourceLabel(s: McpServerEntry): string {
+	if (s.extensionId) { return 'Extension'; }
+	if (!s.configFiles || s.configFiles.length === 0) { return 'Settings'; }
+	const labels = new Set<string>();
+	for (const f of s.configFiles) {
+		const p = f.replace(/\\/g, '/');
+		if (p.includes('/.vscode/')) { labels.add('Workspace'); }
+		else if (p.includes('/.vs/')) { labels.add('Workspace (VS)'); }
+		else if (p.includes('/.cursor/')) { labels.add('Workspace (Cursor)'); }
+		else if (p.endsWith('/.mcp.json')) { labels.add(p.split('/').slice(-2).join('/')); }
+		else { labels.add('Config file'); }
+	}
+	return [...labels].join(', ');
+}
+
+function _buildMcpSourceOpenBtn(s: McpServerEntry, sourceTip: string): string {
+	if (s.configFiles && s.configFiles.length === 1) {
+		return ` <button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s.configFiles[0])}">open</button>`;
+	}
+	if (s.configFiles && s.configFiles.length > 1) {
+		return ` <button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(sourceTip)}">open</button>`;
+	}
+	if (s.extensionId) {
+		return ` <button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view for ${escapeHtml(s.extensionId)}">open</button>`;
+	}
+	return ` <button class="curation-file-btn" data-command="searchMcpExtensions" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Browse MCP extensions in the marketplace">open</button>`;
+}
+
+function _buildMcpActionCell(s: McpServerEntry): string {
+	if (s.extensionId) {
+		return `<button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open the Extensions view for ${escapeHtml(s.extensionId)} (disable or uninstall to reclaim prompt budget)">Manage Extension</button>`;
+	}
+	if (!s.configFiles || s.configFiles.length === 0) {
+		return `<button class="curation-file-btn" data-command="openToolPicker" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open VS Code tool selection menu">Change Tools</button>`;
+	}
+	if (s.configFiles.length === 1) {
+		return `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s.configFiles[0])}">Change Tools</button>`;
+	}
+	return `<button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Defined in ${s.configFiles.length} config files">Change Tools</button>`;
+}
+
+function _buildMcpServerRowHtml(s: McpServerEntry, bloat: ToolCurationAnalysis['estimatedPromptBloat']): string {
+	const b = bloat.byServer[s.server] ?? 0;
+	const sourceLabel = _mcpSourceLabel(s);
+	const sourceTip = s.configFiles?.join('\n') ?? s.extensionId ?? '';
+	const sourceOpenBtn = _buildMcpSourceOpenBtn(s, sourceTip);
+	const actionCell = _buildMcpActionCell(s);
+	const notConnected = s.availableToolCount === 0;
+	return `<tr class="${s.usedToolCount > 0 ? 'mcp-has-usage' : ''}">
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(s.server)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;" title="${escapeHtml(sourceTip)}">${escapeHtml(sourceLabel)}${sourceOpenBtn}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? '<em style="color:var(--text-secondary)">not connected</em>' : s.availableToolCount}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? '—' : s.usedToolCount}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${b > 0 ? `~${b.toLocaleString()} tokens` : '—'}</td>
+		<td style="padding:5px 8px; font-size:12px;">${actionCell}</td>
+	</tr>`;
+}
+
+function _buildMcpJsonLink(allServers: McpServerEntry[]): string {
+	const allConfigFiles = [...new Set(
+		allServers.filter(s => !s.extensionId).flatMap(s => s.configFiles ?? [])
+	)];
+	const preferredFile = allConfigFiles.find(f => f.replace(/\\/g, '/').endsWith('.vscode/mcp.json')) ?? allConfigFiles[0];
+	if (!preferredFile) { return `<code>.vscode/mcp.json</code>`; }
+	const displayName = preferredFile.replace(/\\/g, '/').split('/').slice(-3).join('/');
+	return `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(preferredFile)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(preferredFile)}">${escapeHtml(displayName)}</button>`;
+}
+
 function buildUnusedMcpHtml(underusedMcpServers: ToolCurationAnalysis['underusedMcpServers'], bloat: ToolCurationAnalysis['estimatedPromptBloat'], windowDays: number): string {
 	// Show all servers, zero-usage first, then partially used, then fully used.
 	const allServers = [...underusedMcpServers].sort((a, b) => {
-		// Sort key: zero-usage → partial-usage → fully-used
 		const aKey = a.usedToolCount === 0 ? 0 : a.usedToolCount < a.availableToolCount ? 1 : 2;
 		const bKey = b.usedToolCount === 0 ? 0 : b.usedToolCount < b.availableToolCount ? 1 : 2;
 		return aKey !== bKey ? aKey - bKey : a.usedToolCount - b.usedToolCount;
 	});
 	if (allServers.length === 0) { return ''; }
-	const toggleId = 'mcp-hide-used-toggle';
-	/** Derive a human-readable scope label from a server's config files / extension id. */
-	function mcpSourceLabel(s: typeof allServers[0]): string {
-		if (s.extensionId) { return 'Extension'; }
-		if (!s.configFiles || s.configFiles.length === 0) { return 'Settings'; }
-		const labels = new Set<string>();
-		for (const f of s.configFiles) {
-			const p = f.replace(/\\/g, '/');
-			if (p.includes('/.vscode/')) { labels.add('Workspace'); }
-			else if (p.includes('/.vs/')) { labels.add('Workspace (VS)'); }
-			else if (p.includes('/.cursor/')) { labels.add('Workspace (Cursor)'); }
-			else if (p.endsWith('/.mcp.json')) {
-				// Could be workspace root or user home — show last 2 segments as hint
-				const parts = p.split('/');
-				labels.add(parts.slice(-2).join('/'));
-			} else {
-				labels.add('Config file');
-			}
-		}
-		return [...labels].join(', ');
-	}
-
-	const rows = allServers.map(s => {
-		const b = bloat.byServer[s.server] ?? 0;
-		const sourceLabel = mcpSourceLabel(s);
-		const sourceTip = s.configFiles?.join('\n') ?? s.extensionId ?? '';
-		let sourceOpenBtn = '';
-		if (s.configFiles && s.configFiles.length === 1) {
-			sourceOpenBtn = ` <button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s.configFiles[0])}">open</button>`;
-		} else if (s.configFiles && s.configFiles.length > 1) {
-			sourceOpenBtn = ` <button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(sourceTip)}">open</button>`;
-		} else if (s.extensionId) {
-			sourceOpenBtn = ` <button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view for ${escapeHtml(s.extensionId)}">open</button>`;
-		} else {
-			// Configured via VS Code UI settings — search the marketplace for MCP extensions
-			sourceOpenBtn = ` <button class="curation-file-btn" data-command="searchMcpExtensions" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Browse MCP extensions in the marketplace">open</button>`;
-		}
-		let actionCell: string;
-		if (s.extensionId) {
-			actionCell = `<button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open the Extensions view for ${escapeHtml(s.extensionId)} (disable or uninstall to reclaim prompt budget)">Manage Extension</button>`;
-		} else if (!s.configFiles || s.configFiles.length === 0) {
-			actionCell = `<button class="curation-file-btn" data-command="openToolPicker" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open VS Code tool selection menu">Change Tools</button>`;
-		} else if (s.configFiles.length === 1) {
-			actionCell = `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s.configFiles[0])}">Change Tools</button>`;
-		} else {
-			actionCell = `<button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Defined in ${s.configFiles.length} config files">Change Tools</button>`;
-		}
-		const notConnected = s.availableToolCount === 0;
-		return `<tr class="${s.usedToolCount > 0 ? 'mcp-has-usage' : ''}">
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(s.server)}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;" title="${escapeHtml(sourceTip)}">${escapeHtml(sourceLabel)}${sourceOpenBtn}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? '<em style="color:var(--text-secondary)">not connected</em>' : s.availableToolCount}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? '—' : s.usedToolCount}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${b > 0 ? `~${b.toLocaleString()} tokens` : '—'}</td>
-			<td style="padding:5px 8px; font-size:12px;">${actionCell}</td>
-		</tr>`;
-	}).join('');
-	// Find the best config file to link in the tip — prefer .vscode/mcp.json, then any file.
-	const allConfigFiles = [...new Set(
-		allServers.filter(s => !s.extensionId).flatMap(s => s.configFiles ?? [])
-	)];
-	const preferredFile = allConfigFiles.find(f => f.replace(/\\/g, '/').endsWith('.vscode/mcp.json'))
-		?? allConfigFiles[0];
-	let mcpJsonLink: string;
-	if (preferredFile) {
-		const displayName = preferredFile.replace(/\\/g, '/').split('/').slice(-3).join('/');
-		mcpJsonLink = `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(preferredFile)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(preferredFile)}">${escapeHtml(displayName)}</button>`;
-	} else {
-		mcpJsonLink = `<code>.vscode/mcp.json</code>`;
-	}
+	const rows = allServers.map(s => _buildMcpServerRowHtml(s, bloat)).join('');
+	const mcpJsonLink = _buildMcpJsonLink(allServers);
 	const usedCount = allServers.filter(s => s.usedToolCount > 0).length;
 	const unusedCount = allServers.length - usedCount;
 	// Pure CSS checkbox trick: input and .mcp-table-wrap are siblings inside <details>;
@@ -2304,6 +2311,35 @@ function refreshInsightsPanel(insights: EvaluatedInsight[]): void {
 	updateTabButtonCount(insights);
 }
 
+function _postOpenFileFromList(pathsJson: string | null): void {
+	if (!pathsJson) { return; }
+	try {
+		const paths = JSON.parse(pathsJson) as string[];
+		vscode.postMessage({ command: 'openFileFromList', paths });
+	} catch (error) {
+		traceCuration('wireCurationButtons.badPathsJson', { error: error instanceof Error ? error.message : String(error) });
+	}
+}
+
+function _handleCurationBtnClick(btn: HTMLButtonElement): void {
+	const command = btn.getAttribute('data-command');
+	if (!command) { return; }
+	if (command === 'openFile') {
+		const filePath = btn.getAttribute('data-path');
+		if (filePath) { vscode.postMessage({ command: 'openFile', path: filePath }); }
+	} else if (command === 'openFileFromList') {
+		_postOpenFileFromList(btn.getAttribute('data-paths'));
+	} else if (command === 'manageExtension') {
+		const extensionId = btn.getAttribute('data-extension-id');
+		if (extensionId) { vscode.postMessage({ command: 'manageExtension', extensionId }); }
+	} else if (command === 'openAgentPlugins') {
+		const pluginName = btn.getAttribute('data-plugin-name') ?? '';
+		vscode.postMessage({ command: 'openAgentPlugins', pluginName });
+	} else {
+		vscode.postMessage({ command });
+	}
+}
+
 function wireCurationButtons(): void {
 	try {
 		const section = document.getElementById('section-tool-curation');
@@ -2316,43 +2352,14 @@ function wireCurationButtons(): void {
 		buttons.forEach(btn => {
 			btn.addEventListener('click', () => {
 				try {
-					const command = btn.getAttribute('data-command');
-					if (!command) { return; }
-					if (command === 'openFile') {
-						const filePath = btn.getAttribute('data-path');
-						if (filePath) { vscode.postMessage({ command: 'openFile', path: filePath }); }
-					} else if (command === 'openFileFromList') {
-						const pathsJson = btn.getAttribute('data-paths');
-						if (pathsJson) {
-							try {
-								const paths = JSON.parse(pathsJson) as string[];
-								vscode.postMessage({ command: 'openFileFromList', paths });
-							} catch (error) {
-								traceCuration('wireCurationButtons.badPathsJson', {
-									error: error instanceof Error ? error.message : String(error),
-								});
-							}
-						}
-					} else if (command === 'manageExtension') {
-						const extensionId = btn.getAttribute('data-extension-id');
-						if (extensionId) { vscode.postMessage({ command: 'manageExtension', extensionId }); }
-					} else if (command === 'openAgentPlugins') {
-						const pluginName = btn.getAttribute('data-plugin-name') ?? '';
-						vscode.postMessage({ command: 'openAgentPlugins', pluginName });
-					} else {
-						vscode.postMessage({ command });
-					}
+					_handleCurationBtnClick(btn);
 				} catch (error) {
-					traceCuration('wireCurationButtons.clickError', {
-						error: error instanceof Error ? error.message : String(error),
-					});
+					traceCuration('wireCurationButtons.clickError', { error: error instanceof Error ? error.message : String(error) });
 				}
 			});
 		});
 	} catch (error) {
-		traceCuration('wireCurationButtons.error', {
-			error: error instanceof Error ? error.message : String(error),
-		});
+		traceCuration('wireCurationButtons.error', { error: error instanceof Error ? error.message : String(error) });
 	}
 }
 

--- a/vscode-extension/src/workspaceHelpers.ts
+++ b/vscode-extension/src/workspaceHelpers.ts
@@ -329,6 +329,17 @@ function scanRecursivePattern(ctx: PatternScanContext, excludeDirs: string[]): C
 	return walkDirectoryForPattern(workspaceFolderPath, maxDepth, ctx, regex, excludeDirs);
 }
 
+function _runPatternScan(ctx: PatternScanContext, excludeDirs: string[]): CustomizationFileEntry[] {
+	const scanMode = ctx.pattern.scanMode ?? 'exact';
+	if (scanMode === 'exact') {
+		const entry = scanExactPattern(ctx);
+		return entry ? [entry] : [];
+	}
+	if (scanMode === 'oneLevel') { return scanOneLevelPattern(ctx, excludeDirs); }
+	if (scanMode === 'recursive') { return scanRecursivePattern(ctx, excludeDirs); }
+	return [];
+}
+
 /**
  * Scan a workspace folder for customization files according to `customizationPatterns.json`.
  */
@@ -344,15 +355,7 @@ export function scanWorkspaceCustomizationFiles(workspaceFolderPath: string): Cu
 	for (const pattern of (cfg.patterns ?? [])) {
 		try {
 			const ctx: PatternScanContext = { workspaceFolderPath, pattern, stalenessDays };
-			const scanMode = pattern.scanMode ?? 'exact';
-			if (scanMode === 'exact') {
-				const entry = scanExactPattern(ctx);
-				if (entry) { results.push(entry); }
-			} else if (scanMode === 'oneLevel') {
-				results.push(...scanOneLevelPattern(ctx, excludeDirs));
-			} else if (scanMode === 'recursive') {
-				results.push(...scanRecursivePattern(ctx, excludeDirs));
-			}
+			results.push(..._runPatternScan(ctx, excludeDirs));
 		} catch {
 			// ignore per-pattern errors
 		}
@@ -762,6 +765,16 @@ export async function extractRepositoryFromContentReferences(contentReferences: 
 	return undefined;
 }
 
+function _resolveCodeWorkspaceEntry(entry: unknown): string | undefined {
+	if (typeof entry !== 'object' || entry === null) { return undefined; }
+	const e = entry as { path?: unknown; uri?: unknown };
+	let folderPath: string | undefined;
+	if (typeof e.path === 'string') { folderPath = e.path; }
+	else if (typeof e.uri === 'string' && e.uri.startsWith('file://')) { folderPath = resolveFileUri(e.uri); }
+	if (!folderPath) { return undefined; }
+	try { return fs.realpathSync.native(folderPath); } catch { return folderPath; }
+}
+
 /**
  * Parse a `.code-workspace` multi-root workspace file and return the resolved folder paths.
  * Returns an empty array if the file cannot be read, is invalid JSON, or has no folders.
@@ -778,20 +791,8 @@ export function parseCodeWorkspaceFolders(codeWorkspacePath: string): string[] {
 		}
 		const folders: string[] = [];
 		for (const entry of obj.folders) {
-			if (typeof entry !== 'object' || entry === null) { continue; }
-			let folderPath: string | undefined;
-			if (typeof entry.path === 'string') {
-				folderPath = entry.path;
-			} else if (typeof entry.uri === 'string' && entry.uri.startsWith('file://')) {
-				folderPath = resolveFileUri(entry.uri);
-			}
-			if (!folderPath) { continue; }
-			try {
-				const resolved = fs.realpathSync.native(folderPath);
-				folders.push(resolved);
-			} catch {
-				folders.push(folderPath);
-			}
+			const resolved = _resolveCodeWorkspaceEntry(entry);
+			if (resolved) { folders.push(resolved); }
 		}
 		return folders;
 	} catch {


### PR DESCRIPTION
## Summary

- Extract helper functions across 6 source files (`extension.ts`, `jetbrains.ts`, `maturityScoring.ts`, `usageAnalysis.ts`, `webview/usage/main.ts`, `workspaceHelpers.ts`) to bring every function below the ESLint complexity thresholds (`complexity ≤ 15`, `sonarjs/cognitive-complexity ≤ 15`, `max-depth ≤ 5`, `max-lines-per-function ≤ 80`)
- Introduces intermediate variables to cache `?.` optional-chain accesses (each `?.` counts as +1 toward cyclomatic complexity)
- No behavior changes — pure structural refactoring

## Test plan

- [ ] `npm run lint` in `vscode-extension/` — zero warnings
- [ ] `npm test` in `vscode-extension/` — all 80 tests pass
- [ ] `npm run build` — clean TypeScript compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)