### PR TITLE
Fix non-Copilot sessions inflating estimated GitHub Copilot spend

### DIFF
--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -1,17 +1,10 @@
 import type { DailyTokenStats, ChartDataPayload, ModelUsage, LanguageUsage } from './types';
-import { addModelUsage } from './statsHelpers';
+import { addModelUsage, COPILOT_EDITOR_NAMES } from './statsHelpers';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 
-/**
- * Editor display names that bill through GitHub Copilot's AI-Credit system.
- * Sessions from these editors should use `copilotPricing` when computing costs.
- * All other editors are billed directly by their own provider (use `provider` pricing).
- */
-export const COPILOT_EDITOR_NAMES = new Set([
-	'VS Code', 'VS Code Insiders', 'VS Code Exploration',
-	'VS Code Server', 'VS Code Server (Insiders)', 'VSCodium',
-	'Visual Studio', 'JetBrains', 'Copilot CLI', 'MS Scout (Copilot CLI)',
-]);
+// Re-exported for existing consumers; the set lives in statsHelpers so the
+// period accumulator can use it without a circular import.
+export { COPILOT_EDITOR_NAMES } from './statsHelpers';
 
 /** Returns the pricing source to use for cost estimation for a given editor. */
 function getPricingSourceForEditor(editor: string): 'provider' | 'copilot' {

--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -9,6 +9,17 @@ import type { ModelUsage, EditorUsage, DailyTokenStats, SessionFileCache, Langua
 import { toLocalDayKey } from './utils/dayKeys';
 
 /**
+ * Editor display names that bill through GitHub Copilot's AI-Credit system.
+ * Sessions from these editors should use `copilotPricing` when computing costs.
+ * All other editors are billed directly by their own provider (use `provider` pricing).
+ */
+export const COPILOT_EDITOR_NAMES = new Set([
+	'VS Code', 'VS Code Insiders', 'VS Code Exploration',
+	'VS Code Server', 'VS Code Server (Insiders)', 'VSCodium',
+	'Visual Studio', 'JetBrains', 'Copilot CLI', 'MS Scout (Copilot CLI)',
+]);
+
+/**
  * Computes a session's total token count from input, output, and thinking tokens.
  *
  * Cached (cache-read) tokens are deliberately excluded: they are already a
@@ -316,7 +327,7 @@ editorUsage: EditorUsage;
 editorModelUsage: { [editor: string]: ModelUsage };
 /** Sum of exact Copilot billing costs (in USD) for sessions that have nanoAiu data. */
 exactCopilotCostDollars: number;
-/** Model usage for sessions that do NOT have exact nanoAiu billing data (used as fallback for Copilot cost estimate). */
+/** Model usage for Copilot-surface sessions that do NOT have exact nanoAiu billing data (used as fallback for Copilot cost estimate). Non-Copilot surfaces (Claude Code, Gemini CLI, …) are excluded — they bill their own provider. */
 modelUsageNoExact: ModelUsage;
 }
 
@@ -384,7 +395,10 @@ function accumulatePeriod(acc: PeriodAccumulator, tokens: number, estimated: num
 	addModelUsage(acc.editorModelUsage[editorType], modelUsage);
 	if (copilotExactCostDollars !== undefined) {
 		acc.exactCopilotCostDollars += copilotExactCostDollars;
-	} else {
+	} else if (COPILOT_EDITOR_NAMES.has(editorType)) {
+		// Only Copilot surfaces feed the Copilot cost-estimate fallback; sessions from
+		// other tools (Claude Code, Gemini CLI, …) bill their own provider and would
+		// otherwise inflate the estimated GitHub Copilot spend.
 		addModelUsage(acc.modelUsageNoExact, modelUsage);
 	}
 }

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -833,3 +833,70 @@ sessionData: makeSession({ tokens: 100, actualTokens: 180, interactions: 1 }),
 const result = aggregatePeriodStats([input], ranges);
 assert.equal(result.todayStats.tokens, 180, 'no cacheReadTokens → actualTokens only');
 });
