### PR TITLE
feat(details): hero summary cards, grouped metrics, plan badge

### DIFF
--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -384,7 +384,7 @@ function buildSummaryCards(stats: DetailedStats): HTMLElement {
 	return cards;
 }
 
-type MetricGroup = { heading: string; accent: string; rows: MetricRow[] };
+type MetricGroup = { heading: string; rows: MetricRow[] };
 
 function buildMetricsGroups(stats: DetailedStats, projections: Projections): MetricGroup[] {
 	const tokenRows: MetricRow[] = [
@@ -405,22 +405,19 @@ function buildMetricsGroups(stats: DetailedStats, projections: Projections): Met
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), month: formatCompact(stats.month.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' },
 	];
 	return [
-		{ heading: '🔢 Tokens', accent: '#c37bff', rows: tokenRows },
-		{ heading: '💰 Cost', accent: '#7ce38b', rows: costRows },
-		{ heading: '💬 Activity', accent: '#66aaff', rows: activityRows },
+		{ heading: '🔢 Tokens', rows: tokenRows },
+		{ heading: '💰 Cost', rows: costRows },
+		{ heading: '💬 Activity', rows: activityRows },
 	];
 }
 
 /** Builds a non-sortable separator row that labels a group of metric rows. */
-function buildGroupHeaderRow(label: string, accent: string): HTMLTableRowElement {
+function buildGroupHeaderRow(label: string): HTMLTableRowElement {
 	const tr = document.createElement('tr');
 	tr.className = 'group-row';
 	const td = document.createElement('td');
 	td.colSpan = 6;
-	td.style.borderLeftColor = accent;
-	const labelSpan = el('span', 'group-label', label);
-	labelSpan.style.color = accent;
-	td.append(labelSpan);
+	td.textContent = label;
 	tr.append(td);
 	return tr;
 }
@@ -448,7 +445,7 @@ thead.append(headerRow);
 table.append(thead);
 const tbody = document.createElement('tbody');
 buildMetricsGroups(stats, projections).forEach(group => {
-tbody.append(buildGroupHeaderRow(group.heading, group.accent));
+tbody.append(buildGroupHeaderRow(group.heading));
 group.rows.forEach(row => {
 const tr = document.createElement('tr');
 tr.append(buildMetricLabelCell(row.icon, row.label, row.color, row.labelTooltip), buildValueCell(row.today), buildValueCell(row.last30Days), buildValueCell(row.month), buildValueCell(row.lastMonth), buildValueCell(row.projected));

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -384,7 +384,7 @@ function buildSummaryCards(stats: DetailedStats): HTMLElement {
 	return cards;
 }
 
-type MetricGroup = { heading: string; rows: MetricRow[] };
+type MetricGroup = { heading: string; accent: string; rows: MetricRow[] };
 
 function buildMetricsGroups(stats: DetailedStats, projections: Projections): MetricGroup[] {
 	const tokenRows: MetricRow[] = [
@@ -405,19 +405,22 @@ function buildMetricsGroups(stats: DetailedStats, projections: Projections): Met
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), month: formatCompact(stats.month.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' },
 	];
 	return [
-		{ heading: '🔢 Tokens', rows: tokenRows },
-		{ heading: '💰 Cost', rows: costRows },
-		{ heading: '💬 Activity', rows: activityRows },
+		{ heading: '🔢 Tokens', accent: '#c37bff', rows: tokenRows },
+		{ heading: '💰 Cost', accent: '#7ce38b', rows: costRows },
+		{ heading: '💬 Activity', accent: '#66aaff', rows: activityRows },
 	];
 }
 
 /** Builds a non-sortable separator row that labels a group of metric rows. */
-function buildGroupHeaderRow(label: string): HTMLTableRowElement {
+function buildGroupHeaderRow(label: string, accent: string): HTMLTableRowElement {
 	const tr = document.createElement('tr');
 	tr.className = 'group-row';
 	const td = document.createElement('td');
 	td.colSpan = 6;
-	td.textContent = label;
+	td.style.borderLeftColor = accent;
+	const labelSpan = el('span', 'group-label', label);
+	labelSpan.style.color = accent;
+	td.append(labelSpan);
 	tr.append(td);
 	return tr;
 }
@@ -445,7 +448,7 @@ thead.append(headerRow);
 table.append(thead);
 const tbody = document.createElement('tbody');
 buildMetricsGroups(stats, projections).forEach(group => {
-tbody.append(buildGroupHeaderRow(group.heading));
+tbody.append(buildGroupHeaderRow(group.heading, group.accent));
 group.rows.forEach(row => {
 const tr = document.createElement('tr');
 tr.append(buildMetricLabelCell(row.icon, row.label, row.color, row.labelTooltip), buildValueCell(row.today), buildValueCell(row.last30Days), buildValueCell(row.month), buildValueCell(row.lastMonth), buildValueCell(row.projected));

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -260,7 +260,12 @@ style.textContent = styles;
 
 const container = el('div', 'container');
 const header = el('div', 'header');
-const title = el('div', 'title', 'AI Engineering Fluency');
+const headerLeft = el('div', 'header-left');
+headerLeft.append(el('div', 'title', 'AI Engineering Fluency'));
+const planBadge = buildPlanBadge(stats);
+if (planBadge) {
+headerLeft.append(planBadge);
+}
 const buttonRow = el('div', 'button-row');
 
 buttonRow.append(
@@ -275,7 +280,7 @@ if (stats.backendConfigured) {
 buttonRow.append(createButton(BUTTONS['btn-dashboard']));
 }
 
-header.append(title, buttonRow);
+header.append(headerLeft, buttonRow);
 
 const footer = el('div', 'footer', `Last updated: ${lastUpdated.toLocaleString()} · Updates every 5 minutes`);
 
@@ -284,6 +289,8 @@ const sections = el('div', 'sections');
 const isEmptyState = (stats.today.tokens ?? 0) === 0 && (stats.last30Days.tokens ?? 0) === 0 && (stats.lastMonth.tokens ?? 0) === 0;
 if (isEmptyState) {
 sections.append(buildEmptyStateSection());
+} else {
+sections.append(buildSummaryCards(stats));
 }
 
 sections.append(buildMetricsSection(stats, projections));
@@ -343,15 +350,44 @@ function buildCachedTokenRow(stats: DetailedStats): MetricRow[] {
 	return [{ label: 'Cached tokens', labelTooltip: 'Cache-read tokens — already included in "Input tokens" above, shown separately because they are billed at a lower rate.', icon: '⚡', color: '#34d399', today: formatCompact(stats.today.cachedTokens || 0), last30Days: formatCompact(stats.last30Days.cachedTokens || 0), month: formatCompact(stats.month.cachedTokens || 0), lastMonth: formatCompact(stats.lastMonth.cachedTokens || 0), projected: '—' }];
 }
 
-function buildCopilotPlanRow(stats: DetailedStats): MetricRow[] {
-	if (!stats.copilotPlan) { return []; }
+/**
+ * Renders the active Copilot plan as a small badge shown under the header
+ * title (plan name + monthly credits) instead of a metrics-table row.
+ */
+function buildPlanBadge(stats: DetailedStats): HTMLElement | null {
+	if (!stats.copilotPlan) { return null; }
 	const plan = stats.copilotPlan;
 	const credits = plan.monthlyAiCreditsUsd > 0 ? `$${plan.monthlyAiCreditsUsd} credits/month` : 'no credits';
-	return [{ label: `${plan.planName} (${credits})`, labelTooltip: `Your active GitHub Copilot subscription plan (ID: ${plan.planId}). Included AI credits cover usage-based billing (1 AI credit = $0.01).`, icon: '🏷️', color: '#60a5fa', today: '—', last30Days: '—', month: '—', lastMonth: '—', projected: '—' }];
+	const badge = el('div', 'plan-badge', `🏷️ ${plan.planName} · ${credits}`);
+	badge.title = `Your active GitHub Copilot subscription plan (ID: ${plan.planId}). Included AI credits cover usage-based billing (1 AI credit = $0.01).`;
+	return badge;
 }
 
-function buildMetricsRows(stats: DetailedStats, projections: Projections): MetricRow[] {
-	const rows: MetricRow[] = [
+/** Creates a single summary card (label above value), matching the chart webview pattern. */
+function buildCard(id: string, label: string, value: string): HTMLElement {
+	const card = el('div', 'card');
+	card.id = id;
+	card.append(el('div', 'card-label', label), el('div', 'card-value', value));
+	return card;
+}
+
+/** Builds the row of hero summary cards shown above the metrics table. */
+function buildSummaryCards(stats: DetailedStats): HTMLElement {
+	const cards = el('div', 'cards');
+	cards.id = 'summary-cards';
+	cards.append(
+		buildCard('card-today-tokens', '📅 Tokens Today', totalTokenCell(stats.today)),
+		buildCard('card-30d-tokens', '📈 Tokens Last 30 Days', totalTokenCell(stats.last30Days)),
+		buildCard('card-month-cost', '💰 Est. Cost This Month (UBB)', formatCost(stats.month.estimatedCostCopilot ?? 0)),
+		buildCard('card-today-sessions', '📂 Sessions Today', formatNumber(stats.today.sessions)),
+	);
+	return cards;
+}
+
+type MetricGroup = { heading: string; rows: MetricRow[] };
+
+function buildMetricsGroups(stats: DetailedStats, projections: Projections): MetricGroup[] {
+	const tokenRows: MetricRow[] = [
 		{ label: 'Total tokens', labelTooltip: 'All LLM API tokens counted across every call in this period — matches the status bar. When debug logs are available this is the definitive total; otherwise it falls back to per-model attribution or the text-based estimate.', icon: '🟣', color: '#c37bff', today: totalTokenCell(stats.today), last30Days: totalTokenCell(stats.last30Days), month: totalTokenCell(stats.month), lastMonth: totalTokenCell(stats.lastMonth), projected: formatCompact(projections.projectedTokens) },
 		{ label: 'Input tokens', labelTooltip: 'Total prompt tokens sent to the model, including any cache-read tokens (shown separately below).', icon: '⬆️', color: '#c37bff', today: inputTokenCell(stats.today), last30Days: inputTokenCell(stats.last30Days), month: inputTokenCell(stats.month), lastMonth: inputTokenCell(stats.lastMonth), projected: '—' },
 		{ label: 'Output tokens', icon: '⬇️', color: '#c37bff', today: outputTokenCell(stats.today), last30Days: outputTokenCell(stats.last30Days), month: outputTokenCell(stats.month), lastMonth: outputTokenCell(stats.lastMonth), projected: '—' },
@@ -359,13 +395,31 @@ function buildMetricsRows(stats: DetailedStats, projections: Projections): Metri
 		{ label: 'Tokens (user estimated)', icon: '📝', color: '#b39ddb', today: formatCompact(stats.today.estimatedTokens), last30Days: formatCompact(stats.last30Days.estimatedTokens), month: formatCompact(stats.month.estimatedTokens), lastMonth: formatCompact(stats.lastMonth.estimatedTokens), projected: '—' },
 		{ label: 'Service overhead %', icon: '☁️', color: '#90a4ae', today: serviceOverheadPct(stats.today), last30Days: serviceOverheadPct(stats.last30Days), month: serviceOverheadPct(stats.month), lastMonth: serviceOverheadPct(stats.lastMonth), projected: '—' },
 		{ label: 'Thinking tokens', icon: '🧠', color: '#a78bfa', today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), month: formatCompact(stats.month.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: '—' },
+	];
+	const costRows: MetricRow[] = [
 		{ label: 'Estimated cost (UBB)', labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. UBB = Usage Based Billing.', icon: '🟢', color: '#7ce38b', today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), month: formatCost(stats.month.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) },
-		...buildCopilotPlanRow(stats),
+	];
+	const activityRows: MetricRow[] = [
 		{ label: 'Sessions', icon: '📂', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), month: formatNumber(stats.month.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
 		{ label: 'Average interactions/session', icon: '💬', color: '#8ce0ff', today: formatNumber(stats.today.avgInteractionsPerSession), last30Days: formatNumber(stats.last30Days.avgInteractionsPerSession), month: formatNumber(stats.month.avgInteractionsPerSession), lastMonth: formatNumber(stats.lastMonth.avgInteractionsPerSession), projected: '—' },
 		{ label: 'Average tokens/session', icon: '🔢', color: '#7ce38b', today: formatCompact(stats.today.avgTokensPerSession), last30Days: formatCompact(stats.last30Days.avgTokensPerSession), month: formatCompact(stats.month.avgTokensPerSession), lastMonth: formatCompact(stats.lastMonth.avgTokensPerSession), projected: '—' },
 	];
-	return rows;
+	return [
+		{ heading: '🔢 Tokens', rows: tokenRows },
+		{ heading: '💰 Cost', rows: costRows },
+		{ heading: '💬 Activity', rows: activityRows },
+	];
+}
+
+/** Builds a non-sortable separator row that labels a group of metric rows. */
+function buildGroupHeaderRow(label: string): HTMLTableRowElement {
+	const tr = document.createElement('tr');
+	tr.className = 'group-row';
+	const td = document.createElement('td');
+	td.colSpan = 6;
+	td.textContent = label;
+	tr.append(td);
+	return tr;
 }
 
 function buildMetricsSection(
@@ -373,7 +427,7 @@ stats: DetailedStats,
 projections: Projections
 ): HTMLElement {
 const section = el('div', 'section');
-section.append(el('h3', '', 'AI Engineering Fluency'));
+section.append(el('h3', '', '📊 Key Metrics'));
 const table = document.createElement('table');
 table.className = 'stats-table';
 const thead = document.createElement('thead');
@@ -390,10 +444,13 @@ headerRow.append(th);
 thead.append(headerRow);
 table.append(thead);
 const tbody = document.createElement('tbody');
-buildMetricsRows(stats, projections).forEach(row => {
+buildMetricsGroups(stats, projections).forEach(group => {
+tbody.append(buildGroupHeaderRow(group.heading));
+group.rows.forEach(row => {
 const tr = document.createElement('tr');
 tr.append(buildMetricLabelCell(row.icon, row.label, row.color, row.labelTooltip), buildValueCell(row.today), buildValueCell(row.last30Days), buildValueCell(row.month), buildValueCell(row.lastMonth), buildValueCell(row.projected));
 tbody.append(tr);
+});
 });
 table.append(tbody);
 section.append(table);

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -145,8 +145,8 @@ body {
 }
 
 .stats-table tr.group-row td {
-	background: var(--bg-tertiary);
-	color: var(--text-primary);
+	background: var(--list-hover-bg);
+	color: var(--text-secondary);
 	font-size: 12px;
 	font-weight: 700;
 	text-transform: uppercase;

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -145,13 +145,19 @@ body {
 }
 
 .stats-table tr.group-row td {
-	background: var(--list-hover-bg);
-	color: var(--text-secondary);
-	font-size: 11px;
+	background: var(--bg-tertiary);
+	font-size: 12.5px;
 	font-weight: 700;
 	text-transform: uppercase;
-	letter-spacing: 0.4px;
-	padding: 6px 12px;
+	letter-spacing: 1px;
+	padding: 8px 12px;
+	border-left: 3px solid var(--text-secondary);
+	border-bottom: 1px solid var(--border-subtle);
+}
+
+/* Breathing room above each group after the first, so groups read as blocks */
+.stats-table tbody tr.group-row:not(:first-child) td {
+	border-top: 10px solid var(--bg-primary);
 }
 
 .metric-label {

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -145,19 +145,20 @@ body {
 }
 
 .stats-table tr.group-row td {
-	background: transparent;
-	color: var(--text-muted);
-	font-size: 11px;
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	font-size: 12px;
 	font-weight: 700;
 	text-transform: uppercase;
-	letter-spacing: 1.5px;
-	padding: 14px 12px 6px;
-	border-bottom: 1px solid var(--border-subtle);
+	letter-spacing: 1px;
+	padding: 8px 12px;
+	border-top: 1px solid var(--border-color);
+	border-bottom: 1px solid var(--border-color);
 }
 
-/* First group sits right under the table header, no extra lead-in */
+/* First group sits right under the table header, no extra top rule needed */
 .stats-table tbody tr.group-row:first-child td {
-	padding-top: 6px;
+	border-top: none;
 }
 
 .metric-label {

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -145,19 +145,19 @@ body {
 }
 
 .stats-table tr.group-row td {
-	background: var(--bg-tertiary);
-	font-size: 12.5px;
+	background: transparent;
+	color: var(--text-muted);
+	font-size: 11px;
 	font-weight: 700;
 	text-transform: uppercase;
-	letter-spacing: 1px;
-	padding: 8px 12px;
-	border-left: 3px solid var(--text-secondary);
+	letter-spacing: 1.5px;
+	padding: 14px 12px 6px;
 	border-bottom: 1px solid var(--border-subtle);
 }
 
-/* Breathing room above each group after the first, so groups read as blocks */
-.stats-table tbody tr.group-row:not(:first-child) td {
-	border-top: 10px solid var(--bg-primary);
+/* First group sits right under the table header, no extra lead-in */
+.stats-table tbody tr.group-row:first-child td {
+	padding-top: 6px;
 }
 
 .metric-label {

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -22,6 +22,12 @@ body {
 	padding-bottom: 4px;
 }
 
+.header-left {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
 .title {
 	display: flex;
 	align-items: center;
@@ -29,6 +35,48 @@ body {
 	font-size: 16px;
 	font-weight: 700;
 	color: var(--text-primary);
+}
+
+.plan-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	align-self: flex-start;
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-subtle);
+	border-radius: 999px;
+	padding: 2px 10px;
+	font-size: 11px;
+	color: var(--text-secondary);
+	cursor: help;
+}
+
+.cards {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	gap: 10px;
+	text-align: center;
+}
+
+.card {
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-color);
+	border-radius: 10px;
+	padding: 12px;
+	box-shadow: 0 4px 10px var(--shadow-color);
+	text-align: center;
+}
+
+.card-label {
+	color: var(--text-secondary);
+	font-size: 11px;
+	margin-bottom: 6px;
+}
+
+.card-value {
+	color: var(--text-primary);
+	font-size: 18px;
+	font-weight: 700;
 }
 
 
@@ -94,6 +142,16 @@ body {
 .stats-table th.align-right,
 .stats-table td.align-right {
 	text-align: right;
+}
+
+.stats-table tr.group-row td {
+	background: var(--list-hover-bg);
+	color: var(--text-secondary);
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	padding: 6px 12px;
 }
 
 .metric-label {


### PR DESCRIPTION
## What

Redesigns the VS Code extension's **Details** webview for better visual hierarchy:

- **Hero summary cards** at the top of the view: Today tokens, Last 30 Days tokens, Current-month estimated cost (UBB), and Today's sessions — reusing the card pattern from the Chart view.
- **Copilot plan as a badge**: the plan row previously sat inside the metrics table with five empty `—` cells; it now renders as a compact badge under the header (tooltip preserved).
- **Grouped metrics table**: rows are grouped into Tokens / Cost / Activity blocks with subtle separator rows instead of one interleaved list.
- **Deduplicated heading**: the first section was titled "AI Engineering Fluency", identical to the panel header; it now reads "Key Metrics".

## Scope

Only `vscode-extension/src/webview/details/main.ts` and its `styles.css` (+126/−11). No host-side, shared-src, or data changes; empty state, editor/model tables, sorting, and `updateStats` message handling are untouched.

## Verification

- `npm run compile` (tsc + eslint + esbuild) clean
- `npm run test:node` passing
- Manually tested in the Extension Development Host

## Notes

Part of a UI review that produced three sibling branches (`ui/sidebar-navigation`, `ui/consistent-nav`, `ui/recent-sessions`) — kept separate on purpose; this PR contains only the Details view changes. The `sync-host-views` skill should flag nothing here since no views were added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)