### PR TITLE
Add Devin (desktop app + CLI) as tracked editors

### DIFF
--- a/docs/logFilesSchema/README.md
+++ b/docs/logFilesSchema/README.md
@@ -37,13 +37,26 @@ This is the **primary reference** for understanding Copilot session file structu
 ### devin-windsurf-session-format.md
 **Research documentation** of Devin (Cognition Labs' desktop IDE) and its relationship to
 Windsurf. Devin is a direct fork/rebrand of Windsurf and shares the exact same Cascade
-`.pb` trajectory storage, bundled `codeium.windsurf` extension, and gRPC API — this file
-documents:
+`.pb` trajectory storage, bundled `codeium.windsurf` extension, and gRPC API — covers the
+**desktop app only**. This file documents:
 - The `product.json` / `oldDataFolderName` evidence that Devin is a Windsurf fork
 - Why `src/windsurf.ts` (`WindsurfDataAccess`) is the single data access layer for both editors
 - How live sessions are attributed to "Windsurf" vs. "Devin" based on `vscode.env.appName`
 - The known limitation for file-based `.pb` fallback discovery (always labeled "Windsurf")
-- The separate, out-of-scope Devin CLI (`sessions.db`) tool
+- A cross-reference to devin-cli-session-format.md for the separate Devin CLI tool
+
+### devin-cli-session-format.md
+**Research documentation** of Devin CLI (Cognition Labs' separate, ACP-based CLI agent
+tool — distinct from the Devin desktop app above). Integrated as a regular
+`IEcosystemAdapter` (`DevinCliAdapter`/`DevinCliDataAccess`), not a special case. This file
+documents:
+- The global `sessions.db` SQLite schema (`sessions`, `message_nodes` tree via
+  `parent_node_id`/`main_chain_id`, `prompt_history`, `tool_call_state`)
+- Best-effort `chat_message` JSON parsing inferred from the ACP v2 protocol schema
+- Why token counts are estimated (ACP has no per-message token counts; `cogs_json` field
+  names are guessed defensively) rather than actual API usage
+- The known limitation that all data tables were empty on the machine this was researched
+  on, so the schema is confirmed but example values are not
 
 ### gemini-cli-session-format.md
 **Research documentation** of an observed Gemini CLI session format on Windows. This file describes:

--- a/docs/logFilesSchema/README.md
+++ b/docs/logFilesSchema/README.md
@@ -34,6 +34,17 @@ This is the **primary reference** for understanding Copilot session file structu
 - Model attribution heuristic from `toolCallId` prefix (`toolu_*` ⇒ Anthropic, `call_*` ⇒ OpenAI)
 - Why the JetBrains JSONL must NOT be conflated with the Copilot CLI JSONL under `~/.copilot/session-state/`
 
+### devin-windsurf-session-format.md
+**Research documentation** of Devin (Cognition Labs' desktop IDE) and its relationship to
+Windsurf. Devin is a direct fork/rebrand of Windsurf and shares the exact same Cascade
+`.pb` trajectory storage, bundled `codeium.windsurf` extension, and gRPC API — this file
+documents:
+- The `product.json` / `oldDataFolderName` evidence that Devin is a Windsurf fork
+- Why `src/windsurf.ts` (`WindsurfDataAccess`) is the single data access layer for both editors
+- How live sessions are attributed to "Windsurf" vs. "Devin" based on `vscode.env.appName`
+- The known limitation for file-based `.pb` fallback discovery (always labeled "Windsurf")
+- The separate, out-of-scope Devin CLI (`sessions.db`) tool
+
 ### gemini-cli-session-format.md
 **Research documentation** of an observed Gemini CLI session format on Windows. This file describes:
 - File locations under `~/.gemini/`

--- a/docs/logFilesSchema/devin-cli-session-format.md
+++ b/docs/logFilesSchema/devin-cli-session-format.md
@@ -1,0 +1,153 @@
+# Devin CLI Session Storage (SQLite)
+
+## Summary
+
+Devin CLI (Cognition Labs) is a **separate tool from the Devin desktop app** (which is a
+fork/rebrand of Windsurf — see [devin-windsurf-session-format.md](./devin-windsurf-session-format.md)).
+It is an [ACP](https://agentclientprotocol.com) (Agent Client Protocol) based CLI agent.
+Its backend binary is internally named "chisel" (log messages reference `chisel_server`,
+`chisel_agent`, `chisel_api` crates), confirming a Rust implementation. It authenticates
+with a `windsurf-api-key` method id, reflecting the shared Cognition/Codeium lineage even
+though the storage format itself is entirely separate from Windsurf's Cascade `.pb` files.
+
+Unlike the Devin desktop app, Devin CLI is integrated as a regular `IEcosystemAdapter`
+(`DevinCliAdapter` in `src/adapters/devinCliAdapter.ts`, backed by `DevinCliDataAccess` in
+`src/devinCli.ts`) registered in the shared `src/adapters/adapterRegistry.ts` — it is
+**not** a hand-rolled special case like Windsurf/Devin-desktop.
+
+## Storage location
+
+All sessions across all projects/working-directories are stored in a single **global**
+SQLite database (no per-project registry, unlike Crush's `projects.json`):
+
+| OS | Path |
+|---|---|
+| Windows | `%APPDATA%\devin\cli\sessions.db` (confirmed on a live install) |
+| macOS | `~/Library/Application Support/devin/cli/sessions.db` (inferred — Rust `dirs` crate convention, not verified on a live install) |
+| Linux | `$XDG_DATA_HOME/devin/cli/sessions.db`, falling back to `~/.local/share/devin/cli/sessions.db` (inferred, not verified) |
+
+Windows also has a separate `%LOCALAPPDATA%\devin\cli\` directory holding cached
+config/model data (`team_settings.bin`, `model_configs*.bin`) — this is **not** session
+data and is not read by this integration.
+
+## Virtual path scheme
+
+`<absolute-path-to-sessions.db>#<session-id>`, mirroring the Crush (`crush.db#<uuid>`) and
+OpenCode (`opencode.db#ses_<id>`) convention. Example (Windows):
+
+```
+C:\Users\alice\AppData\Roaming\devin\cli\sessions.db#3ee22c56-...
+```
+
+## Schema
+
+Confirmed via `PRAGMA table_info` / `refinery_schema_history` (16 migrations) on a live
+install. **Important caveat: at the time this integration was built, every data table below
+was completely empty (0 rows) despite an actively-running Devin CLI ACP server process on
+the test machine** — the column list is confirmed, but real example values for
+`chat_message` and `cogs_json` could not be observed. See "Known limitations" below.
+
+### `sessions`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT (PK) | Session id, used in the virtual path suffix |
+| `working_directory` | TEXT | cwd the session was started in |
+| `backend_type` | TEXT | e.g. backend/model provider identifier |
+| `model` | TEXT | Model id for the session (no per-message model field exists — see below) |
+| `agent_mode` | TEXT | Agent mode identifier |
+| `created_at` | INTEGER | Epoch timestamp — **unit (seconds vs ms) unverified**, assumed seconds (see below) |
+| `last_activity_at` | INTEGER | Epoch timestamp, same caveat |
+| `title` | TEXT (nullable) | Session title |
+| `main_chain_id` | INTEGER (nullable) | `node_id` of the head of the active message chain (see message forest below) |
+| `shell_last_seen_index` | INTEGER | Shell prompt-history cursor |
+| `cogs_json` | TEXT (nullable) | Likely cost/token accounting blob ("cogs" = cost-of-goods-sold), added via the `add_session_cogs` migration. Shape unconfirmed. |
+| `workspace_dirs` | TEXT (nullable) | Additional workspace directories |
+| `hidden` | INTEGER | 0/1 — archived/deleted sessions |
+| `metadata` | TEXT (nullable) | Free-form JSON |
+
+### `message_nodes`
+
+Messages form a **tree**, not a flat list — `parent_node_id` links each node to its
+predecessor, and `NULL` marks a root. This happens because editing/regenerating a message
+creates a new branch without discarding the old one. `sessions.main_chain_id` identifies
+the `node_id` of the head (leaf) of the currently active branch; the adapter walks
+`parent_node_id` pointers backwards from that leaf to the root to reconstruct the ordered
+"main" conversation, falling back to `created_at` ordering across all nodes when
+`main_chain_id` is absent (see `DevinCliDataAccess.buildMainChain`).
+
+| Column | Type | Notes |
+|---|---|---|
+| `row_id` | INTEGER (PK) | |
+| `session_id` | TEXT (FK) | |
+| `node_id` | INTEGER | Id within the session's message forest |
+| `parent_node_id` | INTEGER (nullable) | `NULL` = root of the forest |
+| `chat_message` | TEXT | JSON — shape **inferred from the ACP v2 protocol schema**, not confirmed against live data (see below) |
+| `created_at` | INTEGER | Epoch timestamp |
+| `metadata` | TEXT (nullable) | |
+
+### `prompt_history`, `tool_call_state`
+
+| Table | Columns | Purpose |
+|---|---|---|
+| `prompt_history` | `id`, `content`, `timestamp`, `session_id`, `is_shell` | Shell/prompt entries; used as a fallback interaction count when `message_nodes` is empty |
+| `tool_call_state` | `session_id`, `tool_call_id`, `tool_call_json`, `tool_call_update_json` | Serialised `acp::ToolCall` / `acp::ToolCallUpdate` — tool name extracted defensively from `title`/`name`/`kind` fields |
+
+`rendered_commits`, `app_state`, `sqlite_sequence`, `refinery_schema_history` are not used
+by this integration.
+
+## `chat_message` parsing (best-effort — unconfirmed shape)
+
+No live populated row was available at implementation time. Parsing is inferred from the
+[ACP v2 JSON schema](https://github.com/agentclientprotocol/agent-client-protocol) and is
+intentionally defensive (`DevinCliDataAccess.parseChatMessage`), handling several plausible
+shapes:
+
+- `{ role: 'user' | 'assistant' | 'tool', content: string | ContentBlock[] }`
+- `{ sessionUpdate: 'user_message' | 'agent_message' | ..., content: ContentBlock[] }`
+  (ACP's own tagged-union `SessionUpdate` wire shape)
+- A flat `{ text: string }` fallback
+
+`ContentBlock`s of `type: 'text'` are concatenated to produce the message text. If neither
+shape matches, the message contributes no text (but does not throw).
+
+## Token/cost accounting (estimated, not actual API tokens)
+
+The core ACP protocol does not define per-message token counts — its `UsageUpdate` type is
+a **context-window snapshot** (`{ used, size }`, tokens currently in context vs. total
+window size), not cumulative per-turn input/output billing. The adapter therefore:
+
+1. First probes `sessions.cogs_json` for common field names (`input_tokens`/`prompt_tokens`,
+   `output_tokens`/`completion_tokens`, `reasoning_tokens`/`thinking_tokens`, and a
+   `used`/`total_tokens` fallback for an ACP-style snapshot) — this is speculative field-name
+   guessing, not confirmed against real data.
+2. Falls back to a **~4 characters/token estimate** from the concatenated text of all
+   `message_nodes.chat_message` entries when no recognised `cogs_json` fields are found
+   (the same estimation approach used by `ContinueAdapter`/JetBrains for editors that don't
+   persist real API token counts).
+
+Because ACP does not expose a per-message model field, all estimated tokens for a session
+are attributed to the single `sessions.model` value — mid-session model switches (if they
+occur) cannot be represented.
+
+## Timestamp units
+
+`created_at` / `last_activity_at` are epoch integers. Their unit (seconds vs. milliseconds)
+could not be verified against live data (all tables were empty). This implementation
+**assumes epoch seconds** (multiplying by 1000 before constructing JS `Date` objects),
+consistent with Crush's convention for a similar Rust/SQLite CLI-agent tool. **This should
+be re-verified once real session data exists on a machine with populated tables.**
+
+## Known limitations
+
+- **All data tables were empty (0 rows) on the machine this integration was built on**,
+  despite an actively-running Devin CLI ACP server process. The `chat_message` and
+  `cogs_json` shapes are inferred from the ACP protocol specification, not confirmed
+  against real examples. Token counts, model attribution, and turn reconstruction should
+  be spot-checked once genuine session data is available.
+- Per-turn token attribution (when falling back to text-length estimation) is currently a
+  simple length-based split between the user message and the immediately-following
+  assistant text — it does not use `cogs_json` even when present, since no live example
+  confirmed whether `cogs_json` holds per-turn or only session-level totals.
+- Cross-platform paths for macOS/Linux are inferred from Rust `dirs`-crate conventions and
+  have not been verified against a live non-Windows install.

--- a/docs/logFilesSchema/devin-windsurf-session-format.md
+++ b/docs/logFilesSchema/devin-windsurf-session-format.md
@@ -1,0 +1,96 @@
+# Devin & Windsurf Session Storage (Shared Cascade Format)
+
+## Summary
+
+Devin's desktop IDE (Cognition Labs) is a direct fork/rebrand of Windsurf, produced after
+Cognition acquired the Windsurf/Codeium team. It is **not** a new session-data format —
+Devin and Windsurf share the exact same on-disk Cascade trajectory storage, the same
+bundled first-party AI extension, and the same gRPC-over-HTTP/1.1 language-server API.
+
+This document exists so future contributors don't accidentally re-derive a "new" schema
+for Devin — there isn't one. `src/windsurf.ts` (`WindsurfDataAccess`) is the single data
+access layer for both editors; Devin support is a thin labeling layer on top of it.
+
+## Key findings (verified on a live Devin install)
+
+1. **`product.json`** (`resources/app/product.json` inside the Devin install) contains:
+   - `"nameShort": "Devin"`, `"nameLong": "Devin"`, `"applicationName": "devin-desktop"`
+   - `"dataFolderName": ".devin"`, **`"oldDataFolderName": ".windsurf"`**, `"oldNameShort": "Windsurf"`
+   - `vscode.env.appName` when running inside Devin is therefore `"Devin"` (not `"Windsurf"`).
+
+2. **The bundled first-party AI extension is literally the same extension as Windsurf's**:
+   `resources/app/extensions/windsurf/package.json` has `"name": "windsurf"`,
+   `"publisher": "codeium"` (displayName is "Devin", but the extension id is unchanged:
+   `codeium.windsurf`). `vscode.extensions.getExtension('codeium.windsurf')` — used by
+   `WindsurfDataAccess`'s credential-capture logic — works unmodified inside Devin.
+
+3. **Cascade trajectory storage is fully shared with Windsurf**: Devin writes its `.pb`
+   trajectory files into the exact same `~/.codeium/windsurf/cascade/*.pb` and
+   `~/.codeium/windsurf/implicit/*.pb` directories that a real Windsurf install uses.
+   There is **no separate Devin-specific session directory**.
+
+4. Devin's own user-data folder (`%APPDATA%\devin`, `~/.devin`) mirrors a standard
+   VS-Code-family layout (`User\workspaceStorage\<hash>\state.vscdb`,
+   `User\globalStorage\state.vscdb`, `User\History`, etc.) but does **not** contain
+   session/chat data — `chat.ChatSessionStore.index`, `agentSessions.model.cache`, and
+   `agentSessions.state.cache` were all empty on a live install. A leftover
+   `windsurf.devin.settingsMigrationComplete` setting and `windsurfAgentSidebarViewletState`
+   key confirm the UI is still internally called "windsurfAgent". **The authoritative
+   session data lives in the shared Cascade `.pb` files, not in Devin's own `state.vscdb`.**
+
+5. There is also a separate, currently-unused `%APPDATA%\devin\cli\sessions.db` (SQLite,
+   `sessions` / `message_nodes` / `prompt_history` / `tool_call_state` / `rendered_commits`
+   / `app_state` tables managed via `refinery_schema_history` migrations) belonging to a
+   **Devin CLI** (agent-mode, ACP-based) tool that is separate from the desktop app. It is
+   out of scope for this integration — see "Future work" below.
+
+## How the extension attributes sessions
+
+Because the storage is shared, the only way to know which app actually *produced* a
+given trajectory is to know which app is *currently running the extension* — the file
+itself carries no reliable per-origin signal.
+
+- **Live API discovery** (only possible while the extension is actually loaded inside
+  Windsurf or Devin): `WindsurfDataAccess.getHostEditorLabel()` inspects
+  `vscode.env.appName` at discovery time and labels newly-discovered sessions
+  `editorSource: 'windsurf' | 'devin'`, `editorName: 'Windsurf' | 'Devin'`, using virtual
+  path scheme `windsurf://trajectory/{id}` or `devin://trajectory/{id}` respectively.
+- **File-based `.pb` fallback discovery** (used when the extension runs in plain VS Code,
+  where neither app is present to distinguish origin): sessions are always labeled
+  `Windsurf` / `windsurf://trajectory/{id}`, matching prior behavior. **This is a known
+  limitation** — a Devin-only trajectory discovered this way will show up as "Windsurf" in
+  the session list until/unless a reliable per-file origin signal is found in the `.pb`
+  format.
+- Once a session's virtual path is decided (either scheme), the rest of the pipeline
+  (`resolveSession`, `extractTrajectoryId`, `getFamilyEditorName`, `isWindsurfSessionFile`)
+  treats `windsurf://` and `devin://` symmetrically, deriving the on-disk `.pb` path and
+  editor label directly from whichever prefix is present.
+
+## Where this lives in code
+
+| Concern | Location |
+|---|---|
+| Data access (both editors) | `src/windsurf.ts` (`WindsurfDataAccess`) |
+| Host-app detection | `isRunningInWindsurf()`, `isRunningInDevin()`, `isRunningInWindsurfFamily()` |
+| Session file recognition | `isWindsurfSessionFile()` (matches both `windsurf://` and `devin://` schemes) |
+| Path/label detection | `src/workspaceHelpers.ts` (`getEditorTypeFromPath`, `detectEditorSource`, `getEditorNameFromRoot`) |
+| Diagnostics candidate path | `src/sessionDiscovery.ts` (`getDiagnosticCandidatePaths`) — labels the shared Cascade folder per current host app |
+| Icon | `src/editorIcons.ts` (`EDITOR_ICON_MAP['Devin']`) |
+
+This is a **legacy hand-rolled special case** outside the `IEcosystemAdapter` registry
+(`src/adapters/adapterRegistry.ts`), matching how Windsurf itself is integrated — see the
+note in `.github/agents/new-editor-support.agent.md` about Windsurf being a pre-existing
+exception to the adapter-registry pattern. Devin extends that same special case rather
+than introducing a second one, since the underlying mechanism is identical.
+
+## Future work
+
+- **Devin CLI** (`%APPDATA%\devin\cli\sessions.db`) is a distinct, ACP-based agent-mode
+  tool with its own SQLite schema. It was empty/unused on the machine this was
+  researched on. If it becomes actively used, it should be integrated as its own
+  `IEcosystemAdapter` (SQLite-backed, similar to `CrushAdapter`) — it is unrelated to the
+  Cascade-sharing described above.
+- If a reliable way to distinguish Devin-origin vs. Windsurf-origin `.pb` files without
+  live API access is ever found (e.g. a field inside the protobuf payload), the
+  file-based fallback discovery could attribute origin correctly instead of always
+  defaulting to "Windsurf".

--- a/docs/logFilesSchema/devin-windsurf-session-format.md
+++ b/docs/logFilesSchema/devin-windsurf-session-format.md
@@ -1,5 +1,9 @@
 # Devin & Windsurf Session Storage (Shared Cascade Format)
 
+> **Scope:** this document covers the **Devin desktop app** (the Windsurf-fork IDE) only.
+> For the separate **Devin CLI** tool (a global sessions.db SQLite database), see
+> [devin-cli-session-format.md](./devin-cli-session-format.md).
+
 ## Summary
 
 Devin's desktop IDE (Cognition Labs) is a direct fork/rebrand of Windsurf, produced after
@@ -83,13 +87,17 @@ note in `.github/agents/new-editor-support.agent.md` about Windsurf being a pre-
 exception to the adapter-registry pattern. Devin extends that same special case rather
 than introducing a second one, since the underlying mechanism is identical.
 
+## Scope
+
+**This document covers the Devin *desktop app* only** (the Windsurf-fork IDE). Devin CLI
+— a separate, unrelated tool that stores sessions in a global `%APPDATA%\devin\cli\sessions.db`
+SQLite database — is documented in
+[`devin-cli-session-format.md`](./devin-cli-session-format.md). It is integrated as a
+regular `IEcosystemAdapter` (`DevinCliAdapter`), unlike the desktop app's legacy special
+case described here.
+
 ## Future work
 
-- **Devin CLI** (`%APPDATA%\devin\cli\sessions.db`) is a distinct, ACP-based agent-mode
-  tool with its own SQLite schema. It was empty/unused on the machine this was
-  researched on. If it becomes actively used, it should be integrated as its own
-  `IEcosystemAdapter` (SQLite-backed, similar to `CrushAdapter`) — it is unrelated to the
-  Cascade-sharing described above.
 - If a reliable way to distinguish Devin-origin vs. Windsurf-origin `.pb` files without
   live API access is ever found (e.g. a field inside the protobuf payload), the
   file-based fallback discovery could attribute origin correctly instead of always

--- a/src/adapters/adapterRegistry.ts
+++ b/src/adapters/adapterRegistry.ts
@@ -28,6 +28,7 @@ import { PiDataAccess } from '../pi';
 import { CursorDataAccess } from '../cursor';
 import { KiroDataAccess } from '../kiro';
 import { KiroCliDataAccess } from '../kirocli';
+import { DevinCliDataAccess } from '../devinCli';
 
 import { OpenCodeAdapter } from './openCodeAdapter';
 import { CrushAdapter } from './crushAdapter';
@@ -46,6 +47,7 @@ import { CopilotCliAdapter } from './copilotCliAdapter';
 import { JetBrainsAdapter } from './jetbrainsAdapter';
 import { KiroAdapter } from './kiroAdapter';
 import { KiroCliAdapter } from './kiroCliAdapter';
+import { DevinCliAdapter } from './devinCliAdapter';
 
 /** Data-access instances and callbacks required to build the adapter registry. */
 export interface AdapterRegistryDeps {
@@ -63,6 +65,7 @@ pi: PiDataAccess;
 cursor: CursorDataAccess;
 kiro: KiroDataAccess;
 kiroCli: KiroCliDataAccess;
+devinCli: DevinCliDataAccess;
 /** Estimates token count from raw text for a given model. */
 estimateTokens: (text: string, model?: string) => number;
 /** Returns true when the tool name identifies an MCP server tool. */
@@ -103,6 +106,7 @@ pi: new PiDataAccess(),
 cursor: new CursorDataAccess(extensionUri),
 kiro: new KiroDataAccess(),
 kiroCli: new KiroCliDataAccess(),
+devinCli: new DevinCliDataAccess(),
 };
 }
 
@@ -136,6 +140,7 @@ new PiAdapter(deps.pi),
 new CursorAdapter(deps.cursor),
 new KiroAdapter(deps.kiro),
 new KiroCliAdapter(deps.kiroCli),
+new DevinCliAdapter(deps.devinCli),
 // Copilot Chat / CLI adapters: discovery-only. Their handles() returns
 // false so processSessionFile() falls through to the shared parser path
 // for VS Code Copilot Chat and CLI files. See issue #654.

--- a/src/adapters/devinCliAdapter.ts
+++ b/src/adapters/devinCliAdapter.ts
@@ -1,0 +1,176 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ModelUsage, ChatTurn } from '../types';
+import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
+import { DevinCliDataAccess } from '../devinCli';
+import { createEmptyContextRefs } from '../tokenEstimation';
+import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+
+/**
+ * Adapter for Devin CLI (Cognition Labs' separate ACP-based CLI agent tool — NOT the
+ * Devin desktop app, which is a Windsurf fork handled as a legacy special case in
+ * windsurf.ts). See src/devinCli.ts and docs/logFilesSchema/devin-cli-session-format.md
+ * for the schema, virtual path scheme, and known data-availability limitations.
+ */
+export class DevinCliAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
+	readonly id = 'devincli';
+	readonly displayName = 'Devin CLI';
+
+	constructor(private readonly devinCli: DevinCliDataAccess) {}
+
+	handles(sessionFile: string): boolean {
+		return this.devinCli.isDevinCliSessionFile(sessionFile);
+	}
+
+	getBackingPath(sessionFile: string): string {
+		return this.devinCli.getDbPathFromVirtual(sessionFile);
+	}
+
+	async stat(sessionFile: string): Promise<fs.Stats> {
+		return this.devinCli.statSessionFile(sessionFile);
+	}
+
+	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+		const result = await this.devinCli.getTokens(sessionFile);
+		return { ...result, actualTokens: result.tokens };
+	}
+
+	async countInteractions(sessionFile: string): Promise<number> {
+		return this.devinCli.countInteractions(sessionFile);
+	}
+
+	async getModelUsage(sessionFile: string): Promise<ModelUsage> {
+		return this.devinCli.getModelUsage(sessionFile);
+	}
+
+	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+		const session = await this.devinCli.readSession(sessionFile);
+		const nodes = await this.devinCli.getMessageNodes(sessionFile);
+		const timestamps: number[] = [];
+		if (session?.created_at) { timestamps.push(session.created_at * 1000); }
+		if (session?.last_activity_at) { timestamps.push(session.last_activity_at * 1000); }
+		for (const node of nodes) {
+			if (node.created_at) { timestamps.push(node.created_at * 1000); }
+		}
+		timestamps.sort((a, b) => a - b);
+		return {
+			title: session?.title || undefined,
+			firstInteraction: timestamps.length > 0 ? new Date(timestamps[0]).toISOString() : null,
+			lastInteraction: timestamps.length > 0 ? new Date(timestamps[timestamps.length - 1]).toISOString() : null,
+			workspacePath: session?.working_directory || undefined,
+		};
+	}
+
+	getEditorRoot(sessionFile: string): string {
+		return path.dirname(this.devinCli.getDbPathFromVirtual(sessionFile));
+	}
+
+	async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
+		const candidatePaths = this.getCandidatePaths();
+		const sessionFiles: string[] = [];
+		const dbPath = this.devinCli.getDbPath();
+		log(`📁 Checking Devin CLI DB path: ${dbPath}`);
+		try {
+			await fs.promises.access(dbPath);
+			const sessionIds = await this.devinCli.discoverSessionIds();
+			if (sessionIds.length > 0) {
+				log(`📄 Found ${sessionIds.length} session(s) in Devin CLI database`);
+			}
+			sessionFiles.push(...sessionIds.map(id => this.devinCli.virtualPath(id)));
+		} catch (e) {
+			log(`Could not read Devin CLI database: ${e}`);
+		}
+		return { sessionFiles, candidatePaths };
+	}
+
+	getCandidatePaths(): CandidatePath[] {
+		return [{ path: this.devinCli.getDbPath(), source: 'Devin CLI (sessions.db)' }];
+	}
+
+	async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
+		const turns: ChatTurn[] = [];
+		const session = await this.devinCli.readSession(sessionFile);
+		const nodes = await this.devinCli.getMessageNodes(sessionFile);
+		const chain = this.devinCli.buildMainChain(nodes, session?.main_chain_id ?? null);
+		let turnNumber = 0;
+		for (let i = 0; i < chain.length; i++) {
+			const parsed = this.devinCli.parseChatMessage(chain[i].chat_message);
+			if (parsed.role !== 'user') { continue; }
+			turnNumber++;
+			turns.push(this.buildDevinCliTurn(chain, i, parsed.text, session, turnNumber));
+		}
+		return { turns };
+	}
+
+	/** Per-turn token estimates are derived directly from message text length (~4 chars/token),
+	 * since no confirmed per-turn cost/usage data exists in cogs_json (see class doc comment). */
+	private buildDevinCliTurn(
+		chain: ReturnType<DevinCliDataAccess['buildMainChain']>,
+		userIndex: number,
+		userText: string,
+		session: Awaited<ReturnType<DevinCliDataAccess['readSession']>>,
+		turnNumber: number
+	): ChatTurn {
+		let assistantText = '';
+		for (let j = userIndex + 1; j < chain.length; j++) {
+			const next = this.devinCli.parseChatMessage(chain[j].chat_message);
+			if (next.role === 'user') { break; }
+			if (next.role === 'assistant') { assistantText += (assistantText ? '\n' : '') + next.text; }
+		}
+		const node = chain[userIndex];
+		return {
+			turnNumber,
+			timestamp: node.created_at ? new Date(node.created_at * 1000).toISOString() : null,
+			mode: 'cli',
+			userMessage: userText,
+			assistantResponse: assistantText,
+			model: session?.model || null,
+			toolCalls: [],
+			contextReferences: createEmptyContextRefs(),
+			mcpTools: [],
+			inputTokensEstimate: Math.ceil(userText.length / 4),
+			outputTokensEstimate: Math.ceil(assistantText.length / 4),
+			thinkingTokensEstimate: 0
+		};
+	}
+
+	async getDailyFractions(sessionFile: string): Promise<Record<string, number>> {
+		return this.devinCli.getDailyFractions(sessionFile);
+	}
+
+	async analyzeUsage(sessionFile: string, ctx: UsageAnalysisAdapterContext): Promise<import('../types').SessionUsageAnalysis> {
+		const analysis = createEmptySessionUsageAnalysis();
+		const session = await this.devinCli.readSession(sessionFile);
+		const nodes = await this.devinCli.getMessageNodes(sessionFile);
+		const chain = this.devinCli.buildMainChain(nodes, session?.main_chain_id ?? null);
+		const toolCalls = await this.devinCli.getToolCalls(sessionFile);
+		const model = session?.model || 'unknown';
+		const models: string[] = [];
+		for (const node of chain) {
+			const parsed = this.devinCli.parseChatMessage(node.chat_message);
+			if (parsed.role === 'user') { analysis.modeUsage.cli++; models.push(model); }
+		}
+		analysis.toolCalls.total = toolCalls.length;
+		for (const tc of toolCalls) {
+			const toolName = this.extractToolName(tc.tool_call_json);
+			analysis.toolCalls.byTool[toolName] = (analysis.toolCalls.byTool[toolName] || 0) + 1;
+		}
+		const uniqueModels = [...new Set(models)];
+		analysis.modelSwitching.uniqueModels = uniqueModels;
+		analysis.modelSwitching.modelCount = uniqueModels.length;
+		analysis.modelSwitching.totalRequests = models.length;
+		applyModelTierClassification(ctx.modelPricing, uniqueModels, models, analysis);
+		return analysis;
+	}
+
+	private extractToolName(toolCallJson: string | null): string {
+		if (!toolCallJson) { return 'unknown'; }
+		try {
+			const parsed = JSON.parse(toolCallJson) as Record<string, unknown>;
+			const title = parsed['title'] ?? parsed['name'] ?? parsed['kind'];
+			return typeof title === 'string' && title ? title : 'unknown';
+		} catch {
+			return 'unknown';
+		}
+	}
+}

