### PR TITLE
chore: bump versions for release (vscode 0.12.4, cli 0.2.13)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bumps

This PR bumps version numbers for the two components that have changed since their last release tags.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.12.3 | v0.12.4 |
| CLI (`@rajbos/ai-engineering-fluency`) | v0.2.12 | v0.2.13 |

### What's in this release

**CLI (since `cli/v0.2.12`):**
- Kiro IDE and Kiro CLI added as separate tracked editors
- Shared extension/CLI code extracted into top-level `src/` folder
- CLI shared-logic contract test added; stale import paths fixed

**VS Code extension (since `vscode/v0.12.3`):**
- Kiro IDE and Kiro CLI support
- Fix: cloud agent AI credits shown ~1e9x too high (#1554)
- Fix: preserve session repository across cache-miss rebuilds
- Friendly tool names from issues #1534, #1557, #1560, #1561
- Dependency updates (ovsx 1.0.2, @azure/arm-storage, @types/node, minor/patch group)

### After merging, run these releases:

1. **VS Code extension** — Actions → *Extensions - Release* (`release.yml`) → Run workflow on `main` with `vscode_only=true`, `create_tag=true`, `publish_marketplace=true`
2. **CLI** — do **not** use workflow_dispatch (it re-bumps the version). Push the tag instead:
   ```bash
   git fetch origin main
   git tag -a cli/v0.2.13 origin/main -m "Release cli/v0.2.13"
   git push origin cli/v0.2.13
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)