### PR TITLE
Raise VS Code cache caps and log snapshot load time

### DIFF
--- a/src/cachePolicy.ts
+++ b/src/cachePolicy.ts
@@ -5,6 +5,10 @@
  * cache storage mechanics in CacheManager and cliCache.
  */
 
+export const VS_CODE_CACHE_MAX_ENTRIES = 20_000;
+export const VS_CODE_CACHE_EVICT_BATCH = 100;
+export const VS_CODE_CACHE_TRIGGER_THRESHOLD = VS_CODE_CACHE_MAX_ENTRIES + VS_CODE_CACHE_EVICT_BATCH - 1;
+
 /** Minimum metadata required by any cache entry for policy decisions. */
 export interface CacheEntryMeta {
 	mtime: number;
@@ -27,8 +31,10 @@ export interface CachePolicy<T extends CacheEntryMeta> {
  *
  * - Validates using mtime + size equality; treats a missing `size` field as
  *   invalid so old-format entries are upgraded automatically.
- * - Triggers eviction when the map grows past `triggerThreshold` and removes
- *   the `evictCount` oldest entries (Maps preserve insertion order).
+ * - Targets roughly `VS_CODE_CACHE_MAX_ENTRIES` live entries. To avoid pruning
+ *   on every insert near the limit, eviction waits until the map exceeds the
+ *   target by one batch and then removes the `evictCount` oldest entries
+ *   (Maps preserve insertion order).
  */
 export class VsCodeCachePolicy<T extends CacheEntryMeta> implements CachePolicy<T> {
 	private readonly triggerThreshold: number;
@@ -37,8 +43,8 @@ export class VsCodeCachePolicy<T extends CacheEntryMeta> implements CachePolicy<
 
 	constructor(
 		log: (msg: string) => void,
-		triggerThreshold = 3100,
-		evictCount = 100,
+		triggerThreshold = VS_CODE_CACHE_TRIGGER_THRESHOLD,
+		evictCount = VS_CODE_CACHE_EVICT_BATCH,
 	) {
 		this.log = log;
 		this.triggerThreshold = triggerThreshold;

--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -16,11 +16,15 @@ export interface CacheManagerDeps {
 }
 
 export class CacheManager {
+	private static readonly SNAPSHOT_SCHEMA_VERSION = 1;
+	private static readonly SNAPSHOT_MAX_ENTRIES = 20_000;
+
 	private sessionFileCache: Map<string, SessionFileCache> = new Map();
 	private readonly context: vscode.ExtensionContext;
 	private readonly deps: CacheManagerDeps;
 	private readonly cacheVersion: number;
 	private readonly policy: CachePolicy<SessionFileCache>;
+	private lastLoadedSnapshotMtime = 0;
 
 	constructor(
 		context: vscode.ExtensionContext,
@@ -294,6 +298,7 @@ export class CacheManager {
 	 * Also removes any legacy cache data from globalState as a one-time migration.
 	 */
 	async loadCacheFromStorage(): Promise<void> {
+		const loadStartedAt = Date.now();
 		try {
 			const cacheId = this.getCacheIdentifier();
 
@@ -332,7 +337,7 @@ export class CacheManager {
 				this.sessionFileCache = new Map(
 					Object.entries(envelope.entries as Record<string, SessionFileCache>),
 				);
-				this.deps.log(`Loaded ${this.sessionFileCache.size} cached session files from disk snapshot (${cacheId})`);
+				this.deps.log(`Loaded ${this.sessionFileCache.size} cached session files from disk snapshot (${cacheId}) in ${Date.now() - loadStartedAt}ms`);
 
 				// Record the snapshot mtime so loadSharedSnapshotIfChanged won't reload it redundantly.
 				try {
@@ -419,15 +424,6 @@ export class CacheManager {
 	// edition). Writes are atomic (temp file + rename) so readers never observe a
 	// partially written file.
 	// ---------------------------------------------------------------------------
-
-	/** Schema version for the snapshot envelope; bump on incompatible shape changes. */
-	private static readonly SNAPSHOT_SCHEMA_VERSION = 1;
-
-	/** Upper bound on entries kept in the shared snapshot (newest by mtime). */
-	private static readonly SNAPSHOT_MAX_ENTRIES = 5000;
-
-	/** mtime (ms) of the snapshot file the last time this window loaded it. */
-	private lastLoadedSnapshotMtime = 0;
 
 	getSharedSnapshotPath(): string {
 		const cacheId = this.getCacheIdentifier();
@@ -544,6 +540,7 @@ export class CacheManager {
 	 * Returns the number of entries merged.
 	 */
 	async loadSharedSnapshotIfChanged(): Promise<number> {
+		const loadStartedAt = Date.now();
 		const snapshotPath = this.getSharedSnapshotPath();
 		let mtimeMs: number;
 		try {
@@ -564,7 +561,7 @@ export class CacheManager {
 		const merged = this.mergeSnapshotEntries(entries);
 		this.lastLoadedSnapshotMtime = mtimeMs;
 		if (merged > 0) {
-			this.deps.log(`Warmed cache from shared snapshot: merged ${merged} entr${merged === 1 ? 'y' : 'ies'}`);
+			this.deps.log(`Warmed cache from shared snapshot: merged ${merged} entr${merged === 1 ? 'y' : 'ies'} in ${Date.now() - loadStartedAt}ms`);
 		}
 		return merged;
 	}

--- a/vscode-extension/test/unit/cacheManager-snapshot.test.ts
+++ b/vscode-extension/test/unit/cacheManager-snapshot.test.ts
@@ -130,6 +130,23 @@ test('writeSharedSnapshot merges with existing snapshot without regressing newer
 	assert.equal(entries!['/b.json'].mtime, 3000, 'follower\'s extra /b.json must be added');
 });
 
+test('writeSharedSnapshot caps the shared snapshot at 20000 newest entries', async () => {
+	const dir = tmpDir();
+	const writer = makeManager(dir);
+	for (let i = 0; i < 20_050; i++) {
+		writer.setCachedSessionData(`/file${i}.json`, entry(i), 10);
+	}
+	await writer.writeSharedSnapshot();
+
+	const entries = await writer.readSharedSnapshot();
+	assert.ok(entries);
+	assert.equal(Object.keys(entries!).length, 20_000, 'snapshot should keep only the newest 20000 entries');
+	assert.equal(entries!['/file0.json'], undefined, 'oldest snapshot entry should be pruned');
+	assert.equal(entries!['/file49.json'], undefined, 'entries outside the newest 20000 should be pruned');
+	assert.equal(entries!['/file50.json']?.mtime, 50, 'newest retained window should start at entry 50');
+	assert.equal(entries!['/file20049.json']?.mtime, 20049, 'newest entry should be retained');
+});
+
 test('refresh lock: acquire then release; renew only when owned', async () => {
 	const dir = tmpDir();
 	const m = makeManager(dir);
@@ -161,11 +178,19 @@ test('loadCacheFromStorage: loads entries from existing snapshot', async () => {
 	writer.setCachedSessionData('/b.json', entry(2000), 20);
 	await writer.writeSharedSnapshot();
 
-	const reader = makeManager(dir);
+	const logs: string[] = [];
+	const context: any = {
+		extensionMode: 1,
+		globalStorageUri: { fsPath: dir },
+		globalState: createMockMemento(),
+	};
+	const reader = new CacheManager(context, { log: (m: string) => logs.push(m), warn: () => {}, error: () => {} }, 1);
 	await reader.loadCacheFromStorage();
 	assert.equal(reader.cache.size, 2, 'should load both entries');
 	assert.equal(reader.cache.get('/a.json')?.mtime, 1000);
 	assert.equal(reader.cache.get('/b.json')?.mtime, 2000);
+	assert.ok(logs.some(l => /Loaded 2 cached session files from disk snapshot \(prod\) in \d+ms/.test(l)),
+		'should log load duration');
 });
 
 test('loadCacheFromStorage: starts with empty cache when no snapshot exists', async () => {

--- a/vscode-extension/test/unit/cachePolicy.test.ts
+++ b/vscode-extension/test/unit/cachePolicy.test.ts
@@ -2,7 +2,13 @@ import './vscode-shim-register';
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { VsCodeCachePolicy, CliCachePolicy } from '../../../src/cachePolicy';
+import {
+	CliCachePolicy,
+	VS_CODE_CACHE_EVICT_BATCH,
+	VS_CODE_CACHE_MAX_ENTRIES,
+	VS_CODE_CACHE_TRIGGER_THRESHOLD,
+	VsCodeCachePolicy,
+} from '../../../src/cachePolicy';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -53,37 +59,37 @@ function makeVsCodeCache(count: number): Map<string, TestEntry> {
 	return m;
 }
 
-test('VsCodeCachePolicy.evict: no-op when size is at the threshold (3100)', () => {
+test('VsCodeCachePolicy.evict: no-op when size is at the threshold', () => {
 	const logs: string[] = [];
 	const policy = new VsCodeCachePolicy((m) => logs.push(m));
-	const cache = makeVsCodeCache(3100);
+	const cache = makeVsCodeCache(VS_CODE_CACHE_TRIGGER_THRESHOLD);
 	policy.evict(cache);
-	assert.equal(cache.size, 3100, 'Should not evict when at threshold');
+	assert.equal(cache.size, VS_CODE_CACHE_TRIGGER_THRESHOLD, 'Should not evict when at threshold');
 	assert.equal(logs.length, 0, 'Should not log when no eviction');
 });
 
-test('VsCodeCachePolicy.evict: triggers when size exceeds threshold (3101)', () => {
+test('VsCodeCachePolicy.evict: triggers when size exceeds threshold', () => {
 	const logs: string[] = [];
 	const policy = new VsCodeCachePolicy((m) => logs.push(m));
-	const cache = makeVsCodeCache(3101);
+	const cache = makeVsCodeCache(VS_CODE_CACHE_TRIGGER_THRESHOLD + 1);
 	policy.evict(cache);
-	assert.equal(cache.size, 3001, 'Should evict 100 entries from 3101 → 3001');
+	assert.equal(cache.size, VS_CODE_CACHE_MAX_ENTRIES, 'Should evict one batch back to the steady-state cap');
 	assert.ok(logs.some(l => l.includes('removed 100 oldest entries')), 'Should log eviction');
 });
 
 test('VsCodeCachePolicy.evict: removes oldest by insertion order, not by mtime', () => {
 	const logs: string[] = [];
-	const policy = new VsCodeCachePolicy((m) => logs.push(m), 3100, 100);
+	const policy = new VsCodeCachePolicy((m) => logs.push(m), VS_CODE_CACHE_TRIGGER_THRESHOLD, VS_CODE_CACHE_EVICT_BATCH);
 	const cache = new Map<string, TestEntry>();
-	// Insert 3101 entries, with the "oldest" by insertion having the highest mtime
-	for (let i = 3100; i >= 0; i--) {
+	// Insert threshold+1 entries, with the "oldest" by insertion having the highest mtime
+	for (let i = VS_CODE_CACHE_TRIGGER_THRESHOLD; i >= 0; i--) {
 		cache.set(`file${i}`, { mtime: i * 1000, size: i });
 	}
 	policy.evict(cache);
-	// The first-inserted keys are file3100..file3001 (oldest by insertion order)
-	assert.equal(cache.has('file3100'), false, 'First inserted key should be evicted');
-	assert.equal(cache.has('file3001'), false, 'Insertion-oldest keys should be evicted');
-	assert.equal(cache.has('file3000'), true, 'key inserted at position 101 should survive');
+	// The first-inserted keys are file20099..file20000 (oldest by insertion order)
+	assert.equal(cache.has(`file${VS_CODE_CACHE_TRIGGER_THRESHOLD}`), false, 'First inserted key should be evicted');
+	assert.equal(cache.has(`file${VS_CODE_CACHE_MAX_ENTRIES}`), false, 'Insertion-oldest keys should be evicted');
+	assert.equal(cache.has(`file${VS_CODE_CACHE_MAX_ENTRIES - 1}`), true, 'key inserted just after the eviction batch should survive');
 	assert.equal(cache.has('file0'), true, 'Last-inserted key should survive');
 });
 


### PR DESCRIPTION
This raises the VS Code cache ceilings so we can observe whether keeping much larger session sets warm improves real-world scans before we invest in a different storage format. It also logs snapshot load durations so the output channel shows when the larger cache starts to hurt startup or cross-window resync performance.

## What changed
- raise the VS Code in-memory cache target from about 3k entries to 20k entries
- raise the shared snapshot cap from 5k entries to 20k entries so persisted cache data matches the larger live cache
- log disk snapshot load duration during startup cache restore
- log shared snapshot warm-load duration when follower windows pull in fresher cache data
- update cache policy and snapshot tests to cover the new limits and timing output

## Validation
- `npm run test:node`

## Notes
- `npm run compile` still reports the repository's existing complexity warnings in unrelated files; this change does not add new warnings.