--- a/src/devinCli.ts
+++ b/src/devinCli.ts
@@ -110,6 +110,8 @@ export class DevinCliDataAccess {
 	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
 	private _dbCache: Map<string, DbCacheEntry> = new Map();
 	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
+	/** Test-only override for the sessions.db path, so tests don't depend on the real OS default location. */
+	private _dbPathOverride: string | null = null;
 
 	dispose(): void {
 		for (const entry of this._dbCache.values()) {
@@ -137,7 +139,12 @@ export class DevinCliDataAccess {
 
 	/** Absolute path to sessions.db. */
 	getDbPath(): string {
-		return path.join(this.getConfigDir(), 'sessions.db');
+		return this._dbPathOverride ?? path.join(this.getConfigDir(), 'sessions.db');
+	}
+
+	/** Test-only: override the sessions.db path so tests don't depend on the real OS default location. */
+	setDbPathOverrideForTests(dbPath: string | null): void {
+		this._dbPathOverride = dbPath;
 	}
 
 	/** Build a virtual session path for the given session id. */

--- a/src/devinCli.ts
+++ b/src/devinCli.ts
@@ -1,0 +1,549 @@
+/**
+ * DevinCliDataAccess — reads session data from Devin CLI's global SQLite database.
+ *
+ * Devin CLI (Cognition Labs) is a separate tool from the Devin desktop app (which is a
+ * fork/rebrand of Windsurf, see windsurf.ts / devin-windsurf-session-format.md). Devin CLI
+ * is an ACP (Agent Client Protocol, https://agentclientprotocol.com) based agent whose
+ * backend binary is internally named "chisel" (crates: chisel_server, chisel_agent,
+ * chisel_api) — confirming a Rust implementation.
+ *
+ * All sessions across all projects/working-directories are stored in a single global
+ * SQLite database (no per-project registry, unlike Crush's projects.json):
+ *   Windows: %APPDATA%\devin\cli\sessions.db
+ *   macOS:   ~/Library/Application Support/devin/cli/sessions.db   (inferred, Rust `dirs`
+ *            crate convention — not verified on a live macOS install)
+ *   Linux:   $XDG_DATA_HOME/devin/cli/sessions.db or ~/.local/share/devin/cli/sessions.db
+ *            (inferred, same convention — not verified)
+ *
+ * Virtual path scheme: <absolute-path-to-sessions.db>#<session-id>
+ * Example (Windows): C:\Users\alice\AppData\Roaming\devin\cli\sessions.db#3ee22c56-...
+ * Mirrors the Crush (crush.db#<uuid>) / OpenCode (opencode.db#ses_<id>) convention.
+ *
+ * Schema (confirmed via PRAGMA table_info / refinery_schema_history on a live but EMPTY
+ * install — see docs/logFilesSchema/devin-cli-session-format.md for the full writeup and
+ * known limitations):
+ *   sessions:          id, working_directory, backend_type, model, agent_mode, created_at,
+ *                      last_activity_at, title, main_chain_id, shell_last_seen_index,
+ *                      cogs_json, workspace_dirs, hidden, metadata
+ *   message_nodes:     row_id, session_id, node_id, parent_node_id (NULL = root), chat_message
+ *                      (JSON — shape inferred from the ACP v2 schema since no live populated
+ *                      row was available at implementation time), created_at, metadata
+ *   prompt_history:    id, content, timestamp, session_id, is_shell
+ *   tool_call_state:   session_id, tool_call_id, tool_call_json, tool_call_update_json
+ *
+ * IMPORTANT CAVEAT: at the time this adapter was written, sessions.db had zero rows in
+ * every data table despite an actively running Devin CLI ACP server process on the test
+ * machine. The chat_message JSON shape and cogs_json token/cost shape are therefore
+ * inferred from the ACP v2 protocol spec (UsageUpdate/Cost/ContentBlock types), not
+ * confirmed against real data. Parsing is intentionally defensive/best-effort; the token
+ * count falls back to a ~4-chars/token text estimate when no structured usage data is found.
+ *
+ * created_at / last_activity_at are documented in the task as epoch integers; their unit
+ * (seconds vs milliseconds) could not be verified against live data. This implementation
+ * assumes epoch SECONDS (consistent with Crush's convention for the same Cognition/Charm
+ * SQLite-based CLI-agent pattern) and multiplies by 1000 before constructing JS Dates.
+ * This should be re-verified once real session data exists.
+ */
+/// <reference types="sql.js" />
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import initSqlJs from 'sql.js';
+import type { ModelUsage } from './types';
+import { toLocalDayKey } from './utils/dayKeys';
+
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+type SqlDatabase = initSqlJs.Database;
+
+const DB_MARKER = 'devin/cli/sessions.db#';
+
+export interface DevinCliSession {
+	id: string;
+	working_directory: string | null;
+	backend_type: string | null;
+	model: string | null;
+	agent_mode: string | null;
+	created_at: number | null;
+	last_activity_at: number | null;
+	title: string | null;
+	main_chain_id: number | null;
+	cogs_json: string | null;
+	hidden: number | null;
+}
+
+export interface DevinCliMessageNode {
+	row_id: number;
+	session_id: string;
+	node_id: number;
+	parent_node_id: number | null;
+	chat_message: string | null;
+	created_at: number | null;
+	metadata: string | null;
+}
+
+export interface DevinCliToolCall {
+	session_id: string;
+	tool_call_id: string;
+	tool_call_json: string | null;
+	tool_call_update_json: string | null;
+}
+
+/** Parsed representation of a message_nodes.chat_message row, best-effort. */
+export interface ParsedChatMessage {
+	role: 'user' | 'assistant' | 'tool' | 'unknown';
+	text: string;
+}
+
+type DbCacheEntry = { db: SqlDatabase; mtimeMs: number; size: number };
+
+/** Returns the first finite numeric value found among the given keys, else 0. */
+function firstNumericField(obj: Record<string, unknown>, keys: string[]): number {
+	for (const key of keys) {
+		const v = obj[key];
+		if (typeof v === 'number' && Number.isFinite(v) && v !== 0) { return v; }
+	}
+	return 0;
+}
+
+export class DevinCliDataAccess {
+	private _sqlJsModule: SqlJsStatic | null = null;
+	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
+	private _dbCache: Map<string, DbCacheEntry> = new Map();
+	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
+
+	dispose(): void {
+		for (const entry of this._dbCache.values()) {
+			try { entry.db.close(); } catch { /* ignore */ }
+		}
+		this._dbCache.clear();
+		this._dbCacheInflight.clear();
+		this._sqlJsInitPromise = null;
+	}
+
+	/** Cross-platform config/data dir for Devin CLI. */
+	getConfigDir(): string {
+		if (process.platform === 'win32') {
+			const appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
+			return path.join(appData, 'devin', 'cli');
+		}
+		if (process.platform === 'darwin') {
+			return path.join(os.homedir(), 'Library', 'Application Support', 'devin', 'cli');
+		}
+		// Linux and other Unix-likes: XDG_DATA_HOME or ~/.local/share (inferred, unverified).
+		const xdgDataHome = process.env['XDG_DATA_HOME'];
+		const base = xdgDataHome && xdgDataHome.trim() ? xdgDataHome : path.join(os.homedir(), '.local', 'share');
+		return path.join(base, 'devin', 'cli');
+	}
+
+	/** Absolute path to sessions.db. */
+	getDbPath(): string {
+		return path.join(this.getConfigDir(), 'sessions.db');
+	}
+
+	/** Build a virtual session path for the given session id. */
+	virtualPath(sessionId: string): string {
+		return `${this.getDbPath()}#${sessionId}`;
+	}
+
+	/** Returns true if the path is a Devin CLI virtual session path (backslashes normalised). */
+	isDevinCliSessionFile(filePath: string): boolean {
+		return filePath.replace(/\\/g, '/').toLowerCase().includes(DB_MARKER);
+	}
+
+	/** Extract the real DB file path from a virtual session path. */
+	getDbPathFromVirtual(virtualPath: string): string {
+		const idx = virtualPath.lastIndexOf('sessions.db#');
+		if (idx === -1) { return virtualPath; }
+		return virtualPath.substring(0, idx + 'sessions.db'.length);
+	}
+
+	/** Extract the session id from a virtual session path. */
+	getSessionId(virtualPath: string): string | null {
+		const idx = virtualPath.lastIndexOf('sessions.db#');
+		if (idx === -1) { return null; }
+		const id = virtualPath.substring(idx + 'sessions.db#'.length);
+		return id || null;
+	}
+
+	/** Stat the underlying sessions.db file for a virtual path. */
+	async statSessionFile(virtualPath: string): Promise<fs.Stats> {
+		return fs.promises.stat(this.getDbPathFromVirtual(virtualPath));
+	}
+
+	private closeDb(db: SqlDatabase): void {
+		try { db.close(); } catch { /* ignore */ }
+	}
+
+	private isMissingFileError(error: unknown): boolean {
+		const code = (error as NodeJS.ErrnoException)?.code;
+		return code === 'ENOENT' || code === 'ENOTDIR';
+	}
+
+	private async statDb(dbPath: string): Promise<fs.Stats | null> {
+		try {
+			return await fs.promises.stat(dbPath);
+		} catch (error) {
+			if (this.isMissingFileError(error) && this._dbCache.has(dbPath)) {
+				this.closeDb(this._dbCache.get(dbPath)!.db);
+				this._dbCache.delete(dbPath);
+			}
+			return null;
+		}
+	}
+
+	private isCachedDbCurrent(dbPath: string, stats: fs.Stats): boolean {
+		const entry = this._dbCache.get(dbPath);
+		return !!entry && entry.mtimeMs === stats.mtimeMs && entry.size === stats.size;
+	}
+
+	private sameDbStats(left: fs.Stats, right: fs.Stats): boolean {
+		return left.mtimeMs === right.mtimeMs && left.size === right.size;
+	}
+
+	private async refreshDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
+		let db: SqlDatabase;
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = await fs.promises.readFile(dbPath);
+			db = new SQL.Database(buffer);
+		} catch {
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+		const currentStats = await this.statDb(dbPath);
+		if (!currentStats || !this.sameDbStats(stats, currentStats)) {
+			this.closeDb(db);
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+		const existing = this._dbCache.get(dbPath);
+		if (existing) { this.closeDb(existing.db); }
+		this._dbCache.set(dbPath, { db, mtimeMs: stats.mtimeMs, size: stats.size });
+		return db;
+	}
+
+	/**
+	 * Returns a cached SQL.Database instance, re-opening only when the file's
+	 * mtime/size change. Single-flight deduplication prevents duplicate reads.
+	 */
+	private async getDb(dbPath: string): Promise<SqlDatabase | null> {
+		const stats = await this.statDb(dbPath);
+		if (!stats) { return this._dbCache.get(dbPath)?.db ?? null; }
+		if (this.isCachedDbCurrent(dbPath, stats)) { return this._dbCache.get(dbPath)!.db; }
+		const cacheKey = `${dbPath}:${stats.mtimeMs}:${stats.size}`;
+		const inflight = this._dbCacheInflight.get(cacheKey);
+		if (inflight) { return inflight; }
+		const createDbPromise = this.refreshDb(dbPath, stats);
+		this._dbCacheInflight.set(cacheKey, createDbPromise);
+		try {
+			return await createDbPromise;
+		} finally {
+			if (this._dbCacheInflight.get(cacheKey) === createDbPromise) {
+				this._dbCacheInflight.delete(cacheKey);
+			}
+		}
+	}
+
+	/** Lazily initialise and cache the sql.js WASM module. */
+	async initSqlJs(): Promise<SqlJsStatic> {
+		if (this._sqlJsModule) { return this._sqlJsModule; }
+		if (!this._sqlJsInitPromise) {
+			this._sqlJsInitPromise = (async () => {
+				const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+				let wasmBinary: Uint8Array | undefined;
+				try {
+					wasmBinary = await fs.promises.readFile(wasmPath);
+				} catch { /* WASM file not present — proceed without pre-loaded binary */ }
+				const module = await initSqlJs(wasmBinary ? { wasmBinary: wasmBinary.buffer as ArrayBuffer } : undefined);
+				this._sqlJsModule = module;
+				return module;
+			})().catch(err => {
+				this._sqlJsInitPromise = null;
+				throw err;
+			});
+		}
+		return this._sqlJsInitPromise;
+	}
+
+	private rowsToObjects(result: initSqlJs.QueryExecResult[]): Record<string, unknown>[] {
+		if (result.length === 0) { return []; }
+		const { columns, values } = result[0];
+		return values.map(row => {
+			const obj: Record<string, unknown> = {};
+			columns.forEach((c, i) => { obj[c] = row[i]; });
+			return obj;
+		});
+	}
+
+	/** Discover all non-hidden session ids in the DB. */
+	async discoverSessionIds(): Promise<string[]> {
+		const dbPath = this.getDbPath();
+		const db = await this.getDb(dbPath);
+		if (!db) { return []; }
+		try {
+			const result = db.exec('SELECT id FROM sessions WHERE hidden = 0 OR hidden IS NULL ORDER BY last_activity_at DESC');
+			return this.rowsToObjects(result).map(r => r['id'] as string);
+		} catch {
+			try {
+				// hidden column may not exist on very old schema versions — fall back.
+				const result = db.exec('SELECT id FROM sessions ORDER BY last_activity_at DESC');
+				return this.rowsToObjects(result).map(r => r['id'] as string);
+			} catch {
+				return [];
+			}
+		}
+	}
+
+	/** Read session metadata for a virtual session path. */
+	async readSession(virtualPath: string): Promise<DevinCliSession | null> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId) { return null; }
+		const db = await this.getDb(dbPath);
+		if (!db) { return null; }
+		try {
+			const result = db.exec(
+				`SELECT id, working_directory, backend_type, model, agent_mode, created_at,
+				        last_activity_at, title, main_chain_id, cogs_json, hidden
+				 FROM sessions WHERE id = ?`,
+				[sessionId],
+			);
+			const rows = this.rowsToObjects(result);
+			if (rows.length === 0) { return null; }
+			return rows[0] as unknown as DevinCliSession;
+		} catch {
+			return null;
+		}
+	}
+
+	/** Read all message nodes for a session (unordered — caller reconstructs the chain). */
+	async getMessageNodes(virtualPath: string): Promise<DevinCliMessageNode[]> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId) { return []; }
+		const db = await this.getDb(dbPath);
+		if (!db) { return []; }
+		try {
+			const result = db.exec(
+				`SELECT row_id, session_id, node_id, parent_node_id, chat_message, created_at, metadata
+				 FROM message_nodes WHERE session_id = ? ORDER BY created_at ASC`,
+				[sessionId],
+			);
+			return this.rowsToObjects(result) as unknown as DevinCliMessageNode[];
+		} catch {
+			return [];
+		}
+	}
+
+	/** Read all tool call state rows for a session. */
+	async getToolCalls(virtualPath: string): Promise<DevinCliToolCall[]> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId) { return []; }
+		const db = await this.getDb(dbPath);
+		if (!db) { return []; }
+		try {
+			const result = db.exec(
+				`SELECT session_id, tool_call_id, tool_call_json, tool_call_update_json
+				 FROM tool_call_state WHERE session_id = ?`,
+				[sessionId],
+			);
+			return this.rowsToObjects(result) as unknown as DevinCliToolCall[];
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * Reconstruct the ordered "main" conversation chain for a session.
+	 *
+	 * message_nodes form a tree (parent_node_id), not a flat list — this happens when a
+	 * user edits/regenerates a message, leaving abandoned branches. When session.main_chain_id
+	 * identifies the head (leaf) node_id of the currently active branch, this walks parent
+	 * pointers from that leaf back to the root and reverses the result. If main_chain_id is
+	 * absent or the leaf can't be resolved, falls back to created_at ordering of all nodes
+	 * (which may include abandoned branches, but is a reasonable best-effort fallback).
+	 */
+	buildMainChain(nodes: DevinCliMessageNode[], mainChainId: number | null): DevinCliMessageNode[] {
+		if (nodes.length === 0) { return []; }
+		if (mainChainId === null || mainChainId === undefined) {
+			return [...nodes].sort((a, b) => (a.created_at ?? 0) - (b.created_at ?? 0));
+		}
+		const byNodeId = new Map<number, DevinCliMessageNode>();
+		for (const n of nodes) { byNodeId.set(n.node_id, n); }
+		const chain: DevinCliMessageNode[] = [];
+		let current = byNodeId.get(mainChainId);
+		const seen = new Set<number>();
+		while (current && !seen.has(current.node_id)) {
+			seen.add(current.node_id);
+			chain.push(current);
+			current = current.parent_node_id !== null ? byNodeId.get(current.parent_node_id) : undefined;
+		}
+		if (chain.length === 0) {
+			return [...nodes].sort((a, b) => (a.created_at ?? 0) - (b.created_at ?? 0));
+		}
+		return chain.reverse();
+	}
+
+	/**
+	 * Best-effort parse of a message_nodes.chat_message JSON blob.
+	 *
+	 * Shape is inferred from the ACP v2 protocol (UserMessage/AgentMessage/ContentBlock)
+	 * since no live populated row was available. Handles a few plausible shapes defensively:
+	 *  - { role: 'user'|'assistant'|'tool', content: string | ContentBlock[] }
+	 *  - { sessionUpdate: 'user_message'|'agent_message'|..., content: ContentBlock[] }
+	 *  - { text: string } (flat fallback)
+	 */
+	parseChatMessage(raw: string | null): ParsedChatMessage {
+		if (!raw) { return { role: 'unknown', text: '' }; }
+		let json: unknown;
+		try { json = JSON.parse(raw); } catch { return { role: 'unknown', text: raw }; }
+		if (typeof json !== 'object' || json === null) { return { role: 'unknown', text: '' }; }
+		const obj = json as Record<string, unknown>;
+		return { role: this.extractRole(obj), text: this.extractText(obj) };
+	}
+
+	private extractRole(obj: Record<string, unknown>): ParsedChatMessage['role'] {
+		const role = obj['role'];
+		if (role === 'user' || role === 'assistant' || role === 'tool') { return role; }
+		const sessionUpdate = obj['sessionUpdate'] ?? obj['session_update'];
+		if (typeof sessionUpdate === 'string') {
+			if (sessionUpdate.startsWith('user_message')) { return 'user'; }
+			if (sessionUpdate.startsWith('agent_message')) { return 'assistant'; }
+			if (sessionUpdate.includes('tool_call')) { return 'tool'; }
+		}
+		return 'unknown';
+	}
+
+	private extractText(obj: Record<string, unknown>): string {
+		const content = obj['content'];
+		if (typeof content === 'string') { return content; }
+		if (Array.isArray(content)) {
+			return content
+				.filter((block): block is Record<string, unknown> => typeof block === 'object' && block !== null)
+				.filter(block => block['type'] === 'text' && typeof block['text'] === 'string')
+				.map(block => block['text'] as string)
+				.join('\n');
+		}
+		if (typeof obj['text'] === 'string') { return obj['text'] as string; }
+		return '';
+	}
+
+	private estimateTokens(text: string): number {
+		if (!text) { return 0; }
+		return Math.ceil(text.length / 4);
+	}
+
+	/**
+	 * Best-effort extraction of a token/usage summary from sessions.cogs_json.
+	 * Field names are guessed defensively (no live example available) — probes several
+	 * plausible names used by cost-tracking ("cogs" = cost-of-goods-sold) systems.
+	 */
+	private extractCogsTokens(cogsJson: string | null): { input: number; output: number; thinking: number } | null {
+		const obj = this.parseJsonObject(cogsJson);
+		if (!obj) { return null; }
+		const input = firstNumericField(obj, ['input_tokens', 'prompt_tokens', 'inputTokens']);
+		const output = firstNumericField(obj, ['output_tokens', 'completion_tokens', 'outputTokens']);
+		const thinking = firstNumericField(obj, ['reasoning_tokens', 'thinking_tokens', 'reasoningTokens']);
+		if (input === 0 && output === 0 && thinking === 0) {
+			// ACP UsageUpdate-style snapshot: { used, size } — 'used' is context tokens currently
+			// in context, not a cumulative total, but is the best signal available if present.
+			const used = firstNumericField(obj, ['used', 'total_tokens', 'tokens_used']);
+			return used > 0 ? { input: used, output: 0, thinking: 0 } : null;
+		}
+		return { input, output, thinking };
+	}
+
+	private parseJsonObject(raw: string | null): Record<string, unknown> | null {
+		if (!raw) { return null; }
+		try {
+			const json = JSON.parse(raw);
+			return (typeof json === 'object' && json !== null) ? json as Record<string, unknown> : null;
+		} catch {
+			return null;
+		}
+	}
+
+	/** Get token counts (actual when available via cogs_json, else estimated from text). */
+	async getTokens(virtualPath: string): Promise<{ tokens: number; thinkingTokens: number }> {
+		const session = await this.readSession(virtualPath);
+		const cogs = this.extractCogsTokens(session?.cogs_json ?? null);
+		if (cogs) {
+			return { tokens: cogs.input + cogs.output + cogs.thinking, thinkingTokens: cogs.thinking };
+		}
+		const nodes = await this.getMessageNodes(virtualPath);
+		let tokens = 0;
+		for (const node of nodes) {
+			const parsed = this.parseChatMessage(node.chat_message);
+			tokens += this.estimateTokens(parsed.text);
+		}
+		return { tokens, thinkingTokens: 0 };
+	}
+
+	/** Count user-role interactions (turns) in the session's main chain. */
+	async countInteractions(virtualPath: string): Promise<number> {
+		const nodes = await this.getMessageNodes(virtualPath);
+		let count = 0;
+		for (const node of nodes) {
+			if (this.parseChatMessage(node.chat_message).role === 'user') { count++; }
+		}
+		if (count > 0) { return count; }
+		// Fall back to prompt_history (shell/prompt entries) when message_nodes is empty.
+		return this.countPromptHistory(virtualPath);
+	}
+
+	private async countPromptHistory(virtualPath: string): Promise<number> {
+		const dbPath = this.getDbPathFromVirtual(virtualPath);
+		const sessionId = this.getSessionId(virtualPath);
+		if (!sessionId) { return 0; }
+		const db = await this.getDb(dbPath);
+		if (!db) { return 0; }
+		try {
+			const result = db.exec('SELECT COUNT(*) as c FROM prompt_history WHERE session_id = ?', [sessionId]);
+			const rows = this.rowsToObjects(result);
+			return rows.length > 0 ? (rows[0]['c'] as number) || 0 : 0;
+		} catch {
+			return 0;
+		}
+	}
+
+	/**
+	 * Per-model token usage. ACP does not expose a per-message model field, so the
+	 * session-level `model` column is used to attribute all estimated tokens for the
+	 * session — this cannot represent mid-session model switches (not exposed by the schema).
+	 */
+	async getModelUsage(virtualPath: string): Promise<ModelUsage> {
+		const session = await this.readSession(virtualPath);
+		const model = session?.model || 'unknown';
+		const nodes = await this.getMessageNodes(virtualPath);
+		const usage: ModelUsage = { [model]: { inputTokens: 0, outputTokens: 0 } };
+		for (const node of nodes) {
+			const parsed = this.parseChatMessage(node.chat_message);
+			const est = this.estimateTokens(parsed.text);
+			if (parsed.role === 'user') { usage[model].inputTokens += est; }
+			else if (parsed.role === 'assistant') { usage[model].outputTokens += est; }
+		}
+		return usage;
+	}
+
+	/** Per-local-day fractions for accurate multi-day attribution. */
+	async getDailyFractions(virtualPath: string): Promise<Record<string, number>> {
+		const nodes = await this.getMessageNodes(virtualPath);
+		const counts: Record<string, number> = {};
+		let total = 0;
+		for (const node of nodes) {
+			if (!node.created_at) { continue; }
+			const dateKey = toLocalDayKey(new Date(node.created_at * 1000));
+			counts[dateKey] = (counts[dateKey] || 0) + 1;
+			total++;
+		}
+		if (total === 0) {
+			const session = await this.readSession(virtualPath);
+			const fallbackDate = session?.last_activity_at
+				? toLocalDayKey(new Date(session.last_activity_at * 1000))
+				: toLocalDayKey(new Date());
+			return { [fallbackDate]: 1.0 };
+		}
+		const fractions: Record<string, number> = {};
+		for (const [day, count] of Object.entries(counts)) { fractions[day] = count / total; }
+		return fractions;
+	}
+}

