### PR TITLE
Track discovered editors with one-time notifications

### DIFF
--- a/vscode-extension/src/editorDiscovery.ts
+++ b/vscode-extension/src/editorDiscovery.ts
@@ -1,0 +1,64 @@
+/**
+ * Tracks which editor labels have been seen before so we can surface only newly
+ * discovered editors to the user.
+ */
+export type SeenEditorsUpdate = {
+	seenEditors: string[];
+	newEditors: string[];
+};
+
+export type NotifiedEditorsUpdate = {
+	notifiedEditors: string[];
+	editorsToNotify: string[];
+};
+
+function normalizeEditorNames(editors: Iterable<string>): string[] {
+	const result = new Set<string>();
+	for (const editor of editors) {
+		const name = editor.trim();
+		if (!name || name === 'Unknown') { continue; }
+		result.add(name);
+	}
+	return [...result].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Merges newly discovered editor labels into the persisted seen set.
+ * When no prior state exists (first run after feature rollout), it seeds the
+ * baseline without reporting all current editors as "new".
+ */
+export function mergeSeenEditors(
+	previousSeenEditors: readonly string[] | undefined,
+	discoveredEditors: Iterable<string>,
+): SeenEditorsUpdate {
+	const normalizedDiscovered = normalizeEditorNames(discoveredEditors);
+	if (previousSeenEditors === undefined) {
+		return { seenEditors: normalizedDiscovered, newEditors: [] };
+	}
+
+	const normalizedPrevious = normalizeEditorNames(previousSeenEditors);
+	const previousSet = new Set(normalizedPrevious);
+	const newEditors = normalizedDiscovered.filter(editor => !previousSet.has(editor));
+	return {
+		seenEditors: normalizeEditorNames([...normalizedPrevious, ...normalizedDiscovered]),
+		newEditors,
+	};
+}
+
+/**
+ * Computes which editors still need a one-time notification, and returns the
+ * updated persisted notification set.
+ */
+export function mergeNotifiedEditors(
+	previousNotifiedEditors: readonly string[] | undefined,
+	candidateEditors: Iterable<string>,
+): NotifiedEditorsUpdate {
+	const normalizedCandidates = normalizeEditorNames(candidateEditors);
+	const normalizedPrevious = normalizeEditorNames(previousNotifiedEditors ?? []);
+	const notifiedSet = new Set(normalizedPrevious);
+	const editorsToNotify = normalizedCandidates.filter(editor => !notifiedSet.has(editor));
+	return {
+		notifiedEditors: normalizeEditorNames([...normalizedPrevious, ...normalizedCandidates]),
+		editorsToNotify,
+	};
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -220,6 +220,7 @@ import { getNonce, buildCspMeta, getCodiconStylesheetTag } from './utils/webview
 import { isGuidMcpTool } from '../../src/utils/toolUtils';
 import { toLocalDayKey } from '../../src/utils/dayKeys';
 import { determineOnboardingAction } from './onboarding';
+import { mergeNotifiedEditors, mergeSeenEditors } from './editorDiscovery';
 
 type LocalViewRegressionProbeResult = {
   pass: boolean;
@@ -336,6 +337,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private static readonly CACHE_VERSION = 59; // Detect Auto model and Foundry local models from request-level fields
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
+	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';
+	private static readonly NOTIFIED_EDITORS_STATE_KEY = 'discovery.notifiedEditors';
 
 	private diagnosticsPanel?: vscode.WebviewPanel;
 	// Tracks whether the diagnostics panel has already received its session files
@@ -1436,6 +1439,43 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 	}
 
+	private async storeDiscoveredEditorsAndNotify(discoveredEditors: Iterable<string>): Promise<void> {
+		const existingSeenEditors = this.context.globalState.get<string[] | undefined>(
+			CopilotTokenTracker.SEEN_EDITORS_STATE_KEY,
+			undefined,
+		);
+		const existingNotifiedEditors = this.context.globalState.get<string[] | undefined>(
+			CopilotTokenTracker.NOTIFIED_EDITORS_STATE_KEY,
+			undefined,
+		);
+		const { seenEditors, newEditors } = mergeSeenEditors(existingSeenEditors, discoveredEditors);
+
+		const changed =
+			existingSeenEditors === undefined ||
+			existingSeenEditors.length !== seenEditors.length ||
+			existingSeenEditors.some((editor, i) => editor !== seenEditors[i]);
+		if (changed) {
+			await this.context.globalState.update(CopilotTokenTracker.SEEN_EDITORS_STATE_KEY, seenEditors);
+		}
+		const { notifiedEditors, editorsToNotify } = mergeNotifiedEditors(existingNotifiedEditors, newEditors);
+		const notifiedChanged =
+			existingNotifiedEditors === undefined ||
+			existingNotifiedEditors.length !== notifiedEditors.length ||
+			existingNotifiedEditors.some((editor, i) => editor !== notifiedEditors[i]);
+		if (notifiedChanged) {
+			await this.context.globalState.update(CopilotTokenTracker.NOTIFIED_EDITORS_STATE_KEY, notifiedEditors);
+		}
+		if (editorsToNotify.length === 0) { return; }
+
+		const names = editorsToNotify.join(', ');
+		this.log(`🆕 New editor${editorsToNotify.length > 1 ? 's' : ''} discovered: ${names}`);
+		void vscode.window.showInformationMessage(
+			editorsToNotify.length === 1
+				? `🆕 New editor detected: ${editorsToNotify[0]}. New session data from this editor is now included in your stats.`
+				: `🆕 New editors detected: ${names}. New session data from these editors is now included in your stats.`
+		);
+	}
+
 	private setStatusBarText(text: string): void {
 		this._statusBarBaseText = text;
 		this.statusBarItem.text = this._devBranch ? `${text} [${this._devBranch}]` : text;
@@ -2179,6 +2219,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		);
 		const missBudget = isLeader ? undefined : { remaining: CopilotTokenTracker.FOLLOWER_MISS_BUDGET };
 		const { sessionFiles, preloaded } = await this._preloadSessionFiles(fileLoadCutoffMs, progressCallback, discoveredEditorSet, missBudget);
+		try {
+			await this.storeDiscoveredEditorsAndNotify(discoveredEditorSet);
+		} catch (error) {
+			this.warn(`Failed to update seen-editor state: ${error}`);
+		}
 
 		this.sendLoadingPanelMessage({ command: 'loadingStep', step: 'computing' });
 		if (!silent && !this._detailsPanelIsLoading) { this.statusBarItem.tooltip = this.buildLoadingTooltipMarkdown('computing'); }
@@ -8003,6 +8048,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       openDisplaySettings: () => this.dispatch('openDisplaySettings:diagnostics', () => vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.display")),
       openToolFamiliesSettings: () => this.dispatch('openToolFamiliesSettings:diagnostics', () => vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.toolFamilies")),
       resetDebugCounters: () => this.dispatch('resetDebugCounters:diagnostics', () => this.diagHandleResetDebugCounters()),
+      resetDiscoveredEditors: () => this.dispatch('resetDiscoveredEditors:diagnostics', () => this.diagHandleResetDiscoveredEditors()),
       authenticateGitHub: () => this.dispatch('authenticateGitHub:diagnostics', () => this.diagHandleGitHubAuth(true)),
       signOutGitHub: () => this.dispatch('signOutGitHub:diagnostics', () => this.diagHandleGitHubAuth(false)),
       pickFolder: () => this.dispatch('pickFolder:diagnostics', () => this.diagHandlePickFolder()),
@@ -8141,6 +8187,13 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     await this.context.globalState.update('news.fluencyScoreBanner.v1.dismissed', false);
     await this.context.globalState.update('news.unknownMcpTools.dismissedVersion', undefined);
     vscode.window.showInformationMessage('Debug counters and dismissed flags have been reset.');
+    await this.showDiagnosticReport();
+  }
+
+  private async diagHandleResetDiscoveredEditors(): Promise<void> {
+    await this.context.globalState.update(CopilotTokenTracker.SEEN_EDITORS_STATE_KEY, undefined);
+    await this.context.globalState.update(CopilotTokenTracker.NOTIFIED_EDITORS_STATE_KEY, undefined);
+    vscode.window.showInformationMessage('Discovered editor tracking has been reset.');
     await this.showDiagnosticReport();
   }
 

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1511,6 +1511,9 @@ function handleGlobalClickEvent(event: MouseEvent): void {
   if (target.id === "btn-reset-debug-counters") {
     vscode.postMessage({ command: "resetDebugCounters" });
   }
+  if (target.id === "btn-reset-discovered-editors") {
+    vscode.postMessage({ command: "resetDiscoveredEditors" });
+  }
   if (target.classList.contains("debug-counter-set")) {
     handleDebugCounterSetClick(target);
   }
@@ -2025,6 +2028,22 @@ ${quotaContent}
 </div>`;
 }
 
+function renderEditorDiscoveryCardHtml(): string {
+  return `<div class="backend-card">
+<h4>🆕 Editor Discovery Notifications</h4>
+<p>
+The extension remembers which editors it has already seen so each editor triggers a discovery notification only once.
+Use this reset to clear that memory and start tracking from scratch.
+</p>
+<div class="button-group">
+<button class="button secondary" id="btn-reset-discovered-editors">
+<span>♻️</span>
+<span>Reset Discovered Editors</span>
+</button>
+</div>
+</div>`;
+}
+
 function renderDiagDisplayTabHtml(data: DiagnosticsData): string {
   const showTokens = data.displaySettings?.showTokens ?? 'both';
   const showCost = data.displaySettings?.showCost ?? 'none';
@@ -2083,6 +2102,7 @@ ${
 }
 </div>
 ${renderQuotaCardHtml(data)}
+${renderEditorDiscoveryCardHtml()}
 <div class="backend-card">
 <h4>🔢 Number Formatting</h4>
 <p>

--- a/vscode-extension/test/unit/editorDiscovery.test.ts
+++ b/vscode-extension/test/unit/editorDiscovery.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import { mergeNotifiedEditors, mergeSeenEditors } from '../../src/editorDiscovery';
+
+test('mergeSeenEditors', async (t) => {
+	await t.test('seeds baseline without notifying when no previous state exists', () => {
+		const result = mergeSeenEditors(undefined, ['VS Code', 'Cursor']);
+		assert.deepEqual(result.seenEditors, ['Cursor', 'VS Code']);
+		assert.deepEqual(result.newEditors, []);
+	});
+
+	await t.test('returns only unseen editors as newly discovered', () => {
+		const result = mergeSeenEditors(['Cursor', 'VS Code'], ['VS Code', 'JetBrains', 'Windsurf']);
+		assert.deepEqual(result.seenEditors, ['Cursor', 'JetBrains', 'VS Code', 'Windsurf']);
+		assert.deepEqual(result.newEditors, ['JetBrains', 'Windsurf']);
+	});
+
+	await t.test('normalizes duplicate and unknown values', () => {
+		const result = mergeSeenEditors(['VS Code', 'VS Code', 'Unknown'], ['  Cursor  ', '', 'Unknown', 'Cursor']);
+		assert.deepEqual(result.seenEditors, ['Cursor', 'VS Code']);
+		assert.deepEqual(result.newEditors, ['Cursor']);
+	});
+});
+
+test('mergeNotifiedEditors', async (t) => {
+	await t.test('returns only editors that have not been notified yet', () => {
+		const result = mergeNotifiedEditors(['Cursor'], ['Cursor', 'JetBrains']);
+		assert.deepEqual(result.notifiedEditors, ['Cursor', 'JetBrains']);
+		assert.deepEqual(result.editorsToNotify, ['JetBrains']);
+	});
+
+	await t.test('normalizes candidate values and ignores unknown entries', () => {
+		const result = mergeNotifiedEditors(undefined, ['Unknown', '', '  VS Code  ', 'VS Code']);
+		assert.deepEqual(result.notifiedEditors, ['VS Code']);
+		assert.deepEqual(result.editorsToNotify, ['VS Code']);
+	});
+});


### PR DESCRIPTION
## Why
New editor sources can start contributing session data without an explicit signal to the user. We need to surface that change, but only once per editor so notifications do not repeat every refresh.

## What changed
- Added `vscode-extension/src/editorDiscovery.ts` with pure helpers to normalize editor names and merge persisted discovery state.
- Added a second persisted state key for notification history so discovery and notification are tracked separately:
  - `discovery.seenEditors`
  - `discovery.notifiedEditors`
- Updated refresh flow in `vscode-extension/src/extension.ts` to:
  - persist newly discovered editors
  - notify only for editors that have never been notified before
- Added a new diagnostics action in the Display settings tab to reset editor discovery tracking.
- Wired a new diagnostics command handler to clear both discovery keys.

## Notes for reviewers
- First run seeds the baseline discovered editors without a notification burst.
- After that, each editor can trigger a discovery notification only once unless the new diagnostics reset is used.

## Tests
- Added unit coverage in `vscode-extension/test/unit/editorDiscovery.test.ts` for:
  - baseline seeding behavior
  - new-editor detection
  - one-time notification gating
  - normalization and unknown filtering