### PR TITLE
feat(webviews): consistent navigation across all panels

### DIFF
--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck // Chart.js ESM bundle is loaded dynamically; skip CJS resolution noise
 import { el, createButton } from '../shared/domUtils';
-import { BUTTONS } from '../shared/buttonConfig';
+import { getNavButtons } from '../shared/buttonConfig';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import { getCurrentPeriodFraction, computeProjectionExtra } from './projectionUtils';
@@ -216,12 +216,7 @@ function buildChartHeader(data: InitialChartData): HTMLElement {
 	title.id = 'chart-title';
 	headerLeft.append(el('span', 'header-icon', '📈'), title);
 	const buttons = el('div', 'button-row');
-	buttons.append(
-		createButton(BUTTONS['btn-refresh']), createButton(BUTTONS['btn-details']),
-		createButton(BUTTONS['btn-usage']), createButton(BUTTONS['btn-environmental']),
-		createButton(BUTTONS['btn-diagnostics']), createButton(BUTTONS['btn-maturity']),
-	);
-	if (data.backendConfigured) { buttons.append(createButton(BUTTONS['btn-dashboard'])); }
+	buttons.append(...getNavButtons('btn-chart', !!data.backendConfigured).map(config => createButton(config)));
 	header.append(headerLeft, buttons);
 	return header;
 }

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -2,7 +2,7 @@
 import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
 import { getEditorIcon, getCharsPerToken, formatFixed, formatPercent, formatNumber, formatCost, formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { el, createButton } from '../shared/domUtils';
-import { BUTTONS } from '../shared/buttonConfig';
+import { getNavButtons } from '../shared/buttonConfig';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
@@ -268,17 +268,7 @@ headerLeft.append(planBadge);
 }
 const buttonRow = el('div', 'button-row');
 
-buttonRow.append(
-createButton(BUTTONS['btn-refresh']),
-createButton(BUTTONS['btn-chart']),
-createButton(BUTTONS['btn-usage']),
-createButton(BUTTONS['btn-environmental']),
-createButton(BUTTONS['btn-diagnostics']),
-createButton(BUTTONS['btn-maturity']),
-);
-if (stats.backendConfigured) {
-buttonRow.append(createButton(BUTTONS['btn-dashboard']));
-}
+buttonRow.append(...getNavButtons('btn-details', !!stats.backendConfigured).map(config => createButton(config)));
 
 header.append(headerLeft, buttonRow);
 

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1,5 +1,5 @@
 // Diagnostics Report webview with tabbed interface
