### PR TITLE
fix(maturity): make radar grid lines visible on all dark themes

### DIFF
--- a/vscode-extension/src/webview/maturity/styles.css
+++ b/vscode-extension/src/webview/maturity/styles.css
@@ -126,7 +126,20 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .stage-4 { color: #089
 }
 
 .radar-svg .radar-grid {
-	stroke: var(--border-subtle);
+	/*
+	 * Derive the grid from the editor foreground at low opacity rather than
+	 * --border-subtle (--vscode-widget-border), which many dark themes leave
+	 * undefined or nearly invisible against the editor background.
+	 */
+	stroke: var(--text-primary);
+	stroke-opacity: 0.25;
+}
+
+/* High-contrast themes need crisp, full-strength grid lines. */
+body[data-vscode-theme-kind="vscode-high-contrast"] .radar-svg .radar-grid,
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .radar-svg .radar-grid {
+	stroke: var(--vscode-contrastBorder, var(--text-primary));
+	stroke-opacity: 1;
 }
 
 .radar-svg .radar-dot {


### PR DESCRIPTION
## What changed

The Fluency Score spider/radar chart now draws its grid rings and axis spokes with a theme-adaptive stroke that stays visible on every theme.

- `.radar-grid` now uses `var(--text-primary)` (editor foreground, always defined) at `stroke-opacity: 0.25` instead of `var(--border-subtle)`.
- Added a high-contrast override that keeps crisp, full-opacity lines via `var(--vscode-contrastBorder)` so HC themes retain required contrast.

File: `vscode-extension/src/webview/maturity/styles.css`

## Why

The grid was styled with `--border-subtle` → `--vscode-widget-border`, which many dark VS Code themes leave undefined or set to a near-invisible color against the editor background. The result was that the spider-web axis lines and rings on the Fluency Score chart effectively disappeared, making the radar hard to read.

## Reviewer notes

- Both the concentric rings and the radial axis spokes share the `.radar-grid` class, so both are fixed by this change.
- The committed Visual Studio host bundle (`visualstudio-extension/.../webview/maturity.js`) inlines a built copy of this CSS and won't reflect the change until regenerated via the `sync-host-views` skill (typically done before a VS release). Not included here to keep the diff to the source fix.