### PR TITLE
Bump VS Code extension to v0.13.0 (minor)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the VS Code extension will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-11
+
+### Features
+- Long-context pricing discovery, insights, and Context Window section
+- Added friendly tool names from multiple community issues (#1571, #1573, #1577, #1581)
+- Clarified provider cost tooltip: unified budget/spend bars, add totals
+
+### Bug Fixes
+- Use notifier's real pricing data instead of hardcoded 0.00 stubs
+
 ## [0.11.6] - 2026-06-07
 
 ### Features

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.12.5",
+      "version": "0.13.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Summary
Minor version bump for the VS Code extension: **0.12.5 → 0.13.0**.

- Bumped `vscode-extension/package.json` and `package-lock.json` via `npm version minor`
- Added CHANGELOG entry summarizing changes since `vscode/v0.12.5`
- No other components (cli, visualstudio-extension, jetbrains-plugin) were touched
- `npm run compile` (tsc + eslint + esbuild) passes clean

## After merge
Run the **Extensions - Release** workflow (`release.yml`) on `main` with:
- `vscode_only: true`
- `publish_marketplace: true`
- `create_tag: true`

This will publish VS Code extension v0.13.0 to the Marketplace and create tag `vscode/v0.13.0`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>