### PR TITLE
fix: stop agent sessions from popping open real VS Code windows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,16 @@ Key categories:
 - **Focused Modifications**: Make surgical, precise changes without affecting other functionality.
 - **Preserve Existing Structure**: Don't refactor or reorganize unless essential for the task.
 
+## Never Launch a Real Editor/IDE Instance
+
+AI agents (Claude Code, GitHub Copilot, etc.) must never launch a real, visible instance of an IDE as part of testing or verifying a change — e.g. `code .` / `code <file>`, pressing `F5` to start the VS Code Extension Development Host, `./gradlew runIde` (JetBrains sandbox IDE), or opening Visual Studio/`devenv`. These pop open real windows on the developer's machine, which is disruptive and unexpected when it happens mid-session, especially in unattended or scheduled agent runs.
+
+These steps are documented in places like `.github/instructions/vscode-extension.instructions.md` and `.github/instructions/jetbrains-plugin.instructions.md` **for human developers only**, who can watch the window, click through the UI, and close it when done. An agent has no way to "close" a window it opens and no way to observe it, so these steps are meaningless for automated verification and only cause disruptive side effects.
+
+Instead, verify changes using non-interactive tooling: compile/build scripts (`npm run compile`, `./gradlew build`, `dotnet build`), automated unit test suites (`npm run test:node`, `./gradlew test`, `dotnet test`), and linters/type-checkers. If you are writing or editing a skill, prompt, or instructions file, do not add steps that tell an agent to launch a GUI editor/IDE — mark such steps explicitly as manual/human-only, or omit them entirely from agent-facing docs.
+
+This also governs `.github/github-app.yml`. Its `code .` script has **no `triggers` entry**, on purpose — that makes it an on-demand action a human clicks in the GitHub App's session UI, not something that fires automatically. **Never attach `triggers: [session.create]` (or any other trigger) to a script that launches an editor/IDE.** `automation.auto_issue_session: true` means sessions can be created unattended (e.g. an issue auto-assigned to Copilot) with nobody there to click anything — a triggered `code .` would pop open a real VS Code window during those unattended sessions too, which is the exact bug this section exists to prevent. Non-GUI setup steps (installing dependencies, compiling) are fine to keep on `session.create` since they have no visible side effect.
+
 ## CLI Must Reuse Shared Extension Functions
 
 The CLI (`cli/`) is a thin consumer of the VS Code extension's TypeScript modules. **Never reimplement session parsing or cost attribution logic in the CLI — always call the shared functions from `vscode-extension/src/`.**

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,16 +1,13 @@
 scripts:
-- name: Install VS Code extension dependencies
-  command: cd vscode-extension && npm ci
-  triggers:
-  - session.create
-- name: Compile VS Code extension
-  command: cd vscode-extension && npm run compile
+- name: Install and compile VS Code extension
+  command: |
+    cd vscode-extension
+    npm ci
+    npm run compile
   triggers:
   - session.create
 - name: Open in VS Code
   command: code .
-  triggers:
-  - session.create
 automation:
   auto_issue_session: true
   remote_control: true

--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -51,7 +51,7 @@ The entire extension's logic is contained within the `CopilotTokenTracker` class
 - **Setup**: Run `npm install` inside `vscode-extension/` to install dependencies.
 - **Build**: Run `npm run compile` from `vscode-extension/` to lint and build the extension using `esbuild`. The output is a single file: `vscode-extension/dist/extension.js`.
 - **Watch Mode**: For active development, use `npm run watch` from `vscode-extension/`. This will automatically recompile the extension on file changes.
-- **Testing/Debugging**: Press `F5` in VS Code to open the Extension Development Host. This will launch a new VS Code window with the extension running. `console.log` statements from `vscode-extension/src/extension.ts` will appear in the Developer Tools console of this new window (Help > Toggle Developer Tools).
+- **Testing/Debugging (human developers only)**: Press `F5` in VS Code to open the Extension Development Host. This will launch a new VS Code window with the extension running. `console.log` statements from `vscode-extension/src/extension.ts` will appear in the Developer Tools console of this new window (Help > Toggle Developer Tools). **AI agents must never do this** — see "Never launch a real editor/IDE instance" in the root `.github/copilot-instructions.md`. Use `npm run compile` and `npm run test:node` / `npm run test:coverage` to validate changes instead.
 
 **Important build guidance:** After making changes to source code or related files (TypeScript, JavaScript, JSON, or other code files used by the extension), always run both `npm ci` and then `npm run compile` from `vscode-extension/` to validate that the project still builds and lints cleanly before opening a pull request or releasing. Also run the unit tests with `npm run test:node` to catch any regressions. You do not need to run the full compile step for documentation-only changes (Markdown files), but you should run it after any edits that touch source, configuration, or JSON data files.
 
@@ -108,10 +108,12 @@ These are two completely separate logging systems:
 
 ### Debugging Without Logs
 
