### PR TITLE
Load Copilot CLI OTel export off the main thread, and read it incrementally

### DIFF
--- a/src/copilotCliOtel.ts
+++ b/src/copilotCliOtel.ts
@@ -122,6 +122,9 @@ function accumulateOtelChatSpanUsage(index: Map<string, CopilotCliOtelSessionUsa
  */
 const OTEL_CHAT_LINE_HINT = '"name":"chat ';
 
+/** ASCII newline byte, used for byte-level line scanning of the export files. */
+const NEWLINE_BYTE = 0x0a;
+
 /** Merges one already-parsed OTel record into `index` when it's a `chat <model>` span; ignores anything else. */
 function consolidateOtelRecord(record: OtelSpanRecord, index: Map<string, CopilotCliOtelSessionUsage>): void {
 	if (record.type !== 'span' || !record.name?.startsWith('chat ')) { return; }
@@ -130,23 +133,29 @@ function consolidateOtelRecord(record: OtelSpanRecord, index: Map<string, Copilo
 	accumulateOtelChatSpanUsage(index, sessionId, readOtelChatSpanUsage(record.attributes));
 }
 
-/** Parses one line of an OTel export file, merging its usage into `index` if it's a `chat <model>` span. */
-function parseOtelLine(line: string, index: Map<string, CopilotCliOtelSessionUsage>): void {
-	if (!line.includes(OTEL_CHAT_LINE_HINT)) { return; }
-	let record: OtelSpanRecord;
-	try {
-		record = JSON.parse(line);
-	} catch {
-		return;
-	}
-	consolidateOtelRecord(record, index);
+/** Parses one export line into a `chat <model>` candidate record, or null when it can't be one. */
+function parseChatCandidateLine(line: string): OtelSpanRecord | null {
+	if (!line.includes(OTEL_CHAT_LINE_HINT)) { return null; }
+	try { return JSON.parse(line) as OtelSpanRecord; } catch { return null; }
 }
 
-/** Parses one OTel export file's `chat <model>` spans, merging per-session totals into `index`. */
-function parseOtelFileInto(content: string, index: Map<string, CopilotCliOtelSessionUsage>): void {
-	for (const line of content.split('\n')) {
-		parseOtelLine(line, index);
-	}
+/** One export file to read, over the half-open byte range [start, end). */
+interface OtelReadPlanItem { name: string; start: number; end: number; }
+
+/**
+ * Result of reading a plan: the parsed `chat <model>` candidate records, plus, per file, the
+ * byte offset just past the last complete (newline-terminated) line we consumed. A trailing
+ * partial line (still being appended) is left unconsumed so it's re-read once it completes.
+ */
+interface OtelReadResult { records: OtelSpanRecord[]; consumed: Record<string, number>; }
+
+/** Coerces an untrusted worker payload into a well-formed OtelReadResult. */
+function normalizeReadResult(result: unknown): OtelReadResult {
+	const r = result as Partial<OtelReadResult> | undefined;
+	return {
+		records: Array.isArray(r?.records) ? r!.records : [],
+		consumed: r?.consumed && typeof r.consumed === 'object' ? r.consumed : {},
+	};
 }
 
 /**
@@ -154,46 +163,67 @@ function parseOtelFileInto(content: string, index: Map<string, CopilotCliOtelSes
  * self-contained string that touches only Node built-ins so it needs no separate entry point
  * or runtime path resolution — it bundles identically across every build layout (tsc → out/,
  * esbuild → extension dist/, esbuild → cli dist/). It does the expensive part off the caller's
- * main thread: streaming each export file line-by-line (never holding the whole 100+ MB file
- * in memory), cheaply pre-filtering, and JSON.parsing only the handful of `chat <model>`
- * candidate lines. It posts that small candidate array back for the main thread to consolidate.
+ * main thread: for each planned byte range it streams the file in chunks (never holding the
+ * whole 100+ MB file in memory), scans for line boundaries at the byte level, cheaply
+ * pre-filters, and JSON.parses only the handful of `chat <model>` candidate lines. It posts
+ * back the small candidate array plus how far it consumed each file, so the main thread can
+ * consolidate and remember offsets for the next (incremental) refresh.
  */
 const OTEL_WORKER_SOURCE = `
 const { parentPort, workerData } = require('worker_threads');
 const fs = require('fs');
 const path = require('path');
-const readline = require('readline');
-const HINT = ${JSON.stringify(OTEL_CHAT_LINE_HINT)};
+const HINT = Buffer.from(${JSON.stringify(OTEL_CHAT_LINE_HINT)});
+const NL = 0x0a;
+function readRange(full, start, end) {
+	return new Promise((resolve) => {
+		const records = [];
+		if (end <= start) { resolve({ records, consumed: start }); return; }
+		const stream = fs.createReadStream(full, { start, end: end - 1 });
+		let carry = null;
+		let consumed = start;
+		stream.on('data', (chunk) => {
+			const buf = carry ? Buffer.concat([carry, chunk]) : chunk;
+			let from = 0, nl;
+			while ((nl = buf.indexOf(NL, from)) !== -1) {
+				const line = buf.subarray(from, nl);
+				if (line.indexOf(HINT) !== -1) {
+					try { records.push(JSON.parse(line.toString('utf8'))); } catch { /* malformed line — skip */ }
+				}
+				consumed += (nl - from) + 1;
+				from = nl + 1;
+			}
+			carry = from < buf.length ? buf.subarray(from) : null;
+		});
+		stream.on('end', () => resolve({ records, consumed }));
+		stream.on('error', () => resolve({ records, consumed }));
+	});
+}
 async function run() {
 	const records = [];
-	let entries;
-	try { entries = await fs.promises.readdir(workerData.dir); }
-	catch { parentPort.postMessage(records); return; }
-	for (const name of entries) {
-		if (!name.endsWith('.jsonl')) { continue; }
+	const consumed = {};
+	for (const item of workerData.plan) {
 		try {
-			const rl = readline.createInterface({ input: fs.createReadStream(path.join(workerData.dir, name), { encoding: 'utf8' }), crlfDelay: Infinity });
-			for await (const line of rl) {
-				if (!line.includes(HINT)) { continue; }
-				try { records.push(JSON.parse(line)); } catch { /* malformed line — skip */ }
-			}
-		} catch { /* unreadable file — skip */ }
+			const r = await readRange(path.join(workerData.dir, item.name), item.start, item.end);
+			for (const rec of r.records) { records.push(rec); }
+			consumed[item.name] = r.consumed;
+		} catch { /* unreadable file — leave its offset untouched */ }
 	}
-	parentPort.postMessage(records);
+	parentPort.postMessage({ records, consumed });
 }
-run().catch(() => { try { parentPort.postMessage([]); } catch { /* worker tearing down */ } });
+run().catch(() => { try { parentPort.postMessage({ records: [], consumed: {} }); } catch { /* worker tearing down */ } });
 `;
 
 /**
- * Runs the OTel read+filter+parse in a worker thread, resolving the parsed `chat <model>`
- * candidate records. Rejects if the worker can't be created or dies before posting, so the
- * caller can fall back to an in-process read.
+ * Runs a read plan in a worker thread, resolving the parsed candidate records and per-file
+ * consumed offsets. Rejects if the worker can't be created or dies before posting, so the
+ * caller can fall back to an in-process read of the same plan.
  */
-function loadOtelRecordsViaWorker(dir: string): Promise<OtelSpanRecord[]> {
-	return new Promise<OtelSpanRecord[]>((resolve, reject) => {
+function loadOtelRecordsViaWorker(dir: string, plan: OtelReadPlanItem[]): Promise<OtelReadResult> {
+	return new Promise<OtelReadResult>((resolve, reject) => {
 		let worker: Worker;
 		try {
-			worker = new Worker(OTEL_WORKER_SOURCE, { eval: true, workerData: { dir } });
+			worker = new Worker(OTEL_WORKER_SOURCE, { eval: true, workerData: { dir, plan } });
 		} catch (err) {
 			reject(err);
 			return;
@@ -205,16 +235,61 @@ function loadOtelRecordsViaWorker(dir: string): Promise<OtelSpanRecord[]> {
 			void worker.terminate();
 			done();
 		};
-		worker.once('message', (records: OtelSpanRecord[]) => finish(() => resolve(Array.isArray(records) ? records : [])));
+		worker.once('message', (result: unknown) => finish(() => resolve(normalizeReadResult(result))));
 		worker.once('error', (err) => finish(() => reject(err)));
 		worker.once('exit', (code) => finish(() => reject(new Error(`OTel worker exited before posting results (code ${code})`))));
 	});
 }
 
+/** Reads bytes [start, end) of a file into a Buffer (used for small incremental tails read in-process). */
+async function readByteRange(file: string, start: number, end: number): Promise<Buffer> {
+	if (end <= start) { return Buffer.alloc(0); }
+	const fh = await fs.promises.open(file, 'r');
+	try {
+		const length = end - start;
+		const buf = Buffer.allocUnsafe(length);
+		const { bytesRead } = await fh.read(buf, 0, length, start);
+		return bytesRead === length ? buf : buf.subarray(0, bytesRead);
+	} finally {
+		await fh.close();
+	}
+}
+
+/**
+ * In-process reader for a plan, used for small tails (where a worker's spawn cost would dwarf
+ * the work) and as the fallback when a worker can't be spawned. Mirrors the worker's contract:
+ * parse `chat <model>` candidate lines and report how far each file was consumed.
+ */
+async function loadOtelRecordsInProcess(dir: string, plan: OtelReadPlanItem[]): Promise<OtelReadResult> {
+	const records: OtelSpanRecord[] = [];
+	const consumed: Record<string, number> = {};
+	for (const item of plan) {
+		try {
+			const buf = await readByteRange(path.join(dir, item.name), item.start, item.end);
+			const lastNl = buf.lastIndexOf(NEWLINE_BYTE);
+			if (lastNl === -1) { consumed[item.name] = item.start; continue; } // no complete line yet
+			for (const line of buf.subarray(0, lastNl + 1).toString('utf8').split('\n')) {
+				const record = parseChatCandidateLine(line);
+				if (record) { records.push(record); }
+			}
+			consumed[item.name] = item.start + lastNl + 1;
+		} catch { /* unreadable file — leave its offset untouched */ }
+	}
+	return { records, consumed };
+}
+
 let cachedIndex: Map<string, CopilotCliOtelSessionUsage> | null = null;
 let cachedAt = 0;
+/**
+ * Bytes we've already consumed from each export file, keyed by filename. Lets a refresh read
+ * only the newly-appended tail instead of re-reading the whole (ever-growing) file, since the
+ * Copilot CLI export is strictly append-only. Reset on a full rebuild.
+ */
+let fileOffsets = new Map<string, number>();
 /** Re-scan the OTel directory at most this often; the export file grows across a live CLI session. */
 const CACHE_TTL_MS = 30_000;
+/** Reads larger than this go to a worker thread; smaller tails are parsed in-process (sub-ms, no spawn cost). */
+const OTEL_WORKER_MIN_BYTES = 1_000_000;
 /**
  * In-flight load, cached (not just the resolved value) so concurrent callers on a cold
  * cache all await the same read+parse instead of each independently reading the OTel
@@ -223,38 +298,90 @@ const CACHE_TTL_MS = 30_000;
  */
 let inFlightLoad: Promise<Map<string, CopilotCliOtelSessionUsage>> | null = null;
 
-async function readCopilotCliOtelIndex(): Promise<Map<string, CopilotCliOtelSessionUsage>> {
-	const index = new Map<string, CopilotCliOtelSessionUsage>();
-	const dir = getCopilotCliOtelDir();
+/** Current byte size of each named export file in `dir` (skipping any that vanished mid-scan). */
+async function statOtelFiles(dir: string, names: string[]): Promise<Map<string, number>> {
+	const sizes = new Map<string, number>();
+	for (const name of names) {
+		try { sizes.set(name, (await fs.promises.stat(path.join(dir, name))).size); }
+		catch { /* vanished between readdir and stat — skip */ }
+	}
+	return sizes;
+}
+
+/**
+ * Whether to rebuild the index from scratch rather than append incrementally: true on a cold
+ * cache, or when a tracked file shrank or vanished (log rotation / truncation), since the
+ * cached totals then include bytes that no longer exist.
+ */
+function otelNeedsRebuild(sizes: Map<string, number>): boolean {
+	if (cachedIndex === null) { return true; }
+	for (const [name, off] of fileOffsets) {
+		const size = sizes.get(name);
+		if (size === undefined || size < off) { return true; }
+	}
+	return false;
+}
+
+/** Plans the byte range to read for each file that grew past its consumed offset (the whole file on a rebuild). */
+function buildOtelReadPlan(sizes: Map<string, number>, baseOffsets: Map<string, number>): { plan: OtelReadPlanItem[]; totalBytes: number } {
+	const plan: OtelReadPlanItem[] = [];
+	let totalBytes = 0;
+	for (const [name, size] of sizes) {
+		const start = baseOffsets.get(name) ?? 0;
+		if (size > start) { plan.push({ name, start, end: size }); totalBytes += size - start; }
+	}
+	return { plan, totalBytes };
+}
+
+/** Reads a plan off the main thread for large tails, in-process for small ones, falling back to in-process if the worker fails. */
+async function runOtelReadPlan(dir: string, plan: OtelReadPlanItem[], totalBytes: number): Promise<OtelReadResult> {
 	try {
-		// Do the heavy streaming read+parse off the main thread; consolidate the small result here.
-		const records = await loadOtelRecordsViaWorker(dir);
-		for (const record of records) { consolidateOtelRecord(record, index); }
-		return index;
+		return totalBytes > OTEL_WORKER_MIN_BYTES
+			? await loadOtelRecordsViaWorker(dir, plan)
+			: await loadOtelRecordsInProcess(dir, plan);
 	} catch {
-		// Worker unavailable or failed (e.g. constrained runtime) — fall back to an in-process read
-		// so callers still get data, just without the off-thread benefit.
-		return readCopilotCliOtelIndexInProcess(dir);
+		// Worker path failed (e.g. constrained runtime) — retry the same plan in-process.
+		return loadOtelRecordsInProcess(dir, plan);
 	}
 }
 
-/** In-process read+parse of the OTel export, used only when the worker thread can't be used. */
-async function readCopilotCliOtelIndexInProcess(dir: string): Promise<Map<string, CopilotCliOtelSessionUsage>> {
-	const index = new Map<string, CopilotCliOtelSessionUsage>();
+async function readCopilotCliOtelIndex(): Promise<Map<string, CopilotCliOtelSessionUsage>> {
+	const dir = getCopilotCliOtelDir();
+	let names: string[];
 	try {
-		const entries = await fs.promises.readdir(dir);
-		for (const name of entries) {
-			if (!name.endsWith('.jsonl')) { continue; }
-			try {
-				const content = await fs.promises.readFile(path.join(dir, name), 'utf8');
-				parseOtelFileInto(content, index);
-			} catch { /* unreadable file — skip */ }
-		}
-	} catch { /* ~/.copilot/otel doesn't exist — OTel export not enabled, no data available */ }
+		names = (await fs.promises.readdir(dir)).filter((n) => n.endsWith('.jsonl'));
+	} catch {
+		// ~/.copilot/otel doesn't exist — OTel export not enabled. Forget any prior offsets.
+		fileOffsets = new Map();
+		return new Map();
+	}
+
+	const sizes = await statOtelFiles(dir, names);
+	const rebuild = otelNeedsRebuild(sizes);
+	const index = rebuild ? new Map<string, CopilotCliOtelSessionUsage>() : cachedIndex!;
+	const baseOffsets = rebuild ? new Map<string, number>() : fileOffsets;
+
+	const { plan, totalBytes } = buildOtelReadPlan(sizes, baseOffsets);
+	if (plan.length === 0) {
+		// Nothing new to read; keep the current (possibly freshly-rebuilt-empty) index and offsets.
+		fileOffsets = baseOffsets;
+		return index;
+	}
+
+	const result = await runOtelReadPlan(dir, plan, totalBytes);
+	for (const record of result.records) { consolidateOtelRecord(record, index); }
+
+	const nextOffsets = new Map(baseOffsets);
+	for (const [name, off] of Object.entries(result.consumed)) { nextOffsets.set(name, off); }
+	fileOffsets = nextOffsets;
 	return index;
 }
 
-/** Loads (and caches) the OTel usage index by scanning every .jsonl file under ~/.copilot/otel/. */
+/**
+ * Loads (and caches) the OTel usage index. The first load reads every .jsonl file under
+ * ~/.copilot/otel/ off the main thread; later refreshes (after the TTL) read only the bytes
+ * appended since, since the export is append-only.
+ */
 export async function loadCopilotCliOtelIndex(): Promise<Map<string, CopilotCliOtelSessionUsage>> {
 	const now = Date.now();
 	if (cachedIndex && now - cachedAt < CACHE_TTL_MS) { return cachedIndex; }
@@ -270,9 +397,19 @@ export async function loadCopilotCliOtelIndex(): Promise<Map<string, CopilotCliO
 	return inFlightLoad;
 }
 
-/** Clears the cached OTel index. Exposed for tests. */
+/** Clears the cached OTel index and per-file offsets. Exposed for tests. */
 export function clearCopilotCliOtelCache(): void {
 	cachedIndex = null;
+	cachedAt = 0;
+	inFlightLoad = null;
+	fileOffsets = new Map();
+}
+
+/**
+ * Expires the cache TTL while keeping the index and per-file offsets, so the next
+ * loadCopilotCliOtelIndex() performs an incremental refresh. Exposed for tests.
+ */
+export function expireCopilotCliOtelCacheForTests(): void {
 	cachedAt = 0;
 	inFlightLoad = null;
 }

--- a/src/copilotCliOtel.ts
+++ b/src/copilotCliOtel.ts
@@ -11,6 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { Worker } from 'worker_threads';
 import type { ModelUsage } from './types';
 
 /** Per-session usage aggregated from OTel `chat <model>` spans. */
@@ -111,19 +112,34 @@ function accumulateOtelChatSpanUsage(index: Map<string, CopilotCliOtelSessionUsa
 	entry.nanoAiu += usage.nanoAiu;
 }
 
+/**
+ * Substring that every Copilot CLI `chat <model>` span line contains. The export interleaves
+ * these few spans with tens of thousands of metric/log/other-span lines we never use, so this
+ * cheap string test lets us skip JSON.parse on the ~99.8% of lines that can't be a chat span
+ * (measured: 165 of 108,112 lines on a real 134 MB export). It's only a pre-filter —
+ * consolidateOtelRecord still fully validates each candidate — so a stray substring match at
+ * worst costs one wasted parse.
+ */
+const OTEL_CHAT_LINE_HINT = '"name":"chat ';
+
+/** Merges one already-parsed OTel record into `index` when it's a `chat <model>` span; ignores anything else. */
+function consolidateOtelRecord(record: OtelSpanRecord, index: Map<string, CopilotCliOtelSessionUsage>): void {
+	if (record.type !== 'span' || !record.name?.startsWith('chat ')) { return; }
+	const sessionId = record.attributes?.['gen_ai.conversation.id'];
+	if (!sessionId) { return; }
+	accumulateOtelChatSpanUsage(index, sessionId, readOtelChatSpanUsage(record.attributes));
+}
+
 /** Parses one line of an OTel export file, merging its usage into `index` if it's a `chat <model>` span. */
 function parseOtelLine(line: string, index: Map<string, CopilotCliOtelSessionUsage>): void {
-	if (!line.trim()) { return; }
+	if (!line.includes(OTEL_CHAT_LINE_HINT)) { return; }
 	let record: OtelSpanRecord;
 	try {
 		record = JSON.parse(line);
 	} catch {
 		return;
 	}
-	if (record.type !== 'span' || !record.name?.startsWith('chat ')) { return; }
-	const sessionId = record.attributes?.['gen_ai.conversation.id'];
-	if (!sessionId) { return; }
-	accumulateOtelChatSpanUsage(index, sessionId, readOtelChatSpanUsage(record.attributes));
+	consolidateOtelRecord(record, index);
 }
 
 /** Parses one OTel export file's `chat <model>` spans, merging per-session totals into `index`. */
@@ -131,6 +147,68 @@ function parseOtelFileInto(content: string, index: Map<string, CopilotCliOtelSes
 	for (const line of content.split('\n')) {
 		parseOtelLine(line, index);
 	}
+}
+
+/**
+ * Source for the OTel-parsing worker, run via `new Worker(src, { eval: true })`. Kept as a
+ * self-contained string that touches only Node built-ins so it needs no separate entry point
+ * or runtime path resolution — it bundles identically across every build layout (tsc → out/,
+ * esbuild → extension dist/, esbuild → cli dist/). It does the expensive part off the caller's
+ * main thread: streaming each export file line-by-line (never holding the whole 100+ MB file
+ * in memory), cheaply pre-filtering, and JSON.parsing only the handful of `chat <model>`
+ * candidate lines. It posts that small candidate array back for the main thread to consolidate.
+ */
+const OTEL_WORKER_SOURCE = `
+const { parentPort, workerData } = require('worker_threads');
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const HINT = ${JSON.stringify(OTEL_CHAT_LINE_HINT)};
+async function run() {
+	const records = [];
+	let entries;
+	try { entries = await fs.promises.readdir(workerData.dir); }
+	catch { parentPort.postMessage(records); return; }
+	for (const name of entries) {
+		if (!name.endsWith('.jsonl')) { continue; }
+		try {
+			const rl = readline.createInterface({ input: fs.createReadStream(path.join(workerData.dir, name), { encoding: 'utf8' }), crlfDelay: Infinity });
+			for await (const line of rl) {
+				if (!line.includes(HINT)) { continue; }
+				try { records.push(JSON.parse(line)); } catch { /* malformed line — skip */ }
+			}
+		} catch { /* unreadable file — skip */ }
+	}
+	parentPort.postMessage(records);
+}
+run().catch(() => { try { parentPort.postMessage([]); } catch { /* worker tearing down */ } });
+`;
+
+/**
+ * Runs the OTel read+filter+parse in a worker thread, resolving the parsed `chat <model>`
+ * candidate records. Rejects if the worker can't be created or dies before posting, so the
+ * caller can fall back to an in-process read.
+ */
+function loadOtelRecordsViaWorker(dir: string): Promise<OtelSpanRecord[]> {
+	return new Promise<OtelSpanRecord[]>((resolve, reject) => {
+		let worker: Worker;
+		try {
+			worker = new Worker(OTEL_WORKER_SOURCE, { eval: true, workerData: { dir } });
+		} catch (err) {
+			reject(err);
+			return;
+		}
+		let settled = false;
+		const finish = (done: () => void): void => {
+			if (settled) { return; }
+			settled = true;
+			void worker.terminate();
+			done();
+		};
+		worker.once('message', (records: OtelSpanRecord[]) => finish(() => resolve(Array.isArray(records) ? records : [])));
+		worker.once('error', (err) => finish(() => reject(err)));
+		worker.once('exit', (code) => finish(() => reject(new Error(`OTel worker exited before posting results (code ${code})`))));
+	});
 }
 
 let cachedIndex: Map<string, CopilotCliOtelSessionUsage> | null = null;
@@ -148,6 +226,21 @@ let inFlightLoad: Promise<Map<string, CopilotCliOtelSessionUsage>> | null = null
 async function readCopilotCliOtelIndex(): Promise<Map<string, CopilotCliOtelSessionUsage>> {
 	const index = new Map<string, CopilotCliOtelSessionUsage>();
 	const dir = getCopilotCliOtelDir();
+	try {
+		// Do the heavy streaming read+parse off the main thread; consolidate the small result here.
+		const records = await loadOtelRecordsViaWorker(dir);
+		for (const record of records) { consolidateOtelRecord(record, index); }
+		return index;
+	} catch {
+		// Worker unavailable or failed (e.g. constrained runtime) — fall back to an in-process read
+		// so callers still get data, just without the off-thread benefit.
+		return readCopilotCliOtelIndexInProcess(dir);
+	}
+}
+
+/** In-process read+parse of the OTel export, used only when the worker thread can't be used. */
+async function readCopilotCliOtelIndexInProcess(dir: string): Promise<Map<string, CopilotCliOtelSessionUsage>> {
+	const index = new Map<string, CopilotCliOtelSessionUsage>();
 	try {
 		const entries = await fs.promises.readdir(dir);
 		for (const name of entries) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -99,7 +99,7 @@ import { PiDataAccess } from '../../src/pi';
 import { getVSCodeUserPaths } from '../../src/adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from '../../src/jetbrains';
-import { extractCopilotCliSessionId, getCopilotCliOtelUsage, getCopilotCliOtelStatus } from '../../src/copilotCliOtel';
+import { extractCopilotCliSessionId, getCopilotCliOtelUsage, getCopilotCliOtelStatus, loadCopilotCliOtelIndex } from '../../src/copilotCliOtel';
 import { createWakeupGate } from './utils/promises';
 
 // --- Session parsing & token estimation ---
@@ -10005,6 +10005,12 @@ function registerDiagnosticAndAuthCommands(context: vscode.ExtensionContext, tok
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<AiFluencyExtensionApi> {
+  // Kick off the Copilot CLI OTel export load immediately, on a worker thread, so the heavy
+  // streaming read+parse of the (100+ MB, ever-growing) export file overlaps the rest of
+  // activation instead of blocking the first usage analysis. Fire-and-forget: the result is
+  // cached inside the module, and every consumer already awaits loadCopilotCliOtelIndex() lazily.
+  void loadCopilotCliOtelIndex().catch(() => { /* off-by-default export; degrades to no data */ });
+
   // Create the token tracker
   const tokenTracker = new CopilotTokenTracker(context.extensionUri, context);
 

--- a/vscode-extension/test/unit/copilotCliOtel.test.ts
+++ b/vscode-extension/test/unit/copilotCliOtel.test.ts
@@ -127,28 +127,18 @@ test('getCopilotCliOtelUsage: returns null for a non-Copilot-CLI path without to
 	});
 });
 
-test('loadCopilotCliOtelIndex: concurrent callers on a cold cache share one read, not N', async (t) => {
+test('loadCopilotCliOtelIndex: concurrent callers on a cold cache share one load, not N', async (t) => {
 	await withHomedir(t, async (homeDir) => {
 		const otelDir = path.join(homeDir, '.copilot', 'otel');
 		fs.mkdirSync(otelDir, { recursive: true });
 		fs.writeFileSync(path.join(otelDir, 'copilot-otel.jsonl'), chatSpan(SESSION_ID));
 
-		let readFileCalls = 0;
-		const originalReadFile = fs.promises.readFile;
-		(fs.promises as { readFile: typeof fs.promises.readFile }).readFile = (async (...args: Parameters<typeof fs.promises.readFile>) => {
-			readFileCalls++;
-			// Yield to let other concurrent callers reach loadCopilotCliOtelIndex before this resolves,
-			// so a buggy (non-deduplicating) implementation would have already kicked off its own reads.
-			await new Promise((r) => setImmediate(r));
-			return originalReadFile(...args);
-		}) as typeof fs.promises.readFile;
-
-		try {
-			// Fire 10 concurrent loads before any of them can populate the cache.
-			await Promise.all(Array.from({ length: 10 }, () => loadCopilotCliOtelIndex()));
-			assert.equal(readFileCalls, 1, 'the OTel export file should be read exactly once, not once per concurrent caller');
-		} finally {
-			(fs.promises as { readFile: typeof fs.promises.readFile }).readFile = originalReadFile;
-		}
+		// Fire 10 concurrent loads before any of them can populate the cache. The load runs off
+		// the main thread now, so we can't count read calls here — instead assert the dedup
+		// guarantee directly: every concurrent caller resolves to the *same* index instance. A
+		// non-deduplicating implementation would build (and return) a distinct Map per caller.
+		const results = await Promise.all(Array.from({ length: 10 }, () => loadCopilotCliOtelIndex()));
+		assert.ok(results.every((r) => r === results[0]), 'concurrent cold-cache loads should share one index instance, not one per caller');
+		assert.equal(results[0].get(SESSION_ID)?.actualTokens, 110, 'the shared index should hold the parsed span usage');
 	});
 });

--- a/vscode-extension/test/unit/copilotCliOtel.test.ts
+++ b/vscode-extension/test/unit/copilotCliOtel.test.ts
@@ -9,9 +9,23 @@ import {
 	getCopilotCliOtelUsage,
 	loadCopilotCliOtelIndex,
 	clearCopilotCliOtelCache,
+	expireCopilotCliOtelCacheForTests,
 } from '../../../src/copilotCliOtel';
 
 const SESSION_ID = 'a19abe35-b44e-4713-bf70-27f015393772';
+const SESSION_ID_2 = 'b28cf946-c55b-5824-cf81-38f126404883';
+const OTEL_FILE = 'copilot-otel.jsonl';
+
+/** Writes spans as a fresh newline-terminated .jsonl file (real exports terminate every record with \n). */
+function writeOtelSpans(otelDir: string, spans: string[], filename = OTEL_FILE): void {
+	fs.mkdirSync(otelDir, { recursive: true });
+	fs.writeFileSync(path.join(otelDir, filename), spans.map((s) => s + '\n').join(''));
+}
+
+/** Appends more newline-terminated spans to an existing export file. */
+function appendOtelSpans(otelDir: string, spans: string[], filename = OTEL_FILE): void {
+	fs.appendFileSync(path.join(otelDir, filename), spans.map((s) => s + '\n').join(''));
+}
 
 function eventsJsonlPath(homeDir: string, sessionId: string): string {
 	return path.join(homeDir, '.copilot', 'session-state', sessionId, 'events.jsonl');
@@ -86,11 +100,10 @@ test('extractCopilotCliSessionId: returns null for non-Copilot-CLI paths', () =>
 test('getCopilotCliOtelUsage: aggregates multiple chat spans for the same session', async (t) => {
 	await withHomedir(t, async (homeDir) => {
 		const otelDir = path.join(homeDir, '.copilot', 'otel');
-		fs.mkdirSync(otelDir, { recursive: true });
-		fs.writeFileSync(
-			path.join(otelDir, 'copilot-otel.jsonl'),
-			[chatSpan(SESSION_ID), chatSpan(SESSION_ID, { 'gen_ai.usage.input_tokens': 50, 'gen_ai.usage.output_tokens': 5 })].join('\n')
-		);
+		writeOtelSpans(otelDir, [
+			chatSpan(SESSION_ID),
+			chatSpan(SESSION_ID, { 'gen_ai.usage.input_tokens': 50, 'gen_ai.usage.output_tokens': 5 }),
+		]);
 
 		const usage = await getCopilotCliOtelUsage(eventsJsonlPath(homeDir, SESSION_ID));
 		assert.ok(usage);
@@ -104,8 +117,7 @@ test('getCopilotCliOtelUsage: aggregates multiple chat spans for the same sessio
 test('getCopilotCliOtelUsage: matches session-store.db virtual paths against the same session id', async (t) => {
 	await withHomedir(t, async (homeDir) => {
 		const otelDir = path.join(homeDir, '.copilot', 'otel');
-		fs.mkdirSync(otelDir, { recursive: true });
-		fs.writeFileSync(path.join(otelDir, 'copilot-otel.jsonl'), chatSpan(SESSION_ID));
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID)]);
 
 		const usage = await getCopilotCliOtelUsage(dbVirtualPath(homeDir, SESSION_ID));
 		assert.ok(usage);
@@ -130,8 +142,7 @@ test('getCopilotCliOtelUsage: returns null for a non-Copilot-CLI path without to
 test('loadCopilotCliOtelIndex: concurrent callers on a cold cache share one load, not N', async (t) => {
 	await withHomedir(t, async (homeDir) => {
 		const otelDir = path.join(homeDir, '.copilot', 'otel');
-		fs.mkdirSync(otelDir, { recursive: true });
-		fs.writeFileSync(path.join(otelDir, 'copilot-otel.jsonl'), chatSpan(SESSION_ID));
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID)]);
 
 		// Fire 10 concurrent loads before any of them can populate the cache. The load runs off
 		// the main thread now, so we can't count read calls here — instead assert the dedup
@@ -140,5 +151,60 @@ test('loadCopilotCliOtelIndex: concurrent callers on a cold cache share one load
 		const results = await Promise.all(Array.from({ length: 10 }, () => loadCopilotCliOtelIndex()));
 		assert.ok(results.every((r) => r === results[0]), 'concurrent cold-cache loads should share one index instance, not one per caller');
 		assert.equal(results[0].get(SESSION_ID)?.actualTokens, 110, 'the shared index should hold the parsed span usage');
+	});
+});
+
+test('loadCopilotCliOtelIndex: parses a large export via the worker path', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const otelDir = path.join(homeDir, '.copilot', 'otel');
+		// Exceed the in-process byte threshold (1 MB) so the load routes through the worker thread.
+		// Each span is a few hundred bytes, so a few thousand of them is comfortably over 1 MB.
+		const spanCount = 4000;
+		writeOtelSpans(otelDir, Array.from({ length: spanCount }, () => chatSpan(SESSION_ID)));
+		assert.ok(fs.statSync(path.join(otelDir, OTEL_FILE)).size > 1_000_000, 'test fixture should exceed the worker threshold');
+
+		const usage = await getCopilotCliOtelUsage(eventsJsonlPath(homeDir, SESSION_ID));
+		assert.ok(usage);
+		assert.equal(usage!.actualTokens, spanCount * 110, 'every span across the large file should be aggregated exactly once');
+		assert.equal(usage!.modelUsage['claude-sonnet-5'].inputTokens, spanCount * 100);
+	});
+});
+
+test('loadCopilotCliOtelIndex: an incremental refresh reads only appended spans, without re-counting old ones', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const otelDir = path.join(homeDir, '.copilot', 'otel');
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID)]);
+
+		const first = await getCopilotCliOtelUsage(eventsJsonlPath(homeDir, SESSION_ID));
+		assert.equal(first!.actualTokens, 110);
+
+		// Append a second span, then expire the TTL (keeping offsets) to force a refresh. If the
+		// refresh re-read the whole file instead of just the tail, the first span would be counted
+		// twice (110 + 110 + 55 = 275) rather than once (110 + 55 = 165).
+		appendOtelSpans(otelDir, [chatSpan(SESSION_ID, { 'gen_ai.usage.input_tokens': 50, 'gen_ai.usage.output_tokens': 5 })]);
+		expireCopilotCliOtelCacheForTests();
+
+		const second = await getCopilotCliOtelUsage(eventsJsonlPath(homeDir, SESSION_ID));
+		assert.equal(second!.actualTokens, 110 + 55, 'the appended span should be added once, and the original not re-counted');
+		assert.equal(second!.modelUsage['claude-sonnet-5'].inputTokens, 150);
+	});
+});
+
+test('loadCopilotCliOtelIndex: a shrunken (rotated/truncated) export triggers a full rebuild', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const otelDir = path.join(homeDir, '.copilot', 'otel');
+		// Start with two spans for SESSION_ID so the file (and tracked offset) is comparatively large.
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID), chatSpan(SESSION_ID)]);
+		const before = await loadCopilotCliOtelIndex();
+		assert.equal(before.get(SESSION_ID)?.actualTokens, 220);
+
+		// Overwrite with a single, smaller span for a different session: size now < tracked offset,
+		// which must be detected as rotation and rebuilt from scratch (dropping the stale session).
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID_2)]);
+		expireCopilotCliOtelCacheForTests();
+
+		const after = await loadCopilotCliOtelIndex();
+		assert.equal(after.get(SESSION_ID), undefined, 'the pre-rotation session should be gone after a rebuild');
+		assert.equal(after.get(SESSION_ID_2)?.actualTokens, 110, 'the post-rotation session should be parsed fresh');
 	});
 });


### PR DESCRIPTION
## Why

The Copilot CLI OpenTelemetry export (`~/.copilot/otel/*.jsonl`) is a single, append-only log that grows without bound — measured at **134 MB / 108,112 lines** on a real machine. The old loader read the whole file into memory and `JSON.parse`d **every** line on the main thread, then repeated that on every 30 s cache refresh.

Two problems:
1. **~486 ms of synchronous work froze the extension host** at startup (and again each refresh), even though only **165** of those 108k lines are the `chat <model>` spans we actually keep.
2. Because the file only grows, re-reading all 134 MB every 30 s is pure waste.

## What changed

**Off the main thread + skip the 99.8% we discard** (`648a0aec`)
- Cheap `"name":"chat "` substring pre-filter skips `JSON.parse` on lines that can't be a chat span.
- Read+parse moved into a `worker_threads` worker. It's an inline eval-worker (source as a string, Node built-ins only), so it needs no separate entry file or runtime path resolution and bundles identically across all three build layouts (tsc → `out/`, esbuild → extension `dist/`, esbuild → cli `dist/`).
- The main thread just consolidates the small candidate array the worker posts back.
- In-process fallback if a worker can't be spawned; eager prefetch fired at the start of `activate()` so the load overlaps the rest of activation.

**Incremental tail-read** (`85607250`)
- Track per-file byte offsets; after the first load, read only the bytes appended since and merge them into the existing index.
- Small tails parse in-process (sub-ms, no worker-spawn cost); only large reads (first load / rebuild) use the worker.
- Detect rotation/truncation (a tracked file that shrank or vanished) and rebuild from scratch, so stale bytes can't linger or double-count.
- The worker scans at the byte level over streamed chunks, so it never holds the whole file in memory.

## Results (measured on a real 134 MB export)

| | Before | After |
|---|---|---|
| Main-thread block during load | ~486 ms frozen | ~15 ms lag (off-thread) |
| 30 s refresh with no new data | full 134 MB re-read | ~1.2 ms (readdir + stat only) |
| Result correctness | — | identical (6 sessions, 15.4M tokens) |

## Notes for reviewers

- Public API of `src/copilotCliOtel.ts` is unchanged; all consumers (`usageAnalysis`, `copilotCliAdapter`, extension, CLI) keep calling `getCopilotCliOtelUsage` / `loadCopilotCliOtelIndex` as before.
- The concurrency test was rewritten: it can no longer count `fs.promises.readFile` (the worker reads via a stream in another thread), so it now asserts the same dedup guarantee via result-identity (all concurrent cold-cache callers get the same `Map` instance).
- Test fixtures were updated to write newline-terminated records, matching real exports (verified the real file ends in `\n`); the offset logic consumes only up to the last complete newline and defers any partial trailing line.
- One `expireCopilotCliOtelCacheForTests()` export was added to exercise the incremental refresh path (expires the TTL while keeping offsets).

## Testing

- 11 OTel unit tests pass — added coverage for the worker path (>1 MB), incremental append (no re-counting), and rotation-triggered rebuild.
- 246 adjacent tests pass (CLI adapter, usage analysis, token estimation).
- `tsc --noEmit` clean; eslint clean on the changed module; extension production esbuild bundle builds with the worker string intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)