### PR TITLE
Add worktree discovery, sizing, and cleanup to the diagnostics panel

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -598,6 +598,7 @@ export interface SessionFileDetails {
   editorName?: string; // friendly editor name (e.g., 'VS Code')
   title?: string; // session title (customTitle from session file)
   repository?: string; // Git remote origin URL for the session's workspace
+  workspacePath?: string; // absolute local cwd/workspace path the session ran in (from adapter getMeta)
   /** Parent session info (Copilot CLI and pi sessions; populated from data.db / JSONL parentSession field). */
   parentInfo?: SessionRelationRef | null;
   /** Direct child sessions (Copilot CLI and pi sessions; populated from data.db / JSONL parentSession field). */

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -50,6 +50,23 @@ export function normalizePathForDedup(
 }
 
 /**
+ * Normalize a session workspace path up to its parent repository root by stripping a trailing
+ * agent-worktree segment created by Copilot CLI or Claude Code:
+ *   "<repo>/copilot-worktrees/<name>[/...]"      -> "<repo>"
+ *   "<repo>/.claude/worktrees/<name>[/...]"       -> "<repo>"
+ * This lets the worktree scanner cover the whole repo (finding sibling worktrees) instead of a
+ * single worktree subfolder. The original path is returned unchanged when neither pattern is
+ * present, and the input's separator style is preserved.
+ */
+export function normalizeToRepoRoot(p: string): string {
+	const copilot = p.match(/^(.+?)[\\/]copilot-worktrees[\\/][^\\/]+(?:[\\/].*)?$/i);
+	if (copilot) { return copilot[1]; }
+	const claude = p.match(/^(.+?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]+(?:[\\/].*)?$/i);
+	if (claude) { return claude[1]; }
+	return p;
+}
+
+/**
  * Strip the synthetic leading slash from Windows drive-letter URI paths.
  * Example: "/C:/repo/file.ts" -> "C:/repo/file.ts".
  */

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -27,7 +27,8 @@ export {
 	normalizePath,
 	normalizePathForComparison,
 	normalizePathForDedup,
-	normalizePathSeparators
+	normalizePathSeparators,
+	normalizeToRepoRoot
 } from './utils/pathUtils';
 
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -172,6 +172,8 @@ import {
   normalizeMcpToolName as _normalizeMcpToolName,
   extractMcpServerName as _extractMcpServerName,
   normalizePath as _normalizePath,
+  normalizePathForDedup as _normalizePathForDedup,
+  normalizeToRepoRoot as _normalizeToRepoRoot,
 } from '../../src/workspaceHelpers';
 
 // --- Chart building ---
@@ -359,6 +361,23 @@ interface CopilotCliOtelComparison {
 	sessions: CopilotCliOtelComparisonSession[];
 }
 
+/**
+ * A discovered git worktree row for the diagnostics Worktrees tab. `files`/`folders`/`bytes`
+ * are -1 while their (expensive) size walk is still pending; `pushed` is "?" until the
+ * background push-status check completes.
+ */
+interface WorktreeScanResult {
+	path: string;
+	repoLabel: string;
+	branch: string;
+	lastCommit: string;
+	lastCommitDate: string | null;
+	pushed: "yes" | "no" | "?";
+	files: number;
+	folders: number;
+	bytes: number;
+}
+
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
 	private static readonly CACHE_VERSION = 59; // Detect Auto model and Foundry local models from request-level fields
@@ -376,6 +395,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private lastDiagnosticReport: string = '';
 	// Incremented on each worktree scan start/cancel; in-flight scans check this to stop early
 	private worktreeScanId: number = 0;
+	// Incremented on each cleanup start/cancel; an in-flight cleanup loop checks this to stop early
+	private worktreeCleanupId: number = 0;
 	private logViewerPanel?: vscode.WebviewPanel;
 	private logViewerSessionFilePath: string = '';
 	private logViewerCurrentData?: SessionLogData;
@@ -4942,6 +4963,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			editorSource: this.detectEditorSource(sessionFile),
 			title: cached.title,
 			repository: cached.repository,
+			workspacePath: cached.workspaceFolderPath,
 			...(cached.modelUsage && Object.keys(cached.modelUsage).length > 0 ? { modelUsage: cached.modelUsage } : {}),
 		};
 
@@ -4993,11 +5015,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 			firstInteraction: details.firstInteraction,
 			lastInteraction: details.lastInteraction,
 			title: details.title,
-			repository: details.repository
+			repository: details.repository,
+			workspaceFolderPath: this.resolveCachedWorkspacePath(details, existingCache),
 		};
 
 		cacheEntry.usageAnalysis!.contextReferences = details.contextReferences;
 		this.setCachedSessionData(sessionFile, cacheEntry, stat.size);
+	}
+
+	/** Resolve the session's local workspace path for caching, preferring fresh details over the cached value. */
+	private resolveCachedWorkspacePath(details: SessionFileDetails, existingCache: SessionFileCache | undefined): string | undefined {
+		return details.workspacePath ?? existingCache?.workspaceFolderPath;
 	}
 
 	private resolveTokensForCacheUpdate(tokenResult: { tokens: number; thinkingTokens: number; actualTokens: number } | undefined, existingCache: SessionFileCache | undefined): { tokens: number; actualTokens: number | undefined; thinkingTokens: number | undefined; cacheReadTokens: number | undefined } {
@@ -5126,7 +5154,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		details.interactions = interactionCount;
 		details.editorRoot = eco.getEditorRoot(sessionFile);
 		details.editorName = getEcosystemDisplayName(eco, sessionFile);
-		if (meta.workspacePath) { details.repository = path.basename(meta.workspacePath); }
+		if (meta.workspacePath) { details.repository = path.basename(meta.workspacePath); details.workspacePath = meta.workspacePath; }
 		await this.updateCacheWithSessionDetails(sessionFile, stat, details, tokenResult, modelUsage);
 		return details;
 	}
@@ -8238,6 +8266,9 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       pickWorktreeRoot: () => this.dispatch('pickWorktreeRoot:diagnostics', () => this.diagHandlePickWorktreeRoot()),
       scanWorktrees: () => this.dispatch('scanWorktrees:diagnostics', () => this.diagHandleScanWorktrees(message)),
       cancelWorktreeScan: () => this.dispatch('cancelWorktreeScan:diagnostics', () => this.diagHandleCancelWorktreeScan()),
+      deleteWorktree: () => this.dispatch('deleteWorktree:diagnostics', () => this.diagHandleDeleteWorktree(message)),
+      cleanupPushedWorktrees: () => this.dispatch('cleanupPushedWorktrees:diagnostics', () => this.diagHandleCleanupPushedWorktrees(message)),
+      cancelCleanupPushedWorktrees: () => this.dispatch('cancelCleanupPushedWorktrees:diagnostics', () => this.diagHandleCancelCleanupPushedWorktrees()),
     };
     if (simpleCommands[message.command]) { await simpleCommands[message.command](); return; }
     await this.handleDiagnosticConditionalCommand(message);
@@ -8599,12 +8630,14 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     const scanId = ++this.worktreeScanId;
     const excludeDirs = new Set(["node_modules", ".git", ".hg", ".svn", "packages", "vendor"]);
     const startTime = Date.now();
-    let totalFound = 0;
     const isActive = () => scanId === this.worktreeScanId;
     const send = (msg: Record<string, unknown>) => { if (this.isPanelOpen(panel)) { panel.webview.postMessage(msg); } };
 
     send({ command: "worktreeScanStarted", rootPaths });
 
+    // Phase 1 — fast discovery: locate worktrees and report each with cheap git metadata only
+    // (size and push status are left pending and filled in during phase 2).
+    const discovered: WorktreeScanResult[] = [];
     for (const root of rootPaths) {
       if (!isActive()) { return; }
       let isDirectory = false;
@@ -8616,51 +8649,112 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
 
       send({ command: "worktreeScanRootStarted", root });
       const gitMarkers: string[] = [];
-      await this.findGitMarkerFiles(root, excludeDirs, gitMarkers, isActive);
+      // Report folder-walk progress (throttled) so the user sees activity on large roots
+      // long before the first worktree is found.
+      let dirsScanned = 0;
+      let lastWalkPost = 0;
+      const onDir = (): void => {
+        dirsScanned++;
+        const now = Date.now();
+        if (now - lastWalkPost >= 200) {
+          lastWalkPost = now;
+          send({ command: "worktreeScanWalkProgress", root, dirsScanned, markersFound: gitMarkers.length, elapsedMs: now - startTime });
+        }
+      };
+      await this.findGitMarkerFiles(root, excludeDirs, gitMarkers, isActive, onDir);
       if (!isActive()) { return; }
       send({ command: "worktreeScanRootMarkersFound", root, count: gitMarkers.length });
 
-      totalFound += await this.processWorktreeMarkers(gitMarkers, root, isActive, send, startTime);
+      discovered.push(...await this.discoverWorktreesFromMarkers(gitMarkers, root, isActive, send, startTime));
       if (!isActive()) { return; }
     }
 
-    send({ command: "worktreeScanComplete", totalWorktrees: totalFound, elapsedMs: Date.now() - startTime });
+    // Phase 2 — background enrichment: compute disk size and push status concurrently and
+    // patch each row as results arrive, so discovery is not blocked by these slow operations.
+    await this.enrichWorktrees(discovered, isActive, send, startTime);
+    if (!isActive()) { return; }
+
+    send({ command: "worktreeScanComplete", totalWorktrees: discovered.length, elapsedMs: Date.now() - startTime });
   }
 
