### PR TITLE
fix(claudecode): attribute multi-day tokens by day and discover subagent transcripts

### DIFF
--- a/src/adapters/claudeCodeAdapter.ts
+++ b/src/adapters/claudeCodeAdapter.ts
@@ -93,6 +93,10 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		};
 	}
 
+	async getDailyFractions(sessionFile: string): Promise<Record<string, number>> {
+		return await this.claudeCode.getClaudeCodeDailyFractions(sessionFile);
+	}
+
 	getEditorRoot(_sessionFile: string): string {
 		return this.claudeCode.getClaudeCodeProjectsDir();
 	}

--- a/src/claudecode.ts
+++ b/src/claudecode.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import type { ModelUsage } from './types';
 import { withErrorRecovery } from './utils/errors';
 import { normalizePathForComparison } from './workspaceHelpers';
+import { toLocalDayKey } from './utils/dayKeys';
 
 /**
  * Normalize a Claude Code API model ID to the dot-notation format used throughout this codebase.
@@ -68,7 +69,8 @@ export class ClaudeCodeDataAccess {
 	}
 
 	/**
-	 * Get all Claude Code session file paths (top-level session files, excluding subagent files).
+	 * Get all Claude Code session file paths, including subagent/workflow transcripts
+	 * written under <project>/<sessionId>/subagents/**\/*.jsonl (issue #1608).
 	 */
 	async getClaudeCodeSessionFiles(): Promise<string[]> {
 		const projectsDir = this.getClaudeCodeProjectsDir();
@@ -91,22 +93,30 @@ export class ClaudeCodeDataAccess {
 		}
 	}
 