-import { buttonHtml } from "../shared/buttonConfig";
+import { navButtonsHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
 import { escapeHtml, formatFileSize, getTimeSince, getEditorIcon } from "../shared/formatUtils";
 import { createViewStateManager } from "../shared/viewState";
@@ -2271,13 +2271,7 @@ function buildDiagRootHtml(
 <span class="header-title">Diagnostic Report</span>
 </div>
 <div class="button-row">
-${buttonHtml("btn-refresh")}
-${buttonHtml("btn-details")}
-${buttonHtml("btn-chart")}
-${buttonHtml("btn-usage")}
-${buttonHtml("btn-environmental")}
-${buttonHtml("btn-maturity")}
-${data?.backendConfigured ? buttonHtml("btn-dashboard") : ""}
+${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
 </div>
 </div>
 

--- a/vscode-extension/src/webview/environmental/main.ts
+++ b/vscode-extension/src/webview/environmental/main.ts
@@ -1,6 +1,6 @@
 // Environmental Impact webview
 import { el, createButton } from '../shared/domUtils';
-import { BUTTONS } from '../shared/buttonConfig';
+import { getNavButtons } from '../shared/buttonConfig';
 import { formatFixed, formatNumber, formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 // CSS imported as text via esbuild
@@ -142,17 +142,7 @@ function render(stats: EnvironmentalStats): void {
 	const title = el('div', 'title', '🌿 Environmental Impact');
 
 	const buttonRow = el('div', 'button-row');
-	buttonRow.append(
-		createButton(BUTTONS['btn-refresh']),
-		createButton(BUTTONS['btn-details']),
-		createButton(BUTTONS['btn-chart']),
-		createButton(BUTTONS['btn-usage']),
-		createButton(BUTTONS['btn-diagnostics']),
-		createButton(BUTTONS['btn-maturity']),
-	);
-	if (stats.backendConfigured) {
-		buttonRow.append(createButton(BUTTONS['btn-dashboard']));
-	}
+	buttonRow.append(...getNavButtons('btn-environmental', !!stats.backendConfigured).map(config => createButton(config)));
 	header.append(title, buttonRow);
 
 	const footer = el('div', 'footer', `Last updated: ${lastUpdated.toLocaleString()} · Updates every 5 minutes`);

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -1,5 +1,5 @@
 // Maturity Score webview
-import { buttonHtml } from '../shared/buttonConfig';
+import { navButtonsHtml } from '../shared/buttonConfig';
 import type { ContextReferenceUsage } from '../shared/contextRefUtils';
 import { escapeHtml, markdownToHtml, STAGE_LABELS, STAGE_DESCRIPTIONS } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
@@ -400,13 +400,7 @@ function buildMaturityRootHtml(
           <span class="header-title">AI Engineering Fluency Score</span>
         </div>
         <div class="button-row">
-          ${buttonHtml('btn-refresh')}
-          ${buttonHtml('btn-details')}
-          ${buttonHtml('btn-chart')}
-          ${buttonHtml('btn-usage')}
-          ${buttonHtml('btn-environmental')}
-          ${buttonHtml('btn-diagnostics')}
-          ${data.backendConfigured ? buttonHtml('btn-dashboard') : ''}
+          ${navButtonsHtml('btn-maturity', !!data.backendConfigured)}
         </div>
       </div>
       <div class="info-box">

--- a/vscode-extension/src/webview/shared/buttonConfig.ts
+++ b/vscode-extension/src/webview/shared/buttonConfig.ts
@@ -11,6 +11,8 @@ export interface ButtonConfig {
 	appearance?: 'primary' | 'secondary';
 	/** When true, the button is not rendered in the UI (code is preserved for re-enabling later). */
 	hidden?: boolean;
+	/** When true, the button represents the currently open view and is rendered in a distinct, non-clickable state. */
+	active?: boolean;
 }
 
 /**
@@ -64,12 +66,47 @@ export function getButton(id: ButtonId): ButtonConfig {
 }
 
 /**
- * Generates an HTML string for a vscode-button element from a button config.
- * Useful for template strings where DOM manipulation isn't available.
+ * Canonical order of the shared navigation button row rendered by every webview panel.
  */
-export function buttonHtml(id: ButtonId): string {
-	const config = BUTTONS[id];
+const NAV_ORDER: ButtonId[] = [
+	'btn-refresh',
+	'btn-details',
+	'btn-chart',
+	'btn-usage',
+	'btn-maturity',
+	'btn-environmental',
+	'btn-diagnostics',
+	'btn-dashboard'
+];
+
+/**
+ * Returns the full navigation button row in the canonical order.
+ * The button matching `activeView` is marked active so it renders in a
+ * visually distinct, non-clickable state (the nav reads as a tab strip).
+ * The Team Dashboard button is only included when a backend is configured.
+ */
+export function getNavButtons(activeView: ButtonId | null, backendConfigured: boolean): ButtonConfig[] {
+	return NAV_ORDER
+		.filter(id => id !== 'btn-dashboard' || backendConfigured)
+		.map(id => ({ ...BUTTONS[id], active: id === activeView }));
+}
+
+/**
+ * Generates an HTML string for a vscode-button element from a button config
+ * (or a button ID). Useful for template strings where DOM manipulation isn't available.
+ */
+export function buttonHtml(idOrConfig: ButtonId | ButtonConfig): string {
+	const config = typeof idOrConfig === 'string' ? BUTTONS[idOrConfig] : idOrConfig;
 	if (config.hidden) { return ''; }
 	const appearance = config.appearance ? ` appearance="${config.appearance}"` : '';
-	return `<vscode-button id="${config.id}"${appearance}>${config.label}</vscode-button>`;
+	const active = config.active ? ' class="nav-active" disabled aria-current="page"' : '';
+	return `<vscode-button id="${config.id}"${appearance}${active}>${config.label}</vscode-button>`;
+}
+
+/**
+ * Generates the HTML for the full shared navigation button row.
+ * String-template counterpart of `getNavButtons` + `createButton`.
+ */
+export function navButtonsHtml(activeView: ButtonId | null, backendConfigured: boolean): string {
+	return getNavButtons(activeView, backendConfigured).map(config => buttonHtml(config)).join('\n');
 }

--- a/vscode-extension/src/webview/shared/domUtils.ts
+++ b/vscode-extension/src/webview/shared/domUtils.ts
@@ -31,6 +31,11 @@ export function createButton(configOrId: ButtonConfig | string, label?: string, 
 		button.textContent = config.label;
 		if (config.appearance) { button.setAttribute('appearance', config.appearance); }
 		if (config.hidden) { button.hidden = true; }
+		if (config.active) {
+			button.classList.add('nav-active');
+			button.setAttribute('disabled', '');
+			button.setAttribute('aria-current', 'page');
+		}
 	}
 	
 	return button;

--- a/vscode-extension/src/webview/shared/theme.css
+++ b/vscode-extension/src/webview/shared/theme.css
@@ -94,6 +94,21 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
 	flex-wrap: wrap;
 }
 
+/* Active view indicator — the nav button for the currently open view.
+   Rendered non-clickable (disabled) but kept fully opaque and marked with a
+   secondary background plus an accent underline so the row reads as a tab strip. */
+.button-row vscode-button.nav-active {
+	opacity: 1;
+	pointer-events: none;
+}
+
+.button-row vscode-button.nav-active::part(control) {
+	background: var(--button-secondary-bg);
+	color: var(--button-secondary-fg);
+	border-bottom: 2px solid var(--focus-border);
+	cursor: default;
+}
+
 /* ------------------------------------------------------------------ *
  * High contrast themes — INDUSTRIAL REDUX
  * Stark outlines, uppercase navigation, neon stage colors, monospace.
@@ -251,6 +266,23 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .button-row .nav-butto
 	background-color: var(--vscode-foreground) !important;
 	color: var(--vscode-editor-background) !important;
 	border-bottom: 3px solid var(--vscode-terminal-ansiCyan) !important; /* Cyber/Industrial accent indicator */
+}
+
+/* Active view indicator (high contrast) — inverted like hover, with the accent underline */
+body[data-vscode-theme-kind="vscode-high-contrast"] .button-row vscode-button.nav-active,
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .button-row vscode-button.nav-active {
+	background-color: var(--vscode-foreground) !important;
+	color: var(--vscode-editor-background) !important;
+	border-bottom: 3px solid var(--vscode-terminal-ansiCyan) !important;
+	opacity: 1;
+	pointer-events: none;
+}
+
+body[data-vscode-theme-kind="vscode-high-contrast"] .button-row vscode-button.nav-active::part(control),
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .button-row vscode-button.nav-active::part(control) {
+	background-color: var(--vscode-foreground) !important;
+	color: var(--vscode-editor-background) !important;
+	cursor: default;
 }
 
 /* Industrial header + title (high contrast only) */

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1,6 +1,6 @@
 // Usage Analysis webview
 import { el } from '../shared/domUtils';
-import { buttonHtml } from '../shared/buttonConfig';
+import { navButtonsHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
 import { escapeHtml, formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
@@ -237,8 +237,16 @@ interface RepoAnalysisRecord {
 	error?: string;
 }
 
-const vscode = acquireVsCodeApi();
+/** Webview state persisted by VS Code across tab switches (survives the panel being hidden). */
+interface UsageWebviewState {
+	aboutCollapsed?: boolean;
+}
+
+const vscode = acquireVsCodeApi<UsageWebviewState>();
 const curationTraceOnceKeys = new Set<string>();
+
+/** Collapsed state of the "About This Dashboard" info box, restored from webview state. */
+let aboutCollapsed = vscode.getState()?.aboutCollapsed ?? false;
 
 function traceCuration(stage: string, details?: Record<string, unknown>): void {
 	try {
@@ -2453,19 +2461,16 @@ function buildUsageRootHtml(
 					<span class="header-title">Usage Analysis</span>
 				</div>
 				<div class="button-row">
-				${buttonHtml('btn-refresh')}
-				${buttonHtml('btn-details')}
-				${buttonHtml('btn-chart')}
-				${buttonHtml('btn-environmental')}
-				${buttonHtml('btn-diagnostics')}
-				${buttonHtml('btn-maturity')}
-				${stats.backendConfigured ? buttonHtml('btn-dashboard') : ''}
+				${navButtonsHtml('btn-usage', !!stats.backendConfigured)}
 				</div>
 			</div>
 
 			<div class="info-box">
-				<div class="info-box-title">📋 About This Dashboard</div>
-				<div>
+				<div class="info-box-title info-box-toggle" id="about-info-toggle" role="button" tabindex="0" aria-expanded="${!aboutCollapsed}" aria-controls="about-info-body">
+					<span>📋 About This Dashboard</span>
+					<span class="info-box-chevron" aria-hidden="true">${aboutCollapsed ? '▸' : '▾'}</span>
+				</div>
+				<div class="info-box-body" id="about-info-body"${aboutCollapsed ? ' style="display:none"' : ''}>
 					This dashboard analyzes your GitHub Copilot usage patterns by examining session log files.
 					It tracks modes (ask/edit/agent), tool usage, context references (#file, @workspace, etc.),
 					and MCP (Model Context Protocol) tools to help you understand how you interact with Copilot.
@@ -2477,8 +2482,8 @@ function buildUsageRootHtml(
 				<button class="tab-button ${activeTab === 'sessions' ? 'active' : ''}" data-tab="sessions">📋 Today's Sessions</button>
 				<button class="tab-button ${activeTab === 'tools' ? 'active' : ''}" data-tab="tools">🔧 Tools &amp; Integrations</button>
 				<button class="tab-button ${activeTab === 'health' ? 'active' : ''}" data-tab="health">🏗️ Workspace Health</button>
-				<button class="tab-button ${activeTab === 'repos' ? 'active' : ''}" data-tab="repos">🤖 Repository PRs</button>
-				<button class="tab-button ${activeTab === 'agent' ? 'active' : ''}" data-tab="agent">🤖 Cloud Agent</button>
+				<button class="tab-button ${activeTab === 'repos' ? 'active' : ''}" data-tab="repos">🔀 Repository PRs</button>
+				<button class="tab-button ${activeTab === 'agent' ? 'active' : ''}" data-tab="agent">☁️ Cloud Agent</button>
 				<button class="tab-button ${activeTab === 'insights' ? 'active' : ''}" data-tab="insights">💡 Insights${(stats.insights ?? []).filter(i => i.status === 'new').length > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(stats.insights ?? []).filter(i => i.status === 'new').length}</span>` : ''}</button>
 			</div>
 
@@ -2970,6 +2975,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 	);
 
 	wireNavigationButtons();
+	wireAboutInfoToggle();
 	wireRepositoryButtons();
 	wireCurationButtons();
 	renderRepositoryHygienePanels();
@@ -2978,6 +2984,28 @@ function renderLayout(stats: UsageAnalysisStats): void {
 	// Initialize currentInsights from the stats and wire card buttons
 	currentInsights = stats.insights ?? [];
 	wireInsightCardButtons();
+}
+
+/** Wires up the collapsible "About This Dashboard" info box; the collapsed state is persisted via webview state. */
+function wireAboutInfoToggle(): void {
+	const toggle = document.getElementById('about-info-toggle');
+	const body = document.getElementById('about-info-body');
+	if (!toggle || !body) { return; }
+	const chevron = toggle.querySelector('.info-box-chevron');
+	const applyToggle = (): void => {
+		aboutCollapsed = !aboutCollapsed;
+		body.style.display = aboutCollapsed ? 'none' : '';
+		toggle.setAttribute('aria-expanded', String(!aboutCollapsed));
+		if (chevron) { chevron.textContent = aboutCollapsed ? '▸' : '▾'; }
+		vscode.setState({ ...(vscode.getState() ?? {}), aboutCollapsed });
+	};
+	toggle.addEventListener('click', applyToggle);
+	toggle.addEventListener('keydown', (event: KeyboardEvent) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			applyToggle();
+		}
+	});
 }
 
 /** Wires up top-level navigation toolbar buttons (refresh, details, chart, etc.). */

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -307,6 +307,25 @@ body {
 	margin-bottom: 6px;
 }
 
+.info-box-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	cursor: pointer;
+	user-select: none;
+	margin-bottom: 0;
+}
+
+.info-box-chevron {
+	font-size: 10px;
+	color: var(--text-secondary);
+}
+
+.info-box-body {
+	margin-top: 6px;
+}
+
 
 .repo-hygiene-results {
 	margin-top: 4px;


### PR DESCRIPTION
## What

Unifies navigation across the VS Code extension's webviews, which previously had inconsistent button sets/ordering and no indication of which panel you were on.

- **`buttonConfig.getNavButtons(activeView, backendConfigured)`**: one canonical nav order for every webview — Refresh, Details, Chart, Usage Analysis, Fluency Score, Environmental Impact, Diagnostics, Team Dashboard (Team Dashboard only when a backend is configured). The button for the current view renders in a distinct active/highlighted state instead of being omitted.
- Applied to the **details, chart, usage, environmental, maturity, and diagnostics** webviews so they all render the identical nav strip.
- **Distinct tab icons** on the Usage Analysis dashboard: "Repository PRs" and "Cloud Agent" both used 🤖 previously; they now have their own icons.
- **Collapsible "About This Dashboard"** info box on Usage Analysis, with its collapsed/expanded state persisted.

## Scope

Touches `buttonConfig.ts`, `domUtils.ts`, `theme.css` (shared), and the six webview `main.ts`/`styles.css` files listed above. No host-side (`extension.ts`) or shared `src/` changes.

## Verification

- Rebased onto current `main` (after #1586 merged) — no conflicts; hero-cards changes and nav changes coexist cleanly in `details/main.ts`
- `npm run compile` (tsc + eslint + esbuild) clean
- `npm run test:node` — all tests passing
- Manually tested in the Extension Development Host

## Notes

Part of the same UI review as #1586. Two sibling branches remain (`ui/sidebar-navigation`, `ui/recent-sessions`) and are kept separate on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)