### PR TITLE
feat(usage): Recent Sessions browser with lookback, duration, and column toggles

### DIFF
--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -31,6 +31,19 @@ export function computeSessionTotalTokens(inputTokens: number, outputTokens: num
 }
 
 /**
+ * Computes a session's duration in milliseconds from its first and last
+ * interaction timestamps (ISO strings). Returns undefined when either
+ * timestamp is missing/invalid or the range is negative.
+ */
+export function computeSessionDurationMs(firstInteraction: string | null | undefined, lastInteraction: string | null | undefined): number | undefined {
+	if (!firstInteraction || !lastInteraction) { return undefined; }
+	const start = new Date(firstInteraction).getTime();
+	const end = new Date(lastInteraction).getTime();
+	if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) { return undefined; }
+	return end - start;
+}
+
+/**
  * Merges `source` model usage into `target` (in-place).
  * All four token fields are summed: inputTokens, outputTokens,
  * cachedReadTokens (optional), and cacheCreationTokens (optional).

--- a/src/types.ts
+++ b/src/types.ts
@@ -452,7 +452,7 @@ nonCopilotFiles: CustomizationFileEntry[];
 }
 
 
-/** Summary of a single session for the "Today's Sessions" tab. */
+/** Summary of a single session for the "Recent Sessions" tab. */
 export interface TodaySessionSummary {
   title: string | null;
   filePath: string;
@@ -477,6 +477,10 @@ export interface TodaySessionSummary {
   contextWindowLimit?: number;
   /** Last known context fill in tokens (Copilot CLI, from data.db context_current_tokens). */
   contextReachedTokens?: number;
+  /** Session duration in milliseconds (last interaction − first interaction). Absent when not derivable. */
+  durationMs?: number;
+  /** Workspace/repository name the session belongs to. Absent when attribution is unavailable. */
+  workspace?: string;
 }
 
 export interface UsageAnalysisStats {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6025,6 +6025,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 			case 'traceUsageCuration':
 				this._logTraceCuration(message);
 				break;
+			case 'saveSessionColumnSettings':
+				await this.dispatch('saveSessionColumnSettings', () =>
+					this.context.globalState.update('usage.sessionColumnSettings', message.settings)
+				);
+				break;
 		}
 	}
 
@@ -8921,6 +8926,8 @@ ${this.getLoadingHtmlScript()}
       .getConfiguration('aiEngineeringFluency')
       .get<string[]>('suppressedUnknownTools', []);
 
+    const sessionColumnSettings = this.context.globalState.get('usage.sessionColumnSettings', {});
+
     const initialData = stats ? JSON.stringify({
       today: stats.today,
       last30Days: stats.last30Days,
@@ -8937,6 +8944,7 @@ ${this.getLoadingHtmlScript()}
       use24HourTime: this.getUse24HourTimeSetting(),
       insights: this.buildCurrentInsights(stats),
       curationAnalysis: stats.curationAnalysis ?? null,
+      sessionColumnSettings,
     }).replace(/</g, "\\u003c") : 'null';
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -176,7 +176,7 @@ import {
 import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceForBillingGroup } from '../../src/chartDataBuilder';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, type SessionAggregateInput } from '../../src/statsHelpers';
+import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, type SessionAggregateInput } from '../../src/statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -3606,6 +3606,33 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return { results, totalFiles: sessionFiles.length };
 	}
 
