### PR TITLE
security: graduate harden-runner to egress-policy block in stable workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,10 +16,18 @@ jobs:
   run-actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block all outbound calls except allowed)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          # Allowlist inferred from the harden-runner audit output of the 10 most
+          # recent successful runs of this workflow (run ids 28548602130..28791579209).
+          allowed-endpoints: >
+            auth.docker.io:443
+            github.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
+            results-receiver.actions.githubusercontent.com:443
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,36 @@ jobs:
         node-version: [22.x, 24.x]
     
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: Harden the runner (Block all outbound calls except allowed)
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        # Allowlist inferred from the harden-runner audit output of the 10 most
+        # recent successful runs of this workflow (run ids 28795599767..28802373956).
+        allowed-endpoints: >
+          azcliprod.blob.core.windows.net:443
+          broker.actions.githubusercontent.com:443
+          dc.services.visualstudio.com:443
+          github.com:443
+          hosted-compute-watchdog-prod-iad-02.githubapp.com:443
+          management.azure.com:443
+          productionresultssa2.blob.core.windows.net:443
+          productionresultssa3.blob.core.windows.net:443
+          productionresultssa4.blob.core.windows.net:443
+          productionresultssa5.blob.core.windows.net:443
+          productionresultssa8.blob.core.windows.net:443
+          productionresultssa10.blob.core.windows.net:443
+          productionresultssa12.blob.core.windows.net:443
+          productionresultssa13.blob.core.windows.net:443
+          productionresultssa17.blob.core.windows.net:443
+          registry.npmjs.org:443
+          results-receiver.actions.githubusercontent.com:443
+          run-actions-3-azure-eastus.actions.githubusercontent.com:443
+          www.powershellgallery.com:443
 
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      
+
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
@@ -122,10 +144,21 @@ jobs:
     if: github.ref == 'refs/heads/main'
     
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: Harden the runner (Block all outbound calls except allowed)
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: audit
+        egress-policy: block
+        # Allowlist inferred from the harden-runner audit output of the sampled
+        # recent runs that included this job (main pushes only).
+        allowed-endpoints: >
+          github.com:443
+          productionresultssa2.blob.core.windows.net:443
+          productionresultssa5.blob.core.windows.net:443
+          productionresultssa8.blob.core.windows.net:443
+          productionresultssa10.blob.core.windows.net:443
+          productionresultssa13.blob.core.windows.net:443
+          registry.npmjs.org:443
+          results-receiver.actions.githubusercontent.com:443
 
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,18 @@ jobs:
         egress-policy: block
         # Allowlist inferred from the harden-runner audit output of the 10 most
         # recent successful runs of this workflow (run ids 28795599767..28802373956).
+        # Use wildcards for GitHub/Azure infra hosts that rotate between instances.
         allowed-endpoints: >
           azcliprod.blob.core.windows.net:443
           broker.actions.githubusercontent.com:443
           dc.services.visualstudio.com:443
           github.com:443
-          hosted-compute-watchdog-prod-iad-02.githubapp.com:443
+          hosted-compute-watchdog-prod-*.githubapp.com:443
           management.azure.com:443
-          productionresultssa2.blob.core.windows.net:443
-          productionresultssa3.blob.core.windows.net:443
-          productionresultssa4.blob.core.windows.net:443
-          productionresultssa5.blob.core.windows.net:443
-          productionresultssa8.blob.core.windows.net:443
-          productionresultssa10.blob.core.windows.net:443
-          productionresultssa12.blob.core.windows.net:443
-          productionresultssa13.blob.core.windows.net:443
-          productionresultssa17.blob.core.windows.net:443
+          productionresultssa*.blob.core.windows.net:443
           registry.npmjs.org:443
           results-receiver.actions.githubusercontent.com:443
-          run-actions-3-azure-eastus.actions.githubusercontent.com:443
+          run-actions-*-azure-eastus.actions.githubusercontent.com:443
           www.powershellgallery.com:443
 
     - name: Checkout code
@@ -149,14 +142,11 @@ jobs:
       with:
         egress-policy: block
         # Allowlist inferred from the harden-runner audit output of the sampled
-        # recent runs that included this job (main pushes only).
+        # recent runs that included this job (main pushes only). Use a wildcard
+        # for the rotating Actions results storage account names.
         allowed-endpoints: >
           github.com:443
-          productionresultssa2.blob.core.windows.net:443
-          productionresultssa5.blob.core.windows.net:443
-          productionresultssa8.blob.core.windows.net:443
-          productionresultssa10.blob.core.windows.net:443
-          productionresultssa13.blob.core.windows.net:443
+          productionresultssa*.blob.core.windows.net:443
           registry.npmjs.org:443
           results-receiver.actions.githubusercontent.com:443
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,10 +40,25 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block all outbound calls except allowed)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          # Allowlist inferred from the harden-runner audit output of the 10 most
+          # recent successful runs of this workflow (run ids 28795598756..28802374085).
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            productionresultssa0.blob.core.windows.net:443
+            productionresultssa2.blob.core.windows.net:443
+            productionresultssa5.blob.core.windows.net:443
+            productionresultssa9.blob.core.windows.net:443
+            productionresultssa11.blob.core.windows.net:443
+            productionresultssa13.blob.core.windows.net:443
+            productionresultssa15.blob.core.windows.net:443
+            productionresultssa18.blob.core.windows.net:443
+            results-receiver.actions.githubusercontent.com:443
+            uploads.github.com:443
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,17 +46,11 @@ jobs:
           egress-policy: block
           # Allowlist inferred from the harden-runner audit output of the 10 most
           # recent successful runs of this workflow (run ids 28795598756..28802374085).
