### PR TITLE
ci: make VS Code integration tests gate CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
 
     - name: Run tests
       run: cd vscode-extension && npm test
-      continue-on-error: true  # VS Code extension tests can be flaky in CI
       env:
         DISPLAY: :99
       # coactions/setup-xvfb was abandoned on Node.js 20 (no node24 support).


### PR DESCRIPTION
## Summary

The "Run tests" step in `.github/workflows/ci.yml` (the VS Code extension integration tests running under Xvfb) had `continue-on-error: true` with the comment "VS Code extension tests can be flaky in CI". This meant the integration tests could never fail the build, so regressions caught by these tests would silently pass CI.

This PR removes the `continue-on-error: true` line (and its trailing comment) so the step properly gates CI. The `env: DISPLAY: :99` block and the note about `coactions/setup-xvfb` being abandoned are unchanged; nothing else in the file was touched.

## Follow-up note

If the integration tests turn out to be genuinely flaky, the right follow-up is to fix the flakiness (or add targeted retries for the flaky cases) — not to re-silence the tests with `continue-on-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)