+	/**
+	 * Build session summaries for a lookback window (last 7/30 days) and send them
+	 * to the analysis panel. Used by the "Recent Sessions" tab lookback selector;
+	 * the default "Today" view keeps using the summaries bundled with updateStats.
+	 */
+	private async loadRecentSessions(days: number): Promise<void> {
+		if (!this.analysisPanel) { return; }
+		const lookbackDays = days === 30 ? 30 : 7;
+		const now = new Date();
+		const windowStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - lookbackDays);
+		const windowStartKey = toLocalDayKey(windowStart);
+		const sessions: TodaySessionSummary[] = [];
+		try {
+			const { results } = await this.loadUsageSessionFiles(undefined, windowStart.getTime());
+			for (const r of results) {
+				if (!r || r.sessionData.interactions === 0) { continue; }
+				if (this.computeLastActivityKey(r.sessionData, r.mtime) < windowStartKey) { continue; }
+				const analysis = r.sessionData.usageAnalysis || this.buildDefaultSessionAnalysis();
+				sessions.push(this.collectTodaySessionInfo(r.sessionData, r.sessionFile, analysis, r.sessionData.interactions, r.mtime));
+			}
+		} catch (error) {
+			this.error('Error loading recent sessions:', error);
+		}
+		sessions.sort((a, b) => b.interactions - a.interactions);
+		this.analysisPanel.webview.postMessage({ command: 'recentSessionsLoaded', days: lookbackDays, sessions });
+	}
+
 	private computeLastActivityKey(sessionData: SessionFileCache, mtime: number): string {
 		if (sessionData.dailyRollups && Object.keys(sessionData.dailyRollups).length > 0) {
 			return Object.keys(sessionData.dailyRollups).sort().pop()!;
@@ -3633,6 +3660,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	): TodaySessionSummary {
 		const modelUsage = sessionData.modelUsage || {};
 		const { inputTok, outputTok, cachedTok } = this._resolveSessionModelTokens(sessionData, modelUsage);
+		const durationMs = computeSessionDurationMs(sessionData.firstInteraction, sessionData.lastInteraction);
+		const workspace = this.resolveSessionWorkspaceName(sessionData, sessionFile);
 		return {
 			title: sessionData.title || null, filePath: sessionFile, interactions,
 			toolCalls: analysis.toolCalls.total, inputTokens: inputTok, outputTokens: outputTok,
@@ -3644,7 +3673,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(sessionData.truncationCount ? { truncationCount: sessionData.truncationCount } : {}),
 			...(sessionData.maxRequestInputTokens ? { maxRequestInputTokens: sessionData.maxRequestInputTokens } : {}),
 			...(sessionData.contextTier ? { contextTier: sessionData.contextTier } : {}),
+			...(durationMs !== undefined ? { durationMs } : {}),
+			...(workspace ? { workspace } : {}),
 		};
+	}
+
+	/**
+	 * Best-effort workspace name for a session summary. Uses the repository name
+	 * already cached on the session data, falling back to the workspaceStorage
+	 * folder resolution (cached per workspace id). Returns undefined when
+	 * attribution is unavailable.
+	 */
+	private resolveSessionWorkspaceName(sessionData: SessionFileCache, sessionFile: string): string | undefined {
+		if (sessionData.repository) { return sessionData.repository; }
+		try {
+			const workspaceFolder = _resolveWorkspaceFolderFromSessionPath(sessionFile, this._workspaceIdToFolderCache);
+			if (workspaceFolder) { return path.basename(workspaceFolder); }
+		} catch { /* attribution is optional */ }
+		return undefined;
 	}
 
 	private _mergeCodeWorkspaceCustomizationFiles(norm: string): CustomizationFileEntry[] {
@@ -5961,6 +6007,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 				break;
 			case 'loadAgentSessions':
 				await this.dispatch('loadAgentSessions', () => this.loadAgentSessions());
+				break;
+			case 'loadRecentSessions':
+				await this.dispatch('loadRecentSessions', () => this.loadRecentSessions(Number(message.days)));
 				break;
 			case 'openSessionFile':
 				if (message.file) {

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -130,6 +130,26 @@ export function formatFileSize(bytes: number): string {
 }
 
 /**
+ * Formats a duration in milliseconds as a short string like "12m" or "1h 04m".
+ * Returns "—" when the value is missing, non-finite, or negative.
+ */
+export function formatDurationShort(durationMs?: number): string {
+	if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 0) {
+		return '—';
+	}
+	const totalMinutes = Math.round(durationMs / 60000);
+	if (totalMinutes < 1) {
+		return '<1m';
+	}
+	if (totalMinutes < 60) {
+		return `${totalMinutes}m`;
+	}
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return `${hours}h ${String(minutes).padStart(2, '0')}m`;
+}
+
+/**
  * Returns a human-readable "time since" string for an ISO timestamp.
  */
 export function getTimeSince(isoString: string): string {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -2,7 +2,7 @@
 import { el } from '../shared/domUtils';
 import { buttonHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
-import { escapeHtml, formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
+import { escapeHtml, formatDurationShort, formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis as BaseModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
@@ -67,6 +67,8 @@ type TodaySessionSummary = {
 	contextTier?: string;
 	contextWindowLimit?: number;
 	contextReachedTokens?: number;
+	durationMs?: number;
+	workspace?: string;
 };
 
 type InsightSeverity = 'tip' | 'opportunity' | 'celebration';
@@ -915,12 +917,18 @@ function renderToolsTable(byTool: { [key: string]: number }, limit = 10, nameRes
 		</table>`;
 }
 
-// --- Today's Sessions table with sortable columns ---
-type SessionSortColumn = 'title' | 'interactions' | 'toolCalls' | 'inputTokens' | 'outputTokens' | 'thinkingTokens' | 'cachedTokens' | 'totalTokens' | 'estimatedCost' | 'editor' | 'lastActivity';
+// --- Recent Sessions table with sortable columns ---
+type SessionSortColumn = 'title' | 'interactions' | 'toolCalls' | 'inputTokens' | 'outputTokens' | 'thinkingTokens' | 'cachedTokens' | 'totalTokens' | 'estimatedCost' | 'editor' | 'workspace' | 'durationMs' | 'lastActivity';
+type SessionsLookback = 'today' | '7' | '30';
 let sessionSortColumn: SessionSortColumn = 'interactions';
 let sessionSortDirection: 'asc' | 'desc' = 'desc';
 let cachedTodaySessions: TodaySessionSummary[] = [];
 let use24HourTime = true;
+// Lookback selector state: "today" renders the summaries bundled with updateStats;
+// longer windows are lazily requested from the extension host and cached here.
+let sessionsLookback: SessionsLookback = 'today';
+let latestTodaySessions: TodaySessionSummary[] = [];
+const recentSessionsCache: { [days: string]: TodaySessionSummary[] } = {};
 
 function getSessionSortIndicator(column: SessionSortColumn): string {
 	if (sessionSortColumn !== column) { return ''; }
@@ -937,6 +945,12 @@ function sortTodaySessions(sessions: TodaySessionSummary[]): TodaySessionSummary
 			case 'editor':
 				cmp = (a.editor || '').localeCompare(b.editor || '');
 				break;
+			case 'workspace':
+				cmp = (a.workspace || '').localeCompare(b.workspace || '');
+				break;
+			case 'durationMs':
+				cmp = (a.durationMs ?? -1) - (b.durationMs ?? -1);
+				break;
 			case 'lastActivity':
 				cmp = (a.lastActivity || '').localeCompare(b.lastActivity || '');
 				break;
@@ -951,7 +965,8 @@ function sortTodaySessions(sessions: TodaySessionSummary[]): TodaySessionSummary
 function renderTodaySessionsTable(sessions: TodaySessionSummary[]): string {
 	cachedTodaySessions = sessions;
 	if (!sessions || sessions.length === 0) {
-		return '<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">No sessions recorded today yet.</div>';
+		const emptyMessage = sessionsLookback === 'today' ? 'No sessions recorded today yet.' : 'No sessions recorded in this period.';
+		return `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">${emptyMessage}</div>`;
 	}
 	return `<div id="sessions-table-container">${buildSessionsTableHtml(sessions)}</div>`;
 }
@@ -963,8 +978,15 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 		const filePath = escapeHtml(s.filePath || '');
 		const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—';
 		const editor = escapeHtml(s.editor || 'unknown');
+		const workspace = escapeHtml(s.workspace || '—');
+		const duration = formatDurationShort(s.durationMs);
 		const cost = s.estimatedCost > 0 ? `$${s.estimatedCost.toFixed(4)}` : '—';
-		const time = s.lastActivity ? new Date(s.lastActivity).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime }) : '—';
+		// For multi-day lookbacks include the date so rows from different days are distinguishable.
+		const time = s.lastActivity
+			? (sessionsLookback === 'today'
+				? new Date(s.lastActivity).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
+				: new Date(s.lastActivity).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: !use24HourTime }))
+			: '—';
 		return `<tr>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${idx + 1}</td>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${title}&quot;"><a href="#" class="session-title-link" data-file="${filePath}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${title}</a></td>
@@ -977,14 +999,16 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.totalTokens)}</td>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${cost}</td>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px;">${editor}</td>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${workspace}">${workspace}</td>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${models}">${models}</td>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; white-space:nowrap; text-align:right;">${duration}</td>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; white-space:nowrap; text-align:right;">${time}</td>
 		</tr>`;
 	}).join('');
 
 	return `
 		<div style="overflow-x:auto;">
-		<table class="sessions-table" style="width:100%; border-collapse:collapse; min-width:900px;">
+		<table class="sessions-table" style="width:100%; border-collapse:collapse; min-width:1050px;">
 			<thead>
 				<tr style="color:var(--text-secondary); font-size:11px; text-align:left;">
 					<th style="padding:6px 8px;">#</th>
@@ -998,7 +1022,9 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 					<th class="sortable" data-sort="totalTokens" style="padding:6px 8px; text-align:right;">Total${getSessionSortIndicator('totalTokens')}</th>
 					<th class="sortable" data-sort="estimatedCost" style="padding:6px 8px; text-align:right;">Cost${getSessionSortIndicator('estimatedCost')}</th>
 					<th class="sortable" data-sort="editor" style="padding:6px 8px;">Editor${getSessionSortIndicator('editor')}</th>
+					<th class="sortable" data-sort="workspace" style="padding:6px 8px;">Workspace${getSessionSortIndicator('workspace')}</th>
 					<th style="padding:6px 8px;">Models</th>
+					<th class="sortable" data-sort="durationMs" style="padding:6px 8px; text-align:right;">Duration${getSessionSortIndicator('durationMs')}</th>
 					<th class="sortable" data-sort="lastActivity" style="padding:6px 8px; text-align:right;">Last Active${getSessionSortIndicator('lastActivity')}</th>
 				</tr>
 			</thead>
@@ -1010,9 +1036,11 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 }
 
 function setupSessionsTableSort(): void {
-	const container = document.getElementById('sessions-table-container');
-	if (!container) { return; }
-	container.addEventListener('click', (e) => {
+	// Delegate from the stable panel body so listeners survive lookback re-renders,
+	// which replace the inner #sessions-table-container element.
+	const body = document.getElementById('sessions-panel-body');
+	if (!body) { return; }
+	body.addEventListener('click', (e) => {
 		// Handle session title link clicks → open in log viewer
 		const link = (e.target as HTMLElement).closest<HTMLAnchorElement>('a.session-title-link');
 		if (link) {
@@ -1034,8 +1062,55 @@ function setupSessionsTableSort(): void {
 			sessionSortColumn = col;
 			sessionSortDirection = 'desc';
 		}
-		container.innerHTML = buildSessionsTableHtml(cachedTodaySessions);
+		const container = document.getElementById('sessions-table-container');
+		if (container) { container.innerHTML = buildSessionsTableHtml(cachedTodaySessions); }
 	});
+	setupSessionsLookbackSelector();
+}
+
+function setupSessionsLookbackSelector(): void {
+	const select = document.getElementById('sessions-lookback') as HTMLSelectElement | null;
+	if (!select) { return; }
+	select.value = sessionsLookback;
+	select.addEventListener('change', () => {
+		const value = select.value;
+		sessionsLookback = (value === '7' || value === '30') ? value : 'today';
+		refreshSessionsPanelBody();
+	});
+	// A full re-render may have restored a non-today lookback whose data was
+	// rendered from cache already; if the cache is empty, request it now.
+	if (sessionsLookback !== 'today' && !recentSessionsCache[sessionsLookback]) {
+		refreshSessionsPanelBody();
+	}
+}
+
+/** Renders the sessions table for the current lookback, requesting host data when needed. */
+function refreshSessionsPanelBody(): void {
+	const body = document.getElementById('sessions-panel-body');
+	if (!body) { return; }
+	if (sessionsLookback === 'today') {
+		body.innerHTML = renderTodaySessionsTable(latestTodaySessions);
+		return;
+	}
+	const cached = recentSessionsCache[sessionsLookback];
+	if (cached) {
+		body.innerHTML = renderTodaySessionsTable(cached);
+		return;
+	}
+	body.innerHTML = `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for the last ${sessionsLookback} days…</div>`;
+	vscode.postMessage({ command: 'loadRecentSessions', days: Number(sessionsLookback) });
+}
+
+function handleRecentSessionsLoaded(message: any): void {
+	const days = Number(message.days);
+	if (days !== 7 && days !== 30) { return; }
+	const sessions = Array.isArray(message.sessions)
+		? message.sessions.filter((s: any) => s && typeof s === 'object' && typeof s.interactions === 'number') as TodaySessionSummary[]
+		: [];
+	recentSessionsCache[String(days)] = sessions;
+	if (sessionsLookback === String(days)) {
+		refreshSessionsPanelBody();
+	}
 }
 
 function unionFill(map: { [key: string]: number }, keys: string[]): { [key: string]: number } {
@@ -2474,7 +2549,7 @@ function buildUsageRootHtml(
 
 			<div class="tab-bar">
 				<button class="tab-button ${activeTab === 'activity' ? 'active' : ''}" data-tab="activity">📊 My Activity</button>
-				<button class="tab-button ${activeTab === 'sessions' ? 'active' : ''}" data-tab="sessions">📋 Today's Sessions</button>
+				<button class="tab-button ${activeTab === 'sessions' ? 'active' : ''}" data-tab="sessions">📋 Recent Sessions</button>
 				<button class="tab-button ${activeTab === 'tools' ? 'active' : ''}" data-tab="tools">🔧 Tools &amp; Integrations</button>
 				<button class="tab-button ${activeTab === 'health' ? 'active' : ''}" data-tab="health">🏗️ Workspace Health</button>
 				<button class="tab-button ${activeTab === 'repos' ? 'active' : ''}" data-tab="repos">🤖 Repository PRs</button>
@@ -2496,13 +2571,25 @@ function buildUsageRootHtml(
 }
 
 function buildSessionsTabPanelHtml(stats: UsageAnalysisStats): string {
+	latestTodaySessions = stats.todaySessions || [];
+	const cachedForLookback = sessionsLookback === 'today' ? latestTodaySessions : recentSessionsCache[sessionsLookback];
+	const bodyHtml = cachedForLookback
+		? renderTodaySessionsTable(cachedForLookback)
+		: `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for the last ${sessionsLookback} days…</div>`;
 	return `
 		<div id="tab-panel-sessions" class="tab-panel"${activeTab !== 'sessions' ? ' style="display:none"' : ''}>
 			<div class="section">
