### PR TITLE
chore: bump VS Code extension to v0.12.2

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Summary
Patch version bump for the VS Code extension: `0.12.1` → `0.12.2`, in preparation for the next release.

## Details
- Bumped `version` in `vscode-extension/package.json` only, matching the established release-prep practice (see the prior `v0.12.0` → `v0.12.1` bump in `5c867f30`).
- The `CHANGELOG.md` `[Unreleased]` section is currently empty and is synced from GitHub releases automatically by the Release workflow, so no changelog edits are needed here.

## Next steps (manual, per repo process)
After merging to `main`, trigger the **Release** workflow from GitHub Actions to tag, build, release, and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)