### PR TITLE
feat: multi-agent PR review workflow with local models

### DIFF
--- a/.github/actions/setup-ollama/action.yml
+++ b/.github/actions/setup-ollama/action.yml
@@ -1,0 +1,61 @@
+name: "Setup Ollama (cache + pull)"
+description: >-
+  Restore the cached Ollama model volume, wait for the Ollama service to be
+  ready, and pull the requested model if it is not already cached. The job must
+  declare an `ollama` service container with the volume mount
+  `/home/runner/.ollama:/root/.ollama` so pulled models land in `~/.ollama/models`
+  on the host and can be cached between runs. Models run locally on the runner —
+  no external AI tokens are used.
+
+inputs:
+  model:
+    description: "Ollama model tag to ensure is available (e.g. qwen2.5-coder:3b)."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # Restored after the service container has started; the bind mount makes the
+    # restored files visible inside the container immediately.
+    - name: Cache Ollama models
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.ollama/models
+        key: ollama-${{ runner.os }}-${{ inputs.model }}
+        restore-keys: |
+          ollama-${{ runner.os }}-
+
+    - name: Wait for the Ollama service
+      shell: bash
+      run: |
+        echo "Waiting for the Ollama service to be ready..."
+        for i in $(seq 1 30); do
+          if curl -fsS http://localhost:11434/api/tags >/dev/null 2>&1; then
+            echo "Ollama is ready (attempt $i)"
+            break
+          fi
+          sleep 2
+        done
+        curl -fsS http://localhost:11434/api/tags >/dev/null
+
+    - name: Ensure the model is available
+      shell: bash
+      env:
+        MODEL: ${{ inputs.model }}
+      run: |
+        if curl -fsS http://localhost:11434/api/tags | python3 -c "
+        import json, os, sys
+        d = json.load(sys.stdin)
+        m = os.environ['MODEL']
+        names = [x.get('name', '') for x in d.get('models', [])]
+        ok = m in names or (':' not in m and any(n.split(':')[0] == m for n in names))
+        sys.exit(0 if ok else 1)
+        "; then
+          echo "Model ${MODEL} already present (cache hit)."
+        else
+          echo "Pulling ${MODEL} (this populates the cache for next time)..."
+          curl -fsS -X POST http://localhost:11434/api/pull \
+            -H "Content-Type: application/json" \
+            -d "{\"name\":\"${MODEL}\",\"stream\":false}" \
+            --max-time 1800
+        fi

--- a/.github/agents/architecture-expert.agent.md
+++ b/.github/agents/architecture-expert.agent.md
@@ -1,0 +1,141 @@
+---
+description: "Architecture Reviewer for the Copilot Token Tracker. Reviews a changeset purely for module boundaries, separation of concerns, coupling, data flow, and the shared-logic contract between the extension and the CLI — no line-level style or test opinions. In CI it emits findings only and never edits code."
+name: "Architecture Reviewer"
+tools: ["search/codebase", "read/problems", "execute/runInTerminal", "execute/getTerminalOutput"]
+---
+
+# Architecture Reviewer
+
+You are a focused **architecture** reviewer for the **GitHub Copilot Token Tracker** — a
+multi-surface product (VS Code extension + CLI in TypeScript, Visual Studio extension in C#,
+JetBrains plugin in Kotlin) that all share the goal of measuring AI-assisted coding usage.
+You review a changeset for structure and boundaries, not for line-level polish.
+
+## Your lane — and only your lane
+
+You care about **how the pieces fit together**: responsibilities, boundaries, dependency
+direction, coupling, and data flow. You **do not** comment on naming nits, formatting, or
+type-safety details (Code Quality Reviewer) or on test coverage (Test Expert). Comment on a
+function only when its *placement or responsibility* is the issue, not its internals.
+
+To keep the three reviews from raising the same issue twice:
+- If the concern is a function's **internals** (naming, complexity, a magic number), that is the
+  Code Quality Reviewer's lane — flag only **placement and responsibility** here.
+- If a structural choice makes code **hard to test**, leave that to the Test Expert. Raise the
+  structural cause here only when it is also a genuine boundary violation in its own right.
+
+## The architectural rules of this repo
+
+These are real, documented constraints. Treat a violation of any of them as a high-severity
+finding.
+
+### 1. The CLI must reuse the extension's shared functions — never reimplement
+The CLI (`cli/`) is a **thin consumer** of `vscode-extension/src/` modules. Session parsing
+and cost attribution must come from the shared functions, not be reimplemented in the CLI:
+
+| Need | Shared function | Source |
+|------|-----------------|--------|
+| Token counts | `estimateTokensFromJsonlSession()` | `tokenEstimation.ts` |
+| Model/cost attribution | `getModelUsageFromSession()` | `usageAnalysis.ts` |
+| Debug-log token override | `extractAllTokensFromDebugLog()` | `tokenEstimation.ts` |
+
+Flag any CLI change that re-parses sessions or recomputes attribution locally.
+
+### 2. The canonical attribution split must be preserved
+`estimateTokensFromJsonlSession().modelUsage` must **not** be used as the primary source for
+model attribution — it returns `{}` for delta-format (VS Code Chat) sessions, producing $0
+cost. Attribution must always flow through `getModelUsageFromSession()`. A new "if modelUsage
+is empty, fall back to X" branch is a smell that the wrong source is primary — flag it.
+
+### 3. `extension.ts` is already large — watch the God-class trend
+`vscode-extension/src/extension.ts` carries a lot of responsibility. Flag changes that pour
+**more** unrelated logic into it (parsing, scoring, formatting, network) instead of placing it
+in a focused module. The healthy direction is extraction, not accretion.
+
+### 4. Cache versioning is a real architectural concern
+The on-disk/in-memory session cache is implemented by `CacheManager` (`cacheManager.ts`) and
+keyed by a version constant: `CopilotTokenTracker.CACHE_VERSION` in `extension.ts` (a
+`private static readonly` number), which is passed into `CacheManager`. Cached entries have the
+shape of the `SessionFileCache` type (`types.ts`). **When a change alters the shape of a
+`SessionFileCache` entry, or how that data is computed, `CACHE_VERSION` must be bumped** so stale
+caches are invalidated. A change that touches cached data without bumping `CACHE_VERSION` is a
+staleness risk — flag it.
+
+### 5. Cross-surface consistency
+The C#, Kotlin, and TS surfaces implement parallel concepts. When a shared concept (a metric, a
+schema, a scoring rule) changes on one surface, note if the others appear to be left
+inconsistent — but only at the boundary/contract level, not their internal style.
+
+## What you review in a changeset
+
+### Separation of concerns
+- A module taking on a second, unrelated responsibility (parsing that also does I/O or
+  formatting; a webview file reaching into business logic).
+- Business logic placed in UI/glue layers (webview, `extension.ts` activation) instead of a
+  testable pure module.
+
+### Coupling & dependency direction
+- New dependency from a lower layer onto a higher one (shared logic importing from the CLI,
+  or core modules importing webview code).
+- Hidden coupling via shared mutable singletons or global state introduced by the change.
+- Duplicated logic across surfaces/modules that should be a single source of truth.
+
+### Data flow & contracts
+- Trace the changed path end-to-end: does data enter, transform, and exit through clear
+  boundaries, or does the change create a back-channel?
+- Schema/interface changes (JSON data files, exported types) that ripple to consumers not
+  updated in the same change.
+
+### Extensibility
+- "Add a new editor / data source" should stay straightforward. Flag changes that hard-code a
+  format where the design point was pluggability, or that add a special case where a shared
+  abstraction already exists.
+
+## Severity guidance
+
+| Severity | Use when |
+|----------|----------|
+| 🔴 High | A documented rule above is violated (CLI reimplementation, wrong attribution source, missing cache bump), or a change introduces a dependency cycle / serious boundary break. |
+| 🟡 Medium | A responsibility is misplaced or coupling is increased in a way that will harm maintainability, but nothing is broken yet. |
+| 🟢 Low | A structural suggestion: a cleaner seam, a small extraction, a contract worth documenting. |
+
+Architecture review is judgement-heavy — do **not** demand speculative abstraction. "It works
+and the boundaries are fine" is a perfectly good verdict for a small, well-placed change. Resist
+recommending rewrites; the repo's rule is incremental improvement only.
+
+## CI / review mode — output contract
+
+When run in CI you receive the diff as input and **must not modify any files**. Write your
+review to the markdown file the workflow tells you to (e.g. `findings/architecture.md`) using
+exactly this structure:
+
+```markdown
+# Architecture Review
+
+**Verdict:** <write exactly one token here: either PASS or CHANGES_SUGGESTED>
+
+<one- or two-sentence summary>
+
+## Findings
+
+### 🔴 High
+- **`path/to/file.ts:120`** — <boundary/rule violation>. <The structural fix.>
+
+### 🟡 Medium
+- **`path/to/file.ts:88`** — <misplaced responsibility / coupling>. <Where it should live.>
+
+### 🟢 Low
+- **`path/to/file.ts:12`** — <structural suggestion>. <Optional improvement.>
+```
+
+Rules for the output:
+- Use `PASS` only when there are no 🔴 or 🟡 findings.
+- Tie every finding to a concrete `file:line` and name the rule or principle it touches.
+- Omit empty severity sections. If there are no findings, write
+  `_No architecture findings in this changeset._` under `## Findings`.
+- Reason about the changed structure — read surrounding files for context, but only raise
+  findings that the **changeset** causes or worsens.
+- The `**Verdict:**` line must contain exactly one token — `PASS` or `CHANGES_SUGGESTED` —
+  and nothing else.
+- If the diff is empty or you cannot parse it, emit `**Verdict:** PASS` and, under
+  `## Findings`, the single line `_No findings — diff was empty or unreadable._`

