### PR TITLE
Fix: chart by output by repo is empty (#1553)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4159,7 +4159,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		await this.applyWindsurfBreakdown(sessionFilePath, resolvedModelUsage, dailyRollups, usageAnalysis);
 
-		const sessionData = this.buildSessionDataObject(tokenResult, interactions, resolvedModelUsage, mtime, fileSize, usageAnalysis, sessionMeta, resolvedActualTokens, finalCacheReadTokens, debugLogTokens, dailyRollups);
+		const sessionData = this.buildSessionDataObject(tokenResult, interactions, resolvedModelUsage, mtime, fileSize, usageAnalysis, sessionMeta, resolvedActualTokens, finalCacheReadTokens, debugLogTokens, dailyRollups, cached);
 		this.setCachedSessionData(sessionFilePath, sessionData, fileSize);
 		return sessionData;
 	}
@@ -4245,7 +4245,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		resolvedActualTokens: number | undefined,
 		finalCacheReadTokens: number | undefined,
 		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number; copilotNanoAiu?: number } | null | undefined,
-		dailyRollups: { [utcDayKey: string]: DailyRollupEntry }
+		dailyRollups: { [utcDayKey: string]: DailyRollupEntry },
+		existingCache?: SessionFileCache
 	): SessionFileCache {
 		const copilotNanoAiu = debugLogTokens?.copilotNanoAiu ?? tokenResult.copilotNanoAiu ?? 0;
 		const copilotExactCostDollars = copilotNanoAiu > 0 ? copilotNanoAiu * NANO_AIU_TO_DOLLARS : undefined;
@@ -4254,6 +4255,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tokens: tokenResult.tokens, interactions, modelUsage: resolvedModelUsage, mtime, size: fileSize,
 			usageAnalysis, title: sessionMeta.title, firstInteraction: sessionMeta.firstInteraction,
 			lastInteraction: sessionMeta.lastInteraction, actualTokens: resolvedActualTokens,
+			// Repository is discovered separately by getSessionFileDetails() (via content-reference
+			// git-root lookup) and is not recomputed here. Without preserving it, every cache-miss
+			// rebuild of this entry (e.g. an actively-edited session whose file keeps changing)
+			// would silently wipe out a previously-known repository, making it fall back to
+			// "Unknown" and disappear from all "By Repository" charts — most noticeably for the
+			// "Output" (lines of code) chart, since LOC is attributed to the most recently active
+			// day, which is exactly the day whose cache entry keeps getting rebuilt.
+			...(existingCache?.repository !== undefined ? { repository: existingCache.repository } : {}),
 			...optionals,
 		};
 	}


### PR DESCRIPTION
## Root cause

Fixes #1553.

The "Output" (lines-of-code) chart's **By Repository** split rendered empty because of a caching bug in `getSessionFileDataCached()`:

- The cache-miss rebuild path (`buildSessionDataObject`) never carried forward the previously-detected `repository` field for a session.
- Any time an actively-edited session file's mtime/size changed (i.e. exactly the sessions still generating new LOC data), its cache entry was rebuilt from scratch **without** `repository`, silently resetting it to `'Unknown'`.
- `chartDataBuilder.ts` filters out `'Unknown'` repositories from every "By Repository" dataset (tokens and output alike).
- LOC/output data is attributed to a session's most recently active day — exactly the data most likely to have just had its cache rebuilt this way — so the **Output by Repository** chart came up empty first and most visibly, while **Tokens by Repository** could still show stale-but-correct historic data from earlier, less-active sessions.

## Fix

Preserve the existing cache's `repository` value when rebuilding a session's cache entry in `buildSessionDataObject`, mirroring the existing preservation pattern already used for debug-log and LOC fields (`preserveExistingDebugLogFields` / `preserveExistingLocFields`).

## Verification

- Reproduced the bug end-to-end with `chartDataBuilder.buildChartData()` using synthetic per-repository LOC data — confirmed the data pipeline itself works correctly once `repository` is present, isolating the bug to the caching layer in `extension.ts`.
- `npx tsc --noEmit` — no errors.
- `npx eslint src ../src` — clean.
- `npm run test:node` — full unit test suite passes (no regressions).