### PR TITLE
Fix: price Claude 1-hour cache-write tokens at their own rate

### DIFF
--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -6,7 +6,7 @@
  * bootstrap-dependent logic lives in helpers.ts.
  */
 import { calculateEstimatedCost } from '../../src/tokenEstimation';
-import { normalizePathForComparison } from '../../src/workspaceHelpers';
+import { normalizePathForComparison, detectClaudeCodeEditorVariant } from '../../src/workspaceHelpers';
 import { createEmptyContextRefs } from '../../src/tokenEstimation';
 import type { ModelUsage, ModelPricing, PeriodStats, UsageAnalysisPeriod } from '../../src/types';
 export type { PeriodStats, UsageAnalysisPeriod } from '../../src/types';
@@ -77,7 +77,7 @@ export function getEditorSourceFromPath(filePath: string): string {
 	if (normalized.includes('/kiro.kiroagent/workspace-sessions/')) { return 'Kiro'; }
 	if (normalized.includes('/.continue/sessions/')) { return 'Continue'; }
 	if (normalized.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
-	if (normalized.includes('/.claude/projects/')) { return 'Claude Code'; }
+	if (normalized.includes('/.claude/projects/')) { return detectClaudeCodeEditorVariant(filePath); }
 	if (normalized.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
 	// Antigravity must be checked before Gemini CLI: both live under ~/.gemini/.
 	if (normalized.includes('/.gemini/antigravity/brain/')) { return 'Antigravity'; }

--- a/src/README.md
+++ b/src/README.md
@@ -128,13 +128,17 @@ identical) GitHub-published rate explicitly.
 | Field | Description |
 |-------|-------------|
 | `cachedInputCostPerMillion` | Cost per million tokens for cache **reads** — tokens already cached and billed at a reduced rate |
-| `cacheCreationCostPerMillion` | Cost per million tokens for cache **creation** — writing tokens into the cache (billed at a premium) |
+| `cacheCreationCostPerMillion` | Cost per million tokens for cache **creation**, 5-minute TTL — writing tokens into the cache (billed at a premium) |
+| `cacheCreation1hCostPerMillion` | Cost per million tokens for cache **creation**, 1-hour TTL — Anthropic's longer-lived cache tier, billed at a higher premium than the 5-minute TTL |
 
 When these fields are absent, the full `inputCostPerMillion` rate is applied to all input tokens.
 
 **Anthropic prompt caching rates** (used for all `claude-*` models):
 - Cache reads: **10% of input rate** (e.g. $0.30/M for Claude Sonnet 4 at $3.00/M input)
-- Cache creation: **125% of input rate** (e.g. $3.75/M for Claude Sonnet 4)
+- Cache creation, 5-minute TTL: **125% of input rate** (e.g. $3.75/M for Claude Sonnet 4)
+- Cache creation, 1-hour TTL: **200% of input rate** (e.g. $6.00/M for Claude Sonnet 4) — Claude Code uses this TTL by default, so its cache-write tokens should be priced with `cacheCreation1hCostPerMillion`, not the 5-minute rate.
+
+For sources that report the TTL breakdown (`cache_creation.ephemeral_1h_input_tokens` vs. `ephemeral_5m_input_tokens` in the raw Anthropic usage object — currently Claude Code and Claude Desktop), `ModelUsage.cacheCreation1hTokens` carries the 1-hour portion of `cacheCreationTokens`, and `calculateEstimatedCost()` prices it separately. When a source doesn't report the split, all cache-creation tokens fall back to the 5-minute rate (prior behavior, unchanged).
 
 **OpenAI prompt caching rates** (automatic prefix matching) vary by model family:
 - Cache reads use the explicit per-model `cachedInputCostPerMillion` values in `modelPricing.json` (for example: GPT-4o = 50% of input, GPT-4.1 = 25%, GPT-5.4 = 10%)

--- a/src/adapters/claudeCodeAdapter.ts
+++ b/src/adapters/claudeCodeAdapter.ts
@@ -3,7 +3,7 @@ import type { ModelUsage, ChatTurn, ActualUsage } from '../types';
 import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
 import { ClaudeCodeDataAccess, normalizeClaudeModelId } from '../claudecode';
 import { readClaudeCodeEventsForAnalysis, createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
-import { isMcpTool, extractMcpServerName } from '../workspaceHelpers';
+import { isMcpTool, extractMcpServerName, detectClaudeCodeEditorVariant } from '../workspaceHelpers';
 import { createEmptyContextRefs } from '../tokenEstimation';
 
 /**
@@ -51,6 +51,15 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 
 	handles(sessionFile: string): boolean {
 		return this.claudeCode.isClaudeCodeSessionFile(sessionFile);
+	}
+
+	/**
+	 * Claude Code (CLI/VS Code extension) and the standalone Claude Desktop app both write
+	 * to ~/.claude/projects/ and are indistinguishable by path alone — only the `entrypoint`
+	 * field inside the session file tells them apart.
+	 */
+	getDisplayName(sessionFile: string): string {
+		return detectClaudeCodeEditorVariant(sessionFile);
 	}
 
 	getBackingPath(sessionFile: string): string {

--- a/src/claudecode.ts
+++ b/src/claudecode.ts
@@ -216,6 +216,49 @@ export class ClaudeCodeDataAccess {
 	}
 
 	/**
+	 * Extract the cache-related token breakdown from an Anthropic usage object:
+	 * total cache-creation tokens, the portion written under the 1-hour TTL, and
+	 * cache-read tokens. Anthropic bills cache-creation at different rates depending
+	 * on TTL, so the 1-hour portion is tracked separately from the total.
+	 */
+	private extractCacheTokenBreakdown(usage: any): { cacheCreation: number; cacheCreation1h: number; cachedRead: number } {
+		const cacheCreation = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+		const cacheCreation1h = typeof usage.cache_creation?.ephemeral_1h_input_tokens === 'number'
+			? usage.cache_creation.ephemeral_1h_input_tokens
+			: 0;
+		const cachedRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
+		return { cacheCreation, cacheCreation1h, cachedRead };
+	}
+
+	private addModelUsageEntry(
+		modelUsage: ModelUsage,
+		model: string,
+		usage: any
+	): void {
+		if (!modelUsage[model]) {
+			modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
+		}
+
+		const { cacheCreation, cacheCreation1h, cachedRead } = this.extractCacheTokenBreakdown(usage);
+		const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
+			+ cacheCreation
+			+ cachedRead;
+		const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+
+		modelUsage[model].inputTokens += inputTokens;
+		modelUsage[model].outputTokens += outputTokens;
+		if (cacheCreation > 0) {
+			modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + cacheCreation;
+		}
+		if (cacheCreation1h > 0) {
+			modelUsage[model].cacheCreation1hTokens = (modelUsage[model].cacheCreation1hTokens ?? 0) + cacheCreation1h;
+		}
+		if (cachedRead > 0) {
+			modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + cachedRead;
+		}
+	}
+
+	/**
 	 * Get per-model token usage from a Claude Code session.
 	 * Uses the model field from assistant event message objects.
 	 * De-duplicates by message.id (last-wins) — see deduplicateAssistantEvents.
@@ -227,26 +270,7 @@ export class ClaudeCodeDataAccess {
 		for (const event of this.deduplicateAssistantEvents(events)) {
 			const usage = event.message.usage;
 			const model = normalizeClaudeModelId(event.message?.model || 'unknown');
-
-			if (!modelUsage[model]) {
-				modelUsage[model] = { inputTokens: 0, outputTokens: 0 };
-			}
-
-			const cacheCreation = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
-			const cachedRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
-			const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
-				+ cacheCreation
-				+ cachedRead;
-			const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
-
-			modelUsage[model].inputTokens += inputTokens;
-			modelUsage[model].outputTokens += outputTokens;
-			if (cacheCreation > 0) {
-				modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + cacheCreation;
-			}
-			if (cachedRead > 0) {
-				modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + cachedRead;
-			}
+			this.addModelUsageEntry(modelUsage, model, usage);
 		}
 
 		return modelUsage;

--- a/src/claudedesktop.ts
+++ b/src/claudedesktop.ts
@@ -195,12 +195,17 @@ export class ClaudeDesktopCoworkDataAccess {
 		return { tokens: totalInputTokens + totalOutputTokens, thinkingTokens: 0 };
 	}
 
-	private computeCoworkTokenCounts(usage: any): { inputTokens: number; outputTokens: number; cacheCreation: number; cachedRead: number } {
+	private computeCoworkTokenCounts(usage: any): { inputTokens: number; outputTokens: number; cacheCreation: number; cachedRead: number; cacheCreation1h: number } {
 		const cacheCreation = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+		// Split out the 1-hour TTL portion of cache-creation tokens (billed at a higher
+		// rate than the default 5-minute TTL) — see calculateEstimatedCost() in tokenEstimation.ts.
+		const cacheCreation1h = typeof usage.cache_creation?.ephemeral_1h_input_tokens === 'number'
+			? usage.cache_creation.ephemeral_1h_input_tokens
+			: 0;
 		const cachedRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
 		const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0) + cacheCreation + cachedRead;
 		const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
-		return { inputTokens, outputTokens, cacheCreation, cachedRead };
+		return { inputTokens, outputTokens, cacheCreation, cachedRead, cacheCreation1h };
 	}
 
 	private extractCoworkEventTokens(event: any, seenRequestIds: Set<string>): { inputTokens: number; outputTokens: number } | null {
@@ -256,19 +261,28 @@ export class ClaudeDesktopCoworkDataAccess {
 		if (event.type !== 'assistant') { return; }
 		const usage = event.message?.usage;
 		if (!usage) { return; }
-		const requestId = event.requestId;
-		if (requestId) {
-			if (!event.message?.stop_reason) { return; }
-			if (seenRequestIds.has(requestId)) { return; }
-			seenRequestIds.add(requestId);
-		}
+		if (!this.shouldCountCoworkRequest(event, seenRequestIds)) { return; }
 		const model = normalizeClaudeModelId(event.message?.model || 'unknown');
 		if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
-		const { inputTokens, outputTokens, cacheCreation, cachedRead } = this.computeCoworkTokenCounts(usage);
-		modelUsage[model].inputTokens += inputTokens;
-		modelUsage[model].outputTokens += outputTokens;
-		if (cacheCreation > 0) { modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + cacheCreation; }
-		if (cachedRead > 0) { modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + cachedRead; }
+		this.applyCoworkTokenCounts(modelUsage[model], usage);
+	}
+
+	private shouldCountCoworkRequest(event: any, seenRequestIds: Set<string>): boolean {
+		const requestId = event.requestId;
+		if (!requestId) { return true; }
+		if (!event.message?.stop_reason) { return false; }
+		if (seenRequestIds.has(requestId)) { return false; }
+		seenRequestIds.add(requestId);
+		return true;
+	}
+
+	private applyCoworkTokenCounts(entry: ModelUsage[string], usage: any): void {
+		const { inputTokens, outputTokens, cacheCreation, cachedRead, cacheCreation1h } = this.computeCoworkTokenCounts(usage);
+		entry.inputTokens += inputTokens;
+		entry.outputTokens += outputTokens;
+		if (cacheCreation > 0) { entry.cacheCreationTokens = (entry.cacheCreationTokens ?? 0) + cacheCreation; }
+		if (cacheCreation1h > 0) { entry.cacheCreation1hTokens = (entry.cacheCreation1hTokens ?? 0) + cacheCreation1h; }
+		if (cachedRead > 0) { entry.cachedReadTokens = (entry.cachedReadTokens ?? 0) + cachedRead; }
 	}
 
 	/**

--- a/src/modelPricing.json
+++ b/src/modelPricing.json
@@ -358,6 +358,7 @@
       "outputCostPerMillion": 15.0,
       "cachedInputCostPerMillion": 0.3,
       "cacheCreationCostPerMillion": 3.75,
+      "cacheCreation1hCostPerMillion": 6,
       "category": "Claude models (Anthropic)",
       "tier": "unknown",
       "multiplier": 1,
@@ -370,6 +371,7 @@
       "outputCostPerMillion": 15.0,
       "cachedInputCostPerMillion": 0.3,
       "cacheCreationCostPerMillion": 3.75,
+      "cacheCreation1hCostPerMillion": 6,
       "category": "Claude models (Anthropic)",
       "tier": "unknown",
       "multiplier": 1,
@@ -382,6 +384,7 @@
       "outputCostPerMillion": 15.0,
       "cachedInputCostPerMillion": 0.3,
       "cacheCreationCostPerMillion": 3.75,
+      "cacheCreation1hCostPerMillion": 6,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 1,
@@ -402,6 +405,7 @@
       "outputCostPerMillion": 15.0,
       "cachedInputCostPerMillion": 0.3,
       "cacheCreationCostPerMillion": 3.75,
+      "cacheCreation1hCostPerMillion": 6,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 1,
@@ -422,6 +426,7 @@
       "outputCostPerMillion": 15.0,
       "cachedInputCostPerMillion": 0.3,
       "cacheCreationCostPerMillion": 3.75,
+      "cacheCreation1hCostPerMillion": 6,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 1.0,
@@ -442,6 +447,7 @@
       "outputCostPerMillion": 15.0,
       "cachedInputCostPerMillion": 0.3,
       "cacheCreationCostPerMillion": 3.75,
+      "cacheCreation1hCostPerMillion": 6,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 1.0,
@@ -462,6 +468,7 @@
       "outputCostPerMillion": 1.25,
       "cachedInputCostPerMillion": 0.025,
       "cacheCreationCostPerMillion": 0.3125,
+      "cacheCreation1hCostPerMillion": 0.5,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 0,
@@ -474,6 +481,7 @@
       "outputCostPerMillion": 5.0,
       "cachedInputCostPerMillion": 0.1,
       "cacheCreationCostPerMillion": 1.25,
+      "cacheCreation1hCostPerMillion": 2,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 0.33,
@@ -494,6 +502,7 @@
       "outputCostPerMillion": 5.0,
       "cachedInputCostPerMillion": 0.1,
       "cacheCreationCostPerMillion": 1.25,
+      "cacheCreation1hCostPerMillion": 2,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 0.33,
@@ -514,6 +523,7 @@
       "outputCostPerMillion": 75.0,
       "cachedInputCostPerMillion": 1.5,
       "cacheCreationCostPerMillion": 18.75,
+      "cacheCreation1hCostPerMillion": 30,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 10,
@@ -526,6 +536,7 @@
       "outputCostPerMillion": 25.0,
       "cachedInputCostPerMillion": 0.5,
       "cacheCreationCostPerMillion": 6.25,
+      "cacheCreation1hCostPerMillion": 10,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 3,
@@ -546,6 +557,7 @@
       "outputCostPerMillion": 25.0,
       "cachedInputCostPerMillion": 0.5,
       "cacheCreationCostPerMillion": 6.25,
+      "cacheCreation1hCostPerMillion": 10,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 3,
@@ -566,6 +578,7 @@
       "outputCostPerMillion": 25.0,
       "cachedInputCostPerMillion": 0.5,
       "cacheCreationCostPerMillion": 6.25,
+      "cacheCreation1hCostPerMillion": 10,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 15.0,
@@ -586,6 +599,7 @@
       "outputCostPerMillion": 25.0,
       "cachedInputCostPerMillion": 0.5,
       "cacheCreationCostPerMillion": 6.25,
+      "cacheCreation1hCostPerMillion": 10,
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "multiplier": 30,
@@ -606,6 +620,7 @@
       "outputCostPerMillion": 25.0,
       "cachedInputCostPerMillion": 0.5,
       "cacheCreationCostPerMillion": 6.25,
+      "cacheCreation1hCostPerMillion": 10,
       "category": "Claude models (Anthropic)",
       "tier": "premium",
       "multiplier": 30,
@@ -1068,7 +1083,8 @@
         "Claude Opus 4.8"
       ],
       "cachedInputCostPerMillion": 0.5,
-      "cacheCreationCostPerMillion": 6.25
+      "cacheCreationCostPerMillion": 6.25,
+      "cacheCreation1hCostPerMillion": 10
     },
     "qwen2.5": {
       "inputCostPerMillion": 0.0,
@@ -1111,7 +1127,8 @@
         "Claude Fable 5"
       ],
       "cachedInputCostPerMillion": 1.0,
-      "cacheCreationCostPerMillion": 12.5
+      "cacheCreationCostPerMillion": 12.5,
+      "cacheCreation1hCostPerMillion": 20
     },
     "deepseek-v4-flash": {
       "inputCostPerMillion": 0.14,
@@ -1144,7 +1161,8 @@
         "Claude Sonnet 5"
       ],
       "cachedInputCostPerMillion": 0.2,
-      "cacheCreationCostPerMillion": 2.5
+      "cacheCreationCostPerMillion": 2.5,
+      "cacheCreation1hCostPerMillion": 4
     },
     "claude-opus-4.8-(fast-mode)-(preview)": {
       "inputCostPerMillion": 10.0,
@@ -1156,7 +1174,8 @@
         "Claude Opus 4.8 (fast mode) (preview)"
       ],
       "cachedInputCostPerMillion": 1.0,
-      "cacheCreationCostPerMillion": 12.5
+      "cacheCreationCostPerMillion": 12.5,
+      "cacheCreation1hCostPerMillion": 20
     },
     "kimi-k2.7-code": {
       "inputCostPerMillion": 0.95,

--- a/src/tokenEstimation.ts
+++ b/src/tokenEstimation.ts
@@ -1204,11 +1204,21 @@ export function getModelCostBucket(modelId: string, modelPricing: { [key: string
  * are available (e.g. Claude Desktop / Claude Code / OpenCode sessions).
  *
  * Cost formula:
+ *   cacheCreation1h = min(cacheCreation1hTokens ?? 0, cacheCreationTokens ?? 0)
+ *   cacheCreation5m = (cacheCreationTokens ?? 0) - cacheCreation1h
  *   uncachedInput = inputTokens - (cachedReadTokens ?? 0) - (cacheCreationTokens ?? 0)
  *   cost = uncachedInput × inputCostPerMillion
  *        + cachedReadTokens × cachedInputCostPerMillion (fallback: inputCostPerMillion)
- *        + cacheCreationTokens × cacheCreationCostPerMillion (fallback: inputCostPerMillion)
+ *        + cacheCreation5m × cacheCreationCostPerMillion (fallback: inputCostPerMillion)
+ *        + cacheCreation1h × cacheCreation1hCostPerMillion (fallback: cacheCreationCostPerMillion, then inputCostPerMillion)
  *        + outputTokens × outputCostPerMillion
+ *
+ * Anthropic bills prompt-cache writes at different premiums depending on the cache TTL:
+ * the default 5-minute TTL is priced via `cacheCreationCostPerMillion`, while the 1-hour
+ * TTL (`cache_creation.ephemeral_1h_input_tokens` in the raw API response — used by
+ * default by Claude Code) is priced via `cacheCreation1hCostPerMillion`, roughly 1.6x the
+ * 5-minute rate. When callers don't split out `cacheCreation1hTokens`, all cache-creation
+ * tokens fall back to the 5-minute rate (unchanged prior behavior).
  *
  * @param modelUsage Object with model names as keys and token counts as values
  * @param modelPricing Pricing table keyed by model id
@@ -1240,14 +1250,17 @@ export function calculateEstimatedCost(
 
 		const cachedRead = usage.cachedReadTokens ?? 0;
 		const cacheCreation = usage.cacheCreationTokens ?? 0;
+		const cacheCreation1h = Math.min(usage.cacheCreation1hTokens ?? 0, cacheCreation);
+		const cacheCreation5m = cacheCreation - cacheCreation1h;
 		const uncachedInput = Math.max(0, usage.inputTokens - cachedRead - cacheCreation);
 
 		const uncachedInputCost = (uncachedInput / 1_000_000) * pricing.inputCostPerMillion;
 		const cachedReadCost = (cachedRead / 1_000_000) * (pricing.cachedInputCostPerMillion ?? pricing.inputCostPerMillion);
-		const cacheCreationCost = (cacheCreation / 1_000_000) * (pricing.cacheCreationCostPerMillion ?? pricing.inputCostPerMillion);
+		const cacheCreation5mCost = (cacheCreation5m / 1_000_000) * (pricing.cacheCreationCostPerMillion ?? pricing.inputCostPerMillion);
+		const cacheCreation1hCost = (cacheCreation1h / 1_000_000) * (pricing.cacheCreation1hCostPerMillion ?? pricing.cacheCreationCostPerMillion ?? pricing.inputCostPerMillion);
 		const outputCost = (usage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
 
-		totalCost += uncachedInputCost + cachedReadCost + cacheCreationCost + outputCost;
+		totalCost += uncachedInputCost + cachedReadCost + cacheCreation5mCost + cacheCreation1hCost + outputCost;
 	}
 
 	return totalCost;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export interface ModelUsage {
     outputTokens: number;
     cachedReadTokens?: number;     // portion of inputTokens that were cache reads (billed at reduced rate)
     cacheCreationTokens?: number;  // portion of inputTokens used to create cache entries (billed at higher rate)
+    /**
+     * Portion of cacheCreationTokens written under Anthropic's 1-hour cache TTL
+     * (`cache_creation.ephemeral_1h_input_tokens`), billed at a higher rate than the
+     * default 5-minute TTL. When present, calculateEstimatedCost() prices this portion
+     * with `cacheCreation1hCostPerMillion` and the remainder of cacheCreationTokens with
+     * the standard `cacheCreationCostPerMillion` (5-minute) rate.
+     */
+    cacheCreation1hTokens?: number;
   };
 }
 
@@ -30,6 +38,7 @@ export interface CopilotLongContextPricing {
   outputCostPerMillion: number;
   cachedInputCostPerMillion?: number;
   cacheCreationCostPerMillion?: number;
+  cacheCreation1hCostPerMillion?: number;
   threshold?: string;           // input-token threshold above which long-context rates apply (e.g. "> 200K")
 }
 
@@ -38,6 +47,7 @@ export interface CopilotPricing {
   outputCostPerMillion: number;
   cachedInputCostPerMillion?: number;
   cacheCreationCostPerMillion?: number;
+  cacheCreation1hCostPerMillion?: number;
   releaseStatus?: string;       // e.g. "GA" or "Public preview"
   category?: string;            // GitHub Copilot capability category (Lightweight / Versatile / Powerful)
   threshold?: string;           // input-token threshold for the Default tier, when the model is tiered
@@ -53,7 +63,8 @@ export interface ModelPricing {
   inputCostPerMillion: number;
   outputCostPerMillion: number;
   cachedInputCostPerMillion?: number;    // cost per million cache-read tokens (e.g. 0.30 for Claude Sonnet 4)
-  cacheCreationCostPerMillion?: number;  // cost per million cache-creation tokens (e.g. 3.75 for Claude Sonnet 4)
+  cacheCreationCostPerMillion?: number;  // cost per million cache-creation tokens, 5-minute TTL (e.g. 3.75 for Claude Sonnet 4)
+  cacheCreation1hCostPerMillion?: number; // cost per million cache-creation tokens, 1-hour TTL (e.g. 6.0 for Claude Sonnet 4)
   category?: string;
   tier?: "standard" | "premium" | "unknown";
   multiplier?: number;

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -943,6 +943,37 @@ function detectCopilotFamilyFromPath(lowerPath: string): string | undefined {
 }
 
 /**
+ * Peek at the start of a Claude Code session file (~/.claude/projects/**) to find the
+ * `entrypoint` field and distinguish the standalone Claude Desktop app from Claude Code
+ * running in a terminal or the VS Code extension. All three write to the same directory
+ * and are indistinguishable by path alone — only file content (the `entrypoint` field on
+ * early JSONL events, e.g. "claude-desktop", "claude-cli", "claude-vscode") tells them apart.
+ * Bounded to the first 64KB so classification stays cheap even for large session files.
+ * @internal
+ */
+export function detectClaudeCodeEditorVariant(filePath: string): string {
+	try {
+		const fd = fs.openSync(filePath, 'r');
+		try {
+			const buffer = Buffer.alloc(65536);
+			const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+			const chunk = buffer.toString('utf8', 0, bytesRead);
+			for (const line of chunk.split('\n')) {
+				const trimmed = line.trim();
+				if (!trimmed) { continue; }
+				let event: any;
+				try { event = JSON.parse(trimmed); } catch { continue; } // partial/truncated line
+				if (event?.entrypoint === 'claude-desktop') { return 'Claude Desktop'; }
+				if (event?.entrypoint) { return 'Claude Code'; }
+			}
+		} finally {
+			fs.closeSync(fd);
+		}
+	} catch { /* file unreadable — fall back to default below */ }
+	return 'Claude Code';
+}
+
+/**
  * Detect tool-specific (non-VS Code family) editors from a lower-cased normalised path.
  * Returns the editor name or undefined if none matched.
  * @internal
@@ -963,7 +994,7 @@ function detectToolEditorFromPath(
 	if (kiroEditor) { return kiroEditor; }
 	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }
 	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
-	if (lowerPath.includes('/.claude/projects/')) { return 'Claude Code'; }
+	if (lowerPath.includes('/.claude/projects/')) { return detectClaudeCodeEditorVariant(filePath); }
 	if (lowerPath.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
 	// Antigravity must be checked before Gemini CLI: both live under ~/.gemini/
 	// but Antigravity sessions are under ~/.gemini/antigravity/brain/ which is more specific.
@@ -993,8 +1024,12 @@ function detectVSCodeVariantFromPath(lowerPath: string): string | undefined {
 /**
  * Determine the editor type from a session file path.
  * Returns: 'VS Code', 'VS Code Insiders', 'VSCodium', 'Cursor', 'Copilot CLI',
- *          'JetBrains', 'OpenCode', 'Claude Code', 'Continue', 'Mistral Vibe',
- *          'Gemini CLI', 'Claude Desktop Cowork', 'Crush', or 'Unknown'.
+ *          'JetBrains', 'OpenCode', 'Claude Code', 'Claude Desktop', 'Continue',
+ *          'Mistral Vibe', 'Gemini CLI', 'Claude Desktop Cowork', 'Crush', or 'Unknown'.
+ * Note: 'Claude Code' and 'Claude Desktop' share the same ~/.claude/projects/ directory
+ * and are distinguished by the `entrypoint` field inside the session file, not the path
+ * (see detectClaudeCodeEditorVariant). 'Claude Desktop Cowork' is a separate, unrelated
+ * feature (local-agent-mode-sessions) and is still detected purely by path.
  */
 export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -9,6 +9,7 @@
 export const EDITOR_ICON_MAP: Record<string, string> = {
 	'Antigravity': '🚀',
 	'Claude Code': '🟠',
+	'Claude Desktop': '🟠',
 	'Claude Desktop Cowork': '🟠',
 	'Continue': '▶️',
 	'Copilot CLI': '🤖',

--- a/vscode-extension/test/unit/claudecode.test.ts
+++ b/vscode-extension/test/unit/claudecode.test.ts
@@ -263,6 +263,55 @@ test('getClaudeCodeModelUsage: aggregates per-model token usage', async () => {
 	}
 });
 
+test('getClaudeCodeModelUsage: tracks 1-hour cache TTL tokens separately from 5-minute TTL (issue #1589)', async () => {
+	// Claude Code defaults to Anthropic's 1-hour prompt-cache TTL, which is billed at a
+	// higher rate than the default 5-minute TTL. The breakdown lives under
+	// message.usage.cache_creation.ephemeral_1h_input_tokens / ephemeral_5m_input_tokens.
+	const events = [
+		{
+			type: 'assistant',
+			message: {
+				id: 'msg_1h',
+				model: 'claude-sonnet-4-6',
+				stop_reason: 'end_turn',
+				usage: {
+					input_tokens: 1,
+					output_tokens: 100,
+					cache_creation_input_tokens: 1000,
+					cache_read_input_tokens: 0,
+					cache_creation: { ephemeral_1h_input_tokens: 1000, ephemeral_5m_input_tokens: 0 }
+				}
+			}
+		},
+		{
+			type: 'assistant',
+			message: {
+				id: 'msg_5m',
+				model: 'claude-sonnet-4-6',
+				stop_reason: 'end_turn',
+				usage: {
+					input_tokens: 1,
+					output_tokens: 50,
+					cache_creation_input_tokens: 400,
+					cache_read_input_tokens: 0,
+					cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 400 }
+				}
+			}
+		}
+	];
+
+	const filePath = createTempSession(events);
+	try {
+		const modelUsage = await claudeCode.getClaudeCodeModelUsage(filePath);
+		const usage = modelUsage['claude-sonnet-4.6'];
+		assert.ok(usage);
+		assert.equal(usage.cacheCreationTokens, 1400); // total cache-write tokens (1000 + 400)
+		assert.equal(usage.cacheCreation1hTokens, 1000); // only the 1h-TTL portion
+	} finally {
+		cleanup(filePath);
+	}
+});
+
 test('getClaudeCodeSessionMeta: extracts title and timestamps', async () => {
 	const events = [
 		{

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -162,6 +162,32 @@ test('ClaudeCodeAdapter.handles: rejects ~/.claude/stats-cache.json', () => {
     assert.ok(!claudeCodeAdapter.handles(path.join(os.homedir(), '.claude', 'stats-cache.json')));
 });
 
+test('ClaudeCodeAdapter.getDisplayName: returns Claude Desktop for entrypoint claude-desktop', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-adapter-'));
+    const projectsDir = path.join(dir, '.claude', 'projects', 'hash');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    const file = path.join(projectsDir, 'session.jsonl');
+    fs.writeFileSync(file, JSON.stringify({ type: 'user', entrypoint: 'claude-desktop', timestamp: '2026-01-01T00:00:00.000Z' }) + '\n');
+    try {
+        assert.equal(claudeCodeAdapter.getDisplayName(file), 'Claude Desktop');
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('ClaudeCodeAdapter.getDisplayName: returns Claude Code for entrypoint claude-cli', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-adapter-'));
+    const projectsDir = path.join(dir, '.claude', 'projects', 'hash');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    const file = path.join(projectsDir, 'session.jsonl');
+    fs.writeFileSync(file, JSON.stringify({ type: 'user', entrypoint: 'claude-cli', timestamp: '2026-01-01T00:00:00.000Z' }) + '\n');
+    try {
+        assert.equal(claudeCodeAdapter.getDisplayName(file), 'Claude Code');
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
 test('MistralVibeAdapter.handles: recognises ~/.vibe/logs/session paths', () => {
     const p = path.join(os.homedir(), '.vibe', 'logs', 'session', 'session_20240101_120000_abc12345', 'meta.json');
     assert.ok(mistralVibeAdapter.handles(p));

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -1550,6 +1550,94 @@ test('calculateEstimatedCost: uses cachedInputCostPerMillion when present', () =
         assert.ok(Math.abs(cost - 6.0) < 1e-9);
 });
 
+// ── calculateEstimatedCost: 1-hour cache-creation TTL pricing ───────────────
+// Anthropic bills prompt-cache writes at different rates depending on TTL:
+// the default 5-minute TTL (cacheCreationCostPerMillion) vs. the 1-hour TTL
+// (cacheCreation1hCostPerMillion) that Claude Code uses by default, which is
+// billed at a higher rate. See issue #1589.
+
+test('calculateEstimatedCost: splits cacheCreationTokens into 1h and 5m portions', () => {
+        const modelUsage = {
+                'claude-sonnet-4-6': {
+                        inputTokens: 1_000_000,
+                        outputTokens: 0,
+                        cacheCreationTokens: 1_000_000,
+                        cacheCreation1hTokens: 400_000 // 400k of the 1M cache-write was 1h TTL, 600k was 5m TTL
+                }
+        };
+        const pricing = {
+                'claude-sonnet-4-6': {
+                        inputCostPerMillion: 3,
+                        outputCostPerMillion: 15,
+                        cacheCreationCostPerMillion: 3.75,
+                        cacheCreation1hCostPerMillion: 6
+                }
+        };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        // uncachedInput = max(0, 1_000_000 - 0 - 1_000_000) = 0
+        // 5m portion = 600_000 → 0.6 * 3.75 = 2.25
+        // 1h portion = 400_000 → 0.4 * 6 = 2.4
+        const expected = 2.25 + 2.4;
+        assert.ok(Math.abs(cost - expected) < 1e-9, `expected ${expected}, got ${cost}`);
+});
+
+test('calculateEstimatedCost: falls back to cacheCreationCostPerMillion when cacheCreation1hCostPerMillion is missing', () => {
+        const modelUsage = {
+                'model-x': {
+                        inputTokens: 100_000,
+                        outputTokens: 0,
+                        cacheCreationTokens: 100_000,
+                        cacheCreation1hTokens: 100_000
+                }
+        };
+        const pricing = {
+                'model-x': { inputCostPerMillion: 3, outputCostPerMillion: 15, cacheCreationCostPerMillion: 3.75 }
+        };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        // No cacheCreation1hCostPerMillion → all 100_000 tokens fall back to the 5-min rate
+        assert.ok(Math.abs(cost - 0.375) < 1e-9);
+});
+
+test('calculateEstimatedCost: cacheCreation1hTokens is clamped to cacheCreationTokens (never exceeds total)', () => {
+        const modelUsage = {
+                'claude-sonnet-4-6': {
+                        inputTokens: 100_000,
+                        outputTokens: 0,
+                        cacheCreationTokens: 50_000,
+                        cacheCreation1hTokens: 999_999 // malformed/overcounted input should not blow up the total
+                }
+        };
+        const pricing = {
+                'claude-sonnet-4-6': {
+                        inputCostPerMillion: 3,
+                        outputCostPerMillion: 15,
+                        cacheCreationCostPerMillion: 3.75,
+                        cacheCreation1hCostPerMillion: 6
+                }
+        };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        // cacheCreation1h clamped to 50_000 → 0.05 * 6 = 0.3, 5m portion = 0
+        // uncachedInput = max(0, 100_000 - 0 - 50_000) = 50_000 → 0.05 * 3 = 0.15
+        assert.ok(Math.abs(cost - 0.45) < 1e-9, `expected 0.45, got ${cost}`);
+});
+
+test('calculateEstimatedCost: no cacheCreation1hTokens behaves exactly as before (backward compatible)', () => {
+        const modelUsage = {
+                'claude-sonnet-4-6': { inputTokens: 100_000, outputTokens: 0, cacheCreationTokens: 100_000 }
+        };
+        const pricing = {
+                'claude-sonnet-4-6': {
+                        inputCostPerMillion: 3,
+                        outputCostPerMillion: 15,
+                        cacheCreationCostPerMillion: 3.75,
+                        cacheCreation1hCostPerMillion: 6
+                }
+        };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        // All 100_000 tokens priced at the 5m rate since cacheCreation1hTokens is absent
+        assert.ok(Math.abs(cost - 0.375) < 1e-9);
+});
+
 // ── getModelTier: additional edge cases ─────────────────────────────────────
 
 test('getModelTier: partial match where modelId includes key', () => {

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -257,7 +257,8 @@ import {
         extractWorkspaceIdFromSessionPath,
         globToRegExp,
         getEditorTypeFromPath,
-        detectEditorSource
+        detectEditorSource,
+        detectClaudeCodeEditorVariant
 } from '../../../src/workspaceHelpers';
 
 // ── extractWorkspaceIdFromSessionPath ───────────────────────────────────
@@ -327,6 +328,54 @@ test('getEditorTypeFromPath: detects Continue', () => {
 
 test('getEditorTypeFromPath: detects Claude Code', () => {
         assert.equal(getEditorTypeFromPath('/home/user/.claude/projects/hash/session.jsonl'), 'Claude Code');
+});
+
+test('detectClaudeCodeEditorVariant: returns Claude Desktop for entrypoint claude-desktop', () => {
+        const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'claude-variant-'));
+        const projectsDir = nodePath.join(dir, '.claude', 'projects', 'hash');
+        fs.mkdirSync(projectsDir, { recursive: true });
+        const file = nodePath.join(projectsDir, 'session.jsonl');
+        fs.writeFileSync(file, JSON.stringify({ type: 'user', entrypoint: 'claude-desktop', timestamp: '2026-01-01T00:00:00.000Z' }) + '\n');
+        try {
+                assert.equal(detectClaudeCodeEditorVariant(file), 'Claude Desktop');
+                assert.equal(getEditorTypeFromPath(file), 'Claude Desktop');
+        } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
+});
+
+test('detectClaudeCodeEditorVariant: returns Claude Code for entrypoint claude-cli', () => {
+        const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'claude-variant-'));
+        const file = nodePath.join(dir, 'session.jsonl');
+        fs.writeFileSync(file, JSON.stringify({ type: 'user', entrypoint: 'claude-cli', timestamp: '2026-01-01T00:00:00.000Z' }) + '\n');
+        try {
+                assert.equal(detectClaudeCodeEditorVariant(file), 'Claude Code');
+        } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
+});
+
+test('detectClaudeCodeEditorVariant: returns Claude Code for entrypoint claude-vscode', () => {
+        const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'claude-variant-'));
+        const file = nodePath.join(dir, 'session.jsonl');
+        fs.writeFileSync(file, JSON.stringify({ type: 'user', entrypoint: 'claude-vscode', timestamp: '2026-01-01T00:00:00.000Z' }) + '\n');
+        try {
+                assert.equal(detectClaudeCodeEditorVariant(file), 'Claude Code');
+        } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
+});
+
+test('detectClaudeCodeEditorVariant: defaults to Claude Code when file is missing or has no entrypoint', () => {
+        assert.equal(detectClaudeCodeEditorVariant('/nonexistent/path/session.jsonl'), 'Claude Code');
+        const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'claude-variant-'));
+        const file = nodePath.join(dir, 'session.jsonl');
+        fs.writeFileSync(file, JSON.stringify({ type: 'queue-operation', timestamp: '2026-01-01T00:00:00.000Z' }) + '\n');
+        try {
+                assert.equal(detectClaudeCodeEditorVariant(file), 'Claude Code');
+        } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
 });
 
 test('getEditorTypeFromPath: detects Cursor', () => {


### PR DESCRIPTION
## Summary

Two related fixes discovered while comparing our extension's surfaced Claude usage stats against Claude's own `/usage` panel for a real session (see #1570, #1589).

### 1. Cache-TTL pricing (fixes #1589)
Claude Code's default 1-hour prompt-cache write (`ephemeral_1h_input_tokens`, billed at 2x base input rate) was being priced the same as the cheaper 5-minute cache write (1.25x), undercounting cost by ~30% for sessions using 1h caching. Added `cacheCreation1hCostPerMillion` to pricing and split the cost formula by TTL.

### 2. Claude Desktop vs Claude Code misclassification (fixes #1593)
Both the standalone Claude Desktop app and Claude Code (CLI/VS Code extension) write to `~/.claude/projects/**/*.jsonl` and were always labeled `"Claude Code"`. The JSONL already carries an `entrypoint` field (`claude-cli`, `claude-vscode`, `claude-desktop`) that distinguishes them — now read and surfaced as a separate `"Claude Desktop"` editor type.

## Changes

- `src/modelPricing.json` — added `cacheCreation1hCostPerMillion` (2x input rate) to all 19 Claude entries.
- `src/types.ts` — new `cacheCreation1h*` fields on `ModelUsage`/`ModelPricing`/`CopilotPricing`/`CopilotLongContextPricing`.
- `src/tokenEstimation.ts` — `calculateEstimatedCost()` splits cache-creation tokens by TTL and prices each portion separately.
- `src/claudecode.ts` / `src/claudedesktop.ts` — parse `cache_creation.ephemeral_1h_input_tokens`.
- `src/workspaceHelpers.ts` — new `detectClaudeCodeEditorVariant()` peeks at the `entrypoint` field to tell Claude Desktop apart from Claude Code; wired into `getEditorTypeFromPath()`/`detectEditorSource()`.
- `src/adapters/claudeCodeAdapter.ts` — `getDisplayName()` uses the same detector for session-list/log-viewer/diagnostics consistency.
- `cli/src/analysis.ts` — reuses the shared detector so the CLI agrees with the extension.
- `vscode-extension/src/editorIcons.ts` — added `"Claude Desktop"` icon entry.
- `src/README.md` — documents the new cache-pricing field.
- Unit tests added for both fixes in `vscode-extension/test/unit/`.

## Verification

- `npm run compile` (vscode-extension): 0 errors, 2 pre-existing unrelated warnings.
- `npm run test:node` (vscode-extension): all ~80 test files pass.
- `cli`: `npm run build` and `npm run test:unit` both pass (23/23).
- Manually re-verified the cache-TTL fix against real session data: recomputed cost ($0.3818) closely matches Claude's own reported cost ($0.3978), down from the prior $0.2774.