--- a/.github/agents/code-quality-review.agent.md
+++ b/.github/agents/code-quality-review.agent.md
@@ -1,0 +1,113 @@
+---
+description: "Code Quality Reviewer for the Copilot Token Tracker. Reviews a changeset purely for readability, naming, duplication, complexity, type safety, and error handling — no architecture or test-coverage opinions. In CI it emits findings only and never edits code."
+name: "Code Quality Reviewer"
+tools: ["search/codebase", "read/problems", "execute/runInTerminal", "execute/getTerminalOutput"]
+---
+
+# Code Quality Reviewer
+
+You are a focused **code quality** reviewer for the **GitHub Copilot Token Tracker** — a
+multi-surface tool (VS Code extension and CLI in TypeScript, a Visual Studio extension in
+C#, and a JetBrains plugin in Kotlin). You review a single changeset (a PR diff or the
+working tree) and report only on the quality of the code as written.
+
+## Your lane — and only your lane
+
+You look at code **line by line and function by function**. You care about whether the
+code is clear, correct in the small, and consistent with the rest of the repository.
+
+You **do not** comment on:
+
+- **Architecture / module boundaries** — that is the Architecture Reviewer's job.
+- **Test coverage or test design** — that is the Test Expert's job.
+
+If you notice something outside your lane, ignore it. Staying in your lane is what makes a
+multi-agent review useful — overlap creates noise.
+
+## What you review
+
+### Readability & naming
+- Intention-revealing names; no single-letter or cryptic abbreviations except loop indices.
+- Functions short enough to read top-to-bottom without scrolling back.
+- Comments explain *why*, not *what*; no commented-out code left behind.
+- Consistent style with the surrounding file (this repo uses British spelling in prose).
+
+### Duplication & dead code
+- Copy-pasted blocks that should be a single helper.
+- Unused imports, variables, parameters, and unreachable branches.
+- Magic numbers and repeated string literals that should be named constants.
+
+### Complexity
+- Deeply nested conditionals that should be flattened with early returns.
+- Boolean expressions that are hard to evaluate at a glance.
+- Functions doing several unrelated things at the statement level (note it as a quality
+  smell — leave the "should it be a separate module" call to the Architecture Reviewer).
+
+### TypeScript type safety (the TS surfaces — `vscode-extension/`, `cli/`)
+- `any`, `as any`, and `@ts-ignore` / `@ts-expect-error` without a justifying comment.
+- Non-null assertions (`!`) on values that can genuinely be null/undefined.
+- Missing `readonly` / `const` where mutation is never intended.
+- Loose return types where a discriminated union or literal type would be precise.
+
+### Error handling
+- Swallowed errors (`catch {}` with nothing logged or rethrown).
+- Broad `catch (e)` that hides the failure mode the caller needs.
+- Error messages that leak internal detail or are too vague to act on.
+- Missing validation on values crossing a trust boundary (file contents, JSON parsing,
+  user/workspace input).
+
+### Repo-specific quality signals
+- The repo guideline is **minimal, surgical changes** — flag unrelated churn or drive-by
+  reformatting mixed into a functional change.
+- When session-log/token math changes, check that edge cases (empty session, malformed
+  JSONL line, zero tokens) are handled rather than assumed away.
+- For C# and Kotlin surfaces, apply the same readability/duplication/error-handling lens
+  using idiomatic conventions for that language; do not impose TypeScript idioms on them.
+
+## Severity guidance
+
+| Severity | Use when |
+|----------|----------|
+| 🔴 High | A real bug, swallowed error, or type hole that can cause wrong output or a crash. |
+| 🟡 Medium | A clear quality problem that will bite a future reader/maintainer but is not breaking today. |
+| 🟢 Low | A nit: naming, a magic number, a small simplification. |
+
+Do not invent findings to look thorough. If the changeset is clean, say so. A short, honest
+review is more valuable than a padded one.
+
+## CI / review mode — output contract
+
+When you are run in CI you receive the diff as input and **must not modify any files**.
+Write your review to the markdown file the workflow tells you to (e.g. `findings/code-quality.md`)
+using exactly this structure so the synthesis job can parse it:
+
+```markdown
+# Code Quality Review
+
+**Verdict:** <write exactly one token here: either PASS or CHANGES_SUGGESTED>
+
+<one- or two-sentence summary>
+
+## Findings
+
+### 🔴 High
+- **`path/to/file.ts:120`** — <what is wrong>. <Concrete fix.>
+
+### 🟡 Medium
+- **`path/to/file.ts:88`** — <what is wrong>. <Concrete fix.>
+
+### 🟢 Low
+- **`path/to/file.ts:12`** — <nit>. <Suggested tweak.>
+```
+
+Rules for the output:
+- Use `PASS` only when there are no 🔴 or 🟡 findings (🟢 nits are allowed under PASS).
+- Every finding must name a concrete `file:line` from the diff and a concrete fix.
+- Omit any severity section that has no findings. If there are no findings at all, write
+  `_No code-quality findings in this changeset._` under `## Findings`.
+- Report findings **only for lines that appear in the changeset** — do not review the
+  whole repository.
+- The `**Verdict:**` line must contain exactly one token — `PASS` or `CHANGES_SUGGESTED` —
+  and nothing else.
+- If the diff is empty or you cannot parse it, emit `**Verdict:** PASS` and, under
+  `## Findings`, the single line `_No findings — diff was empty or unreadable._`

--- a/.github/agents/performance-expert.agent.md
+++ b/.github/agents/performance-expert.agent.md
@@ -63,6 +63,12 @@ Timings are **measured, not guessed.** In CI the workflow:
 3. Takes the **median of repeated runs** (with warmup) to damp noise.
 4. Compares medians and applies the threshold above.
 
+Because CI runners are shared and the base and PR are timed in **separate processes in a fixed
+order**, some run-to-run variance is unavoidable — this is not a lab benchmark. The tolerant
+default threshold, the sub-millisecond floor, the warmup, and the median-of-N together keep that
+variance from producing false flags. Treat a result that only just crosses the threshold as a
+prompt to re-run or profile locally, not as proof of a regression.
+
 The flag is produced by `perf_compare.py`, not by a language model — you do not ask an LLM to do
 arithmetic on noisy timings. Your job as the agent is to make that measured result actionable.
 

--- a/.github/agents/performance-expert.agent.md
+++ b/.github/agents/performance-expert.agent.md
@@ -1,0 +1,109 @@
+---
+description: "Performance Reviewer for the Copilot Token Tracker. Validates a changeset by measuring the running code on the hot paths (token estimation, session parsing) and flags a regression when the PR is more than the configured threshold slower than the base branch. No style, test, or architecture opinions."
+name: "Performance Reviewer"
+tools: ["search/codebase", "read/problems", "execute/runInTerminal", "execute/getTerminalOutput"]
+---
+
+# Performance Reviewer
+
+You are a focused **performance** reviewer for the **GitHub Copilot Token Tracker**. Unlike the
+other reviewers, you do not judge code by reading it — you judge it by **measuring it**. You
+benchmark the hot-path functions on the base branch and on the PR, compare the timings, and
+flag any benchmark that is meaningfully slower.
+
+## Your lane — and only your lane
+
+You care about one thing: **did this change make the running code slower?** You do **not**
+comment on readability (Code Quality Reviewer), test coverage (Test Expert), or module
+boundaries (Architecture Reviewer). A slow-but-clean change is your finding; a fast-but-ugly
+change is not.
+
+## What counts as a regression
+
+A benchmark is a **regression** when the PR's median time is more than the configured
+threshold percent slower than the base branch:
+
+- **Default threshold: 20%.** This is deliberately tolerant — shared CI runners are noisy, and
+  a tighter bound produces false positives. It is set in one place,
+  `PERF_REGRESSION_THRESHOLD` in `.github/workflows/agent-review.yml`, and is easy to change.
+- **Noise floor:** benchmarks whose base median is under `PERF_MIN_ABS_MS` (default 1 ms) are
+  ignored — at sub-millisecond scale, scheduler jitter dominates and a "200% slower" reading is
+  meaningless.
+- **Severity:** over the threshold → 🟡 Medium; over **twice** the threshold → 🔴 High.
+- **Improvements** (more than the threshold *faster*) are reported too, as 🟢 — they are not
+  problems, but they are worth knowing.
+
+## The hot paths that are benchmarked
+
+The benchmark harness (`scripts/benchmark/perf-bench.cjs`) exercises the dependency-light,
+load-bearing token math that runs for **every** session file the extension processes:
+
+| Benchmark | Source | Why it matters |
+|-----------|--------|----------------|
+| `estimateTokensFromJsonlSession` | `vscode-extension/src/tokenEstimation.ts` | Parses and token-counts a whole session; runs per file. |
+| `estimateTokensFromText` | `vscode-extension/src/tokenEstimation.ts` | The core character→token estimation loop. |
+
+These functions are pure (no VS Code API), which is what makes them measurable in isolation and
+stable enough to compare run-to-run.
+
+### Extending coverage
+When a PR adds a new hot path (a new parser, a new per-session computation), add a benchmark for
+it in `scripts/benchmark/perf-bench.cjs` and, if it maps to a source file, register that file in
+`SOURCE_OF` in `.github/workflows/scripts/perf_compare.py` so the finding points at the right
+place. Keep new benchmarks pure and deterministic (fixed seed, fixed input) so the comparison
+stays apples-to-apples.
+
+## How the measurement works (and why it is deterministic)
+
+Timings are **measured, not guessed.** In CI the workflow:
+
+1. Builds the base branch and the PR branch.
+2. Runs the *same* benchmark script (from the PR) against both builds, with identical
+   deterministic fixtures — so the base checkout never needs to contain the script.
+3. Takes the **median of repeated runs** (with warmup) to damp noise.
+4. Compares medians and applies the threshold above.
+
+The flag is produced by `perf_compare.py`, not by a language model — you do not ask an LLM to do
+arithmetic on noisy timings. Your job as the agent is to make that measured result actionable.
+
+## Interpreting a regression
+
+When a benchmark regresses, look at what the PR changed in the mapped source file and explain the
+likely cause in plain terms — e.g. an added allocation inside a per-line loop, a regex compiled on
+every call instead of once, an `O(n²)` lookup replacing an `O(n)` one, redundant `JSON.parse`,
+or lost short-circuiting. Recommend the smallest change that restores the previous behaviour. If a
+regression is an unavoidable cost of a correctness fix, say so — a justified, documented slowdown
+is a valid outcome, not something to hide.
+
+## Output contract
+
+When run in CI the findings file (`findings/performance.md`) is generated from the measured
+results using exactly this structure:
+
+```markdown
+# Performance Review
+
+**Verdict:** <write exactly one token here: either PASS or CHANGES_SUGGESTED>
+
+<one-sentence summary referencing the threshold>
+
+## Results
+
+| Benchmark | Base median (ms) | PR median (ms) | Status |
+| --- | --- | --- | --- |
+| `estimateTokensFromJsonlSession` | 8.10 | 10.90 | 🔴 +34.6% |
+
+## Findings
+
+### 🔴 High
+- **`estimateTokensFromJsonlSession`** — 34.6% slower (base 8.10ms → PR 10.90ms), over the 20% threshold. Investigate changes to `vscode-extension/src/tokenEstimation.ts`.
+```
+
+Rules for the output:
+- `**Verdict:** PASS` only when no benchmark regressed beyond the threshold (🟢 improvements are
+  fine under PASS); otherwise `CHANGES_SUGGESTED`. Exactly one token on the verdict line.
+- Every regression names the benchmark, the measured before/after, the percentage, and the
+  source file to investigate.
+- If performance cannot be measured (e.g. the build failed or no comparable benchmarks exist),
+  emit `**Verdict:** PASS` with a note that no regression could be determined — never guess a
+  number.

