### PR TITLE
fix: bump engines.vscode to match @types/vscode 1.125.0

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.125.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The VS Code extension release build (v0.12.4) failed at the `vsce package` step:

```
##[error]@types/vscode 1.125.0 greater than engines.vscode ^1.110.0. Either upgrade engines.vscode or use an older @types/vscode version
```

Run: https://github.com/rajbos/ai-engineering-fluency/actions/runs/28978602481/job/85991719213

## Cause

A prior dependency-update commit (`19b68766`) bumped the `@types/vscode` devDependency to `1.125.0` without bumping the `engines.vscode` field, which `vsce` requires to stay in lockstep (major.minor).

## Fix

Bump `engines.vscode` from `^1.110.0` to `^1.125.0`, matching the pattern used previously in this repo (commit `c1581072`, "fix dependency versions").

Verified locally by calling vsce's own `validateVSCodeTypesCompatibility` check directly with the new value — it now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)