### PR TITLE
fix: repair devcontainer bootstrap (postCreateCommand + node_modules volumes)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,11 +28,12 @@
   "mounts": [
     "source=${localEnv:APPDATA}/Code/User,target=/home/node/.config/Code/User,type=bind,readonly=true",
     "source=${localEnv:APPDATA}/Code - Insiders/User,target=/home/node/.config/Code - Insiders/User,type=bind,readonly=true",
-    "source=ai-engineering-fluency-nodemodules,target=/workspaces/ai-engineering-fluency/node_modules,type=volume"
+    "source=ai-engineering-fluency-nodemodules,target=/workspaces/ai-engineering-fluency/vscode-extension/node_modules,type=volume",
+    "source=ai-engineering-fluency-cli-nodemodules,target=/workspaces/ai-engineering-fluency/cli/node_modules,type=volume"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096"
   },
-  "postCreateCommand": "npm ci",
+  "postCreateCommand": "sudo chown node:node vscode-extension/node_modules cli/node_modules && cd vscode-extension && npm ci && cd ../cli && npm ci",
   "remoteUser": "node"
 }


### PR DESCRIPTION
## Problem

The devcontainer bootstrap in `.devcontainer/devcontainer.json` was broken:

- `"postCreateCommand": "npm ci"` ran at the repo root, but there is **no `package.json` at the repo root** — the npm projects live in `vscode-extension/`, `cli/`, and `sharing-server/` — so container creation failed at the post-create step.
- The named volume mount `ai-engineering-fluency-nodemodules` targeted `/workspaces/ai-engineering-fluency/node_modules`, a root-level `node_modules` that is never used, so the fast-volume optimization did nothing.

## Changes

- **postCreateCommand** now installs where the code actually lives: `npm ci` in `vscode-extension/` and then in `cli/`.
- **Volume mounts** retargeted/added:
  - `ai-engineering-fluency-nodemodules` → `/workspaces/ai-engineering-fluency/vscode-extension/node_modules`
  - new `ai-engineering-fluency-cli-nodemodules` → `/workspaces/ai-engineering-fluency/cli/node_modules`
- **Permissions note:** Docker creates named volumes root-owned, and the container runs as `remoteUser: node`, so `npm ci` into the mounted `node_modules` directories would fail with EACCES on first create. The postCreateCommand therefore starts with `sudo chown node:node vscode-extension/node_modules cli/node_modules` (the standard pattern documented for named-volume `node_modules` with the devcontainers node images, which grant the `node` user passwordless sudo).

Nothing else in the file was touched — the `image` line, features, customizations/settings, `containerEnv`, `initializeCommand`, and the two readonly Code User-dir bind mounts are unchanged (another open PR updates the image tag).

Validated that the file still parses as plain JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)