### PR TITLE
Fix cached-token double-counting in Total tokens metrics

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3539,7 +3539,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			title: sessionData.title || null, filePath: sessionFile, interactions,
 			toolCalls: analysis.toolCalls.total, inputTokens: inputTok, outputTokens: outputTok,
 			thinkingTokens: sessionData.thinkingTokens || 0, cachedTokens: cachedTok,
-			totalTokens: inputTok + outputTok + cachedTok + (sessionData.thinkingTokens || 0),
+			totalTokens: inputTok + outputTok + (sessionData.thinkingTokens || 0),
 			estimatedCost: sessionData.copilotExactCostDollars ?? this.calculateEstimatedCost(modelUsage),
 			editor: this.detectEditorSource(sessionFile), models: Object.keys(modelUsage),
 			lastActivity: sessionData.lastInteraction || new Date(mtime).toISOString(),

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -175,7 +175,7 @@ import {
 import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceForBillingGroup } from './chartDataBuilder';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, type SessionAggregateInput } from './statsHelpers';
+import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, type SessionAggregateInput } from './statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -3539,7 +3539,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			title: sessionData.title || null, filePath: sessionFile, interactions,
 			toolCalls: analysis.toolCalls.total, inputTokens: inputTok, outputTokens: outputTok,
 			thinkingTokens: sessionData.thinkingTokens || 0, cachedTokens: cachedTok,
-			totalTokens: inputTok + outputTok + (sessionData.thinkingTokens || 0),
+			totalTokens: computeSessionTotalTokens(inputTok, outputTok, sessionData.thinkingTokens || 0),
 			estimatedCost: sessionData.copilotExactCostDollars ?? this.calculateEstimatedCost(modelUsage),
 			editor: this.detectEditorSource(sessionFile), models: Object.keys(modelUsage),
 			lastActivity: sessionData.lastInteraction || new Date(mtime).toISOString(),

--- a/vscode-extension/src/statsHelpers.ts
+++ b/vscode-extension/src/statsHelpers.ts
@@ -9,6 +9,17 @@ import type { ModelUsage, EditorUsage, DailyTokenStats, SessionFileCache, Langua
 import { toLocalDayKey } from './utils/dayKeys';
 
 /**
+ * Computes a session's total token count from input, output, and thinking tokens.
+ *
+ * Cached (cache-read) tokens are deliberately excluded: they are already a
+ * subset of `inputTokens` (see `ModelUsage.inputTokens`), not an additive
+ * amount, so adding them again here would double-count and inflate the total.
+ */
+export function computeSessionTotalTokens(inputTokens: number, outputTokens: number, thinkingTokens: number): number {
+	return inputTokens + outputTokens + thinkingTokens;
+}
+
+/**
  * Merges `source` model usage into `target` (in-place).
  * All four token fields are summed: inputTokens, outputTokens,
  * cachedReadTokens (optional), and cacheCreationTokens (optional).

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -221,7 +221,7 @@ setCompactNumbers(stats.compactNumbers !== false);
 const root = document.getElementById('root');
 if (!root) { return; }
 
-const projectedTokens = Math.round(calculateProjection(stats.last30Days.tokens + (stats.last30Days.cachedTokens ?? 0) + stats.last30Days.thinkingTokens));
+const projectedTokens = Math.round(calculateProjection(stats.last30Days.tokens + stats.last30Days.thinkingTokens));
 const projectedSessions = Math.round(calculateProjection(stats.last30Days.sessions));
 const projectedCo2 = calculateProjection(stats.last30Days.co2);
 const projectedWater = calculateProjection(stats.last30Days.waterUsage);
@@ -331,7 +331,7 @@ function outputTokenCell(p: PeriodStats): string {
 function totalTokenCell(p: PeriodStats): string {
 	const modelTotal = sumInputTokens(p) + sumOutputTokens(p);
 	if ((p.actualTokens ?? 0) > 0) {
-		return formatCompact(p.tokens + (p.cachedTokens ?? 0) + p.thinkingTokens);
+		return formatCompact(p.tokens + p.thinkingTokens);
 	}
 	return formatCompact(modelTotal > 0 ? modelTotal : p.tokens);
 }

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -6,6 +6,7 @@ addModelUsage,
 addEditorUsage,
 computeUtcDateRanges,
 aggregatePeriodStats,
+computeSessionTotalTokens,
 type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../src/statsHelpers';
@@ -41,6 +42,23 @@ const last30DaysStartMs = last30DaysUtcStart.getTime();
 const lastMonthStartMs = new Date(Date.UTC(lastMonthLastDay.getUTCFullYear(), lastMonthLastDay.getUTCMonth(), 1)).getTime();
 return { todayUtcKey, monthUtcStartKey, lastMonthUtcStartKey, lastMonthUtcEndKey, last30DaysUtcStartKey, last30DaysStartMs, lastMonthStartMs };
 }
+
+// ── computeSessionTotalTokens ────────────────────────────────────────────────
+
+test('computeSessionTotalTokens: sums input, output, and thinking tokens', () => {
+assert.strictEqual(computeSessionTotalTokens(100, 20, 5), 125);
+});
+
+test('computeSessionTotalTokens: does not double-count cached tokens (regression)', () => {
+// inputTokens already includes cache-read tokens (e.g. 100 input tokens of
+// which 40 were cache reads). The total must stay 100 + 20 + 0 = 120 and
+// must NOT add the 40 cached tokens again on top.
+const inputTokensIncludingCache = 100;
+const cachedReadTokensSubsetOfInput = 40;
+const total = computeSessionTotalTokens(inputTokensIncludingCache, 20, 0);
+assert.strictEqual(total, 120);
+assert.notStrictEqual(total, 120 + cachedReadTokensSubsetOfInput);
+});
 
 // ── addModelUsage ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem
The "Total tokens" figure in the AI Engineering Fluency details view was inflated because cached (cache-read) tokens were being added on top of an input-token figure that **already includes** them. Per `ModelUsage.inputTokens` (`vscode-extension/src/types.ts`):

```ts
inputTokens: number;    // total input tokens (uncached + cached reads + cache creation)
cachedReadTokens?: number;     // portion of inputTokens that were cache reads (billed at reduced rate)
```

So `cachedTokens` is a **subset** of `inputTokens`/`tokens`, not additive.

## Fixes in this PR
1. **`vscode-extension/src/webview/details/main.ts`**
   - `totalTokenCell()`: was `p.tokens + (p.cachedTokens ?? 0) + p.thinkingTokens` → now `p.tokens + p.thinkingTokens`
   - `projectedTokens` (Projected Year column): same fix applied
   - The "Cached tokens" row itself is unchanged — still shown as its own informational row in the table.

2. **`vscode-extension/src/extension.ts`** (`collectTodaySessionInfo()`)
   - `totalTokens: inputTok + outputTok + cachedTok + thinkingTokens` → now `inputTok + outputTok + thinkingTokens`
   - This is the same bug, feeding `TodaySessionSummary.totalTokens` shown in the Usage webview's "Today Sessions" table.

## Verification
- `npm run compile` (tsc + eslint + esbuild) passes with no errors.
- No existing unit tests directly covered `totalTokenCell()` or `collectTodaySessionInfo()`; verified behavior via compilation and manual review against the `ModelUsage` type contract.