-				<div class="section-title"><span>📋</span><span>Today's Sessions</span></div>
-				<div class="section-subtitle">Individual session breakdown for today — sorted by number of interactions (most active first).</div>
-				<div style="margin-top: 12px;">
-					${renderTodaySessionsTable(stats.todaySessions || [])}
+				<div class="section-title" style="display:flex; align-items:center; gap:8px;">
+					<span>📋</span><span>Recent Sessions</span>
+					<select id="sessions-lookback" style="margin-left:auto; font-size:12px; padding:2px 6px; background:var(--vscode-dropdown-background, var(--bg-secondary)); color:var(--vscode-dropdown-foreground, var(--text-primary)); border:1px solid var(--border-subtle); border-radius:4px;">
+						<option value="today"${sessionsLookback === 'today' ? ' selected' : ''}>Today</option>
+						<option value="7"${sessionsLookback === '7' ? ' selected' : ''}>Last 7 days</option>
+						<option value="30"${sessionsLookback === '30' ? ' selected' : ''}>Last 30 days</option>
+					</select>
+				</div>
+				<div class="section-subtitle">Individual session breakdown for the selected period — sorted by number of interactions (most active first).</div>
+				<div id="sessions-panel-body" style="margin-top: 12px;">
+					${bodyHtml}
 				</div>
 			</div>
 		</div>`;
@@ -3089,6 +3176,9 @@ function handleUpdateStats(message: any): void {
 	const sanitized = sanitizeStats(message.data);
 	if (sanitized) {
 		_ulLoadingActive = false;
+		// New stats invalidate any lazily-loaded lookback data; it is re-requested on demand.
+		delete recentSessionsCache['7'];
+		delete recentSessionsCache['30'];
 		renderLayout(sanitized);
 		setupSessionsTableSort();
 		renderRepositoryHygienePanels();
@@ -3191,6 +3281,8 @@ function handleExtensionMessage(message: any): void {
 			break;
 		case 'agentSessionsLoaded':
 			handleAgentSessionsLoaded(message.data); break;
+		case 'recentSessionsLoaded':
+			handleRecentSessionsLoaded(message); break;
 		case 'agentSessionsProgress':
 			updateProgressPanel('#agent-sessions-content', 'agent-sessions-progress', 'Fetching agent sessions…', message.done as number, message.total as number);
 			break;

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -102,6 +102,8 @@ type UsageAnalysisStats = {
 	use24HourTime?: boolean;
 	insights?: EvaluatedInsight[];
 	curationAnalysis?: ToolCurationAnalysis | null;
+	/** Persisted "Recent Sessions" column visibility (optional column ids). Absent/invalid entries mean "show all". */
+	sessionColumnSettings?: { enabledColumns?: string[] };
 };
 
 // ── Tool Curation types ──────────────────────────────────────────────────────
@@ -917,9 +919,51 @@ function renderToolsTable(byTool: { [key: string]: number }, limit = 10, nameRes
 		</table>`;
 }
 