--- a/src/sessionDiscovery.ts
+++ b/src/sessionDiscovery.ts
@@ -107,10 +107,15 @@ export class SessionDiscovery {
 
 		if (this.deps.windsurf) {
 			const cascadeDir = this.deps.windsurf.getCascadeDir();
+			// Devin (Cognition Labs' desktop IDE) is a fork/rebrand of Windsurf that writes
+			// its Cascade trajectories into this exact same shared folder — there is no
+			// separate Devin-specific session directory to scan. Label the row per the app
+			// we're actually running in so the diagnostics panel reflects reality.
+			const source = this.deps.windsurf.isRunningInDevin() ? 'Devin Cascade (shared with Windsurf)' : 'Windsurf Cascade';
 			candidates.push({
 				path: cascadeDir,
-				exists: this.pathExistsWithLogging(cascadeDir, 'Windsurf Cascade'),
-				source: 'Windsurf Cascade',
+				exists: this.pathExistsWithLogging(cascadeDir, source),
+				source,
 			});
 		}
 

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -2177,7 +2177,7 @@ export async function analyzeSessionUsage(deps: UsageAnalysisDeps, sessionFile: 
 		if (eco && isAnalyzable(eco)) {
 			return eco.analyzeUsage(sessionFile, { modelPricing: deps.modelPricing, toolNameMap: deps.toolNameMap });
 		}
-		if (sessionFile.startsWith('windsurf://')) {
+		if (sessionFile.startsWith('windsurf://') || sessionFile.startsWith('devin://')) {
 			return analysis;
 		}
 
@@ -2513,7 +2513,7 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 		const eco = deps.ecosystems.find(e => e.handles(sessionFile));
 		if (eco) { return eco.getModelUsage(sessionFile); }
 	}
-	if (sessionFile.startsWith('windsurf://')) {
+	if (sessionFile.startsWith('windsurf://') || sessionFile.startsWith('devin://')) {
 		return modelUsage;
 	}
 	try {

--- a/src/windsurf.ts
+++ b/src/windsurf.ts
@@ -89,11 +89,64 @@ export class WindsurfDataAccess {
 	}
 
 	/**
-	 * Check if a session file is a Windsurf session file.
-	 * Windsurf uses virtual windsurf://trajectory/{id} paths.
+	 * Check if the extension is running inside Devin (Cognition Labs' desktop IDE — a direct
+	 * fork/rebrand of Windsurf after Cognition acquired the Windsurf/Codeium team). Devin's
+	 * product.json reports appName "Devin"; it bundles the same `codeium.windsurf` extension
+	 * and writes Cascade trajectories into the very same ~/.codeium/windsurf/cascade folder.
+	 */
+	isRunningInDevin(): boolean {
+		const appName = vscode.env.appName.toLowerCase();
+		this.log(`[Windsurf] appName="${vscode.env.appName}" → isDevin=${appName.includes('devin')}`);
+		return appName.includes('devin');
+	}
+
+	/**
+	 * True when running inside either Windsurf or Devin — both host the same bundled
+	 * codeium.windsurf extension and gRPC language server, so live API session discovery
+	 * works identically from within either app.
+	 */
+	isRunningInWindsurfFamily(): boolean {
+		return this.isRunningInWindsurf() || this.isRunningInDevin();
+	}
+
+	/**
+	 * Returns the editor label to attribute a *live API-discovered* session to, based on
+	 * which app is actually hosting the extension right now. Only meaningful while running
+	 * inside Windsurf or Devin — callers must not use this for file-based (.pb) fallback
+	 * discovery, where the producing app cannot be determined (see getWindsurfCascadeSessionFiles).
+	 */
+	private getHostEditorLabel(): { source: 'windsurf' | 'devin'; name: string; scheme: string } {
+		if (this.isRunningInDevin()) {
+			return { source: 'devin', name: 'Devin', scheme: 'devin://trajectory/' };
+		}
+		return { source: 'windsurf', name: 'Windsurf', scheme: 'windsurf://trajectory/' };
+	}
+
+	/**
+	 * Given a windsurf:// or devin:// virtual session path, returns the friendly editor
+	 * name encoded by its scheme ('Windsurf' or 'Devin'). Cheaper than resolveSession()
+	 * when only the label (not full session data) is needed.
+	 */
+	getFamilyEditorName(sessionFile: string): string {
+		return sessionFile.startsWith('devin://') ? 'Devin' : 'Windsurf';
+	}
+
+	/**
+	 * Extracts the Cascade trajectory id from a windsurf://trajectory/{id} or
+	 * devin://trajectory/{id} virtual session path (both point at the same
+	 * ~/.codeium/windsurf/cascade/{id}.pb file on disk).
+	 */
+	extractTrajectoryId(sessionFile: string): string {
+		return sessionFile.replace('windsurf://trajectory/', '').replace('devin://trajectory/', '');
+	}
+
+	/**
+	 * Check if a session file is a Windsurf or Devin session file.
+	 * Windsurf uses virtual windsurf://trajectory/{id} paths; Devin (a fork/rebrand of
+	 * Windsurf that shares the same Cascade storage) uses devin://trajectory/{id} paths.
 	 */
 	isWindsurfSessionFile(filePath: string): boolean {
-		return filePath.startsWith('windsurf://trajectory/');
+		return filePath.startsWith('windsurf://trajectory/') || filePath.startsWith('devin://trajectory/');
 	}
 
 	/**
@@ -169,8 +222,8 @@ export class WindsurfDataAccess {
 	 * Get Windsurf credentials by intercepting HTTP requests from the Windsurf extension.
 	 */
 	async getCredentials(): Promise<WindsurfCredentials | null> {
-		if (!this.isRunningInWindsurf()) {
-			this.log('[Windsurf] Not running in Windsurf environment — skipping credential capture');
+		if (!this.isRunningInWindsurfFamily()) {
+			this.log('[Windsurf] Not running in Windsurf/Devin environment — skipping credential capture');
 			return null;
 		}
 
@@ -676,10 +729,15 @@ export class WindsurfDataAccess {
 			// API unavailable - fall through to file-based
 		}
 
-		// Fall back to .pb file metadata
-		const trajectoryId = sessionFile.replace('windsurf://trajectory/', '');
+		// Fall back to .pb file metadata. The origin app cannot be reliably determined
+		// from the file alone (Windsurf and Devin share the same Cascade directory), so
+		// the label is taken from the sessionFile's own virtual-path scheme, which was
+		// decided at discovery time (see getWindsurfCascadeSessionFiles / getHostEditorLabel).
+		const trajectoryId = this.extractTrajectoryId(sessionFile);
 		const cascadeDir = this.getCascadeDir();
 		const pbPath = path.join(cascadeDir, `${trajectoryId}.pb`);
+		const fallbackName = this.getFamilyEditorName(sessionFile);
+		const fallbackSource = fallbackName === 'Devin' ? 'devin' : 'windsurf';
 		try {
 			const stat = await fs.promises.stat(pbPath);
 			return {
@@ -697,9 +755,9 @@ export class WindsurfDataAccess {
 				},
 				firstInteraction: stat.birthtime.toISOString(),
 				lastInteraction: stat.mtime.toISOString(),
-				editorSource: 'windsurf',
-				editorName: 'Windsurf',
-				title: 'Windsurf Session',
+				editorSource: fallbackSource,
+				editorName: fallbackName,
+				title: `${fallbackName} Session`,
 			};
 		} catch {
 			return null;
@@ -831,8 +889,12 @@ export class WindsurfDataAccess {
 			this.log(`[Windsurf] trajectory ${trajectoryId}: stepCount=${activityScore} (no steps returned) → interactions=${stepData.interactions} tokens=${stepData.tokens} lastInteraction=${lastInteraction ?? '(none)'} (UTC day ${utcDayKey})`);
 		}
 
+		// Attribute the session to whichever app is actually hosting the extension right
+		// now (Windsurf or Devin) — both write to the same Cascade folder, so the virtual
+		// path scheme and editor label are decided here at live-API discovery time.
+		const host = this.getHostEditorLabel();
 		return {
-			file: `windsurf://trajectory/${trajectoryId}`,
+			file: `${host.scheme}${trajectoryId}`,
 			modified: summary.lastModifiedTime || new Date().toISOString(),
 			size: activityScore,
 			interactions: stepData.interactions,
@@ -843,9 +905,9 @@ export class WindsurfDataAccess {
 			contextReferences: { file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0, terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0, changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0, byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {} },
 			firstInteraction: summary.createdTime,
 			lastInteraction: lastInteraction || summary.lastModifiedTime,
-			editorSource: 'windsurf',
-			editorName: 'Windsurf',
-			title: summary.summary || `Windsurf Session ${trajectoryId}`
+			editorSource: host.source,
+			editorName: host.name,
+			title: summary.summary || `${host.name} Session ${trajectoryId}`
 		};
 	}
 
@@ -1030,6 +1092,7 @@ export class WindsurfDataAccess {
 
 		diagnostics.environment = {
 			isRunningInWindsurf: this.isRunningInWindsurf(),
+			isRunningInDevin: this.isRunningInDevin(),
 			appName: vscode.env.appName,
 		};
 

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -498,6 +498,11 @@ export function getEditorNameFromRoot(rootPath: string): string {
 	// collides with 'copilot' or 'code', but it is checked early for consistency
 	// with the other editor-specific guards in this function.
 	if (lower.includes('.devin') || lower.includes('devin-desktop')) { return 'Devin'; }
+	// Devin CLI (separate ACP-based CLI agent tool, distinct from the Devin desktop app
+	// above) stores its global sessions.db under a 'devin/cli' data dir. Checked before
+	// the generic checks below since 'devin' alone would otherwise be ambiguous with the
+	// desktop app guard above (that one requires '.devin' or 'devin-desktop' specifically).
+	if (lower.includes('devin/cli')) { return 'Devin CLI'; }
 	// Check obvious markers first (JetBrains must precede Copilot CLI)
 	if (isJetBrainsRoot(lower)) { return 'JetBrains'; }
 	if (isCopilotCliRoot(lower)) { return 'Copilot CLI'; }
@@ -992,6 +997,11 @@ function detectToolEditorFromPath(
 	if (copilotFamily) { return copilotFamily; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
 	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
+	// Devin CLI virtual paths: <...>/devin/cli/sessions.db#<id>. Checked here (not merely
+	// the generic 'devin' substring match in detectIDEEditorSource) so it always wins over
+	// the desktop app's devin:// scheme / Windsurf family checks, which are handled earlier
+	// in getEditorTypeFromPath/detectEditorSource before this function is even called.
+	if (lowerPath.includes('devin/cli/sessions.db#')) { return 'Devin CLI'; }
 	// Cursor virtual paths must be checked before the generic /cursor/ match in detectVSCodeVariantFromPath.
 	if (lowerPath.includes('/cursor/user/globalstorage/state.vscdb#')) { return 'Cursor'; }
 	if (lowerPath.includes('/.pi/agent/sessions/')) { return 'Pi'; }

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -493,6 +493,11 @@ export function getEditorNameFromRoot(rootPath: string): string {
 	// Eclipse roots contain "copilot" (com.microsoft.copilot.eclipse.core), so they
 	// must be matched before the generic Copilot CLI check below.
 	if (lower.includes('com.microsoft.copilot.eclipse')) { return 'Eclipse'; }
+	// Devin (Cognition Labs' desktop IDE, a fork/rebrand of Windsurf) has its own
+	// dataFolderName '.devin' / install marker 'devin-desktop'. Neither substring
+	// collides with 'copilot' or 'code', but it is checked early for consistency
+	// with the other editor-specific guards in this function.
+	if (lower.includes('.devin') || lower.includes('devin-desktop')) { return 'Devin'; }
 	// Check obvious markers first (JetBrains must precede Copilot CLI)
 	if (isJetBrainsRoot(lower)) { return 'JetBrains'; }
 	if (isCopilotCliRoot(lower)) { return 'Copilot CLI'; }
@@ -1033,6 +1038,11 @@ function detectVSCodeVariantFromPath(lowerPath: string): string | undefined {
  */
 export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);
+	// Devin (Cognition Labs' desktop IDE, a fork/rebrand of Windsurf) uses its own
+	// devin://trajectory/{id} virtual path scheme — check before the windsurf:// check
+	// since they are disjoint prefixes, order does not matter here, but keeping the
+	// two paired makes the shared-lineage relationship clear.
+	if (lowerPath.startsWith('devin://')) { return 'Devin'; }
 	if (lowerPath.startsWith('windsurf://')) { return 'Windsurf'; }
 	// Eclipse Copilot conversations live in the workspace metadata; check before
 	// the generic VS Code match (the path can pass through a 'code' folder).
@@ -1053,6 +1063,9 @@ function detectIDEEditorSource(lowerPath: string): string | undefined {
 	if (lowerPath.includes('cursor')) { return 'Cursor'; }
 	if (isCodeInsidersSource(lowerPath)) { return 'VS Code Insiders'; }
 	if (lowerPath.includes('vscodium')) { return 'VSCodium'; }
+	// Devin must be checked before the generic 'windsurf' substring match below is
+	// irrelevant here (disjoint word), but Devin's own data folder is named '.devin'.
+	if (lowerPath.includes('devin')) { return 'Devin'; }
 	if (lowerPath.includes('windsurf')) { return 'Windsurf'; }
 	if (isVisualStudioPath(lowerPath)) { return 'Visual Studio'; }
 	if (lowerPath.includes('code')) { return 'VS Code'; }
@@ -1064,6 +1077,7 @@ function detectIDEEditorSource(lowerPath: string): string | undefined {
  */
 export function detectEditorSource(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);
+	if (lowerPath.startsWith('devin://')) { return 'Devin'; }
 	if (lowerPath.startsWith('windsurf://')) { return 'Windsurf'; }
 	if (lowerPath.includes('com.microsoft.copilot.eclipse')) { return 'Eclipse'; }
 	// Delegate to the shared tool-editor detector (handles JetBrains, Copilot CLI, OpenCode,

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -16,6 +16,7 @@ export const EDITOR_ICON_MAP: Record<string, string> = {
 	'Crush': '🦾',
 	'Cursor': '🖱️',
 	'Devin': '🧠',
+	'Devin CLI': '🧠',
 	'Eclipse': '🌑',
 	'Gemini CLI': '💎',
 	'JetBrains': '🧩',

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -15,6 +15,7 @@ export const EDITOR_ICON_MAP: Record<string, string> = {
 	'Copilot CLI': '🤖',
 	'Crush': '🦾',
 	'Cursor': '🖱️',
+	'Devin': '🧠',
 	'Eclipse': '🌑',
 	'Gemini CLI': '💎',
 	'JetBrains': '🧩',

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4702,7 +4702,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return;
 		}
 		if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
-			details.editorName = 'Windsurf';
+			details.editorName = this.windsurf.getFamilyEditorName(sessionFile);
 			return;
 		}
 		try {
@@ -4910,8 +4910,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (session) {
 			details.title = session.title;
 			details.interactions = session.interactions;
-			details.editorSource = 'windsurf';
-			details.editorName = 'Windsurf';
+			// editorSource/editorName come from the resolved session, which already
+			// attributes to Windsurf or Devin correctly (see WindsurfDataAccess.resolveSession).
+			details.editorSource = session.editorSource;
+			details.editorName = session.editorName;
 			details.firstInteraction = session.firstInteraction ?? stat.mtime.toISOString();
 			details.lastInteraction = session.lastInteraction ?? stat.mtime.toISOString();
 		}
@@ -6379,10 +6381,11 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 
 	public async showLogViewer(sessionFilePath: string): Promise<void> {
 		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
-			const trajectoryId = sessionFilePath.replace('windsurf://trajectory/', '');
+			const trajectoryId = this.windsurf.extractTrajectoryId(sessionFilePath);
 			const pbPath = path.join(os.homedir(), '.codeium', 'windsurf', 'cascade', `${trajectoryId}.pb`);
+			const editorLabel = this.windsurf.getFamilyEditorName(sessionFilePath);
 			vscode.window.showInformationMessage(
-				`Windsurf sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
+				`${editorLabel} sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
 				'Reveal in Explorer'
 			).then(choice => {
 				if (choice === 'Reveal in Explorer') {
@@ -6515,12 +6518,13 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 	 * Does not modify the original file.
 	 */
 	public async showFormattedJsonlFile(sessionFilePath: string): Promise<void> {
-		// Windsurf sessions are binary protobuf files — open the real .pb file in the OS
+		// Windsurf/Devin sessions are binary protobuf files — open the real .pb file in the OS
 		if (this.windsurf.isWindsurfSessionFile(sessionFilePath)) {
-			const trajectoryId = sessionFilePath.replace('windsurf://trajectory/', '');
+			const trajectoryId = this.windsurf.extractTrajectoryId(sessionFilePath);
 			const pbPath = path.join(os.homedir(), '.codeium', 'windsurf', 'cascade', `${trajectoryId}.pb`);
+			const editorLabel = this.windsurf.getFamilyEditorName(sessionFilePath);
 			vscode.window.showInformationMessage(
-				`Windsurf sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
+				`${editorLabel} sessions are stored as binary protobuf files and cannot be viewed as text. The session file is: ${pbPath}`,
 				'Reveal in Explorer'
 			).then(choice => {
 				if (choice === 'Reveal in Explorer') {
@@ -9175,6 +9179,7 @@ Generated: ${new Date().toISOString()}
 
 ## Environment
 - Running in Windsurf: ${diagnostics.environment.isRunningInWindsurf}
+- Running in Devin: ${diagnostics.environment.isRunningInDevin}
 - App Name: ${diagnostics.environment.appName}
 
 ## Extension Status

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -723,6 +723,10 @@ const ESTIMATED_TOKENS_NOTES: Record<string, { title: string; sub: string }> = {
 		title: 'Kiro CLI: token counts are estimated from the message log text (~4 chars/token). The CLI records usage in credits per request but its input/output token counters are always 0, and the model is logged as "auto" (server-side routing).',
 		sub: 'Estimated from message log (CLI meters credits, not tokens)',
 	},
+	'Devin CLI': {
+		title: 'Devin CLI: the ACP protocol used by this tool does not define per-message token counts, so this is a ~4 chars/token estimate from message text. A per-session cogs_json field may hold real usage data, but its exact shape was unconfirmed (no populated example was available) at the time this was implemented.',
+		sub: 'Estimated from message text (ACP has no per-message token counts)',
+	},
 };
 
 function buildEstimatedTokensCard(data: SessionLogData, stats: SummaryStats): string {

--- a/vscode-extension/test/unit/devinCli.test.ts
+++ b/vscode-extension/test/unit/devinCli.test.ts
@@ -1,0 +1,210 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DevinCliDataAccess } from '../../../src/devinCli';
+
+const SESSION_ID = 'sess-abc123';
+
+function createHarness() {
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'devincli-'));
+	const dbPath = path.join(tmpDir, 'sessions.db');
+	const virtualPath = `${dbPath}#${SESSION_ID}`;
+	fs.writeFileSync(dbPath, 'stub');
+
+	type Row = { columns: string[]; values: unknown[][] };
+	const sessionRow: Row = {
+		columns: ['id', 'working_directory', 'backend_type', 'model', 'agent_mode', 'created_at',
+			'last_activity_at', 'title', 'main_chain_id', 'cogs_json', 'hidden'],
+		values: [[SESSION_ID, '/home/alice/project', 'chisel', 'claude-sonnet-4', 'agent', 1700000000,
+			1700003600, 'Fix the bug', 3, null, 0]],
+	};
+	const messageNodeRows: Row = {
+		columns: ['row_id', 'session_id', 'node_id', 'parent_node_id', 'chat_message', 'created_at', 'metadata'],
+		values: [
+			[1, SESSION_ID, 1, null, JSON.stringify({ role: 'user', content: [{ type: 'text', text: 'Hello' }] }), 1700000000, null],
+			[2, SESSION_ID, 2, 1, JSON.stringify({ role: 'assistant', content: [{ type: 'text', text: 'Hi there' }] }), 1700000010, null],
+			[3, SESSION_ID, 3, 2, JSON.stringify({ sessionUpdate: 'user_message', content: [{ type: 'text', text: 'Fix it' }] }), 1700000020, null],
+		],
+	};
+
+	class FakeDatabase {
+		exec(query: string, _params?: unknown[]): Row[] {
+			if (query.includes('FROM sessions WHERE id')) { return [sessionRow]; }
+			if (query.includes('FROM message_nodes')) { return [messageNodeRows]; }
+			if (query.includes('SELECT id FROM sessions')) { return [{ columns: ['id'], values: [[SESSION_ID]] }]; }
+			if (query.includes('FROM tool_call_state')) { return [{ columns: ['session_id', 'tool_call_id', 'tool_call_json', 'tool_call_update_json'], values: [] }]; }
+			if (query.includes('FROM prompt_history')) { return [{ columns: ['c'], values: [[0]] }]; }
+			return [];
+		}
+		close(): void { /* noop */ }
+	}
+
+	const access = new DevinCliDataAccess();
+	(access as any).initSqlJs = async () => ({ Database: FakeDatabase });
+
+	return {
+		access, dbPath, virtualPath,
+		cleanup: () => { access.dispose(); fs.rmSync(tmpDir, { recursive: true, force: true }); },
+	};
+}
+
+test('getConfigDir returns a devin/cli path', () => {
+	const access = new DevinCliDataAccess();
+	const dir = access.getConfigDir().replace(/\\/g, '/').toLowerCase();
+	assert.ok(dir.includes('devin/cli'), `expected devin/cli in ${dir}`);
+});
+
+test('isDevinCliSessionFile recognises the virtual path scheme', () => {
+	const access = new DevinCliDataAccess();
+	const virtual = `${access.getDbPath()}#${SESSION_ID}`;
+	assert.ok(access.isDevinCliSessionFile(virtual));
+	assert.ok(access.isDevinCliSessionFile(virtual.replace(/\//g, '\\')));
+	assert.ok(!access.isDevinCliSessionFile('/home/alice/.crush/crush.db#abc'));
+	assert.ok(!access.isDevinCliSessionFile('/home/alice/.devin/cascade/file.pb'));
+});
+
+test('getDbPathFromVirtual and getSessionId parse the virtual path', () => {
+	const access = new DevinCliDataAccess();
+	const dbPath = access.getDbPath();
+	const virtual = `${dbPath}#${SESSION_ID}`;
+	assert.equal(access.getDbPathFromVirtual(virtual), dbPath);
+	assert.equal(access.getSessionId(virtual), SESSION_ID);
+});
+
+test('virtualPath builds the expected scheme', () => {
+	const access = new DevinCliDataAccess();
+	const vp = access.virtualPath(SESSION_ID);
+	assert.equal(vp, `${access.getDbPath()}#${SESSION_ID}`);
+});
+
+test('parseChatMessage extracts role/text from a direct {role, content} shape', () => {
+	const access = new DevinCliDataAccess();
+	const parsed = access.parseChatMessage(JSON.stringify({ role: 'user', content: [{ type: 'text', text: 'Hello world' }] }));
+	assert.equal(parsed.role, 'user');
+	assert.equal(parsed.text, 'Hello world');
+});
+
+test('parseChatMessage extracts role from an ACP-style sessionUpdate discriminator', () => {
+	const access = new DevinCliDataAccess();
+	const userMsg = access.parseChatMessage(JSON.stringify({ sessionUpdate: 'user_message', content: [{ type: 'text', text: 'Do X' }] }));
+	assert.equal(userMsg.role, 'user');
+	const agentMsg = access.parseChatMessage(JSON.stringify({ sessionUpdate: 'agent_message_chunk', content: [{ type: 'text', text: 'Doing X' }] }));
+	assert.equal(agentMsg.role, 'assistant');
+});
+
+test('parseChatMessage returns unknown role and empty text for malformed JSON', () => {
+	const access = new DevinCliDataAccess();
+	const parsed = access.parseChatMessage('not json');
+	assert.equal(parsed.role, 'unknown');
+});
+
+test('parseChatMessage handles null input', () => {
+	const access = new DevinCliDataAccess();
+	const parsed = access.parseChatMessage(null);
+	assert.equal(parsed.role, 'unknown');
+	assert.equal(parsed.text, '');
+});
+
+test('buildMainChain walks parent_node_id from main_chain_id back to the root', () => {
+	const access = new DevinCliDataAccess();
+	const nodes = [
+		{ row_id: 1, session_id: SESSION_ID, node_id: 1, parent_node_id: null, chat_message: null, created_at: 1, metadata: null },
+		{ row_id: 2, session_id: SESSION_ID, node_id: 2, parent_node_id: 1, chat_message: null, created_at: 2, metadata: null },
+		{ row_id: 3, session_id: SESSION_ID, node_id: 3, parent_node_id: 2, chat_message: null, created_at: 3, metadata: null },
+		// Abandoned branch — regenerated from node 1, should not appear when main_chain_id = 3.
+		{ row_id: 4, session_id: SESSION_ID, node_id: 4, parent_node_id: 1, chat_message: null, created_at: 4, metadata: null },
+	];
+	const chain = access.buildMainChain(nodes, 3);
+	assert.deepEqual(chain.map(n => n.node_id), [1, 2, 3]);
+});
+
+test('buildMainChain falls back to created_at order when main_chain_id is null', () => {
+	const access = new DevinCliDataAccess();
+	const nodes = [
+		{ row_id: 2, session_id: SESSION_ID, node_id: 2, parent_node_id: 1, chat_message: null, created_at: 20, metadata: null },
+		{ row_id: 1, session_id: SESSION_ID, node_id: 1, parent_node_id: null, chat_message: null, created_at: 10, metadata: null },
+	];
+	const chain = access.buildMainChain(nodes, null);
+	assert.deepEqual(chain.map(n => n.node_id), [1, 2]);
+});
+
+test('readSession reads session metadata from the DB', async () => {
+	const harness = createHarness();
+	try {
+		const session = await harness.access.readSession(harness.virtualPath);
+		assert.equal(session?.id, SESSION_ID);
+		assert.equal(session?.model, 'claude-sonnet-4');
+		assert.equal(session?.title, 'Fix the bug');
+		assert.equal(session?.main_chain_id, 3);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getMessageNodes returns all nodes for the session ordered by created_at', async () => {
+	const harness = createHarness();
+	try {
+		const nodes = await harness.access.getMessageNodes(harness.virtualPath);
+		assert.equal(nodes.length, 3);
+		assert.equal(nodes[0].node_id, 1);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('countInteractions counts user-role message nodes', async () => {
+	const harness = createHarness();
+	try {
+		const count = await harness.access.countInteractions(harness.virtualPath);
+		// node 1 (role: user) + node 3 (sessionUpdate: user_message) = 2 user turns.
+		assert.equal(count, 2);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getTokens estimates tokens from message text when cogs_json is absent', async () => {
+	const harness = createHarness();
+	try {
+		const result = await harness.access.getTokens(harness.virtualPath);
+		assert.ok(result.tokens > 0);
+		assert.equal(result.thinkingTokens, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getModelUsage attributes estimated tokens to the session model', async () => {
+	const harness = createHarness();
+	try {
+		const usage = await harness.access.getModelUsage(harness.virtualPath);
+		assert.ok(usage['claude-sonnet-4']);
+		assert.ok(usage['claude-sonnet-4'].inputTokens > 0);
+		assert.ok(usage['claude-sonnet-4'].outputTokens > 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('discoverSessionIds returns session ids from the DB', async () => {
+	const harness = createHarness();
+	try {
+		const ids = await harness.access.discoverSessionIds();
+		assert.deepEqual(ids, [SESSION_ID]);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getDailyFractions attributes turns to their local calendar day', async () => {
+	const harness = createHarness();
+	try {
+		const fractions = await harness.access.getDailyFractions(harness.virtualPath);
+		const total = Object.values(fractions).reduce((sum, f) => sum + f, 0);
+		assert.ok(Math.abs(total - 1) < 1e-9);
+	} finally {
+		harness.cleanup();
+	}
+});

--- a/vscode-extension/test/unit/devinCli.test.ts
+++ b/vscode-extension/test/unit/devinCli.test.ts
@@ -43,6 +43,9 @@ function createHarness() {
 
 	const access = new DevinCliDataAccess();
 	(access as any).initSqlJs = async () => ({ Database: FakeDatabase });
+	// Ensure discoverSessionIds()/getDbPath() use this harness's temp DB instead of the
+	// real OS-default location (which may or may not exist depending on the machine).
+	access.setDbPathOverrideForTests(dbPath);
 
 	return {
 		access, dbPath, virtualPath,

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -27,6 +27,7 @@ import { CopilotCliAdapter } from '../../../src/adapters/copilotCliAdapter';
 import { AntigravityAdapter } from '../../../src/adapters/antigravityAdapter';
 import { KiroAdapter } from '../../../src/adapters/kiroAdapter';
 import { KiroCliAdapter } from '../../../src/adapters/kiroCliAdapter';
+import { DevinCliAdapter } from '../../../src/adapters/devinCliAdapter';
 
 import { OpenCodeDataAccess } from '../../../src/opencode';
 import { CrushDataAccess } from '../../../src/crush';
@@ -40,6 +41,7 @@ import { GeminiCliDataAccess } from '../../../src/geminicli';
 import { AntigravityDataAccess } from '../../../src/antigravity';
 import { KiroDataAccess } from '../../../src/kiro';
 import { KiroCliDataAccess } from '../../../src/kirocli';
+import { DevinCliDataAccess } from '../../../src/devinCli';
 
 // Stub functions for adapters requiring callbacks
 const noopEstimateTokens = (_text: string, _model?: string) => 0;
@@ -59,6 +61,7 @@ const geminiCliDA = new GeminiCliDataAccess();
 const antigravityDA = new AntigravityDataAccess();
 const kiroDA = new KiroDataAccess();
 const kiroCliDA = new KiroCliDataAccess();
+const devinCliDA = new DevinCliDataAccess();
 
 const openCodeAdapter = new OpenCodeAdapter(openCodeDA);
 const crushAdapter = new CrushAdapter(crushDA);
@@ -74,22 +77,23 @@ const copilotCliAdapter = new CopilotCliAdapter();
 const antigravityAdapter = new AntigravityAdapter(antigravityDA);
 const kiroAdapter = new KiroAdapter(kiroDA);
 const kiroCliAdapter = new KiroCliAdapter(kiroCliDA);
+const devinCliAdapter = new DevinCliAdapter(devinCliDA);
 
 const allAdapters: IEcosystemAdapter[] = [
     openCodeAdapter, crushAdapter, continueAdapter, eclipseAdapter,
     claudeCodeAdapter, claudeDesktopAdapter, visualStudioAdapter, mistralVibeAdapter, geminiCliAdapter,
-    copilotChatAdapter, copilotCliAdapter, antigravityAdapter, kiroAdapter, kiroCliAdapter,
+    copilotChatAdapter, copilotCliAdapter, antigravityAdapter, kiroAdapter, kiroCliAdapter, devinCliAdapter,
 ];
 
 // ---------------------------------------------------------------------------
 // isDiscoverable type guard
 // ---------------------------------------------------------------------------
 
-test('isDiscoverable: returns true for all 14 adapters', () => {
+test('isDiscoverable: returns true for all 15 adapters', () => {
     for (const adapter of allAdapters) {
         assert.ok(isDiscoverable(adapter), `Expected ${adapter.id} to be discoverable`);
     }
-    assert.equal(allAdapters.length, 14);
+    assert.equal(allAdapters.length, 15);
 });
 
 test('isDiscoverable: returns false for plain IEcosystemAdapter without discover()', () => {
@@ -123,6 +127,7 @@ test('adapter IDs are stable lowercase identifiers', () => {
     assert.equal(antigravityAdapter.id, 'antigravity');
     assert.equal(kiroAdapter.id, 'kiro');
     assert.equal(kiroCliAdapter.id, 'kirocli');
+    assert.equal(devinCliAdapter.id, 'devincli');
 });
 
 // ---------------------------------------------------------------------------
@@ -239,6 +244,17 @@ test('KiroCliAdapter.handles: recognises ~/.kiro/sessions/cli metadata paths', (
 test('KiroCliAdapter.handles: rejects the .jsonl message log and unrelated paths', () => {
     assert.ok(!kiroCliAdapter.handles(path.join(os.homedir(), '.kiro', 'sessions', 'cli', 'abc.jsonl')));
     assert.ok(!kiroCliAdapter.handles(path.join(os.homedir(), '.continue', 'sessions', 'abc.json')));
+});
+
+test('DevinCliAdapter.handles: recognises the sessions.db virtual path scheme', () => {
+    const p = `${devinCliDA.getDbPath()}#sess-abc123`;
+    assert.ok(devinCliAdapter.handles(p));
+});
+
+test('DevinCliAdapter.handles: rejects unrelated paths and the Devin desktop devin:// scheme', () => {
+    assert.ok(!devinCliAdapter.handles('devin://trajectory/abc123'));
+    assert.ok(!devinCliAdapter.handles(path.join(os.homedir(), '.crush', 'crush.db#abc')));
+    assert.ok(!devinCliAdapter.handles(path.join(os.homedir(), '.continue', 'sessions', 'abc.json')));
 });
 
 test('KiroAdapter.handles: recognises kiro.kiroagent workspace-sessions paths', () => {

--- a/vscode-extension/test/unit/windsurf.test.ts
+++ b/vscode-extension/test/unit/windsurf.test.ts
@@ -218,3 +218,59 @@ test('countToolCalls: returns an empty breakdown when there are no tool steps', 
 	assert.deepEqual(windsurf.countToolCalls(steps), { total: 0, byTool: {} });
 });
 
+
+// ----- Devin (Cognition Labs desktop IDE — fork/rebrand of Windsurf) support -----
+// Devin bundles the same codeium.windsurf extension and shares the exact same
+// ~/.codeium/windsurf/cascade storage. It is distinguished only by vscode.env.appName
+// and by the devin://trajectory/{id} virtual-path scheme used for live API sessions.
+
+test('isRunningInDevin: true only when appName contains "devin"', () => {
+	const originalAppName = (vscode.env as any).appName;
+	try {
+		(vscode.env as any).appName = 'Devin';
+		assert.equal(windsurf.isRunningInDevin(), true);
+		assert.equal(windsurf.isRunningInWindsurf(), false);
+
+		(vscode.env as any).appName = 'Windsurf';
+		assert.equal(windsurf.isRunningInDevin(), false);
+		assert.equal(windsurf.isRunningInWindsurf(), true);
+
+		(vscode.env as any).appName = 'Visual Studio Code';
+		assert.equal(windsurf.isRunningInDevin(), false);
+		assert.equal(windsurf.isRunningInWindsurf(), false);
+	} finally {
+		(vscode.env as any).appName = originalAppName;
+	}
+});
+
+test('isRunningInWindsurfFamily: true for either Windsurf or Devin, false otherwise', () => {
+	const originalAppName = (vscode.env as any).appName;
+	try {
+		(vscode.env as any).appName = 'Devin';
+		assert.equal(windsurf.isRunningInWindsurfFamily(), true);
+
+		(vscode.env as any).appName = 'Windsurf';
+		assert.equal(windsurf.isRunningInWindsurfFamily(), true);
+
+		(vscode.env as any).appName = 'Visual Studio Code';
+		assert.equal(windsurf.isRunningInWindsurfFamily(), false);
+	} finally {
+		(vscode.env as any).appName = originalAppName;
+	}
+});
+
+test('isWindsurfSessionFile: recognises both windsurf:// and devin:// trajectory schemes', () => {
+	assert.equal(windsurf.isWindsurfSessionFile('windsurf://trajectory/abc123'), true);
+	assert.equal(windsurf.isWindsurfSessionFile('devin://trajectory/abc123'), true);
+	assert.equal(windsurf.isWindsurfSessionFile('/some/other/path.json'), false);
+});
+
+test('getFamilyEditorName: labels sessions per their virtual-path scheme', () => {
+	assert.equal(windsurf.getFamilyEditorName('devin://trajectory/abc123'), 'Devin');
+	assert.equal(windsurf.getFamilyEditorName('windsurf://trajectory/abc123'), 'Windsurf');
+});
+
+test('extractTrajectoryId: strips either windsurf:// or devin:// trajectory prefix', () => {
+	assert.equal(windsurf.extractTrajectoryId('windsurf://trajectory/abc123'), 'abc123');
+	assert.equal(windsurf.extractTrajectoryId('devin://trajectory/abc123'), 'abc123');
+});

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -261,6 +261,11 @@ test('getEditorNameFromRoot: devin-desktop install path returns Devin (not miscl
     // contain 'copilot', so this mainly guards against future substring collisions.
     assert.equal(getEditorNameFromRoot('C:\\Users\\user\\AppData\\Local\\Programs\\devin-desktop'), 'Devin');
 });
+
+test('getEditorNameFromRoot: Devin CLI config dir returns "Devin CLI" (distinct from the desktop app)', () => {
+    assert.equal(getEditorNameFromRoot('C:\\Users\\user\\AppData\\Roaming\\devin\\cli'), 'Devin CLI');
+    assert.equal(getEditorNameFromRoot('/home/user/.local/share/devin/cli'), 'Devin CLI');
+});
 // ── Mutation-killing tests ──────────────────────────────────────────────
 
 import {
@@ -446,6 +451,11 @@ test('detectEditorSource: detects Windsurf', () => {
 
 test('detectEditorSource: detects Devin (Cognition Labs fork/rebrand of Windsurf)', () => {
         assert.equal(detectEditorSource('/home/user/.devin/User/workspaceStorage/abc/session.json'), 'Devin');
+});
+
+test('detectEditorSource: detects Devin CLI virtual sessions.db paths (distinct from the desktop app)', () => {
+        const p = 'C:\\Users\\alice\\AppData\\Roaming\\devin\\cli\\sessions.db#sess-abc123';
+        assert.equal(detectEditorSource(p), 'Devin CLI');
 });
 
 test('detectEditorSource: detects VSCodium', () => {
@@ -1340,6 +1350,11 @@ test('getEditorTypeFromPath: devin:// URI returns Devin', () => {
     assert.equal(getEditorTypeFromPath('devin://trajectory/session.json'), 'Devin');
 });
 
+test('getEditorTypeFromPath: Devin CLI sessions.db virtual path returns "Devin CLI"', () => {
+    const p = 'C:\\Users\\alice\\AppData\\Roaming\\devin\\cli\\sessions.db#sess-abc123';
+    assert.equal(getEditorTypeFromPath(p), 'Devin CLI');
+});
+
 test('getEditorTypeFromPath: isGeminiCliPath requires all three conditions (missing /chats/session-)', () => {
     // Has /.gemini/tmp/ and ends with .jsonl, but NO /chats/session- -> NOT Gemini CLI
     const path = '/home/user/.gemini/tmp/project/other/file.jsonl';
@@ -1376,6 +1391,11 @@ test('detectEditorSource: windsurf:// URI returns Windsurf', () => {
 
 test('detectEditorSource: devin:// URI returns Devin', () => {
     assert.equal(detectEditorSource('devin://trajectory/abc123'), 'Devin');
+});
+
+test('detectEditorSource: Devin CLI sessions.db virtual path is not misclassified as VS Code or Devin desktop', () => {
+    const p = '/home/alice/.local/share/devin/cli/sessions.db#sess-abc123';
+    assert.equal(detectEditorSource(p), 'Devin CLI');
 });
 
 test('detectEditorSource: isGeminiCliPath requires all three conditions', () => {

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -251,6 +251,16 @@ test('getEditorNameFromRoot: opencode path returns OpenCode', () => {
 test('getEditorNameFromRoot: .gemini path returns Gemini CLI', () => {
     assert.equal(getEditorNameFromRoot('/home/user/.gemini'), 'Gemini CLI');
 });
+
+test('getEditorNameFromRoot: .devin path returns Devin', () => {
+    assert.equal(getEditorNameFromRoot('/home/user/.devin'), 'Devin');
+});
+
+test('getEditorNameFromRoot: devin-desktop install path returns Devin (not misclassified as Copilot CLI)', () => {
+    // Devin bundles the 'codeium.windsurf' extension and a plugin id that does NOT
+    // contain 'copilot', so this mainly guards against future substring collisions.
+    assert.equal(getEditorNameFromRoot('C:\\Users\\user\\AppData\\Local\\Programs\\devin-desktop'), 'Devin');
+});
 // ── Mutation-killing tests ──────────────────────────────────────────────
 
 import {
@@ -432,6 +442,10 @@ test('detectEditorSource: detects VS Code from Code path', () => {
 
 test('detectEditorSource: detects Windsurf', () => {
         assert.equal(detectEditorSource('/home/user/.config/Windsurf/User/workspaceStorage/abc/session.json'), 'Windsurf');
+});
+
+test('detectEditorSource: detects Devin (Cognition Labs fork/rebrand of Windsurf)', () => {
+        assert.equal(detectEditorSource('/home/user/.devin/User/workspaceStorage/abc/session.json'), 'Devin');
 });
 
 test('detectEditorSource: detects VSCodium', () => {
@@ -1322,6 +1336,10 @@ test('getEditorTypeFromPath: windsurf:// URI returns Windsurf', () => {
     assert.equal(getEditorTypeFromPath('windsurf://some/path/session.json'), 'Windsurf');
 });
 
+test('getEditorTypeFromPath: devin:// URI returns Devin', () => {
+    assert.equal(getEditorTypeFromPath('devin://trajectory/session.json'), 'Devin');
+});
+
 test('getEditorTypeFromPath: isGeminiCliPath requires all three conditions (missing /chats/session-)', () => {
     // Has /.gemini/tmp/ and ends with .jsonl, but NO /chats/session- -> NOT Gemini CLI
     const path = '/home/user/.gemini/tmp/project/other/file.jsonl';
@@ -1354,6 +1372,10 @@ test('getEditorTypeFromPath: Windows path with .copilot\\jb returns JetBrains', 
 
 test('detectEditorSource: windsurf:// URI returns Windsurf', () => {
     assert.equal(detectEditorSource('windsurf://some/path'), 'Windsurf');
+});
+
+test('detectEditorSource: devin:// URI returns Devin', () => {
+    assert.equal(detectEditorSource('devin://trajectory/abc123'), 'Devin');
 });
 
 test('detectEditorSource: isGeminiCliPath requires all three conditions', () => {


### PR DESCRIPTION
## Summary

Adds support for **Devin** (Cognition Labs), tracked in two forms:

1. **Devin desktop app** — verified to be a rebrand of Windsurf: same bundled `codeium.windsurf` extension, same shared `~/.codeium/windsurf/cascade/*.pb` trajectory storage. Extended `WindsurfDataAccess` (`src/windsurf.ts`) to detect and label sessions dynamically based on which app (`Windsurf`/`Devin`) is actually hosting the extension, since they share the exact same session storage mechanism.

2. **Devin CLI** — a separate ACP-based tool storing sessions in a global `%APPDATA%\devin\cli\sessions.db` SQLite database. Implemented as a proper `IEcosystemAdapter` (`src/devinCli.ts` + `src/adapters/devinCliAdapter.ts`), registered in `adapterRegistry.ts` so both the VS Code extension and CLI pick it up automatically.

## Details

### Devin desktop app
- `isRunningInDevin()`, `isRunningInWindsurfFamily()`, dynamic editor-name attribution in `src/windsurf.ts`
- Updated `workspaceHelpers.ts`, `usageAnalysis.ts`, `sessionDiscovery.ts`, `extension.ts`, added icon
- **Known limitation**: file-based `.pb` fallback discovery (from plain VS Code) can't distinguish Devin- vs Windsurf-authored sessions and defaults to "Windsurf" — no reliable per-file signal found.

### Devin CLI
- Reads global `sessions.db`, reconstructs conversations by walking the `message_nodes` parent-chain tree (`main_chain_id`)
- Virtual path scheme: `<sessions.db path>#<session_id>`
- **⚠️ Unverified against real data**: the DB had 0 rows on the dev machine throughout implementation (despite an active CLI session), so message/token parsing is inferred from the ACP protocol spec, not confirmed live. Flagged in code comments, docs, and the log-viewer tooltip. Recommend re-inspecting once real rows appear.

## Testing
- `npm run compile` (vscode-extension): 0 errors
- `npm run test:node`: all suites pass, including new Devin/Devin CLI tests
- `cli/npm run build`: succeeds
- `node cli/dist/cli.js diagnostics`: confirms Devin CLI candidate path resolves correctly

## Docs
- New: `docs/logFilesSchema/devin-cli-session-format.md`
- New: `docs/logFilesSchema/devin-windsurf-session-format.md`