### PR TITLE
Add worktree discovery subview to Diagnostics screen

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -344,6 +344,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private diagnosticsCachedFiles: SessionFileDetails[] = [];
 	// Cache of the last diagnostic report text for copy/issue operations
 	private lastDiagnosticReport: string = '';
+	// Incremented on each worktree scan start/cancel; in-flight scans check this to stop early
+	private worktreeScanId: number = 0;
 	private logViewerPanel?: vscode.WebviewPanel;
 	private logViewerSessionFilePath: string = '';
 	private logViewerCurrentData?: SessionLogData;
@@ -8007,6 +8009,9 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       signOutGitHub: () => this.dispatch('signOutGitHub:diagnostics', () => this.diagHandleGitHubAuth(false)),
       pickFolder: () => this.dispatch('pickFolder:diagnostics', () => this.diagHandlePickFolder()),
       analyzeFolder: () => this.dispatch('analyzeFolder:diagnostics', () => this.diagHandleAnalyzeFolder(message)),
+      pickWorktreeRoot: () => this.dispatch('pickWorktreeRoot:diagnostics', () => this.diagHandlePickWorktreeRoot()),
+      scanWorktrees: () => this.dispatch('scanWorktrees:diagnostics', () => this.diagHandleScanWorktrees(message)),
+      cancelWorktreeScan: () => this.dispatch('cancelWorktreeScan:diagnostics', () => this.diagHandleCancelWorktreeScan()),
     };
     if (simpleCommands[message.command]) { await simpleCommands[message.command](); return; }
     await this.handleDiagnosticConditionalCommand(message);
@@ -8188,6 +8193,196 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       return;
     }
     if (this.diagnosticsPanel) { await this.analyzeFolderPath(this.diagnosticsPanel, folderPath, effectiveToolType); }