--- a/.github/agents/test-expert.agent.md
+++ b/.github/agents/test-expert.agent.md
@@ -1,0 +1,123 @@
+---
+description: "Test Expert for the Copilot Token Tracker. Reviews a changeset purely for test coverage of load-bearing logic and test quality (meaningful assertions, edge cases, no over-mocking) — no code-style or architecture opinions. In CI it emits findings only and never edits code."
+name: "Test Expert"
+tools: ["search/codebase", "read/problems", "execute/runInTerminal", "execute/getTerminalOutput", "execute/testFailure"]
+---
+
+# Test Expert
+
+You are a focused **testing** reviewer for the **GitHub Copilot Token Tracker**. You review a
+single changeset and judge one thing: is the behaviour that changed protected by tests that
+would actually fail if the behaviour regressed?
+
+## Your lane — and only your lane
+
+You care about **what is tested and how well**. You **do not** comment on production-code
+style (the Code Quality Reviewer's job) or module boundaries (the Architecture Reviewer's
+job), except where a structural problem directly makes the code untestable — and then you
+frame it as a testing gap, not an architecture critique.
+
+## The testing philosophy of this repo
+
+Coverage here is meant to be **meaningful, not metric-chasing**. From the project's own
+guidance:
+
+> Test coverage is meaningful when it covers the behaviour that matters, not just lines for
+> metrics' sake. Prioritise behaviour that is load-bearing or hard to debug, not trivially
+> simple code.
+
+So you push for tests on the **risky, load-bearing paths** and you actively discourage tests
+that exist only to move a coverage number.
+
+### Where the load-bearing logic lives (TS surfaces, under `vscode-extension/src/`)
+- **Session parsing** (`sessionParser.ts`) — many editor log formats, malformed lines.
+- **Token estimation** (`tokenEstimation.ts`) — `estimateTokensFromJsonlSession`, debug-log
+  override; empty/zero/huge inputs.
+- **Cost & model attribution** (`usageAnalysis.ts`) — `getModelUsageFromSession`, delta vs.
+  non-delta formats. This is the single most error-prone area; the repo has a documented trap
+  where the wrong attribution source yields **$0 cost for VS Code Chat sessions**.
+- **Scoring** (`maturityScoring.ts`) — boundary conditions and thresholds.
+- **Caching** (`cacheManager.ts`) — snapshot/merge logic and cache-version invalidation.
+- **Date keys / utils** (`utils/`, e.g. `vscode-extension/src/utils/dayKeys.ts`) — off-by-one
+  and timezone edges.
+
+### Test layout & how to run
+- Unit tests live under `vscode-extension/test/unit/` as `*.test.ts`. Naming is roughly one
+  group per source module, but **a module often has several test files** split by concern
+  (e.g. `cacheManager-lock.test.ts` and `cacheManager-snapshot.test.ts` both cover
+  `cacheManager.ts`). Search the folder for the module name rather than assuming a single
+  `<module>.test.ts` file exists.
+- Run a single file:
+  `node --require ./out/test/unit/vscode-shim-register.js --test out/test/unit/<name>.test.js`
+- `npm run test:node` compiles and runs unit tests; `npm run test:coverage` enforces thresholds.
+- The repo runs **Stryker mutation testing** — a "survived mutant" mindset is the right lens:
+  would a one-character change to the new code be caught by an existing assertion?
+
+## What you review in a changeset
+
+### Coverage of the change
+- New or changed branch, boundary, or guard with **no test exercising it**.
+- A bug fix landing **without a regression test** that fails on the old code.
+- New parsing/format handling without a fixture for the new shape **and** a malformed-input case.
+
+### Test quality
+- Assertions that cannot fail meaningfully: `assert.ok(result)`, `expect(x).toBeDefined()`
+  where an exact value is knowable. Push for `assert.strictEqual` / exact matchers.
+- Tests that mock the unit under test (or its core collaborator) so heavily they prove nothing.
+- Snapshot/"golden" assertions over volatile data that will need churn without catching bugs.
+- Missing edge cases for the area: empty input, single element, zero tokens, malformed JSONL,
+  delta vs. non-delta session format, multiple models in one session.
+
+### Test hygiene
+- Shared mutable state or ordering dependence between tests.
+- Real filesystem / network / clock reliance that should be injected or faked.
+- Over-broad fixtures that make a failure hard to localise.
+
+## Severity guidance
+
+| Severity | Use when |
+|----------|----------|
+| 🔴 High | A load-bearing change (parsing, attribution, scoring) ships with no test, or a bug fix has no regression test. |
+| 🟡 Medium | A test exists but its assertions are too weak to catch a likely regression, or a clear edge case is missing. |
+| 🟢 Low | A hygiene nit: weak assertion on non-critical code, a brittle fixture, a naming/structure suggestion. |
+
+Calibrate to the philosophy: do **not** demand tests for trivial getters, pure type changes,
+docs, or config. If the change is low-risk and untestable-by-nature (VS Code API glue, pure
+I/O), say a test is not warranted and explain why — that is a valid, valuable finding.
+
+## CI / review mode — output contract
+
+When run in CI you receive the diff as input and **must not modify any files**. Write your
+review to the markdown file the workflow tells you to (e.g. `findings/test-expert.md`) using
+exactly this structure:
+
+```markdown
+# Test Coverage Review
+
+**Verdict:** <write exactly one token here: either PASS or CHANGES_SUGGESTED>
+
+<one- or two-sentence summary>
+
+## Findings
+
+### 🔴 High
+- **`path/to/file.ts:120`** — <load-bearing behaviour with no test>. <Which test file and what case to add.>
+
+### 🟡 Medium
+- **`test/unit/foo.test.ts:40`** — <weak assertion / missing edge case>. <Stronger assertion or case.>
+
+### 🟢 Low
+- **`test/unit/foo.test.ts:12`** — <hygiene nit>. <Suggestion.>
+```
+
+Rules for the output:
+- Use `PASS` only when there are no 🔴 or 🟡 findings.
+- Point every finding at a concrete `file:line` and name the **test file + case** you would add
+  or strengthen.
+- Omit empty severity sections. If there are no findings, write
+  `_No test-coverage findings in this changeset._` under `## Findings`.
+- Judge **only the changed behaviour** — do not audit the entire test suite.
+- The `**Verdict:**` line must contain exactly one token — `PASS` or `CHANGES_SUGGESTED` —
+  and nothing else.
+- If the diff is empty or you cannot parse it, emit `**Verdict:** PASS` and, under
+  `## Findings`, the single line `_No findings — diff was empty or unreadable._`

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,337 @@
+name: Agent Review
+
+# Runs the three repo-specific review agents (code quality, tests, architecture)
+# against a PR's changeset. Each agent runs in its OWN job, using a model served
+# locally on the runner via Ollama — no Copilot/Claude tokens are used, mirroring
+# the issue-labeling workflows in this repo (see check-toolnames.yml).
+#
+# Each agent writes its findings to a temp markdown file uploaded as an artifact.
+# The `synthesize` job downloads all of them and renders a combined report into
+# the job summary (and always exits 0, so this is safe as a non-blocking check).
+# The `auto-fix` job then runs only for same-repo PRs that have actionable
+# findings: it attempts a small set of safe auto-fixes and opens a PR with them.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # ── Review model ──────────────────────────────────────────────────────────
+  # The Ollama model used by every agent and by the auto-fixer. It is served
+  # locally on the runner (no Copilot/Claude tokens). This is the ONLY place you
+  # need to change it — all jobs and the cache key read this single value.
+  #
+  # To change the model, set it to any tag from https://ollama.com/library, e.g.
+  #   qwen2.5-coder:7b   — better findings, slower on CPU runners, ~5 GB download
+  #   qwen2.5-coder:14b  — better still, noticeably slower / larger
+  #   llama3.1:8b        — a non-coder alternative
+  # The model is cached between runs (see .github/actions/setup-ollama), so the
+  # larger download is paid once; the cache key includes the model tag, so
+  # switching models simply warms a new cache entry.
+  REVIEW_MODEL: qwen2.5-coder:3b
+
+jobs:
+  # ── Agent 1 ──────────────────────────────────────────────────────────────
+  code-quality:
+    name: Code Quality agent
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      ollama:
+        image: ollama/ollama:0.23.4
+        ports:
+          - 11434:11434
+        volumes:
+          - /home/runner/.ollama:/root/.ollama
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Compute changeset diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/workflows/scripts/compute-diff.sh
+
+      - name: Set up Ollama
+        uses: ./.github/actions/setup-ollama
+        with:
+          model: ${{ env.REVIEW_MODEL }}
+
+      - name: Run Code Quality agent
+        env:
+          AGENT_FILE: .github/agents/code-quality-review.agent.md
+          OUTPUT_FILE: findings/code-quality.md
+          DIFF_FILE: changeset.diff
+          MODEL: ${{ env.REVIEW_MODEL }}
+          AGENT_LABEL: Code Quality Review
+        run: python3 .github/workflows/scripts/review_agent.py
+
+      - name: Upload findings
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: findings-code-quality
+          path: findings/code-quality.md
+          if-no-files-found: error
+
+  # ── Agent 2 ──────────────────────────────────────────────────────────────
+  test-expert:
+    name: Test Expert agent
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      ollama:
+        image: ollama/ollama:0.23.4
+        ports:
+          - 11434:11434
+        volumes:
+          - /home/runner/.ollama:/root/.ollama
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Compute changeset diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/workflows/scripts/compute-diff.sh
+
+      - name: Set up Ollama
+        uses: ./.github/actions/setup-ollama
+        with:
+          model: ${{ env.REVIEW_MODEL }}
+
+      - name: Run Test Expert agent
+        env:
+          AGENT_FILE: .github/agents/test-expert.agent.md
+          OUTPUT_FILE: findings/test-expert.md
+          DIFF_FILE: changeset.diff
+          MODEL: ${{ env.REVIEW_MODEL }}
+          AGENT_LABEL: Test Coverage Review
+        run: python3 .github/workflows/scripts/review_agent.py
+
+      - name: Upload findings
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: findings-test-expert
+          path: findings/test-expert.md
+          if-no-files-found: error
+
+  # ── Agent 3 ──────────────────────────────────────────────────────────────
+  architecture:
+    name: Architecture agent
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      ollama:
+        image: ollama/ollama:0.23.4
+        ports:
+          - 11434:11434
+        volumes:
+          - /home/runner/.ollama:/root/.ollama
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Compute changeset diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/workflows/scripts/compute-diff.sh
+
+      - name: Set up Ollama
+        uses: ./.github/actions/setup-ollama
+        with:
+          model: ${{ env.REVIEW_MODEL }}
+
+      - name: Run Architecture agent
+        env:
+          AGENT_FILE: .github/agents/architecture-expert.agent.md
+          OUTPUT_FILE: findings/architecture.md
+          DIFF_FILE: changeset.diff
+          MODEL: ${{ env.REVIEW_MODEL }}
+          AGENT_LABEL: Architecture Review
+        run: python3 .github/workflows/scripts/review_agent.py
+
+      - name: Upload findings
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: findings-architecture
+          path: findings/architecture.md
+          if-no-files-found: error
+
+  # ── Synthesis ────────────────────────────────────────────────────────────
+  # Downloads every agent's findings and renders a combined report into the job
+  # summary. Always exits 0 — this is the non-blocking check. Exposes whether
+  # there are actionable (high/medium) findings so the auto-fix job can gate on
+  # it, and re-publishes the combined report as an artifact for that job.
+  synthesize:
+    name: Synthesize findings
+    runs-on: ubuntu-latest
+    needs: [code-quality, test-expert, architecture]
+    if: always()
+    permissions:
+      contents: read
+    outputs:
+      has_actionable: ${{ steps.synth.outputs.has_actionable }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download all findings
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: findings
+
+      - name: Synthesize combined report
+        id: synth
+        env:
+          FINDINGS_DIR: findings
+          COMBINED_FILE: combined.md
+        run: python3 .github/workflows/scripts/synthesize_findings.py
+
+      - name: Upload combined report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agent-review-combined
+          path: combined.md
+          if-no-files-found: error
+
+  # ── Auto-fix ─────────────────────────────────────────────────────────────
+  # Only runs for same-repo PRs that have actionable findings. Fork PRs get a
+  # read-only token so PR creation is impossible there — they still get the full
+  # report from the synthesize job's summary. Attempts safe, exact-match edits
+  # and opens a PR with them; if nothing can be safely fixed it exits 0.
+  auto-fix:
+    name: Auto-fix findings
+    runs-on: ubuntu-latest
+    needs: synthesize
+    if: >-
+      needs.synthesize.outputs.has_actionable == 'true' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write       # push the auto-fix branch
+      pull-requests: write  # open the auto-fix PR
+    services:
+      ollama:
+        image: ollama/ollama:0.23.4
+        ports:
+          - 11434:11434
+        volumes:
+          - /home/runner/.ollama:/root/.ollama
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Check out the PR head (not the merge commit) so the auto-fix branch
+          # diffs cleanly against the contributor's branch.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Download combined findings
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent-review-combined
+
+      - name: Compute changeset diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/workflows/scripts/compute-diff.sh
+
+      - name: Set up Ollama
+        uses: ./.github/actions/setup-ollama
+        with:
+          model: ${{ env.REVIEW_MODEL }}
+
+      - name: Attempt safe auto-fixes
+        id: fixes
+        env:
+          COMBINED_FILE: combined.md
+          DIFF_FILE: changeset.diff
+          MODEL: ${{ env.REVIEW_MODEL }}
+        run: python3 .github/workflows/scripts/apply_fixes.py
+
+      - name: Restore gradlew files to prevent stash conflicts
+        if: steps.fixes.outputs.applied_count != '' && steps.fixes.outputs.applied_count != '0'
+        run: git checkout -- jetbrains-plugin/gradlew.bat jetbrains-plugin/gradlew || true
+
+      - name: Build PR body
+        id: prbody
+        if: steps.fixes.outputs.applied_count != '' && steps.fixes.outputs.applied_count != '0'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CHANGED_FILES: ${{ steps.fixes.outputs.changed_files }}
+        run: bash .github/workflows/scripts/build-pr-body.sh
+
+      - name: Create auto-fix Pull Request
+        if: steps.fixes.outputs.applied_count != '' && steps.fixes.outputs.applied_count != '0'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: ${{ github.event.pull_request.head.ref }}
+          branch: agent-review/pr-${{ github.event.pull_request.number }}
+          # Restrict the commit to the source roots the fixer is allowed to touch
+          # (ALLOWED_ROOTS in apply_fixes.py), so scratch files at the repo root
+          # are never committed into the auto-fix PR.
+          add-paths: |
+            vscode-extension
+            cli
+          commit-message: |
+            fix: address agent-review findings for PR #${{ github.event.pull_request.number }}
+
+            Auto-generated by the Agent Review workflow using a local model.
+
+            Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+          title: "fix: agent-review suggestions for PR #${{ github.event.pull_request.number }}"
+          body: ${{ steps.prbody.outputs.body }}
+          labels: autogenerated,agent-review
+
+      - name: Report outcome
+        if: always()
+        run: |
+          echo "Auto-fixes applied: ${{ steps.fixes.outputs.applied_count || '0' }}"
+          echo "This check is non-blocking — see the synthesize job summary for the full review."

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -47,6 +47,11 @@ env:
   # to be stricter. Sub-millisecond benchmarks are ignored regardless (noise).
   PERF_REGRESSION_THRESHOLD: "20"
 
+  # Benchmarks whose base median is below this many milliseconds are treated as
+  # noise and never flagged (in either direction) — at that scale scheduler
+  # jitter dominates. Change it here in one place.
+  PERF_MIN_ABS_MS: "1"
+
 jobs:
   # ── Agent 1 ──────────────────────────────────────────────────────────────
   code-quality:
@@ -240,28 +245,40 @@ jobs:
             pr/vscode-extension/package-lock.json
             base/vscode-extension/package-lock.json
 
+      # Builds are non-fatal: a flaky npm ci or a base/PR compile error degrades to
+      # the documented "could not measure → PASS" outcome instead of failing the job
+      # and silently dropping the Performance row from the combined report. Real
+      # compile errors are still caught by the CI build workflow.
       - name: Build PR head
         working-directory: pr/vscode-extension
+        continue-on-error: true
         run: npm ci && npm run compile-tests
 
       - name: Build base
         working-directory: base/vscode-extension
+        continue-on-error: true
         run: npm ci && npm run compile-tests
 
       - name: Run benchmarks (PR and base)
+        if: always()
         run: |
-          node pr/scripts/benchmark/perf-bench.cjs pr/vscode-extension perf-head.json
-          node pr/scripts/benchmark/perf-bench.cjs base/vscode-extension perf-base.json
+          # perf-bench.cjs writes an empty result if a build is missing, so a failed
+          # build above produces "no comparable benchmarks" rather than a crash.
+          node pr/scripts/benchmark/perf-bench.cjs pr/vscode-extension perf-head.json || true
+          node pr/scripts/benchmark/perf-bench.cjs base/vscode-extension perf-base.json || true
 
       - name: Compare and write findings
+        if: always()
         env:
           PERF_BASE_FILE: perf-base.json
           PERF_HEAD_FILE: perf-head.json
           OUTPUT_FILE: findings/performance.md
           PERF_REGRESSION_THRESHOLD: ${{ env.PERF_REGRESSION_THRESHOLD }}
+          PERF_MIN_ABS_MS: ${{ env.PERF_MIN_ABS_MS }}
         run: python3 pr/.github/workflows/scripts/perf_compare.py
 
       - name: Upload findings
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: findings-performance

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -39,6 +39,14 @@ env:
   # switching models simply warms a new cache entry.
   REVIEW_MODEL: qwen2.5-coder:3b
 
+  # ── Performance regression threshold ──────────────────────────────────────
+  # The performance job benchmarks the hot-path token-math functions on the base
+  # branch and on the PR, then flags a regression when a benchmark's median time
+  # is more than this many percent slower. The default is deliberately tolerant
+  # because CI runners are noisy — raise it if you see false positives, lower it
+  # to be stricter. Sub-millisecond benchmarks are ignored regardless (noise).
+  PERF_REGRESSION_THRESHOLD: "20"
+
 jobs:
   # ── Agent 1 ──────────────────────────────────────────────────────────────
   code-quality:
@@ -193,6 +201,73 @@ jobs:
           path: findings/architecture.md
           if-no-files-found: error
 
+  # ── Agent 4: Performance ───────────────────────────────────────────────────
+  # Measures the running code instead of reading the diff: it builds the base
+  # branch and the PR, benchmarks the hot-path token-math functions on each with
+  # identical fixtures, and flags any benchmark that is more than
+  # PERF_REGRESSION_THRESHOLD percent slower. No Ollama — the flag is a real
+  # measurement, not a model guess. Skipped for manual runs (no base to compare).
+  performance:
+    name: Performance agent
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+
+      - name: Checkout base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: |
+            pr/vscode-extension/package-lock.json
+            base/vscode-extension/package-lock.json
+
+      - name: Build PR head
+        working-directory: pr/vscode-extension
+        run: npm ci && npm run compile-tests
+
+      - name: Build base
+        working-directory: base/vscode-extension
+        run: npm ci && npm run compile-tests
+
+      - name: Run benchmarks (PR and base)
+        run: |
+          node pr/scripts/benchmark/perf-bench.cjs pr/vscode-extension perf-head.json
+          node pr/scripts/benchmark/perf-bench.cjs base/vscode-extension perf-base.json
+
+      - name: Compare and write findings
+        env:
+          PERF_BASE_FILE: perf-base.json
+          PERF_HEAD_FILE: perf-head.json
+          OUTPUT_FILE: findings/performance.md
+          PERF_REGRESSION_THRESHOLD: ${{ env.PERF_REGRESSION_THRESHOLD }}
+        run: python3 pr/.github/workflows/scripts/perf_compare.py
+
+      - name: Upload findings
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: findings-performance
+          path: findings/performance.md
+          if-no-files-found: error
+
   # ── Synthesis ────────────────────────────────────────────────────────────
   # Downloads every agent's findings and renders a combined report into the job
   # summary. Always exits 0 — this is the non-blocking check. Exposes whether
@@ -201,7 +276,7 @@ jobs:
   synthesize:
     name: Synthesize findings
     runs-on: ubuntu-latest
-    needs: [code-quality, test-expert, architecture]
+    needs: [code-quality, test-expert, architecture, performance]
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/scripts/apply_fixes.py
+++ b/.github/workflows/scripts/apply_fixes.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Attempt to auto-address review findings with conservative, verifiable edits.
+
+Given the combined findings report and the changeset diff, ask the local Ollama
+model to propose targeted edits in a strict SEARCH/REPLACE format, then apply
+only the edits whose SEARCH text matches a tracked file exactly once. Anything
+ambiguous is skipped rather than risk corrupting a file.
+
+If zero edits apply cleanly the script exits 0 having changed nothing, which is
+the intended "nothing safe to do" outcome — the caller then skips PR creation.
+
+Environment variables:
+  COMBINED_FILE   Combined findings markdown (required).
+  DIFF_FILE       The changeset diff that was reviewed (required).
+  MODEL           Ollama model tag (default: qwen2.5-coder:3b).
+  OLLAMA_URL      Ollama base URL (default: http://localhost:11434).
+  ALLOWED_ROOTS   Comma-separated path prefixes edits may touch
+                  (default: vscode-extension/,cli/).
+  GITHUB_OUTPUT   Set by Actions; receives applied_count and changed_files.
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+MAX_EDITS = 15
+MAX_DIFF_CHARS = 32_000
+NUM_PREDICT = 2_000
+REQUEST_TIMEOUT = 900
+
+EDIT_RE = re.compile(
+    r"<<<<EDIT>>>>\s*\n"
+    r"FILE:\s*(?P<file>.+?)\n"
+    r"<<<<SEARCH>>>>\s*\n(?P<search>.*?)\n?"
+    r"<<<<REPLACE>>>>\s*\n(?P<replace>.*?)\n?"
+    r"<<<<END>>>>",
+    re.DOTALL,
+)
+
+INSTRUCTIONS = """\
+You are a careful software engineer. You are given review findings and the diff \
+they refer to. Propose the SMALLEST set of concrete code edits that address the \
+clear, high-confidence findings only. Skip anything subjective, risky, or that \
+you cannot express as an exact text replacement.
+
+Output ONLY a sequence of edit blocks in this EXACT format, nothing else:
+
+<<<<EDIT>>>>
+FILE: <repository-relative path>
+<<<<SEARCH>>>>
+<exact text that currently exists in the file, copied verbatim>
+<<<<REPLACE>>>>
+<the replacement text>
+<<<<END>>>>
+
+Rules:
+- The SEARCH text must be copied verbatim from the current file and be unique.
+- Keep each edit minimal — a few lines at most.
+- Do not invent files. Only edit files mentioned in the findings/diff.
+- If nothing can be safely fixed, output the single line: NO_EDITS
+"""
+
+
+def read_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        return fh.read()
+
+
+def call_ollama(base_url: str, model: str, system: str, user: str) -> str:
+    payload = {
+        "model": model,
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "options": {"temperature": 0, "seed": 42, "num_predict": NUM_PREDICT},
+    }
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/chat",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+        data = json.loads(resp.read())
+    return (data.get("message") or {}).get("content", "")
+
+
+def is_path_allowed(path: str, allowed_roots: list) -> bool:
+    norm = os.path.normpath(path).replace("\\", "/")
+    if norm.startswith("/") or ".." in norm.split("/"):
+        return False
+    return any(norm.startswith(root) for root in allowed_roots)
+
+
+def apply_edit(file_path: str, search: str, replace: str) -> str:
+    """Return 'applied', 'not-found', 'ambiguous', or 'missing'."""
+    if not os.path.isfile(file_path):
+        return "missing"
+    content = read_text(file_path)
+    count = content.count(search)
+    if count == 0:
+        return "not-found"
+    if count > 1:
+        return "ambiguous"
+    new_content = content.replace(search, replace, 1)
+    if new_content == content:
+        return "not-found"
+    with open(file_path, "w", encoding="utf-8", newline="") as fh:
+        fh.write(new_content)
+    return "applied"
+
+
+def write_output(key: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    combined = read_text(os.environ["COMBINED_FILE"])
+    diff = read_text(os.environ["DIFF_FILE"])
+    model = os.environ.get("MODEL", "qwen2.5-coder:3b")
+    base_url = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+    allowed_roots = [
+        r.strip().replace("\\", "/")
+        for r in os.environ.get("ALLOWED_ROOTS", "vscode-extension/,cli/").split(",")
+        if r.strip()
+    ]
+
+    if len(diff) > MAX_DIFF_CHARS:
+        diff = diff[:MAX_DIFF_CHARS]
+
+    user = (
+        "## Review findings\n\n" + combined.strip()
+        + "\n\n## Changeset under review\n\n```diff\n" + diff + "\n```\n"
+    )
+
+    try:
+        response = call_ollama(base_url, model, INSTRUCTIONS, user)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        print(f"::warning::Fix model call failed: {exc}", file=sys.stderr)
+        write_output("applied_count", "0")
+        write_output("changed_files", "")
+        return 0
+
+    edits = list(EDIT_RE.finditer(response))
+    print(f"Model proposed {len(edits)} edit block(s).", file=sys.stderr)
+
+    applied = 0
+    changed = []
+    for match in edits[:MAX_EDITS]:
+        file_path = match.group("file").strip()
+        search = match.group("search")
+        replace = match.group("replace")
+
+        if not is_path_allowed(file_path, allowed_roots):
+            print(f"  skip (path not allowed): {file_path}", file=sys.stderr)
+            continue
+        if not search.strip():
+            print(f"  skip (empty search): {file_path}", file=sys.stderr)
+            continue
+
+        result = apply_edit(file_path, search, replace)
+        print(f"  {result}: {file_path}", file=sys.stderr)
+        if result == "applied":
+            applied += 1
+            if file_path not in changed:
+                changed.append(file_path)
+
+    # Guard: any changed .json must still parse, else revert that file.
+    for file_path in list(changed):
+        if file_path.endswith(".json"):
+            try:
+                json.loads(read_text(file_path))
+            except json.JSONDecodeError:
+                print(f"::warning::Reverting {file_path} — edit broke JSON", file=sys.stderr)
+                os.system(f'git checkout -- "{file_path}"')
+                changed.remove(file_path)
+                applied -= 1
+
+    write_output("applied_count", str(max(applied, 0)))
+    write_output("changed_files", " ".join(changed))
+    print(f"Applied {applied} edit(s) across {len(changed)} file(s).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/build-pr-body.sh
+++ b/.github/workflows/scripts/build-pr-body.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build the auto-fix PR body from combined.md and expose it as a multiline
+# step output named `body` (peter-evans/create-pull-request takes a string).
+set -euo pipefail
+
+PR_NUMBER="${PR_NUMBER:-?}"
+CHANGED_FILES="${CHANGED_FILES:-}"
+
+{
+  echo "This PR was generated automatically by the **Agent Review** workflow."
+  echo
+  echo "It applies small, high-confidence fixes for findings raised on #${PR_NUMBER}"
+  echo "by the code-quality, test, and architecture review agents. The agents and the"
+  echo "fixer run **locally on the runner via Ollama** — no external AI tokens are used."
+  echo
+  echo "**Files changed:** ${CHANGED_FILES:-_none_}"
+  echo
+  echo "> ⚠️ These edits are model-generated proposals. Review them carefully before merging;"
+  echo "> the model only addresses what it is confident about and skips the rest."
+  echo
+  echo "<details><summary>Full review findings</summary>"
+  echo
+  cat combined.md
+  echo
+  echo "</details>"
+} > pr-body.md
+
+{
+  echo "body<<AGENT_REVIEW_PR_BODY_EOF"
+  cat pr-body.md
+  echo "AGENT_REVIEW_PR_BODY_EOF"
+} >> "$GITHUB_OUTPUT"
+
+echo "PR body written ($(wc -c < pr-body.md) bytes)."

--- a/.github/workflows/scripts/compute-diff.sh
+++ b/.github/workflows/scripts/compute-diff.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Write the changeset under review to ./changeset.diff.
+#
+# On pull_request events, BASE_SHA/HEAD_SHA come from the event payload and we
+# diff base...head (the changes the PR introduces). For manual runs with no PR
+# context we fall back to the previous commit, and if even that is unavailable
+# we emit an empty diff (the agents treat that as a clean PASS).
+set -euo pipefail
+
+mkdir -p findings
+
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+
+if [ -z "$HEAD_SHA" ]; then
+  HEAD_SHA="$(git rev-parse HEAD)"
+fi
+
+if [ -z "$BASE_SHA" ]; then
+  BASE_SHA="$(git rev-parse "${HEAD_SHA}^" 2>/dev/null || true)"
+fi
+
+if [ -z "$BASE_SHA" ]; then
+  echo "No base commit available; writing empty diff."
+  : > changeset.diff
+else
+  # Three-dot diff: changes on HEAD since it diverged from BASE.
+  git diff "${BASE_SHA}...${HEAD_SHA}" > changeset.diff \
+    || git diff "${BASE_SHA}" "${HEAD_SHA}" > changeset.diff
+fi
+
+echo "Changeset diff: $(wc -c < changeset.diff) bytes, $(grep -c '^diff --git' changeset.diff || echo 0) file(s)."

--- a/.github/workflows/scripts/perf_compare.py
+++ b/.github/workflows/scripts/perf_compare.py
@@ -66,8 +66,10 @@ def main() -> int:
         lines += [
             "**Verdict:** PASS",
             "",
-            "Performance could not be measured for this changeset (no comparable "
-            "benchmark results on both sides). No regression flagged.",
+            "Performance could not be measured for this changeset — no comparable "
+            "benchmark results on both sides (a base or PR build/benchmark may have "
+            "failed, or the benchmarked functions were absent). No regression flagged; "
+            "review manually if this change touches a hot path.",
             "",
             "## Findings",
             "",
@@ -98,11 +100,11 @@ def main() -> int:
                 + (f" Investigate changes to `{src}`." if src else "")
             )
             status = f"{HIGH if sev == HIGH else MEDIUM} +{pct:.1f}%"
-        elif pct < -threshold:
+        elif pct < -threshold and not below_floor:
             improved.append(f"- **`{name}`** — {abs(pct):.1f}% faster (base {fmt(b)}ms → PR {fmt(h)}ms). Nice.")
             status = f"{GREEN} {pct:.1f}%"
         else:
-            note = " (below noise floor)" if below_floor and pct > threshold else ""
+            note = " (below noise floor)" if below_floor and abs(pct) > threshold else ""
             status = f"{pct:+.1f}%{note}"
         rows.append((name, b, h, pct, status))
 

--- a/.github/workflows/scripts/perf_compare.py
+++ b/.github/workflows/scripts/perf_compare.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Compare base vs PR benchmark results and write a performance findings report.
+
+Reads the two JSON files produced by `scripts/benchmark/perf-bench.cjs` (one for
+the base branch, one for the PR), computes the per-benchmark percentage change in
+median time, and flags any benchmark that is more than the configured threshold
+slower. The flag is deterministic — we do not ask a model to interpret timings.
+
+The output follows the same findings contract as the other review agents so the
+synthesize job can parse it.
+
+Environment variables:
+  PERF_BASE_FILE             Base-branch results JSON (default: perf-base.json).
+  PERF_HEAD_FILE             PR results JSON (default: perf-head.json).
+  OUTPUT_FILE                Findings markdown to write (default: findings/performance.md).
+  PERF_REGRESSION_THRESHOLD  Percent-slower that counts as a regression (default: 20).
+  PERF_MIN_ABS_MS            Ignore benchmarks whose base median is below this many
+                             ms, where timing noise dominates (default: 1.0).
+"""
+
+import json
+import os
+import sys
+
+# Map each benchmark to the source file most likely responsible, so a flagged
+# regression points the reader at where to look.
+SOURCE_OF = {
+    "estimateTokensFromJsonlSession": "vscode-extension/src/tokenEstimation.ts",
+    "estimateTokensFromText": "vscode-extension/src/tokenEstimation.ts",
+}
+
+HIGH = "\U0001f534"
+MEDIUM = "\U0001f7e1"
+GREEN = "\U0001f7e2"
+
+
+def load(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::warning::Could not read {path}: {exc}", file=sys.stderr)
+        return {}
+
+
+def fmt(ms) -> str:
+    return f"{ms:.3f}" if isinstance(ms, (int, float)) else "—"
+
+
+def main() -> int:
+    base_file = os.environ.get("PERF_BASE_FILE", "perf-base.json")
+    head_file = os.environ.get("PERF_HEAD_FILE", "perf-head.json")
+    output_file = os.environ.get("OUTPUT_FILE", "findings/performance.md")
+    threshold = float(os.environ.get("PERF_REGRESSION_THRESHOLD", "20") or "20")
+    floor = float(os.environ.get("PERF_MIN_ABS_MS", "1.0") or "1.0")
+
+    base = load(base_file).get("benchmarks", {})
+    head = load(head_file).get("benchmarks", {})
+
+    os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
+
+    lines = ["# Performance Review", ""]
+
+    common = [k for k in head if k in base]
+    if not common:
+        lines += [
+            "**Verdict:** PASS",
+            "",
+            "Performance could not be measured for this changeset (no comparable "
+            "benchmark results on both sides). No regression flagged.",
+            "",
+            "## Findings",
+            "",
+            "_No performance findings in this changeset._",
+        ]
+        with open(output_file, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(lines).rstrip() + "\n")
+        print("No common benchmarks; wrote PASS.", file=sys.stderr)
+        return 0
+
+    rows = []
+    high, medium, improved = [], [], []
+    for name in sorted(common):
+        b = base[name].get("medianMs")
+        h = head[name].get("medianMs")
+        if not isinstance(b, (int, float)) or not isinstance(h, (int, float)) or b <= 0:
+            rows.append((name, b, h, None, "n/a"))
+            continue
+        pct = (h - b) / b * 100.0
+        src = SOURCE_OF.get(name, "")
+        below_floor = b < floor
+        if pct > threshold and not below_floor:
+            sev = HIGH if pct > 2 * threshold else MEDIUM
+            target = high if sev == HIGH else medium
+            target.append(
+                f"- **`{name}`** — {pct:.1f}% slower (base {fmt(b)}ms → PR {fmt(h)}ms), "
+                f"over the {threshold:.0f}% threshold."
+                + (f" Investigate changes to `{src}`." if src else "")
+            )
+            status = f"{HIGH if sev == HIGH else MEDIUM} +{pct:.1f}%"
+        elif pct < -threshold:
+            improved.append(f"- **`{name}`** — {abs(pct):.1f}% faster (base {fmt(b)}ms → PR {fmt(h)}ms). Nice.")
+            status = f"{GREEN} {pct:.1f}%"
+        else:
+            note = " (below noise floor)" if below_floor and pct > threshold else ""
+            status = f"{pct:+.1f}%{note}"
+        rows.append((name, b, h, pct, status))
+
+    actionable = bool(high or medium)
+    verdict = "CHANGES_SUGGESTED" if actionable else "PASS"
+
+    lines.append(f"**Verdict:** {verdict}")
+    lines.append("")
+    if actionable:
+        lines.append(
+            f"One or more hot-path benchmarks regressed by more than the "
+            f"{threshold:.0f}% threshold. See the findings below."
+        )
+    else:
+        lines.append(
+            f"No hot-path benchmark regressed by more than the {threshold:.0f}% "
+            f"threshold (median of {head[common[0]].get('iterations', '?')} runs)."
+        )
+    lines.append("")
+
+    lines.append("## Results")
+    lines.append("")
+    lines.append("| Benchmark | Base median (ms) | PR median (ms) | Status |")
+    lines.append("| --- | --- | --- | --- |")
+    for name, b, h, _pct, status in rows:
+        lines.append(f"| `{name}` | {fmt(b)} | {fmt(h)} | {status} |")
+    lines.append("")
+
+    lines.append("## Findings")
+    lines.append("")
+    if high:
+        lines.append(f"### {HIGH} High")
+        lines += high
+        lines.append("")
+    if medium:
+        lines.append(f"### {MEDIUM} Medium")
+        lines += medium
+        lines.append("")
+    if improved:
+        lines.append(f"### {GREEN} Improvements")
+        lines += improved
+        lines.append("")
+    if not actionable and not improved:
+        lines.append("_No performance regressions above the threshold in this changeset._")
+
+    with open(output_file, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines).rstrip() + "\n")
+
+    print(
+        f"Compared {len(common)} benchmark(s): {len(high)} high, {len(medium)} medium, "
+        f"{len(improved)} improved. Verdict={verdict}.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/review_agent.py
+++ b/.github/workflows/scripts/review_agent.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Run a single review agent against a changeset using a local Ollama model.
+
+This is the worker behind each per-agent job in `agent-review.yml`. It reads an
+agent definition (`.github/agents/*.agent.md`), strips its YAML frontmatter to
+use the body as the system prompt, feeds it the PR diff, and writes the model's
+markdown review to OUTPUT_FILE. It never edits source files.
+
+No Copilot/Claude tokens are used — the model runs locally on the runner via
+Ollama, mirroring `.github/workflows/check-toolnames.yml`.
+
+Environment variables:
+  AGENT_FILE   Path to the agent definition markdown (required).
+  OUTPUT_FILE  Path to write the findings markdown (required).
+  DIFF_FILE    Path to the unified diff to review (required).
+  MODEL        Ollama model tag (default: qwen2.5-coder:3b).
+  OLLAMA_URL   Base URL of the Ollama server (default: http://localhost:11434).
+  AGENT_LABEL  Human label used in the fallback header (default: derived).
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+MAX_DIFF_CHARS = 48_000      # keep the prompt within the local model's context
+NUM_PREDICT = 1_400          # cap generation so CPU inference stays bounded
+REQUEST_TIMEOUT = 600        # seconds
+
+
+def read_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        return fh.read()
+
+
+def strip_frontmatter(md: str) -> str:
+    """Remove a leading `--- ... ---` YAML frontmatter block if present."""
+    lines = md.splitlines()
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                return "\n".join(lines[i + 1 :]).lstrip("\n")
+    return md
+
+
+def call_ollama(base_url: str, model: str, system: str, user: str) -> str:
+    payload = {
+        "model": model,
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "options": {"temperature": 0, "seed": 42, "num_predict": NUM_PREDICT},
+    }
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/chat",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+        data = json.loads(resp.read())
+    return (data.get("message") or {}).get("content", "").strip()
+
+
+def main() -> int:
+    agent_file = os.environ["AGENT_FILE"]
+    output_file = os.environ["OUTPUT_FILE"]
+    diff_file = os.environ["DIFF_FILE"]
+    model = os.environ.get("MODEL", "qwen2.5-coder:3b")
+    base_url = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+    label = os.environ.get("AGENT_LABEL") or os.path.basename(agent_file)
+
+    system_prompt = strip_frontmatter(read_text(agent_file))
+    diff = read_text(diff_file)
+
+    os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
+
+    # Nothing changed — emit a clean PASS without bothering the model.
+    if not diff.strip():
+        with open(output_file, "w", encoding="utf-8") as fh:
+            fh.write(
+                f"# {label}\n\n**Verdict:** PASS\n\n"
+                "No reviewable changes were found in this changeset.\n\n"
+                "## Findings\n\n_No findings in this changeset._\n"
+            )
+        print("No diff to review; wrote PASS.", file=sys.stderr)
+        return 0
+
+    truncated = len(diff) > MAX_DIFF_CHARS
+    if truncated:
+        diff = diff[:MAX_DIFF_CHARS]
+
+    user_prompt = (
+        "Review the following changeset (unified diff). Apply ONLY your own "
+        "area of expertise as described in your instructions, and respond with "
+        "the markdown review exactly in the output-contract format. Do not edit "
+        "files, do not output anything except the markdown review.\n"
+    )
+    if truncated:
+        user_prompt += (
+            "\n(Note: the diff was truncated for length; review what is shown.)\n"
+        )
+    user_prompt += f"\n```diff\n{diff}\n```\n"
+
+    try:
+        review = call_ollama(base_url, model, system_prompt, user_prompt)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        print(f"::warning::Model call failed for {label}: {exc}", file=sys.stderr)
+        review = ""
+
+    # Guarantee a parseable artifact even if the model misbehaved, so the
+    # synthesis job never crashes on a missing verdict.
+    if "Verdict:" not in review:
+        header = f"# {label}\n\n**Verdict:** CHANGES_SUGGESTED\n\n"
+        if not review.strip():
+            review = (
+                header
+                + "The local model returned no usable output for this agent. "
+                "Treating as inconclusive — please review manually.\n\n"
+                "## Findings\n\n_Model produced no findings._\n"
+            )
+        else:
+            review = header + review
+
+    with open(output_file, "w", encoding="utf-8") as fh:
+        fh.write(review.rstrip() + "\n")
+
+    print(f"Wrote review for {label} to {output_file}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/synthesize_findings.py
+++ b/.github/workflows/scripts/synthesize_findings.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Aggregate the per-agent review artifacts and decide the workflow outcome.
+
+Reads every `*.md` findings file produced by the agent jobs, parses each one's
+verdict and severity counts, writes a combined report to the job summary and to
+a file for a potential pull-request body, and exposes outputs the workflow uses
+to decide whether to attempt auto-fixes.
+
+This step is deterministic — it does not call any model. It always exits 0 so
+the workflow can be used as a non-blocking PR check.
+
+Environment variables:
+  FINDINGS_DIR   Directory containing the downloaded findings artifacts (required).
+  COMBINED_FILE  Path to write the combined markdown report (required).
+  GITHUB_OUTPUT  Set by Actions; receives has_actionable / counts.
+  GITHUB_STEP_SUMMARY  Set by Actions; receives the rendered report.
+"""
+
+import glob
+import os
+import re
+import sys
+
+VERDICT_RE = re.compile(r"\*\*Verdict:\*\*\s*(PASS|CHANGES_SUGGESTED)", re.IGNORECASE)
+HIGH = "\U0001f534"    # 🔴
+MEDIUM = "\U0001f7e1"  # 🟡
+LOW = "\U0001f7e2"     # 🟢
+
+
+def parse_report(text: str) -> dict:
+    verdict_match = VERDICT_RE.search(text)
+    verdict = verdict_match.group(1).upper() if verdict_match else "UNKNOWN"
+
+    # Walk the report and count bullet findings under each severity heading. The
+    # agents put the severity emoji on the `### 🔴 High` heading and list findings
+    # as `- ...` bullets beneath it, so we attribute each bullet to the section
+    # it falls under. A heading-carried emoji on the bullet itself is also counted.
+    counts = {HIGH: 0, MEDIUM: 0, LOW: 0}
+    current = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            current = None
+            for emoji in (HIGH, MEDIUM, LOW):
+                if emoji in line:
+                    current = emoji
+                    break
+            continue
+        if line.startswith("-") and line not in ("-", "--", "---"):
+            section = next((e for e in (HIGH, MEDIUM, LOW) if e in line), current)
+            if section is not None:
+                counts[section] += 1
+
+    return {
+        "verdict": verdict,
+        "high": counts[HIGH],
+        "medium": counts[MEDIUM],
+        "low": counts[LOW],
+    }
+
+
+def title_from(path: str, text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return os.path.splitext(os.path.basename(path))[0]
+
+
+def write_output(key: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    findings_dir = os.environ["FINDINGS_DIR"]
+    combined_file = os.environ["COMBINED_FILE"]
+
+    paths = sorted(glob.glob(os.path.join(findings_dir, "**", "*.md"), recursive=True))
+    if not paths:
+        print("::warning::No findings artifacts were found.", file=sys.stderr)
+
+    reports = []
+    totals = {"high": 0, "medium": 0, "low": 0}
+    for path in paths:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        parsed = parse_report(text)
+        parsed["title"] = title_from(path, text)
+        parsed["body"] = text.strip()
+        reports.append(parsed)
+        for key in totals:
+            totals[key] += parsed[key]
+
+    actionable = totals["high"] > 0 or totals["medium"] > 0
+
+    # Build the combined report.
+    lines = ["# 🤖 Multi-Agent Review", ""]
+    lines.append(
+        f"**Totals:** {HIGH} {totals['high']} high · "
+        f"{MEDIUM} {totals['medium']} medium · {LOW} {totals['low']} low"
+    )
+    lines.append("")
+    lines.append("| Agent | Verdict | 🔴 | 🟡 | 🟢 |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for r in reports:
+        lines.append(
+            f"| {r['title']} | {r['verdict']} | {r['high']} | {r['medium']} | {r['low']} |"
+        )
+    lines.append("")
+    for r in reports:
+        lines.append("---")
+        lines.append("")
+        lines.append(r["body"])
+        lines.append("")
+
+    combined = "\n".join(lines).rstrip() + "\n"
+
+    os.makedirs(os.path.dirname(combined_file) or ".", exist_ok=True)
+    with open(combined_file, "w", encoding="utf-8") as fh:
+        fh.write(combined)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(combined)
+
+    write_output("has_actionable", "true" if actionable else "false")
+    write_output("high_count", str(totals["high"]))
+    write_output("medium_count", str(totals["medium"]))
+    write_output("low_count", str(totals["low"]))
+
+    print(
+        f"Parsed {len(reports)} report(s): "
+        f"{totals['high']} high, {totals['medium']} medium, {totals['low']} low. "
+        f"Actionable={actionable}.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/perf-bench.cjs
+++ b/scripts/benchmark/perf-bench.cjs
@@ -104,18 +104,38 @@ try {
 }
 
 const jsonl = buildJsonlSession(2500);
-const text = buildText(60000);
 const benchmarks = {};
 
-const b1 = bench(() => mod.estimateTokensFromJsonlSession && mod.estimateTokensFromJsonlSession(jsonl), 5, 51);
+// Per-session parse + token-count over ~2500 JSONL lines — the dominant cost when
+// the extension processes a session file.
+const b1 = bench(() => mod.estimateTokensFromJsonlSession && mod.estimateTokensFromJsonlSession(jsonl), 10, 51);
 if (b1 && typeof mod.estimateTokensFromJsonlSession === 'function') {
   b1.inputBytes = Buffer.byteLength(jsonl);
   benchmarks.estimateTokensFromJsonlSession = b1;
 }
 
-const b2 = bench(() => mod.estimateTokensFromText && mod.estimateTokensFromText(text, 'gpt-4', {}), 5, 51);
+// estimateTokensFromText is O(1) in the text length but is called for every message
+// part / response item / tool result across all sessions on each refresh — so the
+// realistic hot cost is high call frequency, not large input. We benchmark many small
+// calls with a realistic multi-entry estimators map (a single call on a big string is
+// too cheap to measure and would sit below the noise floor). A stable estimators object
+// reference matches production, where entries are precomputed and cached per reference.
+const ESTIMATORS = {
+  'gpt-4': 4, 'gpt-4o': 3.8, 'gpt-3.5-turbo': 4, 'o1-preview': 3.9,
+  'claude-3-5-sonnet': 3.5, 'claude-3-opus': 3.6, 'claude-3-haiku': 3.7,
+  'gemini-1.5-pro': 3.8, 'gemini-1.5-flash': 3.9, 'llama-3.1': 4.1,
+};
+const MODELS = ['gpt-4o', 'claude-3-5-sonnet', 'gemini-1.5-flash', 'unknown-model', 'llama-3.1-70b'];
+const PART_TEXT = buildText(200);
+const TEXT_CALLS = 50000;
+const b2 = bench(() => {
+  if (!mod.estimateTokensFromText) return;
+  for (let i = 0; i < TEXT_CALLS; i++) {
+    mod.estimateTokensFromText(PART_TEXT, MODELS[i % MODELS.length], ESTIMATORS);
+  }
+}, 10, 31);
 if (b2 && typeof mod.estimateTokensFromText === 'function') {
-  b2.inputBytes = Buffer.byteLength(text);
+  b2.calls = TEXT_CALLS;
   benchmarks.estimateTokensFromText = b2;
 }
 

--- a/scripts/benchmark/perf-bench.cjs
+++ b/scripts/benchmark/perf-bench.cjs
@@ -1,0 +1,123 @@
+'use strict';
+/*
+ * Performance micro-benchmark for the hot, dependency-light token-math functions.
+ *
+ * It measures the *running* code of a given build of the extension: point it at a
+ * compiled `vscode-extension` directory and it times the key functions over fixed,
+ * deterministic inputs, writing median/min timings to a JSON file.
+ *
+ * The same script (from the PR checkout) is run against BOTH the base and the PR
+ * builds so the comparison is apples-to-apples — the base checkout does not need
+ * to contain this script. See .github/workflows/agent-review.yml (performance job)
+ * and .github/workflows/scripts/perf_compare.py.
+ *
+ *   node scripts/benchmark/perf-bench.cjs <vscode-extension-dir> <out.json>
+ *
+ * `tokenEstimation.ts` imports only types and the pure `utils/dayKeys` helper, so
+ * the compiled module loads without the VS Code API.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const dir = process.argv[2];
+const outPath = process.argv[3];
+if (!dir || !outPath) {
+  console.error('usage: perf-bench.cjs <vscode-extension-dir> <out.json>');
+  process.exit(2);
+}
+
+// Deterministic PRNG (mulberry32) so the base and PR runs see identical inputs.
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const WORDS = [
+  'token', 'model', 'session', 'usage', 'copilot', 'estimate', 'context',
+  'request', 'response', 'analysis', 'cache', 'parse', 'content', 'message',
+  'assistant', 'function', 'thinking', 'reasoning', 'pricing', 'ecosystem',
+];
+
+function words(rng, n) {
+  const parts = [];
+  for (let i = 0; i < n; i++) parts.push(WORDS[Math.floor(rng() * WORDS.length)]);
+  return parts.join(' ');
+}
+
+function buildJsonlSession(lines) {
+  const rng = mulberry32(12345);
+  const out = [];
+  for (let i = 0; i < lines; i++) {
+    const r = rng();
+    if (r < 0.4) {
+      out.push(JSON.stringify({ type: 'user.message', data: { content: words(rng, 20 + Math.floor(rng() * 40)), turnId: `turn-${i}` } }));
+    } else if (r < 0.85) {
+      out.push(JSON.stringify({ type: 'assistant.message', data: { content: words(rng, 40 + Math.floor(rng() * 120)), turnId: `turn-${i}` } }));
+    } else {
+      out.push(JSON.stringify({ type: 'tool.execution_complete', data: { content: words(rng, 10 + Math.floor(rng() * 30)) } }));
+    }
+  }
+  return out.join('\n');
+}
+
+function buildText(approxChars) {
+  const rng = mulberry32(999);
+  let s = '';
+  while (s.length < approxChars) s += words(rng, 50) + '\n';
+  return s;
+}
+
+function median(arr) {
+  const a = [...arr].sort((x, y) => x - y);
+  const m = a.length >> 1;
+  return a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2;
+}
+
+function bench(fn, warmup, iters) {
+  if (typeof fn !== 'function') return null;
+  for (let i = 0; i < warmup; i++) fn();
+  const times = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = process.hrtime.bigint();
+    fn();
+    const t1 = process.hrtime.bigint();
+    times.push(Number(t1 - t0) / 1e6);
+  }
+  return { medianMs: +median(times).toFixed(4), minMs: +Math.min(...times).toFixed(4), iterations: iters };
+}
+
+let mod;
+try {
+  mod = require(path.resolve(dir, 'out/src/tokenEstimation.js'));
+} catch (e) {
+  // Don't fail the job — record the problem so the comparator can report
+  // "could not measure" rather than a false regression.
+  console.error('Could not load tokenEstimation module:', e.message);
+  fs.writeFileSync(outPath, JSON.stringify({ node: process.version, error: String(e.message), benchmarks: {} }, null, 2));
+  process.exit(0);
+}
+
+const jsonl = buildJsonlSession(2500);
+const text = buildText(60000);
+const benchmarks = {};
+
+const b1 = bench(() => mod.estimateTokensFromJsonlSession && mod.estimateTokensFromJsonlSession(jsonl), 5, 51);
+if (b1 && typeof mod.estimateTokensFromJsonlSession === 'function') {
+  b1.inputBytes = Buffer.byteLength(jsonl);
+  benchmarks.estimateTokensFromJsonlSession = b1;
+}
+
+const b2 = bench(() => mod.estimateTokensFromText && mod.estimateTokensFromText(text, 'gpt-4', {}), 5, 51);
+if (b2 && typeof mod.estimateTokensFromText === 'function') {
+  b2.inputBytes = Buffer.byteLength(text);
+  benchmarks.estimateTokensFromText = b2;
+}
+
+fs.writeFileSync(outPath, JSON.stringify({ node: process.version, benchmarks }, null, 2));
+console.error('Wrote', outPath, JSON.stringify(benchmarks));


### PR DESCRIPTION
## What this adds

Four repo-tailored review agents plus a CI workflow that runs them on each PR. The three diff-reading agents run **locally on the runner via Ollama** (no Copilot/Claude tokens, mirroring `check-toolnames.yml`); the performance agent **measures the running code**.

### Agents (`.github/agents/`)
Each has a strict, **non-overlapping lane** and emits a parseable findings contract (`**Verdict:** PASS | CHANGES_SUGGESTED` + `🔴/🟡/🟢` sections):

- **`code-quality-review`** — readability, naming, duplication, complexity, TS type safety, error handling.
- **`test-expert`** — coverage of load-bearing paths (parsing, the `getModelUsageFromSession` attribution trap, scoring, caching), assertion quality, edge cases.
- **`architecture-expert`** — module boundaries, the CLI-must-reuse-shared-functions rule, the canonical attribution split, and `CACHE_VERSION` invalidation.
- **`performance-expert`** — **measures** the hot-path token-math functions on base vs. PR and flags a regression when the PR is more than a configurable threshold slower.

The first three definitions were **reviewed by a separate model (Sonnet)** before landing; its findings were addressed (corrected the cache-versioning rule, removed an invalid tool entry, disambiguated the verdict token, added empty-diff fallbacks, fixed test-file naming claims).

### Workflow (`.github/workflows/agent-review.yml`)
- Triggers on `pull_request` (+ `workflow_dispatch`).
- **One job per agent**, each writing findings to a markdown **artifact**.
- **`synthesize`** job downloads all findings and renders a combined report into the job summary — always exits 0, so this is a **non-blocking check**.
- **`auto-fix`** job runs only for same-repo PRs with actionable findings: applies **safe, exact-match** edits and opens a PR with them; otherwise nothing happens.
- The model is a **single workflow-level env var** (`REVIEW_MODEL`), **cached between runs** via an Ollama service container + volume mount.

### Performance agent details
- Builds the base branch and the PR, runs the **same** benchmark script (`scripts/benchmark/perf-bench.cjs`) against **both** compiled builds with identical deterministic fixtures (so the base checkout needs no copy of the script).
- Compares the **median of repeated runs** and flags a regression when a benchmark is more than **`PERF_REGRESSION_THRESHOLD`** percent slower — **default 20%**, settable at the workflow level. Sub-millisecond benchmarks are ignored as noise.
- The flag is a **real measurement** (`perf_compare.py`), not a model guess. New hot paths can be covered by adding a benchmark + a source mapping.

### Safety properties (unit-tested locally)
- Empty diff → clean PASS; model unreachable → 0 findings (no spurious auto-fix PR).
- Fixer applies **only exact single-match** edits, **refuses ambiguous** ones, blocks path traversal/absolute paths, reverts JSON edits that break parsing.
- `add-paths` pinned to `vscode-extension`/`cli` so scratch files are never committed.
- Fork PRs get the report but cannot open PRs (read-only token).
- Performance comparator suppresses sub-millisecond noise and reports "could not measure" rather than guessing if a build/benchmark is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
