### PR TITLE
fix(usage-analysis): stop Recent Sessions table clearing on timer refresh

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2781,6 +2781,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 					today: analysisStats.today, last30Days: analysisStats.last30Days, month: analysisStats.month, lastMonth: analysisStats.lastMonth,
 					locale: analysisStats.locale, customizationMatrix: analysisStats.customizationMatrix || null,
 					missedPotential: analysisStats.missedPotential || [],
+					todaySessions: analysisStats.todaySessions || [],
 					lastUpdated: analysisStats.lastUpdated.toISOString(), backendConfigured: this.isBackendConfigured(),
 					currentWorkspacePaths: vscode.workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [],
 					insights: this.buildCurrentInsights(analysisStats),

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -2664,7 +2664,11 @@ function buildUsageRootHtml(
 }
 
 function buildSessionsTabPanelHtml(stats: UsageAnalysisStats): string {
-	latestTodaySessions = stats.todaySessions || [];
+	// Guard against silent host updates that omit todaySessions (e.g. a stale payload
+	// shape): keep showing the last known sessions instead of clearing the table.
+	if (Array.isArray(stats.todaySessions)) {
+		latestTodaySessions = stats.todaySessions;
+	}
 	const cachedForLookback = sessionsLookback === 'today' ? latestTodaySessions : recentSessionsCache[sessionsLookback];
 	const bodyHtml = cachedForLookback
 		? renderTodaySessionsTable(cachedForLookback)


### PR DESCRIPTION
## Summary
- The Usage Analysis "Recent Sessions" tab intermittently showed "No sessions recorded today yet" even when sessions existed — root cause: the 5-minute background timer sends a *silent* `updateStats` postMessage to the webview whose payload never included `todaySessions` (unlike the full HTML rebuild path), so the webview reset its cached session list to empty on every tick.
- `updateAnalysisPanelIfOpen`'s silent-update payload in `vscode-extension/src/extension.ts` now includes `todaySessions`, so periodic refreshes actually deliver current session data.
- Added a defensive guard in `vscode-extension/src/webview/usage/main.ts` (`buildSessionsTabPanelHtml`) so the webview only overwrites its cached sessions list when the incoming payload actually contains an array, preventing any future/other update path from wiping the table.

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] `npm run test:node` — full unit test suite passes
- [ ] Manual verification in a running VS Code extension host that the Recent Sessions table survives a background timer refresh (5 min) without clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)