### PR TITLE
Add active session duration metric excluding idle turn gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ﻿out
 dist
 node_modules
+.impeccable/
 .vscode-test/
 *.vsix
 *.backup

--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -219,6 +219,7 @@ export function createEmptyUsageAnalysisPeriod(): UsageAnalysisPeriod {
 			avgFirstProgressMs: 0,
 			avgTotalElapsedMs: 0,
 			avgWaitTimeMs: 0,
+			activeDurationMs: 0,
 		},
 		conversationPatterns: {
 			multiTurnSessions: 0,

--- a/cli/src/commands/curation.ts
+++ b/cli/src/commands/curation.ts
@@ -61,7 +61,7 @@ export const curationCommand = new Command('curation')
 			repositoriesWithCustomization: [],
 			editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
 			applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
-			sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+			sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0, activeDurationMs: 0 },
 			conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
 			agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
 		};

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3427,7 +3427,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			repositoriesWithCustomization: [],
 			editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
 			applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
-			sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+			sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0, activeDurationMs: 0 },
 			conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
 			agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 }
 		};

--- a/vscode-extension/src/maturityScoring.ts
+++ b/vscode-extension/src/maturityScoring.ts
@@ -807,6 +807,10 @@ function _wiAddSessionDurationEvidence(evidence: string[], p: UsageAnalysisPerio
 	if (p.sessionDuration && p.sessionDuration.avgDurationMs > 0) {
 		evidence.push(`Avg ${Math.round(p.sessionDuration.avgDurationMs / 60000)}min session duration`);
 	}
+	if (p.sessionDuration && p.sessionDuration.activeDurationMs > 0 && p.sessions > 0) {
+		const avgActiveMin = Math.round(p.sessionDuration.activeDurationMs / p.sessions / 60000);
+		evidence.push(`Avg ${avgActiveMin}min active time (interacting + waiting on the agent)`);
+	}
 }
 
 /**

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -373,11 +373,12 @@ export interface ApplyButtonUsage {
 }
 
 export interface SessionDurationData {
-  totalDurationMs: number; // Total session time
-  avgDurationMs: number; // Average session duration
+  totalDurationMs: number; // Total session time (wall clock: last timestamp - first timestamp, includes idle gaps between turns)
+  avgDurationMs: number; // Average session duration (wall clock)
   avgFirstProgressMs: number; // Average time to first response
   avgTotalElapsedMs: number; // Average total request time
   avgWaitTimeMs: number; // Average user wait time between interactions
+  activeDurationMs: number; // Sum of merged [requestTimestamp, requestTimestamp+totalElapsed] windows: actual interactive + tool/agent wait time, excluding idle gaps between turns
 }
 
 export interface ConversationPatterns {

--- a/vscode-extension/src/usageAnalysis.ts
+++ b/vscode-extension/src/usageAnalysis.ts
@@ -515,9 +515,25 @@ function _mergeLanguageUsage(target: LanguageUsage, source: LanguageUsage): void
 	}
 }
 
+/** Accumulate timing-related data (timestamps, timing details, wait times, active intervals) for one request. */
+function _accumulateRequestTiming(
+	timing: TimingMetrics,
+	timestamps: number[],
+	timingsData: { firstProgress?: number; totalElapsed?: number }[],
+	waitTimes: number[],
+	activeIntervals: { start: number; end: number }[]
+): void {
+	if (timing.timestamp !== undefined) { timestamps.push(timing.timestamp); }
+	if (timing.timings) { timingsData.push(timing.timings); }
+	if (timing.waitTime !== undefined) { waitTimes.push(timing.waitTime); }
+	if (timing.timestamp !== undefined && timing.timings?.totalElapsed !== undefined) {
+		activeIntervals.push({ start: timing.timestamp, end: timing.timestamp + timing.timings.totalElapsed });
+	}
+}
+
 /**
  * Process a list of session requests, accumulating enhanced metrics in-place.
- * Mutates editedFiles, timestamps, timingsData, waitTimes and agentCounts.
+ * Mutates editedFiles, timestamps, timingsData, waitTimes, activeIntervals and agentCounts.
  * Returns the total applies and total code blocks counted.
  */
 function processRequestsForEnhancedMetrics(
@@ -526,7 +542,8 @@ function processRequestsForEnhancedMetrics(
 	editedFiles: Set<string>,
 	timestamps: number[],
 	timingsData: { firstProgress?: number; totalElapsed?: number }[],
-	waitTimes: number[]
+	waitTimes: number[],
+	activeIntervals: { start: number; end: number }[]
 ): { totalApplies: number; totalCodeBlocks: number; totalLinesAdded: number; totalLinesRemoved: number; languageUsage: LanguageUsage } {
 	let totalApplies = 0;
 	let totalCodeBlocks = 0;
@@ -536,10 +553,7 @@ function processRequestsForEnhancedMetrics(
 	for (const requestRaw of requests) {
 		if (!requestRaw) { continue; }
 
-		const timing = extractTimingMetrics(requestRaw);
-		if (timing.timestamp !== undefined) { timestamps.push(timing.timestamp); }
-		if (timing.timings) { timingsData.push(timing.timings); }
-		if (timing.waitTime !== undefined) { waitTimes.push(timing.waitTime); }
+		_accumulateRequestTiming(extractTimingMetrics(requestRaw), timestamps, timingsData, waitTimes, activeIntervals);
 
 		const agent = extractAgentMetrics(requestRaw);
 		if (agent.agentType !== null) {
@@ -899,6 +913,7 @@ function _muaMergeApplyUsage(period: UsageAnalysisPeriod, analysis: SessionUsage
 function _muaMergeSessionDuration(period: UsageAnalysisPeriod, analysis: SessionUsageAnalysis): void {
 	if (!analysis.sessionDuration) { return; }
 	period.sessionDuration.totalDurationMs += analysis.sessionDuration.totalDurationMs;
+	period.sessionDuration.activeDurationMs += analysis.sessionDuration.activeDurationMs;
 	const sessionCount = period.sessions;
 	if (sessionCount <= 0) { return; }
 	period.sessionDuration.avgDurationMs = period.sessionDuration.totalDurationMs / sessionCount;
@@ -1019,6 +1034,7 @@ function _muaMergeEnhancedMetrics(period: UsageAnalysisPeriod, analysis: Session
 	}
 	if (analysis.sessionDuration) {
 		period.sessionDuration.totalDurationMs += analysis.sessionDuration.totalDurationMs;
+		period.sessionDuration.activeDurationMs += analysis.sessionDuration.activeDurationMs;
 		const sessionCount = period.sessions;
 		if (sessionCount > 0) {
 			period.sessionDuration.avgDurationMs = period.sessionDuration.totalDurationMs / sessionCount;
@@ -1588,8 +1604,35 @@ type TemState = {
 	totalApplies: number; totalCodeBlocks: number; totalLinesAdded: number; totalLinesRemoved: number;
 	allLanguageUsage: LanguageUsage; editedFiles: Set<string>; timestamps: number[];
 	timingsData: { firstProgress?: number; totalElapsed?: number }[]; waitTimes: number[];
+	activeIntervals: { start: number; end: number }[];
 	agentCounts: { editsAgent: number; defaultAgent: number; workspaceAgent: number; other: number };
 };
+
+/**
+ * Merge overlapping/adjacent [start, end] intervals and sum their combined length.
+ * Used to compute "active" time (interactive use + tool/agent wait) while excluding
+ * idle gaps between an agent's response and the next user message.
+ */
+function mergeIntervalsAndSumMs(intervals: { start: number; end: number }[]): number {
+	if (intervals.length === 0) { return 0; }
+	const sorted = [...intervals].sort((a, b) => a.start - b.start);
+	let totalMs = 0;
+	let curStart = sorted[0].start;
+	let curEnd = sorted[0].end;
+	for (let i = 1; i < sorted.length; i++) {
+		const { start, end } = sorted[i];
+		if (start <= curEnd) {
+			// Overlapping or contiguous: extend the current merged window.
+			curEnd = Math.max(curEnd, end);
+		} else {
+			totalMs += curEnd - curStart;
+			curStart = start;
+			curEnd = end;
+		}
+	}
+	totalMs += curEnd - curStart;
+	return totalMs;
+}
 
 function _temMergeLocUsage(dest: LanguageUsage, src: LanguageUsage): void {
 	for (const [ext, usage] of Object.entries(src)) {
@@ -1611,7 +1654,7 @@ function _temProcessDeltaJsonl(lines: string[], state: TemState): void {
 	}
 	if (sessionState.creationDate !== undefined) { state.timestamps.push(sessionState.creationDate); }
 	if (sessionState.lastMessageDate !== undefined) { state.timestamps.push(sessionState.lastMessageDate); }
-	const result = processRequestsForEnhancedMetrics((sessionState.requests || []) as SessionRequestRaw[], state.agentCounts, state.editedFiles, state.timestamps, state.timingsData, state.waitTimes);
+	const result = processRequestsForEnhancedMetrics((sessionState.requests || []) as SessionRequestRaw[], state.agentCounts, state.editedFiles, state.timestamps, state.timingsData, state.waitTimes, state.activeIntervals);
 	state.totalApplies = result.totalApplies; state.totalCodeBlocks = result.totalCodeBlocks;
 	state.totalLinesAdded = result.totalLinesAdded; state.totalLinesRemoved = result.totalLinesRemoved;
 	_temMergeLocUsage(state.allLanguageUsage, result.languageUsage);
@@ -1621,7 +1664,7 @@ function _temProcessJsonFile(deps: Pick<UsageAnalysisDeps, 'warn'>, sessionFile:
 	if (!isParsedSessionJson(parsed)) { deps.warn(`Unexpected session format in ${sessionFile}`); return false; }
 	if (parsed.creationDate) { state.timestamps.push(parsed.creationDate); }
 	if (parsed.lastMessageDate) { state.timestamps.push(parsed.lastMessageDate); }
-	const result = processRequestsForEnhancedMetrics((parsed.requests ?? []) as SessionRequestRaw[], state.agentCounts, state.editedFiles, state.timestamps, state.timingsData, state.waitTimes);
+	const result = processRequestsForEnhancedMetrics((parsed.requests ?? []) as SessionRequestRaw[], state.agentCounts, state.editedFiles, state.timestamps, state.timingsData, state.waitTimes, state.activeIntervals);
 	state.totalApplies = result.totalApplies; state.totalCodeBlocks = result.totalCodeBlocks;
 	state.totalLinesAdded = result.totalLinesAdded; state.totalLinesRemoved = result.totalLinesRemoved;
 	_temMergeLocUsage(state.allLanguageUsage, result.languageUsage);
@@ -1647,7 +1690,8 @@ function _temStoreResults(analysis: SessionUsageAnalysis, state: TemState): void
 	const avgFirstProgressMs = state.timingsData.length > 0 ? state.timingsData.reduce((s, t) => s + (t.firstProgress || 0), 0) / state.timingsData.length : 0;
 	const avgTotalElapsedMs = state.timingsData.length > 0 ? state.timingsData.reduce((s, t) => s + (t.totalElapsed || 0), 0) / state.timingsData.length : 0;
 	const avgWaitTimeMs = state.waitTimes.length > 0 ? state.waitTimes.reduce((s, w) => s + w, 0) / state.waitTimes.length : 0;
-	analysis.sessionDuration = { totalDurationMs, avgDurationMs: totalDurationMs, avgFirstProgressMs, avgTotalElapsedMs, avgWaitTimeMs };
+	const activeDurationMs = mergeIntervalsAndSumMs(state.activeIntervals);
+	analysis.sessionDuration = { totalDurationMs, avgDurationMs: totalDurationMs, avgFirstProgressMs, avgTotalElapsedMs, avgWaitTimeMs, activeDurationMs };
 	deriveConversationPatterns(analysis);
 	analysis.agentTypes = state.agentCounts;
 }
@@ -1723,6 +1767,7 @@ export async function trackEnhancedMetrics(deps: Pick<UsageAnalysisDeps, 'warn'>
 		const state: TemState = {
 			totalApplies: 0, totalCodeBlocks: 0, totalLinesAdded: 0, totalLinesRemoved: 0,
 			allLanguageUsage: {}, editedFiles: new Set<string>(), timestamps: [], timingsData: [], waitTimes: [],
+			activeIntervals: [],
 			agentCounts: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
 		};
 		if (isJsonl) {

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -19,7 +19,7 @@ type UsageAnalysisPeriod = {
 	repositoriesWithCustomization: string[];
 	editScope?: { singleFileEdits: number; multiFileEdits: number; totalEditedFiles: number; avgFilesPerSession: number };
 	applyUsage?: { totalApplies: number; totalCodeBlocks: number; applyRate: number };
-	sessionDuration?: { totalDurationMs: number; avgDurationMs: number; avgFirstProgressMs: number; avgTotalElapsedMs: number; avgWaitTimeMs: number };
+	sessionDuration?: { totalDurationMs: number; avgDurationMs: number; avgFirstProgressMs: number; avgTotalElapsedMs: number; avgWaitTimeMs: number; activeDurationMs: number };
 	conversationPatterns?: { multiTurnSessions: number; singleTurnSessions: number; avgTurnsPerSession: number; maxTurnsInSession: number };
 	agentTypes?: { editsAgent: number; defaultAgent: number; workspaceAgent: number; other: number };
 };

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -33,7 +33,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
 		repositories: [], repositoriesWithCustomization: [],
 		editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
 		applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
-		sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+		sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0, activeDurationMs: 0 },
 		conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
 		agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
 	};

--- a/vscode-extension/test/unit/maturityScoring.test.ts
+++ b/vscode-extension/test/unit/maturityScoring.test.ts
@@ -62,7 +62,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
         repositories: [], repositoriesWithCustomization: [],
         editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
         applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
-        sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+        sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0, activeDurationMs: 0 },
         conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
         agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
     };

--- a/vscode-extension/test/unit/toolCuration.test.ts
+++ b/vscode-extension/test/unit/toolCuration.test.ts
@@ -66,7 +66,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
 		repositories: [], repositoriesWithCustomization: [],
 		editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
 		applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
-		sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+		sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0, activeDurationMs: 0 },
 		conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
 		agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
 	};

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -76,7 +76,7 @@ function emptyPeriod(): UsageAnalysisPeriod {
         repositories: [], repositoriesWithCustomization: [],
         editScope: { singleFileEdits: 0, multiFileEdits: 0, totalEditedFiles: 0, avgFilesPerSession: 0 },
         applyUsage: { totalApplies: 0, totalCodeBlocks: 0, applyRate: 0 },
-        sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0 },
+        sessionDuration: { totalDurationMs: 0, avgDurationMs: 0, avgFirstProgressMs: 0, avgTotalElapsedMs: 0, avgWaitTimeMs: 0, activeDurationMs: 0 },
         conversationPatterns: { multiTurnSessions: 0, singleTurnSessions: 0, avgTurnsPerSession: 0, maxTurnsInSession: 0 },
         agentTypes: { editsAgent: 0, defaultAgent: 0, workspaceAgent: 0, other: 0 },
     };
@@ -1524,7 +1524,7 @@ test('mergeUsageAnalysis: merges sessionDuration when sessions > 0', () => {
     const period = emptyPeriod();
     period.sessions = 1;
     const a = emptyAnalysis();
-    a.sessionDuration = { totalDurationMs: 30000, avgDurationMs: 30000, avgFirstProgressMs: 300, avgTotalElapsedMs: 1000, avgWaitTimeMs: 100 };
+    a.sessionDuration = { totalDurationMs: 30000, avgDurationMs: 30000, avgFirstProgressMs: 300, avgTotalElapsedMs: 1000, avgWaitTimeMs: 100, activeDurationMs: 15000 };
     mergeUsageAnalysis(period, a);
     assert.equal(period.sessionDuration.totalDurationMs, 30000);
     assert.equal(period.sessionDuration.avgDurationMs, 30000);
@@ -1537,7 +1537,7 @@ test('mergeUsageAnalysis: sessionDuration with sessions=0 skips avg calculation'
     const period = emptyPeriod();
     // period.sessions defaults to 0
     const a = emptyAnalysis();
-    a.sessionDuration = { totalDurationMs: 60000, avgDurationMs: 60000, avgFirstProgressMs: 500, avgTotalElapsedMs: 2000, avgWaitTimeMs: 200 };
+    a.sessionDuration = { totalDurationMs: 60000, avgDurationMs: 60000, avgFirstProgressMs: 500, avgTotalElapsedMs: 2000, avgWaitTimeMs: 200, activeDurationMs: 25000 };
     mergeUsageAnalysis(period, a);
     assert.equal(period.sessionDuration.totalDurationMs, 60000);
     // avgDurationMs stays 0 since sessionCount <= 0


### PR DESCRIPTION
## Why

Session duration was previously only tracked as wall-clock time (`totalDurationMs`/`avgDurationMs` = last timestamp minus first timestamp). That metric skews high because it includes idle time between an agent's response and the next user message, which isn't representative of actual interactive/working time.

## Approach

Added a new `activeDurationMs` metric to `SessionDurationData` that measures interactive use plus tool/agent wait time while excluding idle "thinking" gaps between turns:

- For each request, build an interval `[timestamp, timestamp + result.timings.totalElapsed]` (the window from when the user sent the message to when the agent finished responding, including tool calls).
- Merge overlapping/adjacent intervals per session and sum their combined length via a new `mergeIntervalsAndSumMs()` helper.
- Idle time between the end of one interval and the start of the next (i.e. time the user spent reading/thinking before sending the next message) is naturally excluded since it falls in the gap.
- Propagated the new field through both period-merge code paths so it aggregates correctly across days/weeks.
- Extracted a small `_accumulateRequestTiming` helper to keep the per-request loop's cognitive complexity within lint limits.

## Where it's surfaced

The only current consumer of `SessionDurationData` is the maturity webview's "Workflow Integration" evidence. Added a second evidence line there:

`Avg Xmin active time (interacting + waiting on the agent)`

alongside the existing wall-clock `Avg Xmin session duration`, so users can see both numbers side by side.

## Other changes

- Updated all other `SessionDurationData` literal constructions (CLI defaults, extension.ts default, webview type mirror, unit tests) for the new required field.
- Added `.impeccable/` (a local design-review hook cache) to `.gitignore`.

## Validation

- `vscode-extension`: `npm run compile` -> 0 errors/warnings; `npm run test:node` -> all 74 suites pass.
- `cli`: `npm run build` succeeds and type-checks cleanly against the extended `SessionDurationData`.
- Merged latest `main` into the branch; merge was conflict-free (only `maturityScoring.ts` needed auto-merge) and re-validated after merge.