-  private async processWorktreeMarkers(
+  /**
+   * Resolve .git markers to unique worktree roots (cheap, sequential) then fetch cheap git
+   * metadata concurrently, streaming each worktree to the webview as soon as it is known.
+   */
+  private async discoverWorktreesFromMarkers(
     gitMarkers: string[],
     root: string,
     isActive: () => boolean,
     send: (msg: Record<string, unknown>) => void,
     startTime: number,
-  ): Promise<number> {
+  ): Promise<WorktreeScanResult[]> {
     const foundRoots: string[] = [];
+    const worktreeRoots: string[] = [];
     let checked = 0;
     for (const markerFile of gitMarkers) {
-      if (!isActive()) { return foundRoots.length; }
+      if (!isActive()) { return []; }
       checked++;
       const worktreeRoot = await this.resolveWorktreeRootFromMarker(markerFile, foundRoots);
-      if (worktreeRoot) {
-        const result = await this.buildWorktreeResult(worktreeRoot);
-        if (!isActive()) { return foundRoots.length; }
-        send({ command: "worktreeFound", worktree: result });
-      }
-      if (checked % 5 === 0 || checked === gitMarkers.length) {
-        send({ command: "worktreeScanProgress", root, checked, total: gitMarkers.length, foundCount: foundRoots.length, elapsedMs: Date.now() - startTime });
+      if (worktreeRoot) { worktreeRoots.push(worktreeRoot); }
+      if (checked % 10 === 0 || checked === gitMarkers.length) {
+        send({ command: "worktreeScanProgress", root, checked, total: gitMarkers.length, foundCount: worktreeRoots.length, elapsedMs: Date.now() - startTime });
       }
     }
-    return foundRoots.length;
+
+    const discovered: WorktreeScanResult[] = [];
+    await this.runWithConcurrency(worktreeRoots, async (worktreeRoot) => {
+      if (!isActive()) { return; }
+      const result = await this.buildWorktreeDiscovery(worktreeRoot);
+      if (!isActive()) { return; }
+      discovered.push(result);
+      send({ command: "worktreeFound", worktree: result });
+    }, 8);
+    return discovered;
   }
+
+  /**
+   * Compute disk usage and push status for every discovered worktree, with bounded concurrency,
+   * streaming a `worktreeEnriched` patch per worktree plus throttled overall progress.
+   */
+  private async enrichWorktrees(
+    worktrees: WorktreeScanResult[],
+    isActive: () => boolean,
+    send: (msg: Record<string, unknown>) => void,
+    startTime: number,
+  ): Promise<void> {
+    const total = worktrees.length;
+    if (total === 0) { return; }
+    send({ command: "worktreeEnrichStarted", total, elapsedMs: Date.now() - startTime });
+    let enriched = 0;
+    let lastPost = 0;
+    await this.runWithConcurrency(worktrees.map((w) => w.path), async (worktreePath) => {
+      if (!isActive()) { return; }
+      const [stats, pushed] = await Promise.all([
+        this.computeFolderStats(worktreePath),
+        this.getWorktreePushedStatus(worktreePath),
+      ]);
+      if (!isActive()) { return; }
+      enriched++;
+      send({ command: "worktreeEnriched", path: worktreePath, files: stats.files, folders: stats.folders, bytes: stats.bytes, pushed });
+      const now = Date.now();
+      if (now - lastPost >= 200 || enriched === total) {
+        lastPost = now;
+        send({ command: "worktreeEnrichProgress", enriched, total, elapsedMs: now - startTime });
+      }
+    }, 4);
+  }
+
 
   /**
    * Recursively collects paths to ".git" marker FILES (worktree pointers) under `dir`,
    * skipping excluded directory names for speed. Does not descend into any ".git" entry
    * itself (file or directory), so nested worktrees inside a scanned repo are still found.
    */
-  private async findGitMarkerFiles(dir: string, excludeDirs: Set<string>, results: string[], isActive: () => boolean): Promise<void> {
+  private async findGitMarkerFiles(dir: string, excludeDirs: Set<string>, results: string[], isActive: () => boolean, onDir?: () => void): Promise<void> {
     if (!isActive()) { return; }
     let entries: fs.Dirent[];
     try { entries = await fs.promises.readdir(dir, { withFileTypes: true }); } catch { return; }
+    onDir?.();
     for (const entry of entries) {
       if (!isActive()) { return; }
       if (entry.name === ".git") {
@@ -8668,7 +8762,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
         continue;
       }
       if (entry.isDirectory() && !excludeDirs.has(entry.name)) {
-        await this.findGitMarkerFiles(path.join(dir, entry.name), excludeDirs, results, isActive);
+        await this.findGitMarkerFiles(path.join(dir, entry.name), excludeDirs, results, isActive, onDir);
       }
     }
   }
@@ -8702,13 +8796,24 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     return worktreeRoot;
   }
 
-  private async buildWorktreeResult(worktreeRoot: string): Promise<{ path: string; repoLabel: string; branch: string; lastCommit: string; lastCommitDate: string | null; pushed: "yes" | "no" | "?"; files: number; folders: number; bytes: number }> {
-    const [stats, gitInfo] = await Promise.all([
-      this.computeFolderStats(worktreeRoot),
-      Promise.resolve(this.getWorktreeGitInfo(worktreeRoot)),
-    ]);
+  /**
+   * Fast per-worktree discovery: cheap git metadata only (branch, last commit, remote → repo
+   * label). Size and push status are left pending (-1 / "?") and filled in by enrichWorktrees.
+   */
+  private async buildWorktreeDiscovery(worktreeRoot: string): Promise<WorktreeScanResult> {
+    const gitInfo = await this.getWorktreeGitInfoFast(worktreeRoot);
     const repoLabel = gitInfo.remoteUrl ? this.getRepoLabelFromRemote(gitInfo.remoteUrl) : path.basename(path.dirname(worktreeRoot));
-    return { path: worktreeRoot, repoLabel, branch: gitInfo.branch, lastCommit: gitInfo.lastCommit, lastCommitDate: gitInfo.lastCommitDate, pushed: gitInfo.pushed, files: stats.files, folders: stats.folders, bytes: stats.bytes };
+    return {
+      path: worktreeRoot,
+      repoLabel,
+      branch: gitInfo.branch,
+      lastCommit: gitInfo.lastCommit,
+      lastCommitDate: gitInfo.lastCommitDate,
+      pushed: "?",
+      files: -1,
+      folders: -1,
+      bytes: -1,
+    };
   }
 
   /** Recursively computes file/folder counts and total byte size for a worktree (no exclusions — reflects true disk usage). */
@@ -8732,25 +8837,357 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     return { files, folders, bytes };
   }
 
-  private getWorktreeGitInfo(worktreeRoot: string): { branch: string; lastCommit: string; lastCommitDate: string | null; pushed: "yes" | "no" | "?"; remoteUrl: string } {
-    const opts: childProcess.ExecSyncOptionsWithStringEncoding = { cwd: worktreeRoot, encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] };
-    let branch = "?", lastCommit = "?", lastCommitDate: string | null = null, pushed: "yes" | "no" | "?" = "?", remoteUrl = "";
-    try {
-      branch = childProcess.execSync("git branch --show-current", opts).trim() || "?";
-      try { lastCommit = childProcess.execSync("git log -1 --format=%cr", opts).trim() || "?"; } catch { /* no commits yet */ }
-      try { lastCommitDate = childProcess.execSync("git log -1 --format=%cI", opts).trim() || null; } catch { /* no commits yet */ }
-      try {
-        const unpushed = childProcess.execSync("git log --oneline --not --remotes --branches", opts).trim();
-        pushed = unpushed === "" ? "yes" : "no";
-      } catch { /* leave as unknown */ }
-      try { remoteUrl = childProcess.execSync("git remote get-url origin", opts).trim(); } catch { /* no remote configured */ }
-    } catch { /* not a readable git worktree */ }
-    return { branch, lastCommit, lastCommitDate, pushed, remoteUrl };
+  /** Runs a git subcommand without blocking the event loop; resolves { ok, stdout } (never rejects). */
+  private runGit(args: string[], cwd: string, timeoutMs = 8000): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+      childProcess.execFile(
+        "git",
+        args,
+        { cwd, encoding: "utf8", timeout: timeoutMs, windowsHide: true, maxBuffer: 8 * 1024 * 1024 },
+        (err, stdout, stderr) => resolve({ ok: !err, stdout: String(stdout ?? "").trim(), stderr: String(stderr ?? "").trim() }),
+      );
+    });
+  }
+
+  /** Cheap git metadata for discovery (branch, last commit, remote). Excludes the slow push check. */
+  private async getWorktreeGitInfoFast(worktreeRoot: string): Promise<{ branch: string; lastCommit: string; lastCommitDate: string | null; remoteUrl: string }> {
+    const [branch, lastCommit, lastCommitDate, remoteUrl] = await Promise.all([
+      this.runGit(["branch", "--show-current"], worktreeRoot),
+      this.runGit(["log", "-1", "--format=%cr"], worktreeRoot),
+      this.runGit(["log", "-1", "--format=%cI"], worktreeRoot),
+      this.runGit(["remote", "get-url", "origin"], worktreeRoot),
+    ]);
+    return {
+      branch: branch.stdout || "?",
+      lastCommit: lastCommit.stdout || "?",
+      lastCommitDate: lastCommitDate.stdout || null,
+      remoteUrl: remoteUrl.ok ? remoteUrl.stdout : "",
+    };
+  }
+
+  /** Whether every local commit is present on some remote. "?" when it cannot be determined. */
+  private async getWorktreePushedStatus(worktreeRoot: string): Promise<"yes" | "no" | "?"> {
+    const r = await this.runGit(["log", "--oneline", "--not", "--remotes", "--branches"], worktreeRoot);
+    if (!r.ok) { return "?"; }
+    return r.stdout === "" ? "yes" : "no";
   }
 
   private getRepoLabelFromRemote(remoteUrl: string): string {
     const match = remoteUrl.match(/[:/]([^/]+\/[^/]+?)(\.git)?$/);
     return match ? match[1] : remoteUrl;
+  }
+
+  /**
+   * Resolve the main (non-linked) repository root that owns a given worktree, so `git worktree
+   * remove` can be run from a location git recognizes as the repository. Returns null when the
+   * shared .git directory cannot be resolved or does not sit at the root of a normal (non-bare)
+   * working tree — callers should refuse to proceed rather than guess in that case.
+   */
+  private async resolveMainRepoRoot(worktreePath: string): Promise<string | null> {
+    let commonDir = (await this.runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"], worktreePath)).stdout;
+    if (!commonDir) {
+      const legacy = await this.runGit(["rev-parse", "--git-common-dir"], worktreePath);
+      if (!legacy.ok || !legacy.stdout) { return null; }
+      commonDir = path.isAbsolute(legacy.stdout) ? legacy.stdout : path.resolve(worktreePath, legacy.stdout);
+    }
+    if (path.basename(commonDir).toLowerCase() !== ".git") { return null; }
+    return path.dirname(commonDir);
+  }
+
+  /**
+   * Removes a linked worktree via `git worktree remove` (never a raw folder delete): this keeps
+   * the main repository's worktree registry consistent and — without `force` — refuses when the
+   * worktree has uncommitted or untracked changes, protecting the user from silently losing work.
+   * Committed history is never at risk either way, since it lives in the shared object database.
+   */
+  private async removeGitWorktree(mainRepoRoot: string, worktreePath: string, force: boolean): Promise<{ ok: boolean; stderr: string }> {
+    const args = ["worktree", "remove", ...(force ? ["--force"] : []), worktreePath];
+    const result = await this.runGit(args, mainRepoRoot, 120000);
+    return { ok: result.ok, stderr: result.stderr };
+  }
+
+  /**
+   * True when git's own directory-removal step failed at the OS level (git's message is
+   * "failed to delete/remove '<path>': <errno text>") as opposed to refusing for a safety
+   * reason (uncommitted/untracked changes). On Windows this is a known git-for-windows gap:
+   * its internal directory walker can choke on reparse points/junctions (e.g. a pnpm
+   * node_modules layout) or paths exceeding MAX_PATH, well after git's dirty-tree check has
+   * already passed — so falling back to a direct filesystem delete here does not relax that
+   * safety check, it only swaps out a less capable directory-removal implementation for a
+   * more capable one (Node's fs.rm).
+   */
+  private isWorktreeDirectoryRemovalFailure(stderr: string): boolean {
+    return /failed to (delete|remove) '.*'/i.test(stderr);
+  }
+
+  /** Deletes a worktree's folder directly (Node's fs.rm handles junctions/long paths git's Windows walker sometimes cannot). */
+  private async forceRemoveWorktreeDirectory(worktreePath: string): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await fs.promises.rm(worktreePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 300 });
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Falls back to a direct filesystem delete + git registration cleanup when git's own
+   * directory-removal step failed at the OS level (see isWorktreeDirectoryRemovalFailure).
+   * Returns the final remove/prune result.
+   */
+  private async removeWorktreeDirectoryFallback(mainRepoRoot: string, worktreePath: string): Promise<{ ok: boolean; stderr: string }> {
+    const manual = await this.forceRemoveWorktreeDirectory(worktreePath);
+    if (!manual.ok) {
+      return { ok: false, stderr: `Could not delete the worktree folder: ${manual.error}. Close any editor, terminal, or process using files in "${worktreePath}" and try again.` };
+    }
+    // The folder is gone; git only needs to clean up its now-trivial administrative record.
+    let result = await this.removeGitWorktree(mainRepoRoot, worktreePath, true);
+    if (!result.ok) {
+      const prune = await this.runGit(["worktree", "prune"], mainRepoRoot, 30000);
+      result = { ok: prune.ok, stderr: prune.stderr };
+    }
+    return result;
+  }
+
+  private async diagHandleDeleteWorktree(message: any): Promise<void> {
+    const worktreePath = typeof message?.path === "string" ? message.path.trim() : "";
+    if (!worktreePath) { return; }
+    const branch = typeof message?.branch === "string" && message.branch ? message.branch : "?";
+    const repoLabel = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : path.basename(path.dirname(worktreePath));
+    const pushed = message?.pushed === "yes" || message?.pushed === "no" ? message.pushed : "?";
+
+    if (!(await this.confirmDeleteWorktree(worktreePath, branch, repoLabel, pushed))) { return; }
+
+    const mainRepoRoot = await this.resolveMainRepoRoot(worktreePath);
+    if (!mainRepoRoot || path.resolve(mainRepoRoot).toLowerCase() === path.resolve(worktreePath).toLowerCase()) {
+      vscode.window.showErrorMessage(`Could not safely locate the main repository for "${worktreePath}". Remove it manually with "git worktree remove".`);
+      return;
+    }
+
+    let result = await this.removeGitWorktree(mainRepoRoot, worktreePath, false);
+    if (!result.ok && /modified or untracked/i.test(result.stderr)) {
+      const forceChoice = await vscode.window.showWarningMessage(
+        `"${worktreePath}" has uncommitted or untracked changes.`,
+        { modal: true, detail: "Force-deleting will permanently discard those changes — this cannot be undone. Committed history elsewhere in the repository is not affected." },
+        "Force Delete",
+      );
+      if (forceChoice !== "Force Delete") { return; }
+      result = await this.removeGitWorktree(mainRepoRoot, worktreePath, true);
+    }
+
+    if (!result.ok && this.isWorktreeDirectoryRemovalFailure(result.stderr)) {
+      result = await this.removeWorktreeDirectoryFallback(mainRepoRoot, worktreePath);
+    }
+
+    if (!result.ok) {
+      vscode.window.showErrorMessage(`Could not delete worktree: ${result.stderr || "unknown error"}`);
+      return;
+    }
+
+    this.log(`🗑️ Deleted worktree: ${worktreePath}`);
+    vscode.window.showInformationMessage(`Deleted worktree "${branch}" (${repoLabel}).`);
+    if (this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+      this.diagnosticsPanel.webview.postMessage({ command: "worktreeDeleted", path: worktreePath });
+    }
+  }
+
+  private diagHandleCancelCleanupPushedWorktrees(): void {
+    this.worktreeCleanupId++;
+    if (this.diagnosticsPanel && this.isPanelOpen(this.diagnosticsPanel)) {
+      this.diagnosticsPanel.webview.postMessage({ command: "cleanupCancelled" });
+    }
+  }
+
+  /**
+   * Bulk-deletes worktrees the caller believes are fully pushed, one at a time. Unlike the
+   * single-worktree delete flow, this NEVER force-deletes: if a worktree turns out to have
+   * uncommitted/untracked changes or unpushed commits (re-checked live, not trusted from the
+   * webview's possibly-stale list), it is skipped and the loop moves on to the next one. The
+   * OS-level directory-removal fallback (for git-for-windows junction/long-path failures) still
+   * applies, since that is not a safety bypass — the dirty-tree check already passed by then.
+   */
+  private async diagHandleCleanupPushedWorktrees(message: any): Promise<void> {
+    const candidates: Array<{ path: string; branch: string; repoLabel: string }> = Array.isArray(message?.worktrees)
+      ? message.worktrees
+        .filter((w: any) => w && typeof w.path === "string" && w.path.trim())
+        .map((w: any) => ({
+          path: String(w.path).trim(),
+          branch: typeof w.branch === "string" && w.branch ? w.branch : "?",
+          repoLabel: typeof w.repoLabel === "string" && w.repoLabel ? w.repoLabel : "",
+        }))
+      : [];
+
+    if (!this.diagnosticsPanel || !this.isPanelOpen(this.diagnosticsPanel)) { return; }
+    const panel = this.diagnosticsPanel;
+
+    if (candidates.length === 0) {
+      panel.webview.postMessage({ command: "cleanupDeclined" });
+      return;
+    }
+
+    const choice = await vscode.window.showWarningMessage(
+      `Clean up ${candidates.length} pushed worktree${candidates.length === 1 ? "" : "s"}?`,
+      {
+        modal: true,
+        detail: 'Removes worktrees whose commits are already pushed to a remote, using "git worktree remove". Any worktree found to have uncommitted, untracked, or unpushed changes is automatically skipped (never force-deleted) and the cleanup continues with the rest.',
+      },
+      "Clean Up",
+    );
+    if (choice !== "Clean Up") {
+      panel.webview.postMessage({ command: "cleanupDeclined" });
+      return;
+    }
+
+    const cleanupId = ++this.worktreeCleanupId;
+    const isActive = () => cleanupId === this.worktreeCleanupId;
+    const send = (msg: Record<string, unknown>) => { if (this.isPanelOpen(panel)) { panel.webview.postMessage(msg); } };
+
+    send({ command: "cleanupStarted", total: candidates.length });
+    let deleted = 0, skipped = 0, errors = 0;
+    for (let i = 0; i < candidates.length; i++) {
+      if (!isActive()) { break; }
+      const target = candidates[i];
+      const outcome = await this.cleanupSinglePushedWorktree(target.path);
+      if (outcome.status === "deleted") { deleted++; send({ command: "worktreeDeleted", path: target.path }); }
+      else if (outcome.status === "skipped") { skipped++; }
+      else { errors++; }
+      send({
+        command: "cleanupWorktreeResult",
+        path: target.path, branch: target.branch, repoLabel: target.repoLabel,
+        status: outcome.status, reason: outcome.reason,
+        processed: i + 1, total: candidates.length,
+      });
+    }
+
+    send({ command: "cleanupComplete", deleted, skipped, errors, cancelled: !isActive() });
+    this.log(`🧹 Worktree cleanup finished: ${deleted} deleted, ${skipped} skipped, ${errors} error(s)`);
+  }
+
+  /**
+   * Attempts to delete a single worktree as part of a bulk cleanup. Re-checks push status live
+   * (never trusts the webview's cached value) and never passes --force: a dirty or unpushed
+   * worktree is reported as "skipped", not force-removed.
+   */
+  private async cleanupSinglePushedWorktree(worktreePath: string): Promise<{ status: "deleted" | "skipped" | "error"; reason?: string }> {
+    const mainRepoRoot = await this.resolveMainRepoRoot(worktreePath);
+    if (!mainRepoRoot || path.resolve(mainRepoRoot).toLowerCase() === path.resolve(worktreePath).toLowerCase()) {
+      return { status: "error", reason: "Could not safely locate the main repository." };
+    }
+
+    const pushed = await this.getWorktreePushedStatus(worktreePath);
+    if (pushed !== "yes") {
+      return {
+        status: "skipped",
+        reason: pushed === "no" ? "Has commits not pushed to any remote." : "Push status could not be confirmed.",
+      };
+    }
+
+    let result = await this.removeGitWorktree(mainRepoRoot, worktreePath, false);
+    if (!result.ok && /modified or untracked/i.test(result.stderr)) {
+      return { status: "skipped", reason: "Has uncommitted or untracked changes." };
+    }
+    if (!result.ok && this.isWorktreeDirectoryRemovalFailure(result.stderr)) {
+      result = await this.removeWorktreeDirectoryFallback(mainRepoRoot, worktreePath);
+    }
+    if (!result.ok) {
+      return { status: "error", reason: result.stderr || "unknown error" };
+    }
+    return { status: "deleted" };
+  }
+
+  private async confirmDeleteWorktree(worktreePath: string, branch: string, repoLabel: string, pushed: "yes" | "no" | "?"): Promise<boolean> {
+    const unpushedWarning = pushed === "no"
+      ? " ⚠️ This worktree has commits that have not been pushed to any remote — deleting it will permanently lose that work."
+      : pushed === "?"
+        ? " Push status could not be determined — make sure any important work has been pushed first."
+        : "";
+    const choice = await vscode.window.showWarningMessage(
+      `Delete worktree "${branch}" (${repoLabel})?`,
+      {
+        modal: true,
+        detail: `This removes the working copy at:\n${worktreePath}\n\nOnly the local working copy is removed via "git worktree remove" — committed history stays safe in the repository's shared object database. Only uncommitted or unpushed local changes in this worktree can be lost.${unpushedWarning}`,
+      },
+      "Delete Worktree",
+    );
+    return choice === "Delete Worktree";
+  }
+
+  /**
+   * Derive candidate worktree scan roots from discovered sessions and known session folders.
+   * Session workspace paths are normalized up to their repo root; known candidate folders are
+   * added as-is. Results are deduplicated (case/separator-insensitive) and filtered to paths
+   * that currently exist as directories.
+   */
+  private async computeDiscoveredWorktreeRoots(
+    detailedFiles: SessionFileDetails[],
+    candidatePaths: { path: string; exists: boolean; source: string }[],
+  ): Promise<string[]> {
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    const add = (raw: string | undefined): void => {
+      const value = (raw ?? "").trim();
+      if (!value) { return; }
+      const key = _normalizePathForDedup(value);
+      if (seen.has(key)) { return; }
+      seen.add(key);
+      ordered.push(value);
+    };
+    for (const f of detailedFiles) {
+      if (f.workspacePath) { add(_normalizeToRepoRoot(f.workspacePath)); }
+    }
+    for (const cp of candidatePaths) { add(cp.path); }
+    const result: string[] = [];
+    for (const p of ordered) {
+      try { if ((await fs.promises.stat(p)).isDirectory()) { result.push(p); } } catch { /* skip missing */ }
+    }
+    return result;
+  }
+
+  /** Deduplicate a path list case/separator-insensitively, preserving first-seen order. */
+  private dedupePathList(paths: (string | undefined)[]): string[] {
+    const seen = new Set<string>();
+    const merged: string[] = [];
+    for (const r of paths) {
+      const value = (typeof r === "string" ? r : "").trim();
+      if (!value) { continue; }
+      const key = _normalizePathForDedup(value);
+      if (seen.has(key)) { continue; }
+      seen.add(key);
+      merged.push(value);
+    }
+    return merged;
+  }
+
+  /**
+   * Merge freshly discovered roots into the persisted worktrees.scanRoots set (existing entries
+   * kept first), persist the union, and return it. This is what enables reboot hydration: the
+   * next diagnostics open reads worktrees.scanRoots directly.
+   */
+  private async mergeAndPersistWorktreeRoots(newRoots: string[]): Promise<string[]> {
+    const existing = this.context.globalState.get<string[]>("worktrees.scanRoots") ?? [];
+    const merged = this.dedupePathList([...existing, ...newRoots]);
+    await this.context.globalState.update("worktrees.scanRoots", merged);
+    return merged;
+  }
+
+  /**
+   * Synchronous known-folder roots for first render: the existing candidate-path directories
+   * reported by the discovery adapters (e.g. ~/.claude/projects, Copilot session dirs). File
+   * candidate paths (e.g. *.db) are excluded so the scanner is not handed a non-directory root.
+   */
+  private getKnownFolderWorktreeRoots(): string[] {
+    let candidatePaths: { path: string; exists: boolean; source: string }[] = [];
+    try { candidatePaths = this.sessionDiscovery.getDiagnosticCandidatePaths(); } catch { candidatePaths = []; }
+    const dirs = candidatePaths.filter((cp) => {
+      try { return fs.statSync(cp.path).isDirectory(); } catch { return false; }
+    });
+    return this.dedupePathList(dirs.map((cp) => cp.path));
+  }
+
+  /** Union of persisted scan roots and known-folder roots, for the initial diagnostics render. */
+  private buildInitialWorktreeRoots(): string[] {
+    const persisted = this.context.globalState.get<string[]>("worktrees.scanRoots") ?? [];
+    return this.dedupePathList([...persisted, ...this.getKnownFolderWorktreeRoots()]);
   }
 
   /**
@@ -9191,7 +9628,26 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       const hitRate = totalAccesses > 0 ? ((cacheHits / totalAccesses) * 100).toFixed(1) : "0.0";
       this.log(`Loaded ${detailedSessionFiles.length} session files in background (Cache: ${cacheHits} hits, ${cacheMisses} misses, ${hitRate}% hit rate)`);
       if (panel === this.diagnosticsPanel) { this.diagnosticsHasLoadedFiles = true; }
+      await this.discoverAndSendWorktreeRoots(panel, detailedSessionFiles);
     } catch { this.log("Could not send session files to panel (may be closed)"); }
+  }
+
+  /**
+   * Derive worktree scan roots from the loaded sessions' workspace paths (plus known session
+   * folders), persist the union to worktrees.scanRoots (for reboot hydration), and push it to
+   * the diagnostics webview so the Worktrees tab roots list is pre-filled. Does not start a scan.
+   */
+  private async discoverAndSendWorktreeRoots(panel: vscode.WebviewPanel, detailedSessionFiles: SessionFileDetails[]): Promise<void> {
+    try {
+      const candidatePaths = this.sessionDiscovery.getDiagnosticCandidatePaths();
+      const discovered = await this.computeDiscoveredWorktreeRoots(detailedSessionFiles, candidatePaths);
+      const merged = await this.mergeAndPersistWorktreeRoots(discovered);
+      if (this.isPanelOpen(panel)) {
+        await panel.webview.postMessage({ command: "worktreeRootsDiscovered", roots: merged });
+      }
+    } catch (err) {
+      this.warn(`Could not derive worktree scan roots: ${err}`);
+    }
   }
 
   /**
@@ -9338,7 +9794,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       quotaEntitlements: this._copilotQuotaEntitlements,
       toolCallStats: this.lastUsageAnalysisStats?.last30Days?.toolCalls ?? null,
       toolFamilies: getToolFamilies(),
-      worktreeScanRoots: this.context.globalState.get<string[]>('worktrees.scanRoots') ?? [],
+      worktreeScanRoots: this.buildInitialWorktreeRoots(),
     }).replace(/</g, "\\u003c");
 
     return `<!DOCTYPE html>

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -183,6 +183,17 @@ type WorktreeScanStatus = {
   total: number;
   foundCount: number;
   elapsedMs: number;
+  /**
+   * "walking" while discovering .git markers under the root; "checking" while resolving them;
+   * "enriching" during the background size + push-status pass.
+   */
+  phase?: "walking" | "checking" | "enriching";
+  /** Folders explored during the "walking" phase (live activity indicator). */
+  dirsScanned?: number;
+  /** Worktrees whose size + push status have been computed during the "enriching" phase. */
+  enriched?: number;
+  /** Total worktrees to enrich during the "enriching" phase. */
+  enrichTotal?: number;
 };
 
 type ToolFamilyConfig = {
@@ -254,6 +265,24 @@ let worktreeScanInProgress = false;
 let worktreeScanStatus: WorktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
 let worktreeScanError: string | null = null;
 let worktreeRenderPending = false;
+// Repo labels whose per-worktree details table is expanded in the results view.
+const worktreeExpandedRepos = new Set<string>();
+// Whether the root-folders list is expanded. Collapsed by default when there are more than 2.
+let worktreeRootsExpanded = false;
+// Sort state for the top-level repository table.
+type WorktreeSortColumn = "repo" | "count" | "size";
+let worktreeSortColumn: WorktreeSortColumn = "count";
+let worktreeSortDir: "asc" | "desc" = "desc";
+
+// Bulk "clean up pushed worktrees" state.
+let worktreeCleanupInProgress = false;
+// True from the moment the cleanup button is clicked until the extension's native confirm
+// modal is answered, so a second click can't fire a duplicate confirmation while it's open.
+let worktreeCleanupConfirmPending = false;
+let worktreeCleanupStatus: { processed: number; total: number } = { processed: 0, total: 0 };
+type WorktreeCleanupOutcome = "deleted" | "skipped" | "error";
+type WorktreeCleanupLogEntry = { path: string; branch: string; repoLabel: string; status: WorktreeCleanupOutcome; reason?: string };
+let worktreeCleanupLog: WorktreeCleanupLogEntry[] = [];
 
 function removeSessionFilesSection(reportText: string): string {
   return reportText.replace(SESSION_FILES_SECTION_REGEX, "");
@@ -1168,23 +1197,52 @@ function renderWorktreeRootsList(): string {
   if (worktreeRoots.length === 0) {
     return `<div style="color: var(--text-muted); font-size: 12px; margin: 8px 0;">No root folders added yet. Add a folder to scan for worktrees.</div>`;
   }
-  return `<div class="worktree-roots-list">${worktreeRoots
-    .map(
-      (r, i) =>
-        `<div class="worktree-root-item"><span title="${escapeHtml(r)}">${escapeHtml(r)}</span><button class="button secondary worktree-remove-root" data-index="${i}" ${worktreeScanInProgress ? "disabled" : ""}>✕</button></div>`,
-    )
-    .join("")}</div>`;
+  // With more than 2 locations the list gets long, so collapse it by default and show a count.
+  const collapsible = worktreeRoots.length > 2;
+  const showList = !collapsible || worktreeRootsExpanded;
+  const toggle = collapsible
+    ? `<button class="worktree-roots-toggle" id="btn-toggle-worktree-roots" aria-expanded="${worktreeRootsExpanded}"><span class="worktree-caret">${worktreeRootsExpanded ? "▼" : "▶"}</span>${worktreeRoots.length} root folders found</button>`
+    : "";
+  const list = showList
+    ? `<div class="worktree-roots-list">${worktreeRoots
+        .map(
+          (r, i) =>
+            `<div class="worktree-root-item"><span title="${escapeHtml(r)}">${escapeHtml(r)}</span><button class="button secondary worktree-remove-root" data-index="${i}" ${worktreeScanInProgress ? "disabled" : ""}>✕</button></div>`,
+        )
+        .join("")}</div>`
+    : "";
+  return toggle + list;
 }
 
 function renderWorktreeProgress(): string {
   if (!worktreeScanInProgress) { return ""; }
-  const pct = worktreeScanStatus.total > 0 ? Math.round((worktreeScanStatus.checked / worktreeScanStatus.total) * 100) : 0;
+  const s = worktreeScanStatus;
+  const seconds = (s.elapsedMs / 1000).toFixed(1);
+  if (s.phase === "enriching") {
+    const done = s.enriched ?? 0;
+    const total = s.enrichTotal ?? 0;
+    const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+    return `
+    <div class="info-box" style="margin-top: 12px;">
+      <div class="info-box-title">📦 Computing sizes &amp; push status…</div>
+      <div>${done} / ${total} worktree${total === 1 ? "" : "s"} analyzed (${seconds}s)</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
+    </div>`;
+  }
+  const walking = s.phase === "walking";
+  const title = walking ? "🔍 Scanning folder…" : "⏳ Checking markers…";
+  const dirs = s.dirsScanned ?? 0;
+  const detail = walking
+    ? `Exploring for git worktrees — ${dirs} folder${dirs === 1 ? "" : "s"} scanned (${seconds}s)`
+    : `${s.checked} / ${s.total || "?"} .git markers checked — ${s.foundCount} worktree${s.foundCount === 1 ? "" : "s"} found so far (${seconds}s)`;
+  const pct = walking ? 100 : (s.total > 0 ? Math.round((s.checked / s.total) * 100) : 0);
+  const fillClass = walking ? "worktree-progress-fill indeterminate" : "worktree-progress-fill";
   return `
     <div class="info-box" style="margin-top: 12px;">
-      <div class="info-box-title">⏳ Scanning…</div>
-      <div>Root: <span style="font-family: var(--vscode-editor-font-family, monospace);">${escapeHtml(worktreeScanStatus.root || "…")}</span></div>
-      <div>${worktreeScanStatus.checked} / ${worktreeScanStatus.total || "?"} .git markers checked — ${worktreeScanStatus.foundCount} worktree${worktreeScanStatus.foundCount === 1 ? "" : "s"} found so far (${(worktreeScanStatus.elapsedMs / 1000).toFixed(1)}s)</div>
-      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
+      <div class="info-box-title">${title}</div>
+      <div>Folder: <span style="font-family: var(--vscode-editor-font-family, monospace);">${escapeHtml(s.root || "…")}</span></div>
+      <div>${detail}</div>
+      <div class="worktree-progress-bar"><div class="${fillClass}" style="width: ${pct}%;"></div></div>
     </div>`;
 }
 
@@ -1205,7 +1263,7 @@ function renderWorktreeControls(): string {
         <button class="button secondary" id="btn-add-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>➕ Add</button>
       </div>
       <div style="margin-top: 16px;">
-        <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>🔍 Scan for Worktrees</button>
+        <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeCleanupInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>🔍 Scan for Worktrees</button>
         ${worktreeScanInProgress ? '<button class="button secondary" id="btn-cancel-worktree-scan">✕ Cancel</button>' : ""}
       </div>
       ${worktreeScanError ? `<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>⚠️ ${escapeHtml(worktreeScanError)}</div></div>` : ""}
@@ -1223,36 +1281,155 @@ function groupWorktreesByRepo(results: WorktreeResult[]): Map<string, WorktreeRe
   return groups;
 }
 
+/** A worktree whose size/push status has not been computed yet (bytes are the -1 sentinel). */
+function isWorktreePending(w: WorktreeResult): boolean {
+  return w.bytes < 0;
+}
+
+/** Bytes counted toward totals: pending (-1) worktrees contribute 0 until enriched. */
+function knownBytes(w: WorktreeResult): number {
+  return w.bytes > 0 ? w.bytes : 0;
+}
+
 function buildWorktreeRowHtml(w: WorktreeResult): string {
+  const pending = isWorktreePending(w);
+  // While a scan is running the values are still being computed; if it stopped (e.g. cancelled)
+  // before this row was enriched, show a neutral dash instead of a misleading "computing…".
+  const pendingLabel = (active: string) => `<span class="worktree-pending">${worktreeScanInProgress ? active : "—"}</span>`;
   const pushedIcon = w.pushed === "yes" ? "✅" : w.pushed === "no" ? "🔴" : "❓";
+  const pushedCell = pending ? pendingLabel("checking…") : `${pushedIcon} ${escapeHtml(w.pushed)}`;
+  const filesCell = pending ? pendingLabel("…") : escapeHtml(String(w.files));
+  const sizeCell = pending
+    ? pendingLabel("computing…")
+    : `<span title="${w.bytes.toLocaleString()} bytes">${formatFileSize(w.bytes)}</span>`;
   return `<tr>
     <td title="${escapeHtml(w.path)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(w.path)}</td>
     <td>${escapeHtml(w.branch)}</td>
     <td>${escapeHtml(w.lastCommit)}</td>
-    <td>${pushedIcon} ${escapeHtml(w.pushed)}</td>
-    <td>${escapeHtml(String(w.files))}</td>
-    <td title="${w.bytes.toLocaleString()} bytes">${formatFileSize(w.bytes)}</td>
-    <td><a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(w.path)}">Open</a></td>
+    <td>${pushedCell}</td>
+    <td>${filesCell}</td>
+    <td>${sizeCell}</td>
+    <td>
+      <a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(w.path)}">Open</a>
+      <a href="#" class="worktree-delete-link" data-path="${encodeURIComponent(w.path)}" data-branch="${encodeURIComponent(w.branch)}" data-repo="${encodeURIComponent(w.repoLabel)}" data-pushed="${escapeHtml(w.pushed)}" title="Remove via git worktree remove (asks for confirmation)">🗑️ Delete</a>
+    </td>
   </tr>`;
 }
 
-function buildWorktreeGroupHtml(repoLabel: string, worktrees: WorktreeResult[]): string {
-  const totalBytes = worktrees.reduce((s, w) => s + w.bytes, 0);
-  const sorted = [...worktrees].sort((a, b) => b.bytes - a.bytes);
+/** The per-worktree details table shown when a repository row is expanded. */
+function buildWorktreeDetailsTableHtml(worktrees: WorktreeResult[]): string {
+  const sorted = [...worktrees].sort((a, b) => knownBytes(b) - knownBytes(a));
   const rows = sorted.map(buildWorktreeRowHtml).join("");
-  return `
-    <div class="worktree-group">
-      <div class="worktree-group-header">
-        <span class="worktree-group-title">${escapeHtml(repoLabel)}</span>
-        <span class="worktree-group-stats">${worktrees.length} worktree${worktrees.length === 1 ? "" : "s"} · ${formatFileSize(totalBytes)}</span>
-      </div>
-      <div class="table-container">
-        <table class="session-table">
-          <thead><tr><th>Path</th><th>Branch</th><th>Last Commit</th><th>Pushed</th><th>Files</th><th>Size</th><th>Actions</th></tr></thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>
+  return `<div class="table-container">
+    <table class="session-table">
+      <thead><tr><th>Path</th><th>Branch</th><th>Last Commit</th><th>Pushed</th><th>Files</th><th>Size</th><th>Actions</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </div>`;
+}
+
+/** Size cell text with a trailing "…" hint while any worktree in the set is still being sized. */
+function worktreeSizeText(worktrees: WorktreeResult[]): string {
+  const totalBytes = worktrees.reduce((s, w) => s + knownBytes(w), 0);
+  const pending = worktrees.some(isWorktreePending);
+  const size = `<span title="${totalBytes.toLocaleString()} bytes">${formatFileSize(totalBytes)}</span>`;
+  return pending ? `${size} <span class="worktree-pending">…</span>` : size;
+}
+
+/**
+ * A repository's summary row (Repository | Worktrees | Size) plus a details row that holds the
+ * per-worktree table. The details row is hidden unless the repo is in worktreeExpandedRepos.
+ */
+function buildWorktreeRepoRowsHtml(repoLabel: string, worktrees: WorktreeResult[]): string {
+  const expanded = worktreeExpandedRepos.has(repoLabel);
+  const caret = expanded ? "▼" : "▶";
+  const repoAttr = escapeHtml(repoLabel);
+  const summaryRow = `<tr class="worktree-repo-row${expanded ? " expanded" : ""}" data-repo="${repoAttr}" aria-expanded="${expanded}">
+    <td><span class="worktree-caret">${caret}</span> ${escapeHtml(repoLabel)}</td>
+    <td>${worktrees.length}</td>
+    <td>${worktreeSizeText(worktrees)}</td>
+  </tr>`;
+  const detailsRow = `<tr class="worktree-repo-details" data-repo="${repoAttr}"${expanded ? "" : ' style="display: none;"'}>
+    <td colspan="3">${buildWorktreeDetailsTableHtml(worktrees)}</td>
+  </tr>`;
+  return summaryRow + detailsRow;
+}
+
+function getWorktreeSortIndicator(col: WorktreeSortColumn): string {
+  if (worktreeSortColumn !== col) { return ""; }
+  return worktreeSortDir === "desc" ? " ▼" : " ▲";
+}
+
+/** Sum of the known (enriched) bytes across a repository's worktrees. */
+function groupKnownBytes(worktrees: WorktreeResult[]): number {
+  return worktrees.reduce((s, w) => s + knownBytes(w), 0);
+}
+
+/** Compare two [repoLabel, worktrees] groups per the active sort column/direction. */
+function compareWorktreeGroups(a: [string, WorktreeResult[]], b: [string, WorktreeResult[]]): number {
+  const dir = worktreeSortDir === "desc" ? -1 : 1;
+  if (worktreeSortColumn === "repo") {
+    return dir * a[0].localeCompare(b[0]);
+  }
+  const value = (g: WorktreeResult[]) => (worktreeSortColumn === "count" ? g.length : groupKnownBytes(g));
+  const diff = value(a[1]) - value(b[1]);
+  // Tie-break by repo name (ascending) so equal groups keep a stable order.
+  return diff !== 0 ? dir * diff : a[0].localeCompare(b[0]);
+}
+
+/** Worktrees eligible for the bulk cleanup: known to be pushed and already enriched. */
+function getCleanupCandidates(): WorktreeResult[] {
+  return worktreeResults.filter((w) => w.pushed === "yes" && !isWorktreePending(w));
+}
+
+/** The cleanup trigger, rendered as its own card inside the hero summary-cards row (to the right of Worktrees/Repositories/Total Size). */
+function renderWorktreeCleanupCard(): string {
+  const pushedCount = getCleanupCandidates().length;
+  const disabled = worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress || pushedCount === 0;
+  const label = worktreeCleanupConfirmPending ? "⏳ Waiting…" : `🧹 Clean Up (${pushedCount})`;
+  return `<div class="summary-card worktree-cleanup-card">
+    <div class="summary-label">Pushed Worktrees</div>
+    <div class="worktree-cleanup-card-actions">
+      <button class="button secondary" id="btn-cleanup-pushed-worktrees" ${disabled ? "disabled" : ""}>${label}</button>
+      ${worktreeCleanupInProgress ? '<button class="button secondary" id="btn-cancel-cleanup">✕</button>' : ""}
+    </div>
+  </div>`;
+}
+
+/** Non-deleted cleanup outcomes (skipped/error) — successful deletions just remove the row, no need to list them. */
+function renderWorktreeCleanupLog(): string {
+  const notable = worktreeCleanupLog.filter((e) => e.status !== "deleted");
+  if (notable.length === 0) { return ""; }
+  const rows = notable.map((e) => {
+    const icon = e.status === "skipped" ? "⏭️" : "❌";
+    return `<div class="worktree-cleanup-log-row">
+      <span>${icon}</span>
+      <span class="worktree-cleanup-log-branch">${escapeHtml(e.branch)}</span>
+      <span class="worktree-cleanup-log-repo">${escapeHtml(e.repoLabel)}</span>
+      <span class="worktree-cleanup-log-reason">${escapeHtml(e.reason || "")}</span>
     </div>`;
+  }).join("");
+  return `<div class="worktree-cleanup-log">${rows}</div>`;
+}
+
+function renderWorktreeCleanupStatus(): string {
+  if (worktreeCleanupInProgress) {
+    const { processed, total } = worktreeCleanupStatus;
+    const pct = total > 0 ? Math.round((processed / total) * 100) : 0;
+    return `<div class="info-box" style="margin-top: 12px;">
+      <div class="info-box-title">🧹 Cleaning up pushed worktrees…</div>
+      <div>${processed} / ${total} processed</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
+    </div>${renderWorktreeCleanupLog()}`;
+  }
+  if (worktreeCleanupLog.length === 0) { return ""; }
+  const deleted = worktreeCleanupLog.filter((e) => e.status === "deleted").length;
+  const skipped = worktreeCleanupLog.filter((e) => e.status === "skipped").length;
+  const errors = worktreeCleanupLog.filter((e) => e.status === "error").length;
+  return `<div class="info-box" style="margin-top: 12px;">
+    <div class="info-box-title">🧹 Cleanup finished</div>
+    <div>✅ ${deleted} deleted · ⏭️ ${skipped} skipped (uncommitted/unpushed) · ${errors > 0 ? `❌ ${errors} error${errors === 1 ? "" : "s"}` : "0 errors"}</div>
+  </div>${renderWorktreeCleanupLog()}`;
 }
 
 function renderWorktreeResults(): string {
@@ -1261,18 +1438,28 @@ function renderWorktreeResults(): string {
     return '<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';
   }
   const groups = groupWorktreesByRepo(worktreeResults);
-  const totalBytes = worktreeResults.reduce((s, w) => s + w.bytes, 0);
+  const totalBytes = worktreeResults.reduce((s, w) => s + knownBytes(w), 0);
+  const anyPending = worktreeResults.some(isWorktreePending);
+  const totalSizeHtml = `${formatFileSize(totalBytes)}${anyPending ? ' <span class="worktree-pending">…</span>' : ''}`;
   const summary = `<div class="summary-cards">
     <div class="summary-card"><div class="summary-label">🌳 Worktrees</div><div class="summary-value">${worktreeResults.length}</div></div>
     <div class="summary-card"><div class="summary-label">📦 Repositories</div><div class="summary-value">${groups.size}</div></div>
-    <div class="summary-card"><div class="summary-label">💾 Total Size</div><div class="summary-value" title="${totalBytes.toLocaleString()} bytes">${formatFileSize(totalBytes)}</div></div>
+    <div class="summary-card"><div class="summary-label">💾 Total Size</div><div class="summary-value" title="${totalBytes.toLocaleString()} bytes">${totalSizeHtml}</div></div>
+    ${renderWorktreeCleanupCard()}
   </div>`;
-  const sortedGroups = [...groups.entries()].sort((a, b) => {
-    const aBytes = a[1].reduce((s, w) => s + w.bytes, 0);
-    const bBytes = b[1].reduce((s, w) => s + w.bytes, 0);
-    return bBytes - aBytes;
-  });
-  return summary + sortedGroups.map(([repo, wts]) => buildWorktreeGroupHtml(repo, wts)).join("");
+  const sortedGroups = [...groups.entries()].sort(compareWorktreeGroups);
+  const repoRows = sortedGroups.map(([repo, wts]) => buildWorktreeRepoRowsHtml(repo, wts)).join("");
+  const table = `<div class="table-container">
+    <table class="session-table worktree-repo-table">
+      <thead><tr>
+        <th class="sortable" data-wt-sort="repo">Repository${getWorktreeSortIndicator("repo")}</th>
+        <th class="sortable" data-wt-sort="count">Worktrees${getWorktreeSortIndicator("count")}</th>
+        <th class="sortable" data-wt-sort="size">Size${getWorktreeSortIndicator("size")}</th>
+      </tr></thead>
+      <tbody>${repoRows}</tbody>
+    </table>
+  </div>`;
+  return summary + renderWorktreeCleanupStatus() + table;
 }
 
 function renderWorktreesTab(): string {
@@ -1881,14 +2068,32 @@ function addWorktreeRootFromInput(): void {
 }
 
 function startWorktreeScan(): void {
-  if (worktreeRoots.length === 0 || worktreeScanInProgress) { return; }
+  if (worktreeRoots.length === 0 || worktreeScanInProgress || worktreeCleanupInProgress) { return; }
   worktreeScanInProgress = true;
   worktreeResults = [];
   worktreeScanError = null;
   worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+  worktreeCleanupLog = [];
   updateWorktreeControls();
   updateWorktreeResults();
   vscode.postMessage({ command: "scanWorktrees", rootPaths: worktreeRoots });
+}
+
+/**
+ * Kicks off the bulk "clean up pushed worktrees" flow. The actual confirmation is a native
+ * VS Code modal shown by the extension (see diagHandleCleanupPushedWorktrees) — this only sends
+ * the candidate list and waits for cleanupStarted/cleanupDeclined to know the outcome.
+ */
+function startWorktreeCleanup(): void {
+  if (worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress) { return; }
+  const targets = getCleanupCandidates();
+  if (targets.length === 0) { return; }
+  worktreeCleanupConfirmPending = true;
+  updateWorktreeResults();
+  vscode.postMessage({
+    command: "cleanupPushedWorktrees",
+    worktrees: targets.map((w) => ({ path: w.path, branch: w.branch, repoLabel: w.repoLabel })),
+  });
 }
 
 function handleWorktreeTabClick(event: MouseEvent): void {
@@ -1910,6 +2115,19 @@ function handleWorktreeTabClick(event: MouseEvent): void {
     vscode.postMessage({ command: "cancelWorktreeScan" });
     return;
   }
+  if (target.id === "btn-cleanup-pushed-worktrees") {
+    startWorktreeCleanup();
+    return;
+  }
+  if (target.id === "btn-cancel-cleanup") {
+    vscode.postMessage({ command: "cancelCleanupPushedWorktrees" });
+    return;
+  }
+  if (target.closest("#btn-toggle-worktree-roots")) {
+    worktreeRootsExpanded = !worktreeRootsExpanded;
+    updateWorktreeControls();
+    return;
+  }
   if (target.classList.contains("worktree-remove-root")) {
     const idx = Number(target.getAttribute("data-index"));
     if (!isNaN(idx)) {
@@ -1923,6 +2141,40 @@ function handleWorktreeTabClick(event: MouseEvent): void {
     event.preventDefault();
     const p = decodeURIComponent(revealLink.getAttribute("data-path") || "");
     if (p) { vscode.postMessage({ command: "revealPath", path: p }); }
+    return;
+  }
+  const deleteLink = target.closest(".worktree-delete-link") as HTMLElement | null;
+  if (deleteLink) {
+    event.preventDefault();
+    const p = decodeURIComponent(deleteLink.getAttribute("data-path") || "");
+    const branch = decodeURIComponent(deleteLink.getAttribute("data-branch") || "");
+    const repoLabel = decodeURIComponent(deleteLink.getAttribute("data-repo") || "");
+    const pushed = deleteLink.getAttribute("data-pushed") || "?";
+    // The actual confirmation is a native VS Code modal shown by the extension — it owns the
+    // "git worktree remove" call and any dirty-tree force-confirmation, not this webview.
+    if (p) { vscode.postMessage({ command: "deleteWorktree", path: p, branch, repoLabel, pushed }); }
+    return;
+  }
+  const sortHeader = target.closest("[data-wt-sort]") as HTMLElement | null;
+  if (sortHeader) {
+    const col = sortHeader.getAttribute("data-wt-sort") as WorktreeSortColumn | null;
+    if (col) {
+      if (worktreeSortColumn === col) {
+        worktreeSortDir = worktreeSortDir === "desc" ? "asc" : "desc";
+      } else {
+        worktreeSortColumn = col;
+        worktreeSortDir = col === "repo" ? "asc" : "desc";
+      }
+      updateWorktreeResults();
+    }
+    return;
+  }
+  const repoRow = target.closest(".worktree-repo-row") as HTMLElement | null;
+  if (repoRow) {
+    const repo = repoRow.getAttribute("data-repo") ?? "";
+    if (worktreeExpandedRepos.has(repo)) { worktreeExpandedRepos.delete(repo); }
+    else { worktreeExpandedRepos.add(repo); }
+    updateWorktreeResults();
   }
 }
 
@@ -1965,6 +2217,27 @@ function handleWorktreeRootPicked(message: DiagMessage): void {
   updateWorktreeControls();
 }
 
+/**
+ * Merge auto-discovered scan roots (from known session folders + session workspace paths,
+ * computed by the extension after the background session load) into the editable roots list.
+ * Case-insensitive dedup, existing order preserved. Skipped while a scan is running so the
+ * list is not mutated mid-scan.
+ */
+function handleWorktreeRootsDiscovered(message: DiagMessage): void {
+  if (worktreeScanInProgress || !Array.isArray(message.roots)) { return; }
+  let added = false;
+  for (const raw of message.roots) {
+    if (typeof raw !== "string") { continue; }
+    const root = raw.trim();
+    if (!root) { continue; }
+    if (!worktreeRoots.some((r) => r.toLowerCase() === root.toLowerCase())) {
+      worktreeRoots.push(root);
+      added = true;
+    }
+  }
+  if (added) { updateWorktreeControls(); }
+}
+
 function handleWorktreeScanStarted(): void {
   worktreeScanInProgress = true;
   worktreeResults = [];
@@ -1975,12 +2248,23 @@ function handleWorktreeScanStarted(): void {
 }
 
 function handleWorktreeScanRootStarted(message: DiagMessage): void {
-  worktreeScanStatus = { ...worktreeScanStatus, root: String(message.root || ""), checked: 0, total: 0 };
+  worktreeScanStatus = { ...worktreeScanStatus, root: String(message.root || ""), checked: 0, total: 0, phase: "walking", dirsScanned: 0 };
+  updateWorktreeProgressArea();
+}
+
+function handleWorktreeScanWalkProgress(message: DiagMessage): void {
+  worktreeScanStatus = {
+    ...worktreeScanStatus,
+    root: String(message.root ?? worktreeScanStatus.root),
+    phase: "walking",
+    dirsScanned: numField(message.dirsScanned),
+    elapsedMs: numField(message.elapsedMs),
+  };
   updateWorktreeProgressArea();
 }
 
 function handleWorktreeScanRootMarkersFound(message: DiagMessage): void {
-  worktreeScanStatus = { ...worktreeScanStatus, total: numField(message.count) };
+  worktreeScanStatus = { ...worktreeScanStatus, total: numField(message.count), phase: "checking" };
   updateWorktreeProgressArea();
 }
 
@@ -2003,6 +2287,79 @@ function handleWorktreeScanProgress(message: DiagMessage): void {
 function handleWorktreeFound(message: DiagMessage): void {
   if (!message.worktree) { return; }
   worktreeResults.push(sanitizeWorktreeResult(message.worktree));
+  scheduleWorktreeResultsRender();
+}
+
+/** Remove a worktree row after the extension has confirmed and run "git worktree remove". */
+function handleWorktreeDeleted(message: DiagMessage): void {
+  const targetPath = String(message.path ?? "");
+  if (!targetPath) { return; }
+  const idx = worktreeResults.findIndex((w) => w.path === targetPath);
+  if (idx === -1) { return; }
+  worktreeResults.splice(idx, 1);
+  updateWorktreeResults();
+}
+
+/** The extension's confirm modal was dismissed/declined — re-enable the cleanup button. */
+function handleCleanupDeclined(): void {
+  worktreeCleanupConfirmPending = false;
+  updateWorktreeResults();
+}
+
+function handleCleanupStarted(message: DiagMessage): void {
+  worktreeCleanupConfirmPending = false;
+  worktreeCleanupInProgress = true;
+  worktreeCleanupStatus = { processed: 0, total: numField(message.total) };
+  worktreeCleanupLog = [];
+  updateWorktreeResults();
+}
+
+function handleCleanupWorktreeResult(message: DiagMessage): void {
+  worktreeCleanupStatus = { processed: numField(message.processed), total: numField(message.total) };
+  const rawStatus = message.status;
+  const status: WorktreeCleanupOutcome = rawStatus === "deleted" || rawStatus === "skipped" ? rawStatus : "error";
+  worktreeCleanupLog.push({
+    path: String(message.path ?? ""),
+    branch: String(message.branch ?? "?"),
+    repoLabel: String(message.repoLabel ?? ""),
+    status,
+    reason: typeof message.reason === "string" ? message.reason : undefined,
+  });
+  updateWorktreeResults();
+}
+
+function handleCleanupComplete(): void {
+  worktreeCleanupInProgress = false;
+  updateWorktreeResults();
+}
+
+function handleCleanupCancelled(): void {
+  worktreeCleanupInProgress = false;
+  worktreeCleanupConfirmPending = false;
+  updateWorktreeResults();
+}
+
+function handleWorktreeEnrichStarted(message: DiagMessage): void {
+  worktreeScanStatus = { ...worktreeScanStatus, phase: "enriching", enriched: 0, enrichTotal: numField(message.total), elapsedMs: numField(message.elapsedMs) };
+  updateWorktreeProgressArea();
+}
+
+function handleWorktreeEnrichProgress(message: DiagMessage): void {
+  worktreeScanStatus = { ...worktreeScanStatus, phase: "enriching", enriched: numField(message.enriched), enrichTotal: numField(message.total), elapsedMs: numField(message.elapsedMs) };
+  updateWorktreeProgressArea();
+}
+
+/** Patch a discovered worktree's size + push status once the background enrichment computes them. */
+function handleWorktreeEnriched(message: DiagMessage): void {
+  const targetPath = String(message.path ?? "");
+  if (!targetPath) { return; }
+  const wt = worktreeResults.find((w) => w.path === targetPath);
+  if (!wt) { return; }
+  wt.files = numField(message.files);
+  wt.folders = numField(message.folders);
+  wt.bytes = numField(message.bytes);
+  const pushedRaw = String(message.pushed ?? "?");
+  wt.pushed = pushedRaw === "yes" || pushedRaw === "no" ? pushedRaw : "?";
   scheduleWorktreeResultsRender();
 }
 
@@ -2557,10 +2914,14 @@ function handleFolderAnalysisResult(message: DiagMessage): void {
 function handleWorktreeMessage(message: DiagMessage): void {
   if (message.command === "worktreeRootPicked") {
     handleWorktreeRootPicked(message);
+  } else if (message.command === "worktreeRootsDiscovered") {
+    handleWorktreeRootsDiscovered(message);
   } else if (message.command === "worktreeScanStarted") {
     handleWorktreeScanStarted();
   } else if (message.command === "worktreeScanRootStarted") {
     handleWorktreeScanRootStarted(message);
+  } else if (message.command === "worktreeScanWalkProgress") {
+    handleWorktreeScanWalkProgress(message);
   } else if (message.command === "worktreeScanRootMarkersFound") {
     handleWorktreeScanRootMarkersFound(message);
   } else if (message.command === "worktreeScanRootSkipped") {
@@ -2569,10 +2930,28 @@ function handleWorktreeMessage(message: DiagMessage): void {
     handleWorktreeScanProgress(message);
   } else if (message.command === "worktreeFound") {
     handleWorktreeFound(message);
+  } else if (message.command === "worktreeEnrichStarted") {
+    handleWorktreeEnrichStarted(message);
+  } else if (message.command === "worktreeEnrichProgress") {
+    handleWorktreeEnrichProgress(message);
+  } else if (message.command === "worktreeEnriched") {
+    handleWorktreeEnriched(message);
+  } else if (message.command === "worktreeDeleted") {
+    handleWorktreeDeleted(message);
   } else if (message.command === "worktreeScanComplete") {
     handleWorktreeScanComplete();
   } else if (message.command === "worktreeScanCancelled") {
     handleWorktreeScanCancelled();
+  } else if (message.command === "cleanupDeclined") {
+    handleCleanupDeclined();
+  } else if (message.command === "cleanupStarted") {
+    handleCleanupStarted(message);
+  } else if (message.command === "cleanupWorktreeResult") {
+    handleCleanupWorktreeResult(message);
+  } else if (message.command === "cleanupComplete") {
+    handleCleanupComplete();
+  } else if (message.command === "cleanupCancelled") {
+    handleCleanupCancelled();
   }
 }
 

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -877,28 +877,131 @@ border: 1px solid #1f6feb;
 	transition: width 0.2s ease;
 }
 
-.worktree-group {
-	margin-bottom: 16px;
+/* While walking the folder tree we have no percentage yet, so pulse the bar to
+   signal ongoing activity instead of showing a misleading fixed progress. */
+.worktree-progress-fill.indeterminate {
+	animation: worktree-pulse 1.2s ease-in-out infinite;
 }
 
-.worktree-group-header {
-	display: flex;
-	align-items: baseline;
-	justify-content: space-between;
-	padding: 6px 4px;
-	border-bottom: 1px solid var(--border-color);
-	margin-bottom: 6px;
+@keyframes worktree-pulse {
+	0%,
+	100% {
+		opacity: 0.35;
+	}
+
+	50% {
+		opacity: 1;
+	}
 }
 
-.worktree-group-title {
-	font-weight: 700;
-	font-size: 13px;
-	color: var(--text-primary);
+.worktree-repo-row {
+	cursor: pointer;
+	font-weight: 600;
 }
 
-.worktree-group-stats {
-	font-size: 12px;
+.worktree-repo-row:hover {
+	background: var(--bg-tertiary);
+}
+
+.worktree-repo-row.expanded {
+	background: var(--bg-tertiary);
+}
+
+.worktree-delete-link {
+	margin-left: 8px;
+	color: var(--vscode-errorForeground, #f14c4c);
+}
+
+.worktree-delete-link:hover {
+	text-decoration: underline;
+}
+
+.worktree-caret {
+	display: inline-block;
+	width: 14px;
 	color: var(--text-muted);
+	font-size: 10px;
+}
+
+.worktree-roots-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin: 8px 0;
+	padding: 0;
+	background: none;
+	border: none;
+	color: var(--link-color);
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.worktree-roots-toggle:hover {
+	text-decoration: underline;
+}
+
+.worktree-pending {
+	color: var(--text-muted);
+	font-style: italic;
+	opacity: 0.8;
+}
+
+/* The details row's cell wraps the per-worktree table; trim its padding so the
+   nested table aligns with the parent columns. */
+.worktree-repo-details > td {
+	padding: 0 0 12px 0;
+}
+
+.worktree-cleanup-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+}
+
+.worktree-cleanup-card-actions {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
+.worktree-cleanup-card-actions .button {
+	font-size: 12px;
+	padding: 4px 10px;
+}
+
+.worktree-cleanup-log {
+	margin-top: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 12px;
+}
+
+.worktree-cleanup-log-row {
+	display: flex;
+	gap: 8px;
+	align-items: baseline;
+	padding: 4px 6px;
+	border-radius: 4px;
+	background: var(--bg-tertiary);
+}
+
+.worktree-cleanup-log-branch {
+	font-weight: 600;
+	font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.worktree-cleanup-log-repo {
+	color: var(--text-muted);
+}
+
+.worktree-cleanup-log-reason {
+	color: var(--text-muted);
+	flex: 1;
 }
 
 

--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -123,10 +123,17 @@ export function formatFileSize(bytes: number): string {
 	if (numericBytes < 1024) {
 		return `${numericBytes} B`;
 	}
-	if (numericBytes < 1024 * 1024) {
-		return `${(numericBytes / 1024).toFixed(1)} KB`;
+	// Scale through binary units, picking the largest that keeps the value >= 1.
+	const units = ['KB', 'MB', 'GB', 'TB', 'PB'];
+	let value = numericBytes / 1024;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < units.length - 1) {
+		value /= 1024;
+		unitIndex++;
 	}
-	return `${(numericBytes / (1024 * 1024)).toFixed(2)} MB`;
+	// Keep KB at 1 decimal (small, noisy); MB and up at 2 decimals.
+	const decimals = unitIndex === 0 ? 1 : 2;
+	return `${value.toFixed(decimals)} ${units[unitIndex]}`;
 }
 
 /**

--- a/vscode-extension/test/unit/utils-pathUtils.test.ts
+++ b/vscode-extension/test/unit/utils-pathUtils.test.ts
@@ -7,6 +7,7 @@ import {
 	hasWindowsDriveSegment,
 	normalizePath,
 	normalizePathForDedup,
+	normalizeToRepoRoot,
 	splitNormalizedPath,
 	stripWindowsDriveUriPrefix,
 	toPlatformPath
@@ -115,4 +116,58 @@ test('hasWindowsDriveSegment: on win32 returns false for non-drive segment', () 
 
 test('hasWindowsDriveSegment: on win32 returns false for undefined segment', () => {
 	assert.equal(hasWindowsDriveSegment(undefined, 'win32'), false);
+});
+
+// normalizeToRepoRoot - strips agent-worktree segments up to the repo root
+test('normalizeToRepoRoot: strips Windows .claude/worktrees segment', () => {
+	assert.equal(
+		normalizeToRepoRoot('C:\\Users\\me\\repos\\proj\\.claude\\worktrees\\feature-x'),
+		'C:\\Users\\me\\repos\\proj'
+	);
+});
+
+test('normalizeToRepoRoot: strips POSIX .claude/worktrees segment', () => {
+	assert.equal(
+		normalizeToRepoRoot('/home/me/repos/proj/.claude/worktrees/feature-x'),
+		'/home/me/repos/proj'
+	);
+});
+
+test('normalizeToRepoRoot: strips copilot-worktrees segment', () => {
+	assert.equal(
+		normalizeToRepoRoot('C:\\Users\\me\\repos\\proj\\copilot-worktrees\\session-123'),
+		'C:\\Users\\me\\repos\\proj'
+	);
+});
+
+test('normalizeToRepoRoot: strips trailing sub-path below the worktree name', () => {
+	assert.equal(
+		normalizeToRepoRoot('/home/me/repos/proj/.claude/worktrees/feature-x/src/app'),
+		'/home/me/repos/proj'
+	);
+});
+
+test('normalizeToRepoRoot: is case-insensitive for the marker segments', () => {
+	assert.equal(
+		normalizeToRepoRoot('/home/me/repos/proj/Copilot-Worktrees/session-123'),
+		'/home/me/repos/proj'
+	);
+});
+
+test('normalizeToRepoRoot: returns a plain repo path unchanged', () => {
+	assert.equal(
+		normalizeToRepoRoot('C:\\Users\\me\\repos\\proj'),
+		'C:\\Users\\me\\repos\\proj'
+	);
+});
+
+test('normalizeToRepoRoot: does not strip when the marker has no leading repo prefix', () => {
+	assert.equal(normalizeToRepoRoot('copilot-worktrees/session-123'), 'copilot-worktrees/session-123');
+});
+
+test('normalizeToRepoRoot: ignores an unrelated "worktrees" folder without the .claude parent', () => {
+	assert.equal(
+		normalizeToRepoRoot('/home/me/repos/proj/worktrees/foo'),
+		'/home/me/repos/proj/worktrees/foo'
+	);
 });

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -11,6 +11,7 @@ import {
 	formatNumber,
 	formatCost,
 	formatDurationShort,
+	formatFileSize,
 	escapeHtml,
 	markdownToHtml,
 	STAGE_LABELS,
@@ -197,4 +198,36 @@ test('STAGE_DESCRIPTIONS: defines descriptions for all four stages', () => {
 	assert.ok(STAGE_DESCRIPTIONS[2].length > 0);
 	assert.ok(STAGE_DESCRIPTIONS[3].length > 0);
 	assert.ok(STAGE_DESCRIPTIONS[4].length > 0);
+});
+
+// ── formatFileSize ──────────────────────────────────────────────────────
+
+test('formatFileSize: bytes below 1 KB show as B', () => {
+	assert.equal(formatFileSize(512), '512 B');
+});
+
+test('formatFileSize: kilobytes use one decimal', () => {
+	assert.equal(formatFileSize(1536), '1.5 KB');
+});
+
+test('formatFileSize: megabytes use two decimals', () => {
+	assert.equal(formatFileSize(5 * 1024 * 1024), '5.00 MB');
+});
+
+test('formatFileSize: scales into GB', () => {
+	assert.equal(formatFileSize(3 * 1024 ** 3), '3.00 GB');
+});
+
+test('formatFileSize: scales into TB', () => {
+	assert.equal(formatFileSize(2 * 1024 ** 4), '2.00 TB');
+});
+
+test('formatFileSize: scales into PB and caps there', () => {
+	assert.equal(formatFileSize(4 * 1024 ** 5), '4.00 PB');
+	assert.equal(formatFileSize(2048 * 1024 ** 5), '2048.00 PB');
+});
+
+test('formatFileSize: rejects negative and non-finite values', () => {
+	assert.equal(formatFileSize(-1), 'N/A');
+	assert.equal(formatFileSize(NaN), 'N/A');
 });


### PR DESCRIPTION
## Summary

Overhauls the Diagnostics **Worktrees** tab from a slow, manual, always-expanded list into a fast, self-seeding, self-cleaning tool:

- **Auto-seeded, persisted scan roots** — root folders are now pre-filled from known session-storage folders and each session's workspace path (normalized up to the repo root, e.g. `.claude/worktrees/<x>` → the repo), and persisted in `worktrees.scanRoots` so they hydrate again after a reload. Manual scan only — nothing auto-starts.
- **Fast discovery, background enrichment** — worktrees used to be fully sized and git-checked (including a blocking `execSync` push-status call) *before* being shown at all, so the first result could take a while. The scan is now split: cheap, async (`execFile`-based) discovery reports each worktree immediately, while disk size and push status compute concurrently in the background and patch rows live ("computing…" → real values).
- **Live scan feedback** — a "walking" progress phase now reports the folder being scanned and folders explored during the initial directory walk, not just once `.git` markers are found.
- **Sortable, collapsible repository table** — results are grouped into a top-level Repository | Worktrees | Size table (sortable on any column), each row expandable to the detailed per-worktree table. The root-folders list itself collapses to a count once more than two are found.
- **Human-readable sizes** — `formatFileSize` now scales through GB/TB/PB instead of capping at MB.
- **Safe per-worktree delete** — a "🗑️ Delete" action uses `git worktree remove` (never a raw folder delete), with a native confirm modal, a second confirmation if the worktree turns out dirty, and a fallback to a direct filesystem delete + registration cleanup for the known git-for-windows "Invalid argument" failure (junctions/reparse points, e.g. pnpm `node_modules`, or long paths) — a Windows-only OS-level quirk, not a safety bypass.
- **Bulk "Clean Up Pushed Worktrees"** — a hero-panel action that batch-deletes worktrees already known to be pushed. It re-checks push status live per worktree (never trusts the cached list) and **never force-deletes**: any worktree found dirty or unpushed is skipped and the batch continues with the rest.

## Why

Worktree sprawl accumulates fast across editors/CLIs (Claude Code, Copilot CLI) that create their own scratch worktrees, and the existing tool was too slow and too manual to actually use for cleanup — this makes it a one-click way to find and reclaim that disk space safely.

## Test plan

- [x] `npm run compile` (tsc + eslint + esbuild) — clean, 0 errors
- [x] `npm test` — full suite green, including new unit tests for `normalizeToRepoRoot` and `formatFileSize`'s GB/TB/PB scaling
- [x] `npx stylelint src/webview/diagnostics/styles.css` — no new errors introduced (pre-existing count unchanged)
- [ ] Manual verification in the Extension Development Host (F5): root pre-fill, live scan progress, sortable repo table, single delete, and bulk cleanup against real worktrees — reviewer/maintainer to confirm, since this wasn't drivable headlessly from this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)