-Prefer VS Code's debugger with breakpoints rather than adding log statements:
+For human developers, prefer VS Code's debugger with breakpoints rather than adding log statements:
 1. Press `F5` to launch Extension Development Host
 2. Set breakpoints in `vscode-extension/src/extension.ts`
 3. Use the Debug Console to inspect variables
+
+AI agents cannot use the interactive debugger and must never launch the Extension Development Host (no `F5`, no `code .`, no editing `.vscode/launch.json` to auto-run). Rely on the unit test suite (`npm run test:node`) and, where needed, temporary `console.log`/assertions inside a test file — removed before committing.
 
 ## Parallel Model Usage Aggregation Paths
 

--- a/.github/skills/refresh-json-data/SKILL.md
+++ b/.github/skills/refresh-json-data/SKILL.md
@@ -157,11 +157,10 @@ After updating the JSON files:
    npm run compile
    ```
 
-3. **Test in VS Code**:
-   - Press F5 to launch Extension Development Host
-   - Check that the extension loads without errors
-   - Verify token tracking still works correctly
-   - Review the details panel to confirm pricing calculations
+3. **Validate with the automated test suite** (do not launch VS Code or the Extension Development Host — that is a manual, human-only debugging step; see `.github/copilot-instructions.md`):
+   ```bash
+   npm run test:node
+   ```
 
 4. **Review changes**:
    ```bash
@@ -217,15 +216,13 @@ After updating the JSON files:
 
 **Extension not loading updated data**:
 - Confirm you ran `npm run compile`
-- Reload the Extension Development Host (Cmd/Ctrl+R)
-- Check the output console for errors
+- Confirm `npm run test:node` passes
+- Check the build output for errors
 
 ## Example Update Workflow
 
 ```bash
-# 1. Update the JSON files with new data
-code src/tokenEstimators.json
-code src/modelPricing.json
+# 1. Update src/tokenEstimators.json and src/modelPricing.json with new data
 
 # 2. Validate JSON syntax
 node -e "require('./src/tokenEstimators.json')" && echo "tokenEstimators.json: OK"
@@ -234,8 +231,8 @@ node -e "require('./src/modelPricing.json')" && echo "modelPricing.json: OK"
 # 3. Rebuild the extension
 npm run compile
 
-# 4. Test in VS Code
-# Press F5 to launch Extension Development Host
+# 4. Run the automated test suite
+npm run test:node
 
 # 5. Commit changes
 git add src/tokenEstimators.json src/modelPricing.json


### PR DESCRIPTION
## Summary
- Several agent-facing docs/config told Claude Code / GitHub Copilot to launch a real, visible VS Code window as part of "testing" a change — this is what was causing random VS Code windows to pop open during coding-agent sessions.
- `.github/skills/refresh-json-data/SKILL.md` instructed the agent to run `code <file>` and "Press F5 to launch Extension Development Host" / "Reload the Extension Development Host" — replaced with running `npm run test:node`.
- `.github/instructions/vscode-extension.instructions.md` documented F5/Extension Development Host as *the* way to test/debug with no human-vs-agent distinction — now explicitly marked human-only, with agents pointed at `npm run compile` / `npm run test:node` / `npm run test:coverage`.
- `.github/github-app.yml` ran `code .` on the `session.create` trigger. Since `automation.auto_issue_session: true` can create sessions unattended (e.g. an issue auto-assigned to Copilot), that trigger fires with nobody there to click anything — a real VS Code window would still pop open. Dependency install + compile stay on `session.create` (no visible side effect), but `code .` moved to its own script with **no trigger**, so it now only runs when a human explicitly clicks it in the session UI.
- Added a "Never Launch a Real Editor/IDE Instance" section to `.github/copilot-instructions.md` so this pattern (an agent, skill, or triggered script launching a real IDE window) doesn't get reintroduced.

## Why
The user reported VS Code windows randomly popping open during Claude Code and GitHub Copilot sessions on this repo. Traced to agent-facing instructions/skills describing F5/Extension Development Host as a normal verification step, plus a `github-app.yml` script that ran `code .` on every `session.create` — including unattended, auto-issue-triggered sessions.

## Test plan
- [x] Ran the full `vscode-extension` unit test suite locally (87 files) while polling for new `Code.exe` processes — confirmed the automated test suite itself never launches VS Code.
- [x] Verified `.github/github-app.yml` still installs deps + compiles automatically on session start; `code .` now requires an explicit manual click (no `triggers` key), matching the pattern seen in other public `github-app.yml` configs (e.g. `pholleran-org/octocat_supply-orange-octo-invention`, `davidfowl/build2026demo`).
- [ ] Reviewer: confirm this matches how you actually interact with the GitHub Copilot coding agent session UI (i.e. that a script with no `triggers` key shows up as an on-demand button rather than not running at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)