+  }
+
+  private async diagHandlePickWorktreeRoot(): Promise<void> {
+    const uris = await vscode.window.showOpenDialog({ canSelectFiles: false, canSelectFolders: true, canSelectMany: false, openLabel: "Select Root Folder to Scan" });
+    if (uris && uris.length > 0 && this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+      this.diagnosticsPanel.webview.postMessage({ command: "worktreeRootPicked", folderPath: uris[0].fsPath });
+    }
+  }
+
+  private async diagHandleScanWorktrees(message: any): Promise<void> {
+    const rootPaths: string[] = Array.isArray(message.rootPaths)
+      ? message.rootPaths.filter((p: unknown): p is string => typeof p === "string" && p.trim().length > 0).map((p: string) => p.trim())
+      : [];
+    await this.context.globalState.update("worktrees.scanRoots", rootPaths);
+    if (!this.diagnosticsPanel) { return; }
+    if (rootPaths.length === 0) {
+      this.diagnosticsPanel.webview.postMessage({ command: "worktreeScanComplete", totalWorktrees: 0, elapsedMs: 0 });
+      return;
+    }
+    await this.scanWorktreesIncremental(this.diagnosticsPanel, rootPaths);
+  }
+
+  private diagHandleCancelWorktreeScan(): void {
+    this.worktreeScanId++;
+    if (this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+      this.diagnosticsPanel.webview.postMessage({ command: "worktreeScanCancelled" });
+    }
+  }
+
+  /**
+   * Incrementally discovers uncleaned git worktree folders under the given root paths and
+   * streams progress + per-worktree results to the diagnostics webview as they're found.
+   * A worktree is identified by a ".git" FILE (not a directory) containing a "gitdir:" pointer.
+   */
+  private async scanWorktreesIncremental(panel: vscode.WebviewPanel, rootPaths: string[]): Promise<void> {
+    const scanId = ++this.worktreeScanId;
+    const excludeDirs = new Set(["node_modules", ".git", ".hg", ".svn", "packages", "vendor"]);
+    const startTime = Date.now();
+    let totalFound = 0;
+    const isActive = () => scanId === this.worktreeScanId;
+    const send = (msg: Record<string, unknown>) => { if (this.isPanelOpen(panel)) { panel.webview.postMessage(msg); } };
+
+    send({ command: "worktreeScanStarted", rootPaths });
+
+    for (const root of rootPaths) {
+      if (!isActive()) { return; }
+      let isDirectory = false;
+      try { isDirectory = (await fs.promises.stat(root)).isDirectory(); } catch { isDirectory = false; }
+      if (!isDirectory) {
+        send({ command: "worktreeScanRootSkipped", root, reason: "Path does not exist or is not a directory" });
+        continue;
+      }
+
+      send({ command: "worktreeScanRootStarted", root });
+      const gitMarkers: string[] = [];
+      await this.findGitMarkerFiles(root, excludeDirs, gitMarkers, isActive);
+      if (!isActive()) { return; }
+      send({ command: "worktreeScanRootMarkersFound", root, count: gitMarkers.length });
+
+      totalFound += await this.processWorktreeMarkers(gitMarkers, root, isActive, send, startTime);
+      if (!isActive()) { return; }
+    }
+
+    send({ command: "worktreeScanComplete", totalWorktrees: totalFound, elapsedMs: Date.now() - startTime });
+  }
+
+  private async processWorktreeMarkers(
+    gitMarkers: string[],
+    root: string,
+    isActive: () => boolean,
+    send: (msg: Record<string, unknown>) => void,
+    startTime: number,
+  ): Promise<number> {
+    const foundRoots: string[] = [];
+    let checked = 0;
+    for (const markerFile of gitMarkers) {
+      if (!isActive()) { return foundRoots.length; }
+      checked++;
+      const worktreeRoot = await this.resolveWorktreeRootFromMarker(markerFile, foundRoots);
+      if (worktreeRoot) {
+        const result = await this.buildWorktreeResult(worktreeRoot);
+        if (!isActive()) { return foundRoots.length; }
+        send({ command: "worktreeFound", worktree: result });
+      }
+      if (checked % 5 === 0 || checked === gitMarkers.length) {
+        send({ command: "worktreeScanProgress", root, checked, total: gitMarkers.length, foundCount: foundRoots.length, elapsedMs: Date.now() - startTime });
+      }
+    }
+    return foundRoots.length;
+  }
+
+  /**
+   * Recursively collects paths to ".git" marker FILES (worktree pointers) under `dir`,
+   * skipping excluded directory names for speed. Does not descend into any ".git" entry
+   * itself (file or directory), so nested worktrees inside a scanned repo are still found.
+   */
+  private async findGitMarkerFiles(dir: string, excludeDirs: Set<string>, results: string[], isActive: () => boolean): Promise<void> {
+    if (!isActive()) { return; }
+    let entries: fs.Dirent[];
+    try { entries = await fs.promises.readdir(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (!isActive()) { return; }
+      if (entry.name === ".git") {
+        if (entry.isFile()) { results.push(path.join(dir, entry.name)); }
+        continue;
+      }
+      if (entry.isDirectory() && !excludeDirs.has(entry.name)) {
+        await this.findGitMarkerFiles(path.join(dir, entry.name), excludeDirs, results, isActive);
+      }
+    }
+  }
+
+  /**
+   * Validates a ".git" marker file points to a worktree (starts with "gitdir:") and skips
+   * worktrees nested inside an already-discovered worktree. Returns the worktree root, or null.
+   */
+  private async resolveWorktreeRootFromMarker(markerFile: string, foundRoots: string[]): Promise<string | null> {
+    let firstLine = "";
+    try {
+      const handle = await fs.promises.open(markerFile, "r");
+      try {
+        const buf = Buffer.alloc(200);
+        const { bytesRead } = await handle.read(buf, 0, 200, 0);
+        firstLine = buf.toString("utf8", 0, bytesRead).split(/\r?\n/)[0];
+      } finally {
+        await handle.close();
+      }
+    } catch {
+      return null;
+    }
+    if (!firstLine.startsWith("gitdir:")) { return null; }
+
+    const worktreeRoot = path.dirname(markerFile);
+    const normalizedRoot = worktreeRoot.toLowerCase();
+    for (const known of foundRoots) {
+      if (normalizedRoot.startsWith(known.toLowerCase() + path.sep)) { return null; }
+    }
+    foundRoots.push(worktreeRoot);
+    return worktreeRoot;
+  }
+
+  private async buildWorktreeResult(worktreeRoot: string): Promise<{ path: string; repoLabel: string; branch: string; lastCommit: string; lastCommitDate: string | null; pushed: "yes" | "no" | "?"; files: number; folders: number; bytes: number }> {
+    const [stats, gitInfo] = await Promise.all([
+      this.computeFolderStats(worktreeRoot),
+      Promise.resolve(this.getWorktreeGitInfo(worktreeRoot)),
+    ]);
+    const repoLabel = gitInfo.remoteUrl ? this.getRepoLabelFromRemote(gitInfo.remoteUrl) : path.basename(path.dirname(worktreeRoot));
+    return { path: worktreeRoot, repoLabel, branch: gitInfo.branch, lastCommit: gitInfo.lastCommit, lastCommitDate: gitInfo.lastCommitDate, pushed: gitInfo.pushed, files: stats.files, folders: stats.folders, bytes: stats.bytes };
+  }
+
+  /** Recursively computes file/folder counts and total byte size for a worktree (no exclusions — reflects true disk usage). */
+  private async computeFolderStats(dir: string): Promise<{ files: number; folders: number; bytes: number }> {
+    let files = 0, folders = 0, bytes = 0;
+    const walk = async (d: string): Promise<void> => {
+      let entries: fs.Dirent[];
+      try { entries = await fs.promises.readdir(d, { withFileTypes: true }); } catch { return; }
+      for (const entry of entries) {
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) {
+          folders++;
+          await walk(full);
+        } else if (entry.isFile()) {
+          files++;
+          try { bytes += (await fs.promises.stat(full)).size; } catch { /* unreadable file, skip its size */ }
+        }
+      }
+    };
+    await walk(dir);
+    return { files, folders, bytes };
+  }
+
+  private getWorktreeGitInfo(worktreeRoot: string): { branch: string; lastCommit: string; lastCommitDate: string | null; pushed: "yes" | "no" | "?"; remoteUrl: string } {
+    const opts: childProcess.ExecSyncOptionsWithStringEncoding = { cwd: worktreeRoot, encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] };
+    let branch = "?", lastCommit = "?", lastCommitDate: string | null = null, pushed: "yes" | "no" | "?" = "?", remoteUrl = "";
+    try {
+      branch = childProcess.execSync("git branch --show-current", opts).trim() || "?";
+      try { lastCommit = childProcess.execSync("git log -1 --format=%cr", opts).trim() || "?"; } catch { /* no commits yet */ }
+      try { lastCommitDate = childProcess.execSync("git log -1 --format=%cI", opts).trim() || null; } catch { /* no commits yet */ }
+      try {
+        const unpushed = childProcess.execSync("git log --oneline --not --remotes --branches", opts).trim();
+        pushed = unpushed === "" ? "yes" : "no";
+      } catch { /* leave as unknown */ }
+      try { remoteUrl = childProcess.execSync("git remote get-url origin", opts).trim(); } catch { /* no remote configured */ }
+    } catch { /* not a readable git worktree */ }
+    return { branch, lastCommit, lastCommitDate, pushed, remoteUrl };
+  }
+
+  private getRepoLabelFromRemote(remoteUrl: string): string {
+    const match = remoteUrl.match(/[:/]([^/]+\/[^/]+?)(\.git)?$/);
+    return match ? match[1] : remoteUrl;
   }
 
   /**
@@ -8637,6 +8832,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       quotaEntitlements: this._copilotQuotaEntitlements,
       toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
       toolFamilies: getToolFamilies(),
+      worktreeScanRoots: this.context.globalState.get<string[]>('worktrees.scanRoots') ?? [],
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -128,6 +128,27 @@ type DiagnosticsData = {
   quotaEntitlements?: QuotaEntitlements;
   toolCallStats?: { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } } | null;
   toolFamilies?: ToolFamilyConfig[];
+  worktreeScanRoots?: string[];
+};
+
+type WorktreeResult = {
+  path: string;
+  repoLabel: string;
+  branch: string;
+  lastCommit: string;
+  lastCommitDate: string | null;
+  pushed: "yes" | "no" | "?";
+  files: number;
+  folders: number;
+  bytes: number;
+};
+
+type WorktreeScanStatus = {
+  root: string;
+  checked: number;
+  total: number;
+  foundCount: number;
+  elapsedMs: number;
 };
 
 type ToolFamilyConfig = {
@@ -184,6 +205,14 @@ let storedDetailedFiles: SessionFileDetails[] = [];
 let isLoading = true;
 let currentBackendInfo: BackendStorageInfo | undefined;
 let currentGithubAuth: GitHubAuthStatus | undefined;
+
+// Worktree discovery tab state
+let worktreeRoots: string[] = initialData?.worktreeScanRoots ? [...initialData.worktreeScanRoots] : [];
+let worktreeResults: WorktreeResult[] = [];
+let worktreeScanInProgress = false;
+let worktreeScanStatus: WorktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+let worktreeScanError: string | null = null;
+let worktreeRenderPending = false;
 
 function removeSessionFilesSection(reportText: string): string {
   return reportText.replace(SESSION_FILES_SECTION_REGEX, "");
@@ -951,6 +980,132 @@ function renderFolderAnalysisResults(
     </div>`;
 }
 
+function renderWorktreeRootsList(): string {
+  if (worktreeRoots.length === 0) {
+    return `<div style="color: var(--text-muted); font-size: 12px; margin: 8px 0;">No root folders added yet. Add a folder to scan for worktrees.</div>`;
+  }
+  return `<div class="worktree-roots-list">${worktreeRoots
+    .map(
+      (r, i) =>
+        `<div class="worktree-root-item"><span title="${escapeHtml(r)}">${escapeHtml(r)}</span><button class="button secondary worktree-remove-root" data-index="${i}" ${worktreeScanInProgress ? "disabled" : ""}>✕</button></div>`,
+    )
+    .join("")}</div>`;
+}
+
+function renderWorktreeProgress(): string {
+  if (!worktreeScanInProgress) { return ""; }
+  const pct = worktreeScanStatus.total > 0 ? Math.round((worktreeScanStatus.checked / worktreeScanStatus.total) * 100) : 0;
+  return `
+    <div class="info-box" style="margin-top: 12px;">
+      <div class="info-box-title">⏳ Scanning…</div>
+      <div>Root: <span style="font-family: var(--vscode-editor-font-family, monospace);">${escapeHtml(worktreeScanStatus.root || "…")}</span></div>
+      <div>${worktreeScanStatus.checked} / ${worktreeScanStatus.total || "?"} .git markers checked — ${worktreeScanStatus.foundCount} worktree${worktreeScanStatus.foundCount === 1 ? "" : "s"} found so far (${(worktreeScanStatus.elapsedMs / 1000).toFixed(1)}s)</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
+    </div>`;
+}
+
+function renderWorktreeControls(): string {
+  return `
+    <div class="section">
+      <div class="section-title"><span class="codicon codicon-folder-opened"></span><span>Root Folders</span></div>
+      <div id="worktree-roots-list">${renderWorktreeRootsList()}</div>
+      <div class="folder-input-row" style="margin-top: 8px;">
+        <input
+          type="text"
+          id="worktree-root-input"
+          class="folder-input"
+          placeholder="Paste a root folder path here, e.g. C:\\code\\repos"
+          ${worktreeScanInProgress ? "disabled" : ""}
+        />
+        <button class="button secondary" id="btn-browse-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>📂 Browse…</button>
+        <button class="button secondary" id="btn-add-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>➕ Add</button>
+      </div>
+      <div style="margin-top: 16px;">
+        <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>🔍 Scan for Worktrees</button>
+        ${worktreeScanInProgress ? '<button class="button secondary" id="btn-cancel-worktree-scan">✕ Cancel</button>' : ""}
+      </div>
+      ${worktreeScanError ? `<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>⚠️ ${escapeHtml(worktreeScanError)}</div></div>` : ""}
+      <div id="worktree-progress-area">${renderWorktreeProgress()}</div>
+    </div>`;
+}
+
+function groupWorktreesByRepo(results: WorktreeResult[]): Map<string, WorktreeResult[]> {
+  const groups = new Map<string, WorktreeResult[]>();
+  for (const wt of results) {
+    const key = wt.repoLabel || "Unknown";
+    if (!groups.has(key)) { groups.set(key, []); }
+    groups.get(key)!.push(wt);
+  }
+  return groups;
+}
+
+function buildWorktreeRowHtml(w: WorktreeResult): string {
+  const pushedIcon = w.pushed === "yes" ? "✅" : w.pushed === "no" ? "🔴" : "❓";
+  return `<tr>
+    <td title="${escapeHtml(w.path)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(w.path)}</td>
+    <td>${escapeHtml(w.branch)}</td>
+    <td>${escapeHtml(w.lastCommit)}</td>
+    <td>${pushedIcon} ${escapeHtml(w.pushed)}</td>
+    <td>${escapeHtml(String(w.files))}</td>
+    <td title="${w.bytes.toLocaleString()} bytes">${formatFileSize(w.bytes)}</td>
+    <td><a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(w.path)}">Open</a></td>
+  </tr>`;
+}
+
+function buildWorktreeGroupHtml(repoLabel: string, worktrees: WorktreeResult[]): string {
+  const totalBytes = worktrees.reduce((s, w) => s + w.bytes, 0);
+  const sorted = [...worktrees].sort((a, b) => b.bytes - a.bytes);
+  const rows = sorted.map(buildWorktreeRowHtml).join("");
+  return `
+    <div class="worktree-group">
+      <div class="worktree-group-header">
+        <span class="worktree-group-title">${escapeHtml(repoLabel)}</span>
+        <span class="worktree-group-stats">${worktrees.length} worktree${worktrees.length === 1 ? "" : "s"} · ${formatFileSize(totalBytes)}</span>
+      </div>
+      <div class="table-container">
+        <table class="session-table">
+          <thead><tr><th>Path</th><th>Branch</th><th>Last Commit</th><th>Pushed</th><th>Files</th><th>Size</th><th>Actions</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`;
+}
+
+function renderWorktreeResults(): string {
+  if (worktreeResults.length === 0) {
+    if (worktreeScanInProgress) { return '<div style="padding: 16px; color: var(--text-muted);">Discovering worktrees…</div>'; }
+    return '<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';
+  }
+  const groups = groupWorktreesByRepo(worktreeResults);
+  const totalBytes = worktreeResults.reduce((s, w) => s + w.bytes, 0);
+  const summary = `<div class="summary-cards">
+    <div class="summary-card"><div class="summary-label">🌳 Worktrees</div><div class="summary-value">${worktreeResults.length}</div></div>
+    <div class="summary-card"><div class="summary-label">📦 Repositories</div><div class="summary-value">${groups.size}</div></div>
+    <div class="summary-card"><div class="summary-label">💾 Total Size</div><div class="summary-value" title="${totalBytes.toLocaleString()} bytes">${formatFileSize(totalBytes)}</div></div>
+  </div>`;
+  const sortedGroups = [...groups.entries()].sort((a, b) => {
+    const aBytes = a[1].reduce((s, w) => s + w.bytes, 0);
+    const bBytes = b[1].reduce((s, w) => s + w.bytes, 0);
+    return bBytes - aBytes;
+  });
+  return summary + sortedGroups.map(([repo, wts]) => buildWorktreeGroupHtml(repo, wts)).join("");
+}
+
+function renderWorktreesTab(): string {
+  return `
+    <div id="tab-worktrees" class="tab-content">
+      <div class="info-box">
+        <div class="info-box-title">🌳 Worktree Discovery</div>
+        <div>
+          Scans folders for uncleaned git worktrees and reports disk usage grouped by repository (based on each
+          worktree's git remote). Add one or more root folders below, then click Scan. Results stream in as they're found.
+        </div>
+      </div>
+      <div id="worktree-controls">${renderWorktreeControls()}</div>
+      <div id="worktree-results">${renderWorktreeResults()}</div>
+    </div>`;
+}
+
 function groupSessionFolders(
   raw: Array<{ dir: string; count: number; editorName?: string }>,
 ): Array<{ dir: string; count: number; editorName?: string }> {
@@ -1456,6 +1611,178 @@ function setupFolderAnalyzerHandlers(): void {
   });
 }
 
+function updateWorktreeControls(): void {
+  const controlsEl = document.getElementById("worktree-controls");
+  if (controlsEl) { controlsEl.innerHTML = renderWorktreeControls(); }
+}
+
+function updateWorktreeResults(): void {
+  const resultsEl = document.getElementById("worktree-results");
+  if (resultsEl) { resultsEl.innerHTML = renderWorktreeResults(); }
+}
+
+function updateWorktreeProgressArea(): void {
+  const el = document.getElementById("worktree-progress-area");
+  if (el) { el.innerHTML = renderWorktreeProgress(); }
+}
+
+function scheduleWorktreeResultsRender(): void {
+  if (worktreeRenderPending) { return; }
+  worktreeRenderPending = true;
+  requestAnimationFrame(() => {
+    worktreeRenderPending = false;
+    updateWorktreeResults();
+  });
+}
+
+function addWorktreeRootFromInput(): void {
+  const input = document.getElementById("worktree-root-input") as HTMLInputElement | null;
+  const value = input?.value.trim();
+  if (!value) { return; }
+  if (!worktreeRoots.some((r) => r.toLowerCase() === value.toLowerCase())) {
+    worktreeRoots.push(value);
+  }
+  if (input) { input.value = ""; }
+  updateWorktreeControls();
+}
+
+function startWorktreeScan(): void {
+  if (worktreeRoots.length === 0 || worktreeScanInProgress) { return; }
+  worktreeScanInProgress = true;
+  worktreeResults = [];
+  worktreeScanError = null;
+  worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+  updateWorktreeControls();
+  updateWorktreeResults();
+  vscode.postMessage({ command: "scanWorktrees", rootPaths: worktreeRoots });
+}
+
+function handleWorktreeTabClick(event: MouseEvent): void {
+  const target = event.target as HTMLElement | null;
+  if (!target) { return; }
+  if (target.id === "btn-browse-worktree-root") {
+    vscode.postMessage({ command: "pickWorktreeRoot" });
+    return;
+  }
+  if (target.id === "btn-add-worktree-root") {
+    addWorktreeRootFromInput();
+    return;
+  }
+  if (target.id === "btn-scan-worktrees") {
+    startWorktreeScan();
+    return;
+  }
+  if (target.id === "btn-cancel-worktree-scan") {
+    vscode.postMessage({ command: "cancelWorktreeScan" });
+    return;
+  }
+  if (target.classList.contains("worktree-remove-root")) {
+    const idx = Number(target.getAttribute("data-index"));
+    if (!isNaN(idx)) {
+      worktreeRoots.splice(idx, 1);
+      updateWorktreeControls();
+    }
+    return;
+  }
+  const revealLink = target.closest(".worktree-reveal-link") as HTMLElement | null;
+  if (revealLink) {
+    event.preventDefault();
+    const p = decodeURIComponent(revealLink.getAttribute("data-path") || "");
+    if (p) { vscode.postMessage({ command: "revealPath", path: p }); }
+  }
+}
+
+function setupWorktreesHandlers(): void {
+  const tabEl = document.getElementById("tab-worktrees");
+  if (!tabEl) { return; }
+  tabEl.addEventListener("click", handleWorktreeTabClick);
+  tabEl.addEventListener("keydown", (event) => {
+    const target = event.target as HTMLElement | null;
+    if (target?.id === "worktree-root-input" && (event as KeyboardEvent).key === "Enter") {
+      event.preventDefault();
+      addWorktreeRootFromInput();
+    }
+  });
+}
+
+function sanitizeWorktreeResult(item: unknown): WorktreeResult {
+  const w = (item ?? {}) as Record<string, unknown>;
+  const pushedRaw = String(w.pushed ?? "?");
+  const pushed: WorktreeResult["pushed"] = pushedRaw === "yes" || pushedRaw === "no" ? pushedRaw : "?";
+  return {
+    path: String(w.path ?? ""),
+    repoLabel: String(w.repoLabel ?? "Unknown"),
+    branch: String(w.branch ?? "?"),
+    lastCommit: String(w.lastCommit ?? "?"),
+    lastCommitDate: w.lastCommitDate ? String(w.lastCommitDate) : null,
+    pushed,
+    files: numField(w.files),
+    folders: numField(w.folders),
+    bytes: numField(w.bytes),
+  };
+}
+
+function handleWorktreeRootPicked(message: DiagMessage): void {
+  if (!message.folderPath) { return; }
+  const folderPath = String(message.folderPath);
+  if (!worktreeRoots.some((r) => r.toLowerCase() === folderPath.toLowerCase())) {
+    worktreeRoots.push(folderPath);
+  }
+  updateWorktreeControls();
+}
+
+function handleWorktreeScanStarted(): void {
+  worktreeScanInProgress = true;
+  worktreeResults = [];
+  worktreeScanError = null;
+  worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+  updateWorktreeControls();
+  updateWorktreeResults();
+}
+
+function handleWorktreeScanRootStarted(message: DiagMessage): void {
+  worktreeScanStatus = { ...worktreeScanStatus, root: String(message.root || ""), checked: 0, total: 0 };
+  updateWorktreeProgressArea();
+}
+
+function handleWorktreeScanRootMarkersFound(message: DiagMessage): void {
+  worktreeScanStatus = { ...worktreeScanStatus, total: numField(message.count) };
+  updateWorktreeProgressArea();
+}
+
+function handleWorktreeScanRootSkipped(message: DiagMessage): void {
+  worktreeScanError = `Skipped "${message.root}": ${message.reason || "not accessible"}`;
+  updateWorktreeControls();
+}
+
+function handleWorktreeScanProgress(message: DiagMessage): void {
+  worktreeScanStatus = {
+    root: String(message.root ?? worktreeScanStatus.root),
+    checked: numField(message.checked),
+    total: message.total !== undefined ? numField(message.total) : worktreeScanStatus.total,
+    foundCount: numField(message.foundCount),
+    elapsedMs: numField(message.elapsedMs),
+  };
+  updateWorktreeProgressArea();
+}
+
+function handleWorktreeFound(message: DiagMessage): void {
+  if (!message.worktree) { return; }
+  worktreeResults.push(sanitizeWorktreeResult(message.worktree));
+  scheduleWorktreeResultsRender();
+}
+
+function handleWorktreeScanComplete(): void {
+  worktreeScanInProgress = false;
+  updateWorktreeControls();
+  updateWorktreeResults();
+}
+
+function handleWorktreeScanCancelled(): void {
+  worktreeScanInProgress = false;
+  updateWorktreeControls();
+}
+
 function setupTabHandlers(): void {
   document.querySelectorAll(".tab").forEach((tab) => {
     tab.addEventListener("click", () => {
@@ -1917,6 +2244,18 @@ function handleFolderAnalysisResult(message: DiagMessage): void {
   }
 }
 
+const worktreeMessageHandlers: Record<string, (message: DiagMessage) => void> = {
+  worktreeRootPicked: handleWorktreeRootPicked,
+  worktreeScanStarted: () => handleWorktreeScanStarted(),
+  worktreeScanRootStarted: handleWorktreeScanRootStarted,
+  worktreeScanRootMarkersFound: handleWorktreeScanRootMarkersFound,
+  worktreeScanRootSkipped: handleWorktreeScanRootSkipped,
+  worktreeScanProgress: handleWorktreeScanProgress,
+  worktreeFound: handleWorktreeFound,
+  worktreeScanComplete: () => handleWorktreeScanComplete(),
+  worktreeScanCancelled: () => handleWorktreeScanCancelled(),
+};
+
 function setupMessageHandlers(): void {
   window.addEventListener("message", (event) => {
     const message = event.data as DiagMessage;
@@ -1936,6 +2275,8 @@ function setupMessageHandlers(): void {
       handleFolderPicked(message);
     } else if (message.command === "folderAnalysisResult") {
       handleFolderAnalysisResult(message);
+    } else if (worktreeMessageHandlers[message.command]) {
+      worktreeMessageHandlers[message.command](message);
     }
   });
 }
@@ -2284,6 +2625,7 @@ ${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
 <button class="tab" data-tab="display">⚙️ Settings</button>
 <button class="tab" data-tab="path-analyzer">🔬 Path Analyzer</button>
 <button class="tab" data-tab="tool-analysis">🔧 Tool Analysis</button>
+<button class="tab" data-tab="worktrees">🌳 Worktrees</button>
 ${data.isDebugMode ? '<button class="tab" data-tab="debug">🐛 Debug</button>' : ''}
 </div>
 
@@ -2314,6 +2656,7 @@ ${data.isDebugMode ? renderDebugTab(data.globalStateCounters) : ''}
 ${renderFolderAnalyzerTab()}
 </div>
 ${renderToolAnalysisTab(data.toolCallStats, data.toolFamilies)}
+${renderWorktreesTab()}
 </div>
 `;
 }
@@ -2362,6 +2705,7 @@ function renderLayout(data: DiagnosticsData): void {
   setupStorageLinkHandlers();
   setupGitHubAuthHandlers();
   setupFolderAnalyzerHandlers();
+  setupWorktreesHandlers();
   setupButtonHandlers();
   setupDisplaySettingHandlers();
   setupToolAnalysisSortHandlers();

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -2315,17 +2315,17 @@ function handleFolderAnalysisResult(message: DiagMessage): void {
   }
 }
 
-const worktreeMessageHandlers: Record<string, (message: DiagMessage) => void> = {
-  worktreeRootPicked: handleWorktreeRootPicked,
-  worktreeScanStarted: () => handleWorktreeScanStarted(),
-  worktreeScanRootStarted: handleWorktreeScanRootStarted,
-  worktreeScanRootMarkersFound: handleWorktreeScanRootMarkersFound,
-  worktreeScanRootSkipped: handleWorktreeScanRootSkipped,
-  worktreeScanProgress: handleWorktreeScanProgress,
-  worktreeFound: handleWorktreeFound,
-  worktreeScanComplete: () => handleWorktreeScanComplete(),
-  worktreeScanCancelled: () => handleWorktreeScanCancelled(),
-};
+const worktreeMessageHandlers = new Map<string, (message: DiagMessage) => void>([
+  ["worktreeRootPicked", handleWorktreeRootPicked],
+  ["worktreeScanStarted", () => handleWorktreeScanStarted()],
+  ["worktreeScanRootStarted", handleWorktreeScanRootStarted],
+  ["worktreeScanRootMarkersFound", handleWorktreeScanRootMarkersFound],
+  ["worktreeScanRootSkipped", handleWorktreeScanRootSkipped],
+  ["worktreeScanProgress", handleWorktreeScanProgress],
+  ["worktreeFound", handleWorktreeFound],
+  ["worktreeScanComplete", () => handleWorktreeScanComplete()],
+  ["worktreeScanCancelled", () => handleWorktreeScanCancelled()],
+]);
 
 function setupMessageHandlers(): void {
   window.addEventListener("message", (event) => {
@@ -2346,8 +2346,9 @@ function setupMessageHandlers(): void {
       handleFolderPicked(message);
     } else if (message.command === "folderAnalysisResult") {
       handleFolderAnalysisResult(message);
-    } else if (worktreeMessageHandlers[message.command]) {
-      worktreeMessageHandlers[message.command](message);
+    } else {
+      const worktreeHandler = worktreeMessageHandlers.get(message.command);
+      if (worktreeHandler) { worktreeHandler(message); }
     }
   });
 }

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -2315,17 +2315,28 @@ function handleFolderAnalysisResult(message: DiagMessage): void {
   }
 }
 
-const worktreeMessageHandlers = new Map<string, (message: DiagMessage) => void>([
-  ["worktreeRootPicked", handleWorktreeRootPicked],
-  ["worktreeScanStarted", () => handleWorktreeScanStarted()],
-  ["worktreeScanRootStarted", handleWorktreeScanRootStarted],
-  ["worktreeScanRootMarkersFound", handleWorktreeScanRootMarkersFound],
-  ["worktreeScanRootSkipped", handleWorktreeScanRootSkipped],
-  ["worktreeScanProgress", handleWorktreeScanProgress],
-  ["worktreeFound", handleWorktreeFound],
-  ["worktreeScanComplete", () => handleWorktreeScanComplete()],
-  ["worktreeScanCancelled", () => handleWorktreeScanCancelled()],
-]);
+/** Dispatches worktree-tab messages via static, literal command comparisons (no dynamic method lookup). */
+function handleWorktreeMessage(message: DiagMessage): void {
+  if (message.command === "worktreeRootPicked") {
+    handleWorktreeRootPicked(message);
+  } else if (message.command === "worktreeScanStarted") {
+    handleWorktreeScanStarted();
+  } else if (message.command === "worktreeScanRootStarted") {
+    handleWorktreeScanRootStarted(message);
+  } else if (message.command === "worktreeScanRootMarkersFound") {
+    handleWorktreeScanRootMarkersFound(message);
+  } else if (message.command === "worktreeScanRootSkipped") {
+    handleWorktreeScanRootSkipped(message);
+  } else if (message.command === "worktreeScanProgress") {
+    handleWorktreeScanProgress(message);
+  } else if (message.command === "worktreeFound") {
+    handleWorktreeFound(message);
+  } else if (message.command === "worktreeScanComplete") {
+    handleWorktreeScanComplete();
+  } else if (message.command === "worktreeScanCancelled") {
+    handleWorktreeScanCancelled();
+  }
+}
 
 function setupMessageHandlers(): void {
   window.addEventListener("message", (event) => {
@@ -2347,8 +2358,7 @@ function setupMessageHandlers(): void {
     } else if (message.command === "folderAnalysisResult") {
       handleFolderAnalysisResult(message);
     } else {
-      const worktreeHandler = worktreeMessageHandlers.get(message.command);
-      if (worktreeHandler) { worktreeHandler(message); }
+      handleWorktreeMessage(message);
     }
   });
 }

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -798,4 +798,68 @@ border: 1px solid #1f6feb;
 	to { transform: rotate(360deg); }
 }
 
