### PR TITLE
Eliminate redundant npm ci runs in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -20,6 +20,10 @@
     Which build target to run.  Accepts: build | package | test | clean
     Default: build
 
+.PARAMETER SkipInstall
+    Skip all `npm ci` dependency installs (assumes node_modules is already
+    current in each project).  Useful for fast local iteration.
+
 .EXAMPLE
     ./build.ps1
     # builds vscode-extension and cli (default: all, build)
@@ -27,6 +31,10 @@
 .EXAMPLE
     ./build.ps1 -Project vscode -Target test
     # runs tests for the VS Code extension only
+
+.EXAMPLE
+    ./build.ps1 -Project cli -SkipInstall
+    # builds the CLI without re-running npm ci (node_modules must be current)
 #>
 
 param(
@@ -34,7 +42,9 @@ param(
     [string] $Project = 'all',
 
     [ValidateSet('build', 'package', 'test', 'clean')]
-    [string] $Target = 'build'
+    [string] $Target = 'build',
+
+    [switch] $SkipInstall
 )
 
 Set-StrictMode -Version Latest
@@ -44,6 +54,24 @@ function Write-Step([string]$msg) { Write-Host "`n==> $msg" -ForegroundColor Cya
 function Write-Ok([string]$msg)   { Write-Host "    $msg" -ForegroundColor Green }
 function Write-Err([string]$msg)  { Write-Host "    ERROR: $msg" -ForegroundColor Red }
 
+# Tracks directories whose npm dependencies were already installed during this
+# invocation, so a full build doesn't re-run `npm ci` (which wipes
+# node_modules) for the same project multiple times.
+$script:npmInstalled = @{}
+
+function Ensure-NpmDeps([string]$dir) {
+    if ($SkipInstall) { return }
+    $key = (Resolve-Path $dir).Path
+    if ($script:npmInstalled.ContainsKey($key)) { return }
+    Push-Location $key
+    try {
+        npm ci
+        if ($LASTEXITCODE -ne 0) { throw "npm ci failed in $key" }
+    }
+    finally { Pop-Location }
+    $script:npmInstalled[$key] = $true
+}
+
 # ---------------------------------------------------------------------------
 # VS Code Extension
 # ---------------------------------------------------------------------------
@@ -52,9 +80,9 @@ function Build-VsCode {
     Push-Location "$PSScriptRoot/vscode-extension"
     try {
         switch ($Target) {
-            'build'   { npm ci; npm run compile }
-            'package' { npm ci; npm run package; npx vsce package }
-            'test'    { npm ci; npm run test:node }
+            'build'   { Ensure-NpmDeps .; npm run compile }
+            'package' { Ensure-NpmDeps .; npm run package; npx vsce package }
+            'test'    { Ensure-NpmDeps .; npm run test:node }
             'clean'   { Remove-Item -Recurse -Force dist, out -ErrorAction SilentlyContinue }
         }
         Write-Ok "vscode-extension done."
@@ -70,8 +98,8 @@ function Build-Cli {
     Push-Location "$PSScriptRoot/cli"
     try {
         switch ($Target) {
-            'build'   { npm ci; npm run build }
-            'package' { npm ci; npm run build:production; & pwsh -NoProfile -File bundle-exe.ps1 -SkipBuild }
+            'build'   { Ensure-NpmDeps .; npm run build }
+            'package' { Ensure-NpmDeps .; npm run build:production; & pwsh -NoProfile -File bundle-exe.ps1 -SkipBuild }
             'test'    { Write-Host "    (no CLI tests yet)" }
             'clean'   { Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue }
         }
@@ -87,7 +115,7 @@ function Build-CliExe {
     Write-Step "cli: bundle-exe"
     Push-Location "$PSScriptRoot/cli"
     try {
-        npm ci
+        Ensure-NpmDeps .
         & pwsh -NoProfile -File bundle-exe.ps1
         if ($LASTEXITCODE -ne 0) { throw "CLI exe bundling failed" }
         Write-Ok "cli exe bundled."
@@ -111,7 +139,7 @@ function Build-VisualStudio {
     Write-Step "vscode-extension: compile (for VS webview bundles)"
     Push-Location "$PSScriptRoot/vscode-extension"
     try {
-        npm ci
+        Ensure-NpmDeps .
         npm run compile
         if ($LASTEXITCODE -ne 0) { throw "vscode-extension compile failed" }
         Write-Ok "vscode-extension compiled."
@@ -223,7 +251,7 @@ function Build-Jetbrains {
     Write-Step "vscode-extension: compile (for JetBrains webview bundles)"
     Push-Location "$PSScriptRoot/vscode-extension"
     try {
-        npm ci
+        Ensure-NpmDeps .
         npm run compile
         if ($LASTEXITCODE -ne 0) { throw "vscode-extension compile failed" }
     }
@@ -255,8 +283,8 @@ function Build-Sharing {
     Push-Location "$PSScriptRoot/sharing-server"
     try {
         switch ($Target) {
-            'build'   { npm ci; npm run build }
-            'package' { npm ci; npm run build:production }
+            'build'   { Ensure-NpmDeps .; npm run build }
+            'package' { Ensure-NpmDeps .; npm run build:production }
             'test'    { Write-Host "    (no sharing-server tests yet)" }
             'clean'   { Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue }
         }


### PR DESCRIPTION
## Problem

A full `./build.ps1` run executed `npm ci` in `vscode-extension/` up to three times (`Build-VsCode`, again inside `Build-VisualStudio`, again inside `Build-Jetbrains`) and in `cli/` multiple times (`Build-Cli` plus `Build-CliExe`). Since `npm ci` deletes `node_modules` on every run, this made full builds very slow.

## Changes

- Added a script-scoped tracking set (`$script:npmInstalled`) and an `Ensure-NpmDeps` helper that runs `npm ci` in a directory only once per invocation (keyed on the resolved path) and throws on a non-zero exit code.
- Replaced every bare `npm ci` call in the script with the helper.
- Added a `-SkipInstall` switch that skips `npm ci` entirely for fast local iteration when `node_modules` is already current; documented via `.PARAMETER` and a new `.EXAMPLE` in the help block.
- No other restructuring: build functions, targets, ordering, and output messages are unchanged; `Set-StrictMode -Version Latest` still passes.

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile(...)` reports no errors.
- `Get-Help ./build.ps1` syntax line now shows `[-SkipInstall]`. (Note: the descriptive help text not rendering via Get-Help is pre-existing on `main` as well — the syntax output is identical in style before/after.)
- No full build was run per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)