### PR TITLE
chore: bump versions for release (Visual Studio extension, JetBrains plugin)

### DIFF
--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.1.2
+pluginVersion = 0.1.3
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.14"
+              Version="1.0.15"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>


### PR DESCRIPTION
## Release prep — version bumps

Bumps the two host extensions so the shared webview bundles (refreshed from the VS Code source in #1532) can be published. The VS Code extension (v0.12.3) and CLI (v0.2.12) are already released, so they're not bumped here.

| Component | Old version | New version | Bump |
|-----------|-------------|-------------|------|
| Visual Studio extension | 1.0.14 | **1.0.15** | patch |
| JetBrains plugin | 0.1.2 | **0.1.3** | patch |

### Why

Both hosts render the same compiled webview bundles the VS Code extension owns. Those bundles drifted ~30 days stale (Eclipse support, tool curation, cost-split by editor/billing provider, cached-token double-count fixes, the `@vscode-elements/elements` migration, and a theme/CSS refactor) and were refreshed in #1532.

- **Visual Studio** commits its bundles into the repo — #1532 already updated the committed `webview/*.js`. This bump lets a new VSIX ship them (the Marketplace rejects re-publishing the same version).
- **JetBrains** copies bundles from `vscode-extension/dist/webview` at Gradle build time, so a fresh build packages the current content automatically — it just needs a new plugin version to publish.

### Files
- `visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest` — `<Identity Version>` 1.0.14 → 1.0.15
- `jetbrains-plugin/gradle.properties` — `pluginVersion` 0.1.2 → 0.1.3

### After merging, run these workflows (on `main`)

1. **Visual Studio Extension - Build & Package** (`visualstudio-build.yml`) — set `publish_marketplace: true` to publish **v1.0.15** to the Visual Studio Marketplace.
2. **JetBrains - Publish** (`jetbrains-publish.yml`) — builds and publishes plugin **v0.1.3** (bundles are pulled from the VS Code dist build at package time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)