-// --- Recent Sessions table with sortable columns ---
+// --- Recent Sessions table with sortable, toggleable columns ---
 type SessionSortColumn = 'title' | 'interactions' | 'toolCalls' | 'inputTokens' | 'outputTokens' | 'thinkingTokens' | 'cachedTokens' | 'totalTokens' | 'estimatedCost' | 'editor' | 'workspace' | 'durationMs' | 'lastActivity';
 type SessionsLookback = 'today' | '7' | '30';
+
+/** Optional (toggleable) session table columns. Title is always shown and is not part of this set. */
+type SessionColumnId = 'interactions' | 'toolCalls' | 'inputTokens' | 'outputTokens' | 'thinkingTokens' | 'cachedTokens' | 'totalTokens' | 'estimatedCost' | 'editor' | 'workspace' | 'models' | 'durationMs' | 'lastActivity';
+
+type SessionColumnDef = {
+	id: SessionColumnId;
+	label: string;
+	/** Absent for columns that cannot be sorted (Models). */
+	sortKey?: SessionSortColumn;
+	align: 'left' | 'right';
+	/** Extra inline style appended after the base cell style (later declarations win). */
+	cellStyle?: string;
+	render: (s: TodaySessionSummary) => { html: string; title?: string };
+};
+
+const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
+	{ id: 'interactions', label: 'Turns', sortKey: 'interactions', align: 'right', render: s => ({ html: formatNumber(s.interactions) }) },
+	{ id: 'toolCalls', label: 'Tools', sortKey: 'toolCalls', align: 'right', render: s => ({ html: formatNumber(s.toolCalls) }) },
+	{ id: 'inputTokens', label: 'Input', sortKey: 'inputTokens', align: 'right', render: s => ({ html: formatNumber(s.inputTokens) }) },
+	{ id: 'outputTokens', label: 'Output', sortKey: 'outputTokens', align: 'right', render: s => ({ html: formatNumber(s.outputTokens) }) },
+	{ id: 'thinkingTokens', label: 'Thinking', sortKey: 'thinkingTokens', align: 'right', render: s => ({ html: formatNumber(s.thinkingTokens) }) },
+	{ id: 'cachedTokens', label: 'Cached', sortKey: 'cachedTokens', align: 'right', render: s => ({ html: formatNumber(s.cachedTokens) }) },
+	{ id: 'totalTokens', label: 'Total', sortKey: 'totalTokens', align: 'right', render: s => ({ html: formatNumber(s.totalTokens) }) },
+	{ id: 'estimatedCost', label: 'Cost', sortKey: 'estimatedCost', align: 'right', render: s => ({ html: s.estimatedCost > 0 ? `$${s.estimatedCost.toFixed(4)}` : '—' }) },
+	{ id: 'editor', label: 'Editor', sortKey: 'editor', align: 'left', render: s => ({ html: escapeHtml(s.editor || 'unknown') }) },
+	{ id: 'workspace', label: 'Workspace', sortKey: 'workspace', align: 'left', cellStyle: 'max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const workspace = escapeHtml(s.workspace || '—'); return { html: workspace, title: workspace }; } },
+	{ id: 'models', label: 'Models', align: 'left', cellStyle: 'font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—'; return { html: models, title: models }; } },
+	{ id: 'durationMs', label: 'Duration', sortKey: 'durationMs', align: 'right', cellStyle: 'white-space:nowrap;', render: s => ({ html: formatDurationShort(s.durationMs) }) },
+	{
+		id: 'lastActivity', label: 'Last Active', sortKey: 'lastActivity', align: 'right', cellStyle: 'white-space:nowrap;',
+		render: s => ({
+			html: s.lastActivity
+				? (sessionsLookback === 'today'
+					? new Date(s.lastActivity).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
+					: new Date(s.lastActivity).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: !use24HourTime }))
+				: '—'
+		}),
+	},
+];
+
+const ALL_SESSION_COLUMN_IDS: SessionColumnId[] = SESSION_COLUMN_DEFS.map(c => c.id);
+
 let sessionSortColumn: SessionSortColumn = 'interactions';
 let sessionSortDirection: 'asc' | 'desc' = 'desc';
 let cachedTodaySessions: TodaySessionSummary[] = [];
