### PR TITLE
Fix Cloud Agent Sessions showing AI Credits ~1e9x too high (#1554)

### DIFF
--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -10,7 +10,7 @@ export interface AgentRepoSummary {
 	totalTasks: number;
 	/** Total cloud-agent sessions across all tasks. */
 	totalSessions: number;
-	/** Sum of usage.credits for all cloud-agent sessions (0 when unavailable). */
+	/** Sum of usage.credits (converted from nano-credits to whole AI credits) for all cloud-agent sessions (0 when unavailable). */
 	totalCredits: number;
 	/** How many tasks we fetched full details for (may be less than tasksTotal when capped). */
 	tasksScanned: number;
@@ -235,11 +235,18 @@ async function fetchAllTasksForRepo(
 	return { allTasks };
 }
 
+/**
+ * The GitHub agents API reports `usage.credits` in nano-credits (1 credit = 1_000_000_000 nano-credits),
+ * e.g. a task costing 43.38 AI credits is reported as `43380350000`. Divide by this factor to get the
+ * whole-credit value shown in the UI (where 1 credit = $0.01).
+ */
+const NANO_CREDITS_PER_CREDIT = 1_000_000_000;
+
 function sumCloudSessionCredits(sessions: any[]): { tasks: number; sessions: number; credits: number } {
 	const cloudSessions = sessions.filter(s => detectSessionSource(s) === 'cloud-agent');
 	if (cloudSessions.length === 0) { return { tasks: 0, sessions: 0, credits: 0 }; }
-	const credits = cloudSessions.reduce((sum, s) => sum + (s.usage && typeof s.usage.credits === 'number' ? s.usage.credits : 0), 0);
-	return { tasks: 1, sessions: cloudSessions.length, credits };
+	const rawCredits = cloudSessions.reduce((sum, s) => sum + (s.usage && typeof s.usage.credits === 'number' ? s.usage.credits : 0), 0);
+	return { tasks: 1, sessions: cloudSessions.length, credits: rawCredits / NANO_CREDITS_PER_CREDIT };
 }
 
 async function aggregateTaskDetails(

--- a/vscode-extension/test/unit/agentSessionsService.test.ts
+++ b/vscode-extension/test/unit/agentSessionsService.test.ts
@@ -39,9 +39,12 @@ function makeTask(id: string): any {
 	return { id, name: `Task ${id}`, state: 'completed', created_at: new Date().toISOString() };
 }
 
+/** GitHub's agents API reports usage.credits in nano-credits (1 credit = 1_000_000_000 nano-credits). */
+const NANO_CREDITS_PER_CREDIT = 1_000_000_000;
+
 function makeSession(model: string, credits?: number): any {
 	const s: any = { id: `s-${Math.random()}`, state: 'completed', model, created_at: new Date().toISOString() };
-	if (credits !== undefined) { s.usage = { credits, type: 'ai-credits' }; }
+	if (credits !== undefined) { s.usage = { credits: credits * NANO_CREDITS_PER_CREDIT, type: 'ai_credits' }; }
 	return s;
 }
 
@@ -87,6 +90,21 @@ test('fetchAgentSessionsForRepo: task with no cloud-agent sessions does not coun
 	const result = await fetchAgentSessionsForRepo('owner', 'repo', 'token', SINCE, fetchPage, fetchDetail);
 	assert.equal(result.totalTasks, 0);
 	assert.equal(result.totalSessions, 0);
+});
+
+test('fetchAgentSessionsForRepo: converts real-world nano-credit values to whole AI credits (issue #1554)', async () => {
+	const tasks = [makeTask('t1')];
+	const fetchPage: FetchTaskPageFn = async ({ page }) =>
+		page === 1 ? { tasks } : { tasks: [] };
+	const fetchDetail: FetchTaskDetailFn = async () => ({
+		sessions: [
+			// Raw value as observed from the live GitHub agents API (nano-credits).
+			{ id: 's1', state: 'completed', model: 'sweagent-capi:gpt-5.4', created_at: new Date().toISOString(), usage: { credits: 43380350000, type: 'ai_credits' } },
+		],
+	});
+	const result = await fetchAgentSessionsForRepo('owner', 'repo', 'token', SINCE, fetchPage, fetchDetail);
+	assert.equal(result.totalSessions, 1);
+	assert.ok(Math.abs(result.totalCredits - 43.38035) < 1e-9, `expected ~43.38 credits, got ${result.totalCredits}`);
 });
 
 test('fetchAgentSessionsForRepo: handles missing usage.credits gracefully', async () => {


### PR DESCRIPTION
## Root cause

GitHub's undocumented agents API (`/agents/repos/{owner}/{repo}/tasks/{id}`) reports `usage.credits` in **nano-credits** (1 credit = 1,000,000,000 nano-credits). For example, a task that actually cost 43.38 AI credits is reported as `43380350000`.

Verified against live data from this repo — every sampled completed cloud-agent session had a `usage.credits` value in the billions that divides cleanly to a plausible credit cost (7–43 credits) when divided by 1e9:

```json
"usage": { "credits": 43380350000, "type": "ai_credits" }
```

`vscode-extension/src/agentSessionsService.ts` summed this raw nano-credit value directly and displayed it as-is in the "AI Credits" stat on the Cloud Agent Sessions tab, producing exactly the kind of absurd number reported in the issue (`43380350000.0`).

## Fix

- Added `NANO_CREDITS_PER_CREDIT = 1_000_000_000` and divide the summed raw credits by it in `sumCloudSessionCredits()`.
- Updated `test/unit/agentSessionsService.test.ts` mock helper to scale credits the same way the real API does.
- Added a regression test using the exact raw value from the issue screenshot, asserting it converts to `~43.38` credits.

## Verification

- `npm run compile` (tsc + eslint + esbuild) — clean
- `npm run test:node` — all 78 test files pass, including the new regression test

Fixes #1554

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>