### PR TITLE
Fix Dependabot npm coverage gap; add nuget and devcontainers entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # Enable version updates for npm dependencies
   - package-ecosystem: "npm"
-    directory: "/"
+    directories: ["/vscode-extension", "/sharing-server"]
     schedule:
       interval: "weekly"
       day: "monday"
@@ -91,6 +91,43 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Enable version updates for the Visual Studio extension NuGet dependencies
+  - package-ecosystem: "nuget"
+    directory: "/visualstudio-extension"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    reviewers:
+      - "rajbos"
+    assignees:
+      - "rajbos"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Enable version updates for the dev container configuration
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    reviewers:
+      - "rajbos"
+    assignees:
+      - "rajbos"
+    labels:
+      - "dependencies"
 
   - package-ecosystem: npm
     directory: /.github/scripts


### PR DESCRIPTION
## Problem

The first `npm` entry in `.github/dependabot.yml` used `directory: "/"`, but **there is no `package.json` at the repository root** — so that entry matched nothing. As a result, `vscode-extension/` and `sharing-server/` (both of which have a `package.json` + `package-lock.json`) were receiving **no Dependabot updates at all**. Only `/cli`, `/.github/scripts`, and `/.github/skills/azure-storage-loader` were covered by their separate daily entries.

## Changes

1. **npm entry fixed**: changed `directory: "/"` to `directories: ["/vscode-extension", "/sharing-server"]`, keeping everything else intact (weekly Monday 04:00 UTC schedule, `open-pull-requests-limit: 10`, `npm` commit-message prefix, rajbos as reviewer/assignee, labels, minor-and-patch grouping, and the existing `ignore` rules for major versions of `typescript`, `@types/vscode`, and `vscode`).
2. **New `nuget` entry** for `/visualstudio-extension` with the same weekly schedule, rajbos reviewer/assignee, `dependencies` label, and minor-and-patch grouping.
3. **New `devcontainers` entry** for `/` with the same weekly schedule, rajbos reviewer/assignee, and `dependencies` label.

The existing daily npm entries for `/cli`, `/.github/scripts`, and `/.github/skills/azure-storage-loader` are untouched, and no duplicate ecosystem+directory pairs were introduced.

Validated the YAML parses with PyYAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)