@@ -929,6 +973,12 @@ let use24HourTime = true;
 let sessionsLookback: SessionsLookback = 'today';
 let latestTodaySessions: TodaySessionSummary[] = [];
 const recentSessionsCache: { [days: string]: TodaySessionSummary[] } = {};
+/** Which optional columns are currently visible. Title (and the row number) are always shown. */
+let enabledSessionColumns: Set<SessionColumnId> = new Set(ALL_SESSION_COLUMN_IDS);
+
+function saveSessionColumnSettings(): void {
+	vscode.postMessage({ command: 'saveSessionColumnSettings', settings: { enabledColumns: Array.from(enabledSessionColumns) } });
+}
 
 function getSessionSortIndicator(column: SessionSortColumn): string {
 	if (sessionSortColumn !== column) { return ''; }
@@ -973,37 +1023,28 @@ function renderTodaySessionsTable(sessions: TodaySessionSummary[]): string {
 
 function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 	const sorted = sortTodaySessions(sessions);
+	const visibleColumns = SESSION_COLUMN_DEFS.filter(c => enabledSessionColumns.has(c.id));
+
 	const rows = sorted.map((s, idx) => {
 		const title = escapeHtml(s.title || 'Untitled session');
 		const filePath = escapeHtml(s.filePath || '');
-		const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—';
-		const editor = escapeHtml(s.editor || 'unknown');
-		const workspace = escapeHtml(s.workspace || '—');
-		const duration = formatDurationShort(s.durationMs);
-		const cost = s.estimatedCost > 0 ? `$${s.estimatedCost.toFixed(4)}` : '—';
-		// For multi-day lookbacks include the date so rows from different days are distinguishable.
-		const time = s.lastActivity
-			? (sessionsLookback === 'today'
-				? new Date(s.lastActivity).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
-				: new Date(s.lastActivity).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: !use24HourTime }))
-			: '—';
+		const optionalCells = visibleColumns.map(col => {
+			const { html, title: cellTitle } = col.render(s);
+			const alignStyle = col.align === 'right' ? 'text-align:right;' : '';
+			const titleAttr = cellTitle !== undefined ? ` title="${cellTitle}"` : '';
+			return `<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; ${alignStyle}${col.cellStyle || ''}"${titleAttr}>${html}</td>`;
+		}).join('');
 		return `<tr>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${idx + 1}</td>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${title}&quot;"><a href="#" class="session-title-link" data-file="${filePath}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${title}</a></td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.interactions)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.toolCalls)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.inputTokens)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.outputTokens)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.thinkingTokens)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.cachedTokens)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${formatNumber(s.totalTokens)}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); text-align:right; font-size:12px;">${cost}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px;">${editor}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${workspace}">${workspace}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${models}">${models}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; white-space:nowrap; text-align:right;">${duration}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; white-space:nowrap; text-align:right;">${time}</td>
+			${optionalCells}
 		</tr>`;
+	}).join('');
+
+	const headerCells = visibleColumns.map(col => {
+		const alignStyle = col.align === 'right' ? ' text-align:right;' : '';
+		if (!col.sortKey) { return `<th style="padding:6px 8px;${alignStyle}">${col.label}</th>`; }
+		return `<th class="sortable" data-sort="${col.sortKey}" style="padding:6px 8px;${alignStyle}">${col.label}${getSessionSortIndicator(col.sortKey)}</th>`;
 	}).join('');
 
 	return `
@@ -1013,25 +1054,29 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 				<tr style="color:var(--text-secondary); font-size:11px; text-align:left;">
 					<th style="padding:6px 8px;">#</th>
 					<th class="sortable" data-sort="title" style="padding:6px 8px;">Title${getSessionSortIndicator('title')}</th>
-					<th class="sortable" data-sort="interactions" style="padding:6px 8px; text-align:right;">Turns${getSessionSortIndicator('interactions')}</th>
-					<th class="sortable" data-sort="toolCalls" style="padding:6px 8px; text-align:right;">Tools${getSessionSortIndicator('toolCalls')}</th>
-					<th class="sortable" data-sort="inputTokens" style="padding:6px 8px; text-align:right;">Input${getSessionSortIndicator('inputTokens')}</th>
-					<th class="sortable" data-sort="outputTokens" style="padding:6px 8px; text-align:right;">Output${getSessionSortIndicator('outputTokens')}</th>
-					<th class="sortable" data-sort="thinkingTokens" style="padding:6px 8px; text-align:right;">Thinking${getSessionSortIndicator('thinkingTokens')}</th>
-					<th class="sortable" data-sort="cachedTokens" style="padding:6px 8px; text-align:right;">Cached${getSessionSortIndicator('cachedTokens')}</th>
-					<th class="sortable" data-sort="totalTokens" style="padding:6px 8px; text-align:right;">Total${getSessionSortIndicator('totalTokens')}</th>
-					<th class="sortable" data-sort="estimatedCost" style="padding:6px 8px; text-align:right;">Cost${getSessionSortIndicator('estimatedCost')}</th>
-					<th class="sortable" data-sort="editor" style="padding:6px 8px;">Editor${getSessionSortIndicator('editor')}</th>
-					<th class="sortable" data-sort="workspace" style="padding:6px 8px;">Workspace${getSessionSortIndicator('workspace')}</th>
-					<th style="padding:6px 8px;">Models</th>
-					<th class="sortable" data-sort="durationMs" style="padding:6px 8px; text-align:right;">Duration${getSessionSortIndicator('durationMs')}</th>
-					<th class="sortable" data-sort="lastActivity" style="padding:6px 8px; text-align:right;">Last Active${getSessionSortIndicator('lastActivity')}</th>
+					${headerCells}
 				</tr>
 			</thead>
 			<tbody>
 				${rows}
 			</tbody>
 		</table>
+		</div>`;
+}
+
+/** Builds the "Columns" toggle button and its checkbox dropdown for showing/hiding optional columns. */
+function buildSessionColumnsMenuHtml(): string {
+	const items = SESSION_COLUMN_DEFS.map(col => `
+		<label style="display:flex; align-items:center; gap:6px; padding:4px 8px; font-size:12px; white-space:nowrap; cursor:pointer;">
+			<input type="checkbox" data-column="${col.id}"${enabledSessionColumns.has(col.id) ? ' checked' : ''} />
+			<span>${col.label}</span>
+		</label>`).join('');
+	return `
+		<div class="columns-menu-wrap" style="position:relative;">
+			<button id="sessions-columns-toggle" type="button" style="font-size:12px; padding:2px 8px; background:var(--vscode-dropdown-background, var(--bg-secondary)); color:var(--vscode-dropdown-foreground, var(--text-primary)); border:1px solid var(--border-subtle); border-radius:4px; cursor:pointer;">⚙ Columns</button>
+			<div id="sessions-columns-menu" style="display:none; position:absolute; right:0; top:100%; margin-top:4px; z-index:20; background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:6px; box-shadow:0 4px 10px var(--shadow-color); padding:4px 0; min-width:160px;">
+				${items}
+			</div>
 		</div>`;
 }
 