+          # Use a wildcard for the rotating Actions results storage account names.
           allowed-endpoints: >
             api.github.com:443
             github.com:443
-            productionresultssa0.blob.core.windows.net:443
-            productionresultssa2.blob.core.windows.net:443
-            productionresultssa5.blob.core.windows.net:443
-            productionresultssa9.blob.core.windows.net:443
-            productionresultssa11.blob.core.windows.net:443
-            productionresultssa13.blob.core.windows.net:443
-            productionresultssa15.blob.core.windows.net:443
-            productionresultssa18.blob.core.windows.net:443
+            productionresultssa*.blob.core.windows.net:443
             results-receiver.actions.githubusercontent.com:443
             uploads.github.com:443
 


### PR DESCRIPTION
## Summary

Graduates `step-security/harden-runner` from `egress-policy: audit` to `egress-policy: block` in the three stable workflows:

- `.github/workflows/ci.yml` (jobs `build` and `package`)
- `.github/workflows/actionlint.yml` (job `run-actionlint`)
- `.github/workflows/codeql.yml` (job `analyze`)

The allowlists now use a mix of **explicit domains** and **wildcard patterns** where the observed endpoints are clearly instance-rotating infrastructure hosts. No other workflows were touched, and the pinned harden-runner SHA (`9af89fc7…` / v2.19.4) is unchanged.

## How the allowlists were built

The allowlists were **inferred from the harden-runner audit post-step output** ("Post Harden the runner" → `endpoint called … domain: X` lines) of the **10 most recent runs of each workflow** (all completed with conclusion `success`), taking the union of observed `domain:port` pairs per job. Nothing was added from memory.

Where the sampled endpoints were clearly just numbered or region/instance-specific variants of the same GitHub Actions / Azure infrastructure hostname pattern, those repeated concrete entries were collapsed into wildcard entries instead of being listed one by one.

### Sampled runs

**ci.yml** (10 runs, all with build-job audit data; 4 of them were `main` pushes that also ran the `package` job — 28797234706, 28797842777, 28799587271, 28802373956):
28802373956, 28802168946, 28799587271, 28799335372, 28797842777, 28797624673, 28797574569, 28797234706, 28797030662, 28795599767

**actionlint.yml**:
28791579209, 28777965024, 28776670323, 28776660411, 28776022862, 28767415145, 28767413652, 28671401190, 28670555264, 28548602130

**codeql.yml**:
28802374085, 28802168982, 28799585555, 28799336071, 28797842878, 28797624910, 28797574102, 28797235003, 28797031258, 28795598756

### Observations from the logs

- The task's usual CI suspects — `update.code.visualstudio.com` / VS Code download CDN and the Ubuntu apt mirrors — **do not appear in any of the 10 sampled CI runs**: `npm test` currently runs the Node.js unit-test runner (`scripts/run-node-unit-tests.js`, no VS Code download), and `apt-get install -y xvfb` is a no-op because xvfb is preinstalled on the runner image ("xvfb is already the newest version"). They are therefore intentionally not allowlisted; if the test setup changes to download VS Code again, the blocked endpoints will show up in the harden-runner insights and can be added.
- The CI build job's unit tests shell out to the Azure CLI / pwsh, which is why `management.azure.com`, `dc.services.visualstudio.com`, `azcliprod.blob.core.windows.net`, and `www.powershellgallery.com` were observed and allowlisted.
- `productionresultssa<N>.blob.core.windows.net` (Actions log/results storage) and the regional infra hosts are load-balanced across instances, so the repeated observed concrete hosts were collapsed to wildcard patterns where appropriate:
  - `productionresultssa*.blob.core.windows.net:443`
  - `run-actions-*-azure-eastus.actions.githubusercontent.com:443`
  - `hosted-compute-watchdog-prod-*.githubapp.com:443`
- `actionlint.yml` still uses only explicit entries because its sampled endpoints did not need the same wildcard consolidation.

## Caveat: endpoint misses surface as blocks

If a future run needs an endpoint not on the list (e.g. a new service family outside the current wildcard coverage, a different regional Actions infra host pattern, or a re-introduced VS Code download), harden-runner will **block** it and report it in the run annotations / StepSecurity insights (https://app.stepsecurity.io/github/rajbos/ai-engineering-fluency). Such misses can simply be appended to the corresponding `allowed-endpoints` list.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>