+
+// ── modelUsageNoExact – Copilot cost-estimate fallback attribution ───────────
+
+test('modelUsageNoExact: Copilot-surface session without exact billing is included', () => {
+const ranges = makeRanges('2025-03-15');
+const usage: ModelUsage = { 'gpt-4.1': { inputTokens: 100, outputTokens: 50 } };
+const input: SessionAggregateInput = {
+editorType: 'VS Code',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+lastInteraction: '2025-03-15T10:00:00.000Z',
+sessionData: makeSession({ modelUsage: usage, interactions: 1 }),
+};
+const result = aggregatePeriodStats([input], ranges);
+assert.deepEqual(result.monthStats.modelUsageNoExact['gpt-4.1'], { inputTokens: 100, outputTokens: 50 });
+assert.equal(result.monthStats.exactCopilotCostDollars, 0);
+});
+
+test('modelUsageNoExact: non-Copilot session does not leak into the Copilot cost estimate (regression)', () => {
+// Claude Code sessions bill Anthropic directly. Before the fix they landed in
+// modelUsageNoExact and were priced at Copilot AI-Credit rates, inflating the
+// "GitHub Copilot" monthly spend far beyond actual Copilot usage.
+const ranges = makeRanges('2025-03-15');
+const usage: ModelUsage = { 'claude-fable-5': { inputTokens: 1_000_000, outputTokens: 500_000 } };
+const input: SessionAggregateInput = {
+editorType: 'Claude Code',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+lastInteraction: '2025-03-15T10:00:00.000Z',
+sessionData: makeSession({ modelUsage: usage, interactions: 1 }),
+};
+const result = aggregatePeriodStats([input], ranges);
+assert.deepEqual(result.monthStats.modelUsageNoExact, {}, 'Claude Code usage must not feed the Copilot estimate');
+assert.deepEqual(result.todayStats.modelUsageNoExact, {});
+assert.deepEqual(result.last30DaysStats.modelUsageNoExact, {});
+assert.deepEqual(result.monthStats.modelUsage['claude-fable-5'], { inputTokens: 1_000_000, outputTokens: 500_000 }, 'still counted in overall model usage');
+assert.equal(result.monthStats.editorModelUsage['Claude Code']['claude-fable-5'].inputTokens, 1_000_000, 'still attributed to its billing group via editorModelUsage');
+});
+
+test('modelUsageNoExact: Copilot-surface session with exact nanoAiu billing uses the exact cost instead', () => {
+const ranges = makeRanges('2025-03-15');
+const usage: ModelUsage = { 'gpt-4.1': { inputTokens: 100, outputTokens: 50 } };
+const input: SessionAggregateInput = {
+editorType: 'VS Code',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+lastInteraction: '2025-03-15T10:00:00.000Z',
+sessionData: makeSession({ modelUsage: usage, interactions: 1, copilotExactCostDollars: 1.25 }),
+};
+const result = aggregatePeriodStats([input], ranges);
+assert.equal(result.monthStats.exactCopilotCostDollars, 1.25);
+assert.deepEqual(result.monthStats.modelUsageNoExact, {}, 'exact-billed sessions are excluded from the estimate fallback');
+});
+
+test('modelUsageNoExact: rollup path – non-Copilot rollup days are excluded, Copilot days included', () => {
+const ranges = makeRanges('2025-03-15');
+const usage: ModelUsage = { 'gemini-2.5-pro': { inputTokens: 300, outputTokens: 100 } };
+const input: SessionAggregateInput = {
+editorType: 'Gemini CLI',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+sessionData: makeSession({
+dailyRollups: {
+'2025-03-15': { tokens: 400, actualTokens: 0, thinkingTokens: 0, interactions: 1, modelUsage: usage },
+},
+}),
+};
+const result = aggregatePeriodStats([input], ranges);
+assert.deepEqual(result.monthStats.modelUsageNoExact, {}, 'Gemini CLI rollup must not feed the Copilot estimate');
+assert.deepEqual(result.monthStats.modelUsage['gemini-2.5-pro'], { inputTokens: 300, outputTokens: 100 });
+});


### PR DESCRIPTION
## What changed

`accumulatePeriod` in `src/statsHelpers.ts` added **every** session lacking exact nanoAiu billing data to `modelUsageNoExact` — the fallback bucket that gets priced at Copilot AI-Credit rates to produce the estimated GitHub Copilot spend (`estimatedCostCopilot`). Claude Code, Gemini CLI, Kiro, and other non-Copilot sessions never carry nanoAiu data, so all of their usage landed in that bucket and was reported as GitHub Copilot cost.

The guard now only feeds `modelUsageNoExact` when the session comes from a Copilot surface (`COPILOT_EDITOR_NAMES`).

## Why

With heavy Claude Code usage, the status bar tooltip showed **GitHub Copilot $686.04 / $700.00 (98%)** for the current month — turning the status bar red — while the Copilot API reported under $100 of actual usage. The same Anthropic usage was simultaneously double-counted in the "Anthropic" billing-group row (rows summed to ~$1,290 against a $686 month total). The "Estimated cost (UBB)" tooltip line and the budget-based status bar background color (`updateStatusBarBackgroundColor`) all derive from the same inflated value.

The per-day "By Provider" chart was already correct (it attributes per editor/model via `getBillingGroup`), which is why the chart and the tooltip contradicted each other.

## Notes for reviewers

- `COPILOT_EDITOR_NAMES` moved from `chartDataBuilder.ts` to `statsHelpers.ts` and is re-exported from its old location, so existing imports are untouched. The move avoids a circular import — `chartDataBuilder` already imports from `statsHelpers`.
- Non-Copilot usage is still fully counted in overall totals, `modelUsage`, and `editorModelUsage` (which drives the billing-group rows); it is only excluded from the Copilot cost-estimate fallback.
- Four new unit tests cover both aggregation paths (rollup and session-level fallback): non-Copilot sessions stay out of `modelUsageNoExact`, Copilot sessions without exact billing still enter it, and exact-billed sessions use the exact dollars instead.
- Follow-up worth considering: the tooltip label "Estimated cost (UBB)" now means Copilot-only cost, so it may deserve a clearer label (e.g. "Copilot est. cost (UBB)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)