-	private async collectJsonlFilesFromProject(projectPath: string): Promise<string[]> {
+	/**
+	 * Recursively collect .jsonl files under a project directory, up to maxDepth levels
+	 * deep, so subagent/workflow transcripts nested under <sessionId>/subagents/** are
+	 * discovered alongside the top-level session files.
+	 */
+	private async collectJsonlFilesFromProject(projectPath: string, depth = 0, maxDepth = 6): Promise<string[]> {
+		if (depth > maxDepth) { return []; }
 		try {
 			const entries = await fs.promises.readdir(projectPath, { withFileTypes: true });
 			const results = await Promise.all(
-				entries
-					.filter(e => !e.isDirectory() && e.name.endsWith('.jsonl'))
-					.map(async e => {
-						const fullPath = path.join(projectPath, e.name);
-						try {
-							const st = await fs.promises.stat(fullPath);
-							return st.size > 0 ? [fullPath] : [];
-						} catch (err) {
-							console.error(`[claudecode] Failed to stat ${fullPath}:`, err);
-							return [] as string[];
-						}
-					})
+				entries.map(async e => {
+					const fullPath = path.join(projectPath, e.name);
+					if (e.isDirectory()) {
+						return this.collectJsonlFilesFromProject(fullPath, depth + 1, maxDepth);
+					}
+					if (!e.name.endsWith('.jsonl')) { return []; }
+					try {
+						const st = await fs.promises.stat(fullPath);
+						return st.size > 0 ? [fullPath] : [];
+					} catch (err) {
+						console.error(`[claudecode] Failed to stat ${fullPath}:`, err);
+						return [] as string[];
+					}
+				})
 			);
 			return results.flat();
 		} catch (err) {
@@ -167,27 +177,69 @@ export class ClaudeCodeDataAccess {
 	}
 
 	/**
+	 * Sum input + output tokens (including cache creation/read) from a single assistant
+	 * event's usage object. Shared by getTokensFromClaudeCodeSession and
+	 * getClaudeCodeDailyFractions so both use the identical token formula.
+	 */
+	private getEventTotalTokens(usage: any): number {
+		const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
+			+ (typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0)
+			+ (typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0);
+		const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+		return inputTokens + outputTokens;
+	}
+
+	/**
 	 * Get token counts from a Claude Code session.
 	 * Uses ACTUAL Anthropic API token counts from assistant event message.usage.
 	 * De-duplicates by message.id (last-wins) — see deduplicateAssistantEvents.
 	 */
 	async getTokensFromClaudeCodeSession(sessionFilePath: string): Promise<{ tokens: number; thinkingTokens: number }> {
 		const events = await this.readSessionEvents(sessionFilePath);
-		let totalInputTokens = 0;
-		let totalOutputTokens = 0;
+		let totalTokens = 0;
 
 		for (const event of this.deduplicateAssistantEvents(events)) {
-			const usage = event.message.usage;
-			const inputTokens = (typeof usage.input_tokens === 'number' ? usage.input_tokens : 0)
-				+ (typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0)
-				+ (typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0);
-			const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
-			totalInputTokens += inputTokens;
-			totalOutputTokens += outputTokens;
+			totalTokens += this.getEventTotalTokens(event.message.usage);
 		}
 
 		// Claude Code does not separate thinking tokens — they are included in output_tokens
-		return { tokens: totalInputTokens + totalOutputTokens, thinkingTokens: 0 };
+		return { tokens: totalTokens, thinkingTokens: 0 };
+	}
+
+	/**
+	 * Return the fraction of this session's tokens that occurred on each calendar day,
+	 * bucketed by each assistant event's own timestamp rather than the session's
+	 * firstInteraction. Claude Code logs exact per-event usage and an ISO timestamp per
+	 * assistant event, so multi-day sessions are attributed to the days the tokens were
+	 * actually spent on instead of collapsing everything onto the start day (issue #1608).
+	 */
+	async getClaudeCodeDailyFractions(sessionFilePath: string): Promise<Record<string, number>> {
+		const events = await this.readSessionEvents(sessionFilePath);
+		const tokensPerDay = new Map<string, number>();
+		let totalTokens = 0;
+
+		for (const event of this.deduplicateAssistantEvents(events)) {
+			const tokens = this.getEventTotalTokens(event.message.usage);
+			if (tokens <= 0) { continue; }
+			const ts = event.timestamp ? new Date(event.timestamp).getTime() : NaN;
+			if (isNaN(ts)) { continue; }
+			const dayKey = toLocalDayKey(new Date(ts));
+			tokensPerDay.set(dayKey, (tokensPerDay.get(dayKey) ?? 0) + tokens);
+			totalTokens += tokens;
+		}
+
+		if (totalTokens === 0) {
+			const meta = await this.getClaudeCodeSessionMeta(sessionFilePath);
+			const fallbackMs = meta?.firstInteraction ? Date.parse(meta.firstInteraction) : NaN;
+			const fallback = isNaN(fallbackMs) ? toLocalDayKey(new Date()) : toLocalDayKey(new Date(fallbackMs));
+			return { [fallback]: 1.0 };
+		}
+
+		const fractions: Record<string, number> = {};
+		for (const [dayKey, tokens] of tokensPerDay.entries()) {
+			fractions[dayKey] = tokens / totalTokens;
+		}
+		return fractions;
 	}
 
 	/**

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the VS Code extension will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+- Claude Code: attribute multi-day session tokens to the day each turn actually occurred instead of collapsing everything onto the session's start day, and discover subagent/workflow transcripts under `<sessionId>/subagents/**` that were previously silently excluded (#1608)
+
 ## [0.13.0] - 2026-07-11
 
 ### Features

--- a/vscode-extension/test/unit/claudecode.test.ts
+++ b/vscode-extension/test/unit/claudecode.test.ts
@@ -881,3 +881,154 @@ assert.equal(result.toolCalls.total, 0);
 cleanup(filePath);
 }
 });
+
+// ----- getClaudeCodeDailyFractions (issue #1608, root cause A) -----
+
+test('getClaudeCodeDailyFractions: splits usage by each assistant event day, weighted by tokens', async () => {
+const events = [
+{
+type: 'assistant',
+message: {
+model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn',
+id: 'msg_day1', usage: { input_tokens: 100, output_tokens: 200 }
+},
+timestamp: '2026-07-11T12:00:00.000Z'
+},
+{
+type: 'assistant',
+message: {
+model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn',
+id: 'msg_day2', usage: { input_tokens: 100, output_tokens: 100 }
+},
+// 19h later — a different local day in every timezone from UTC-10 to UTC+14
+timestamp: '2026-07-12T07:00:00.000Z'
+}
+];
+const filePath = createTempSession(events);
+try {
+const fractions = await claudeCode.getClaudeCodeDailyFractions(filePath);
+const keys = Object.keys(fractions).sort();
+assert.equal(keys.length, 2, 'should have exactly 2 local day keys');
+// day1: 300 tokens, day2: 200 tokens, total 500
+const values = keys.map(k => fractions[k]).sort((a, b) => a - b);
+assert.ok(Math.abs(values[0] - 0.4) < 1e-9, `expected 0.4, got ${values[0]}`);
+assert.ok(Math.abs(values[1] - 0.6) < 1e-9, `expected 0.6, got ${values[1]}`);
+const total = Object.values(fractions).reduce((a, b) => a + b, 0);
+assert.ok(Math.abs(total - 1.0) < 1e-9, 'fractions should sum to 1.0');
+} finally {
+cleanup(filePath);
+}
+});
+
+test('getClaudeCodeDailyFractions: de-duplicates streaming fragments by message.id before bucketing', async () => {
+const events = [
+{
+type: 'assistant',
+message: { model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: null, id: 'msg_1', usage: { input_tokens: 10, output_tokens: 20 } },
+timestamp: '2026-07-11T12:00:00.000Z'
+},
+{
+type: 'assistant',
+message: { model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn', id: 'msg_1', usage: { input_tokens: 10, output_tokens: 50 } },
+timestamp: '2026-07-11T12:00:05.000Z'
+}
+];
+const filePath = createTempSession(events);
+try {
+const fractions = await claudeCode.getClaudeCodeDailyFractions(filePath);
+const keys = Object.keys(fractions);
+assert.equal(keys.length, 1);
+assert.ok(Math.abs(fractions[keys[0]] - 1.0) < 1e-9);
+} finally {
+cleanup(filePath);
+}
+});
+
+test('getClaudeCodeDailyFractions: falls back to firstInteraction day when there is no usage data', async () => {
+const events = [
+{
+type: 'user',
+isSidechain: false,
+message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+timestamp: '2026-07-11T12:00:00.000Z'
+}
+];
+const filePath = createTempSession(events);
+try {
+const fractions = await claudeCode.getClaudeCodeDailyFractions(filePath);
+const keys = Object.keys(fractions);
+assert.equal(keys.length, 1);
+assert.equal(fractions[keys[0]], 1.0);
+} finally {
+cleanup(filePath);
+}
+});
+
+test('ClaudeCodeAdapter.getDailyFractions: delegates to ClaudeCodeDataAccess', async () => {
+const events = [
+{
+type: 'assistant',
+message: { model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn', id: 'msg_1', usage: { input_tokens: 10, output_tokens: 20 } },
+timestamp: '2026-07-11T12:00:00.000Z'
+}
+];
+const filePath = createTempSession(events);
+try {
+const fractions = await claudeCodeAdapter.getDailyFractions(filePath);
+const keys = Object.keys(fractions);
+assert.equal(keys.length, 1);
+assert.equal(fractions[keys[0]], 1.0);
+} finally {
+cleanup(filePath);
+}
+});
+
+// ----- getClaudeCodeSessionFiles recursion into subagent transcripts (issue #1608, root cause B) -----
+
+class TestableClaudeCodeDataAccess extends ClaudeCodeDataAccess {
+constructor(private readonly testDataDir: string) { super(); }
+override getClaudeCodeDataDir(): string { return this.testDataDir; }
+}
+
+test('getClaudeCodeSessionFiles: discovers subagent transcripts nested under <sessionId>/subagents/**', async () => {
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-discovery-test-'));
+try {
+const dataDir = path.join(tmpDir, '.claude');
+const projectDir = path.join(dataDir, 'projects', 'test-project');
+const topLevelFile = path.join(projectDir, 'session-1.jsonl');
+const subagentDir = path.join(projectDir, 'session-1', 'subagents', 'workflows', 'wf-1');
+const subagentFile = path.join(subagentDir, 'agent-1.jsonl');
+
+fs.mkdirSync(projectDir, { recursive: true });
+fs.writeFileSync(topLevelFile, JSON.stringify({ type: 'user' }), 'utf8');
+fs.mkdirSync(subagentDir, { recursive: true });
+fs.writeFileSync(subagentFile, JSON.stringify({ type: 'assistant' }), 'utf8');
+
+const cc = new TestableClaudeCodeDataAccess(dataDir);
+const files = (await cc.getClaudeCodeSessionFiles()).map(f => path.normalize(f)).sort();
+assert.deepEqual(files, [path.normalize(subagentFile), path.normalize(topLevelFile)].sort());
+} finally {
+fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+});
+
+test('getClaudeCodeSessionFiles: ignores empty files at any depth', async () => {
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-discovery-test-'));
+try {
+const dataDir = path.join(tmpDir, '.claude');
+const projectDir = path.join(dataDir, 'projects', 'test-project');
+const subagentDir = path.join(projectDir, 'session-1', 'subagents');
+const emptyTopLevel = path.join(projectDir, 'empty.jsonl');
+const emptySubagent = path.join(subagentDir, 'empty-agent.jsonl');
+
+fs.mkdirSync(subagentDir, { recursive: true });
+fs.writeFileSync(emptyTopLevel, '', 'utf8');
+fs.writeFileSync(emptySubagent, '', 'utf8');
+
+const cc = new TestableClaudeCodeDataAccess(dataDir);
+const files = await cc.getClaudeCodeSessionFiles();
+assert.deepEqual(files, []);
+} finally {
+fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+});


### PR DESCRIPTION
## Summary
- Adds `ClaudeCodeDataAccess.getClaudeCodeDailyFractions()` (wired into `ClaudeCodeAdapter.getDailyFractions`) so a Claude Code session's tokens are bucketed by each assistant event's own timestamp instead of being dumped entirely onto the session's `firstInteraction` day. Claude Code logs exact per-event `usage` plus an ISO `timestamp`, so this is an exact split, not an estimate — the same dedup-by-`message.id` logic already used for token counting is reused here.
- Makes `collectJsonlFilesFromProject` recurse into subdirectories (bounded to 6 levels) so subagent/workflow transcripts written under `<project>/<sessionId>/subagents/**/*.jsonl` are discovered instead of being silently excluded.

## Context
Relates to #1608. The original report describes a day showing zero sessions/tokens when Claude Code Desktop was used without VS Code open. A detailed follow-up comment on that issue (with reproduced local numbers) traced this to two root causes in the Claude Code data path:
- **Root cause A** — no `getDailyFractions` on the Claude Code adapter, so multi-day sessions fell back to `computeFallbackDailyRollup`, attributing 100% of tokens to the start day and leaving later days blank.
- **Root cause B** — session discovery only listed files directly inside each project directory, silently excluding subagent/workflow transcripts (each a distinct set of Anthropic API calls with their own token usage).

I verified both root causes against the current code before starting this fix (function names/logic in `vscode-extension/src/extension.ts` `computeDailyRollups`/`computeFallbackDailyRollup` matched exactly) and confirmed this is unrelated to the previously-closed #1365 (that one was about the **Pi** adapter, not Claude Code).

Leaving #1608 open — a comment will follow linking this PR, and the issue reporter can validate once a release ships.

## Test plan
- [x] Added unit tests in `vscode-extension/test/unit/claudecode.test.ts`: token-weighted day splitting, message.id dedup before bucketing, fallback to `firstInteraction` when there's no usage data, adapter delegation, and recursive discovery of nested subagent files (including an empty-file exclusion test).
- [x] Full unit test suite (`node scripts/run-node-unit-tests.js`) passes — 79 suites, all green.
- [x] `tsc --noEmit` and `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)