@@ -1066,6 +1111,38 @@ function setupSessionsTableSort(): void {
 		if (container) { container.innerHTML = buildSessionsTableHtml(cachedTodaySessions); }
 	});
 	setupSessionsLookbackSelector();
+	setupSessionColumnsMenu();
+}
+
+let _documentClickClosesColumnsMenu = false;
+
+function setupSessionColumnsMenu(): void {
+	const toggle = document.getElementById('sessions-columns-toggle');
+	const menu = document.getElementById('sessions-columns-menu');
+	if (!toggle || !menu) { return; }
+	toggle.addEventListener('click', (e) => {
+		e.stopPropagation();
+		menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+	});
+	menu.addEventListener('click', (e) => e.stopPropagation());
+	menu.addEventListener('change', (e) => {
+		const checkbox = e.target as HTMLInputElement;
+		const columnId = checkbox.getAttribute('data-column') as SessionColumnId | null;
+		if (!columnId) { return; }
+		if (checkbox.checked) { enabledSessionColumns.add(columnId); } else { enabledSessionColumns.delete(columnId); }
+		const container = document.getElementById('sessions-table-container');
+		if (container) { container.innerHTML = buildSessionsTableHtml(cachedTodaySessions); }
+		saveSessionColumnSettings();
+	});
+	// Attached once ever (not per re-render) and re-queries the live menu element on
+	// each click, so it keeps working across full DOM rebuilds without leaking listeners.
+	if (!_documentClickClosesColumnsMenu) {
+		_documentClickClosesColumnsMenu = true;
+		document.addEventListener('click', () => {
+			const liveMenu = document.getElementById('sessions-columns-menu');
+			if (liveMenu) { liveMenu.style.display = 'none'; }
+		});
+	}
 }
 
 function setupSessionsLookbackSelector(): void {
@@ -2586,6 +2663,7 @@ function buildSessionsTabPanelHtml(stats: UsageAnalysisStats): string {
 						<option value="7"${sessionsLookback === '7' ? ' selected' : ''}>Last 7 days</option>
 						<option value="30"${sessionsLookback === '30' ? ' selected' : ''}>Last 30 days</option>
 					</select>
+					${buildSessionColumnsMenuHtml()}
 				</div>
 				<div class="section-subtitle">Individual session breakdown for the selected period — sorted by number of interactions (most active first).</div>
 				<div id="sessions-panel-body" style="margin-top: 12px;">
@@ -3794,6 +3872,11 @@ async function bootstrap(): Promise<void> {
 	}
 	setFormatLocale(initialData.locale);
 	use24HourTime = initialData.use24HourTime !== false;
+	const savedColumns = initialData.sessionColumnSettings?.enabledColumns;
+	if (Array.isArray(savedColumns)) {
+		const valid = savedColumns.filter((c): c is SessionColumnId => (ALL_SESSION_COLUMN_IDS as string[]).includes(c));
+		enabledSessionColumns = new Set(valid);
+	}
 	renderLayout(initialData);
 	setupSessionsTableSort();
 

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -7,6 +7,7 @@ addEditorUsage,
 computeUtcDateRanges,
 aggregatePeriodStats,
 computeSessionTotalTokens,
+computeSessionDurationMs,
 type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../../src/statsHelpers';
@@ -58,6 +59,33 @@ const cachedReadTokensSubsetOfInput = 40;
 const total = computeSessionTotalTokens(inputTokensIncludingCache, 20, 0);
 assert.strictEqual(total, 120);
 assert.notStrictEqual(total, 120 + cachedReadTokensSubsetOfInput);
+});
+
+// ── computeSessionDurationMs ─────────────────────────────────────────────────
+
+test('computeSessionDurationMs: returns the difference between first and last interaction', () => {
+assert.strictEqual(
+computeSessionDurationMs('2026-07-11T10:00:00.000Z', '2026-07-11T10:12:00.000Z'),
+12 * 60 * 1000,
+);
+});
+
+test('computeSessionDurationMs: returns 0 for identical timestamps', () => {
+assert.strictEqual(computeSessionDurationMs('2026-07-11T10:00:00.000Z', '2026-07-11T10:00:00.000Z'), 0);
+});
+
+test('computeSessionDurationMs: returns undefined when either timestamp is missing', () => {
+assert.strictEqual(computeSessionDurationMs(null, '2026-07-11T10:00:00.000Z'), undefined);
+assert.strictEqual(computeSessionDurationMs('2026-07-11T10:00:00.000Z', null), undefined);
+assert.strictEqual(computeSessionDurationMs(undefined, undefined), undefined);
+assert.strictEqual(computeSessionDurationMs('', ''), undefined);
+});
+
+test('computeSessionDurationMs: returns undefined for invalid or negative ranges', () => {
+assert.strictEqual(computeSessionDurationMs('not-a-date', '2026-07-11T10:00:00.000Z'), undefined);
+assert.strictEqual(computeSessionDurationMs('2026-07-11T10:00:00.000Z', 'not-a-date'), undefined);
+// last before first (clock skew / corrupt data) must not yield a negative duration
+assert.strictEqual(computeSessionDurationMs('2026-07-11T10:12:00.000Z', '2026-07-11T10:00:00.000Z'), undefined);
 });
 
 // ── addModelUsage ────────────────────────────────────────────────────────────

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -10,6 +10,7 @@ import {
 	formatPercent,
 	formatNumber,
 	formatCost,
+	formatDurationShort,
 	escapeHtml,
 	markdownToHtml,
 	STAGE_LABELS,
@@ -40,6 +41,30 @@ test('getModelDisplayName: decodes URI-encoded segments in unknown model IDs', (
 
 test('getModelDisplayName: returns raw ID when URI decoding fails (malformed percent)', () => {
 	assert.equal(getModelDisplayName('bad%2model'), 'bad%2model');
+});
+
+// ── formatDurationShort ─────────────────────────────────────────────────
+
+test('formatDurationShort: formats minutes-only durations', () => {
+	assert.equal(formatDurationShort(12 * 60 * 1000), '12m');
+	assert.equal(formatDurationShort(59 * 60 * 1000), '59m');
+});
+
+test('formatDurationShort: formats hour durations with zero-padded minutes', () => {
+	assert.equal(formatDurationShort(64 * 60 * 1000), '1h 04m');
+	assert.equal(formatDurationShort(2 * 60 * 60 * 1000), '2h 00m');
+	assert.equal(formatDurationShort((60 + 30) * 60 * 1000), '1h 30m');
+});
+
+test('formatDurationShort: formats sub-minute durations as <1m', () => {
+	assert.equal(formatDurationShort(0), '<1m');
+	assert.equal(formatDurationShort(29 * 1000), '<1m');
+});
+
+test('formatDurationShort: returns em dash for missing or invalid values', () => {
+	assert.equal(formatDurationShort(undefined), '—');
+	assert.equal(formatDurationShort(-1), '—');
+	assert.equal(formatDurationShort(Number.NaN), '—');
 });
 
 // ── getEditorIcon ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Upgrades the Usage Analysis dashboard's "Today's Sessions" tab into a "Recent Sessions" browser:

- **Lookback selector** (Today / Last 7 days / Last 30 days). Today stays the default so nothing changes for existing usage; longer windows are lazily requested from the extension host and cached.
- **Duration column**, computed from a new shared `computeSessionDurationMs()` helper (`src/statsHelpers.ts`) using each session's first/last interaction timestamps.
- **Workspace column**, populated when attribution is cheaply available (`sessionData.repository`, falling back to workspaceStorage folder resolution).
- **Column visibility toggles**: a new "⚙ Columns" dropdown next to the lookback selector lets you show/hide any optional column (Turns, Tools, Input/Output/Thinking/Cached/Total tokens, Cost, Editor, Workspace, Models, Duration, Last Active). **Title is mandatory** and isn't in the list. The selection persists via `context.globalState` (same pattern already used for the Details view's sort settings), so it survives panel reopen and VS Code restarts.
- Table rendering/sorting is now driven by a single column-descriptor table (`SESSION_COLUMN_DEFS`) instead of hand-written per-column markup, so header/cell/sort logic can't drift out of sync as columns are added later.

## Scope

- `vscode-extension/src/webview/usage/main.ts` — table refactor, lookback UI, columns menu
- `vscode-extension/src/extension.ts` — `loadRecentSessions`, session-summary duration/workspace fields, `saveSessionColumnSettings` message handler
- `src/statsHelpers.ts`, `src/types.ts` — additive `computeSessionDurationMs()` helper and optional `durationMs`/`workspace` fields on `TodaySessionSummary` (CLI-safe, no shared-parsing logic changed)
- `vscode-extension/src/webview/shared/formatUtils.ts` — duration formatting helper

## Verification

- Rebased onto current `main` (after #1586 and #1587 merged) — resolved real conflicts in `src/types.ts`, `extension.ts`, and `usage/main.ts` against main's new Copilot-CLI context-window fields (`maxRequestInputTokens`, `contextTier`, etc.); both feature sets are additive and now coexist
- `npm run compile` (tsc + eslint + esbuild) clean — 0 errors (2 pre-existing/threshold complexity warnings, no new errors)
- `npm run test:node` — all tests passing
- Manually tested in the Extension Development Host

## Notes

Part of the same UI review as #1586 and #1587. One sibling branch remains (`ui/sidebar-navigation`), kept separate on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)