### PR TITLE
refactor: decompose _pickOrCreateStorageAccount into focused helpers

### DIFF
--- a/vscode-extension/src/backend/services/azureResourceService.ts
+++ b/vscode-extension/src/backend/services/azureResourceService.ts
@@ -202,11 +202,28 @@ export class AzureResourceService {
 		authMode: BackendAuthMode
 	): Promise<string | null> {
 		const storageMgmt = new StorageManagementClient(credential, subscriptionId);
+		const saNames = await this._listStorageAccountNames(storageMgmt, resourceGroup);
+
+		const saPick = await this._promptStorageAccountChoice(saNames);
+		if (!saPick) { return null; }
+		if (!saPick.createNew) { return saPick.label; }
+
+		const newAccount = await this._promptNewStorageAccountDetails(location);
+		if (!newAccount) { return null; }
+
+		return this._createStorageAccount(storageMgmt, resourceGroup, newAccount.name, newAccount.location, authMode, saNames);
+	}
+
+	private async _listStorageAccountNames(storageMgmt: StorageManagementClient, resourceGroup: string): Promise<string[]> {
 		const saNames: string[] = [];
 		for await (const sa of storageMgmt.storageAccounts.listByResourceGroup(resourceGroup)) {
 			if (sa.name) { saNames.push(sa.name); }
 		}
 		saNames.sort();
+		return saNames;
+	}
+
+	private async _promptStorageAccountChoice(saNames: string[]): Promise<{ createNew: boolean; label: string } | null> {
 		const saPick = await vscode.window.showQuickPick(
 			[
 				{ label: '$(add) Create new storage account…', description: '' },
@@ -215,8 +232,10 @@ export class AzureResourceService {
 			{ title: 'Step 6 of 7: Choose Storage Account' }
 		);
 		if (!saPick) { return null; }
-		if (!saPick.label.includes('Create new storage account')) { return saPick.label; }
+		return { createNew: saPick.label.includes('Create new storage account'), label: saPick.label };
+	}
 
+	private async _promptNewStorageAccountDetails(location: string): Promise<{ name: string; location: string } | null> {
 		const RESERVED_NAMES = ['microsoft', 'azure', 'windows', 'test', 'prod', 'admin'];
 		const name = await vscode.window.showInputBox({
 			title: 'Step 6 of 7: New Storage Account Name',
@@ -237,6 +256,17 @@ export class AzureResourceService {
 		);
 		if (!loc) { return null; }
 
+		return { name, location: loc };
+	}
+
+	private async _createStorageAccount(
+		storageMgmt: StorageManagementClient,
+		resourceGroup: string,
+		name: string,
+		loc: string,
+		authMode: BackendAuthMode,
+		saNames: string[]
+	): Promise<string | null> {
 		const createStorageAccountParams = {
 			location: loc,
 			sku: { name: 'Standard_LRS' },


### PR DESCRIPTION
## Motivation

ESLint's `max-lines-per-function` rule (configured at 50 lines) flagged `_pickOrCreateStorageAccount` in `vscode-extension/src/backend/services/azureResourceService.ts` at 69 lines. The function mixed four distinct concerns — listing existing storage accounts, prompting the user to pick or create one, collecting details for a new account, and performing the actual creation (with policy-blocked-error handling) — which added cognitive overhead when reading or modifying any single step.

## Changes

Extracted the function into four focused private helpers, each with a single responsibility:

| Method | Responsibility |
|---|---|
| `_listStorageAccountNames` | Lists and sorts existing storage account names in the resource group |
| `_promptStorageAccountChoice` | Shows the quick pick for choosing an existing account or "create new" |
| `_promptNewStorageAccountDetails` | Prompts for the new account's name (with validation) and location |
| `_createStorageAccount` | Builds account parameters and creates the account, delegating to the existing `_handlePolicyBlockedStorageCreation` on policy-blocked errors |

`_pickOrCreateStorageAccount` now just orchestrates these steps. No public/exported signatures changed; only internal structure. Only this one source file was modified.

## Verification

- `tsc --noEmit` — clean
- `npm run test:node` — all suites pass, including `azureResourceService.test.js` and `backend-azureResourceService-utils.test.js`
- `node esbuild.js --production` — build succeeds
- `eslint src/backend/services/azureResourceService.ts` — no warnings; `_pickOrCreateStorageAccount` no longer trips `max-lines-per-function`

Pre-existing warnings on `_configureSharingProfile` (57 lines) and `_saveConfigAndActivate` (61 lines) in the same file were **not** touched — out of scope for this change.

Co-authored-by: Claude <noreply@anthropic.com>