+/* Worktrees tab */
+.worktree-roots-list {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.worktree-root-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	padding: 6px 10px;
+	font-family: var(--vscode-editor-font-family, monospace);
+	font-size: 12px;
+}
+
+.worktree-root-item span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.worktree-progress-bar {
+	height: 6px;
+	border-radius: 3px;
+	background: var(--bg-tertiary);
+	overflow: hidden;
+	margin-top: 8px;
+}
+
+.worktree-progress-fill {
+	height: 100%;
+	background: var(--link-color);
+	transition: width 0.2s ease;
+}
+
+.worktree-group {
+	margin-bottom: 16px;
+}
+
+.worktree-group-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	padding: 6px 4px;
+	border-bottom: 1px solid var(--border-color);
+	margin-bottom: 6px;
+}
+
+.worktree-group-title {
+	font-weight: 700;
+	font-size: 13px;
+	color: var(--text-primary);
+}
+
+.worktree-group-stats {
+	font-size: 12px;
+	color: var(--text-muted);
+}
+
 


### PR DESCRIPTION
## Summary
- Adds a new 🌳 **Worktrees** tab to the VS Code extension's Diagnostics screen that discovers uncleaned git worktrees under user-configured root folders and reports their disk usage, mirroring the detection logic from the standalone `Find-Worktrees.ps1` script (a `.git` **file**, not directory, marks a worktree).
- Discovery is incremental: worktree results stream to the UI as soon as their size and git metadata are computed (no waiting for the full scan), with a live progress indicator (root being scanned, markers checked, elapsed time) and a Cancel button.
- Results are grouped per repository (keyed on each worktree's git remote URL, falling back to the parent folder name), showing branch, last commit, pushed status, file count, and size — sorted largest-repo-first, then largest-worktree-first within a group.
- Root folders can be added by pasting a path or via a folder picker, are persisted in `globalState` across sessions, and are disabled while a scan is running.

## Why
The user already has a PowerShell script (`Find-Worktrees.ps1`) for finding stale worktrees on disk from the CLI, and wanted the same discovery available inside the extension's Diagnostics UI, with progress shown while scanning (since these scans can walk large directory trees).

## Implementation notes
- Extension side (`extension.ts`): `scanWorktreesIncremental` walks each root looking for `.git` marker files (skipping `node_modules`, `.git`, `.hg`, `.svn`, `packages`, `vendor` during the *search* only — size computation still walks everything, matching the PowerShell script's behavior), then for each found worktree computes folder stats and git info (`branch`, last commit, pushed-to-remote status, remote URL) via `git` commands with a 5s timeout, mirroring the existing `getGitRepoInfo` pattern already used elsewhere in the file.
- A generation counter (`worktreeScanId`) makes scans cancellable and prevents stale in-flight scans from posting messages after a new scan starts.
- Webview side (`main.ts`, `styles.css`): new tab wired into the existing tab bar, using event delegation for click handling so dynamically-streamed rows don't need re-wiring, and `requestAnimationFrame` batching so bursts of `worktreeFound` messages don't cause excessive re-renders.

## Test plan
- [x] `npm run compile` — 0 errors, 0 new warnings (2 pre-existing warnings unrelated to this change, confirmed present on `main` via `git stash`)
- [x] `npm run test:node` — all existing unit tests pass
- [ ] Manual verification in the Extension Development Host (human-only per repo guidelines — not run by the agent): add a root folder, run a scan, confirm progress/streaming/grouping/cancel all work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)