### PR TITLE
chore: bump versions for release (CLI)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for components that have changed since their last release tags.

| Component | Old version | New version |
|-----------|-------------|-------------|
| CLI | 0.2.11 | 0.2.12 |

### Notable change in this release

- **activeDurationMs session metric** (commit 39c1965b): adds a new session duration metric that excludes idle turn gaps, in `cli/src/analysis.ts` and `cli/src/commands/curation.ts`. This feature has not yet been published to npm (the currently published version, 0.2.11, predates it).

Note: the `cli/v0.2.10` git tag is stale and was never updated when 0.2.11 was published, so version comparison for this release was done against the npm-published 0.2.11, not the tag.

### After merging, run these workflows:

- **CLI - Publish to npm and GitHub** (`cli-publish.yml`) — Actions → CLI - Publish to npm and GitHub → Run workflow (on `main`). Publishes `@rajbos/ai-engineering-fluency@0.2.12` to npm.