### PR TITLE
chore: bump vscode extension version for release (0.12.5)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bump

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.12.4 | v0.12.5 |

### What's in this release

- Fix: non-Copilot sessions (Claude Code, Gemini CLI, etc.) were being priced at Copilot AI-Credit rates and inflating estimated GitHub Copilot spend (e.g. showing $686/mo vs. the real <$100), while also double-counting that usage in the Anthropic billing-group row (#1566)

### After merging, run:

- **Extensions - Release** (`release.yml`) → Run workflow on `main` with `vscode_only=true`, `create_tag=true`, `publish_marketplace=true`

```bash
gh workflow run "Extensions - Release" --ref main \
  -f create_tag=true -f publish_marketplace=true -f vscode_only=true -f vs_only=false -f publish_pre_release=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)