### PR TITLE
fix: resolve eslint complexity warnings

### DIFF
--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -2508,6 +2508,32 @@ function _gmusProcessJsonRequests(sessionContent: ParsedSessionJson, modelUsage:
 	}
 }
 
+/** Resolve model usage for a JSONL-format session, preferring exact OTel usage when available. */
+async function _gmusResolveJsonl(sessionFile: string, fileContent: string, modelUsage: ModelUsage, deps: GmusDeps): Promise<ModelUsage> {
+	// Copilot CLI events.jsonl: prefer exact per-model usage from the OpenTelemetry
+	// file export (when enabled) over the ratio-based estimate below.
+	if (extractCopilotCliSessionId(sessionFile)) {
+		const otel = await getCopilotCliOtelUsage(sessionFile);
+		if (otel && Object.keys(otel.modelUsage).length > 0) { return otel.modelUsage; }
+	}
+	const lines = fileContent.trim().split('\n');
+	const result = _gmusProcessJsonlContent(lines, modelUsage, deps);
+	return result ?? modelUsage;
+}
+
+/** Resolve model usage from a session file's content, dispatching by format. */
+async function _gmusResolveFromContent(sessionFile: string, fileContent: string, modelUsage: ModelUsage, deps: GmusDeps, preloadedParsedJson?: unknown): Promise<ModelUsage> {
+	if (isUuidPointerFile(fileContent)) { return modelUsage; }
+	const isJsonl = sessionFile.endsWith('.jsonl') || isJsonlContent(fileContent);
+	if (isJsonl) {
+		return _gmusResolveJsonl(sessionFile, fileContent, modelUsage, deps);
+	}
+	const parsed: unknown = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
+	if (!isParsedSessionJson(parsed)) { deps.warn(`Unexpected session format in ${sessionFile}`); return modelUsage; }
+	_gmusProcessJsonRequests(parsed, modelUsage, deps);
+	return modelUsage;
+}
+
 export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'warn' | 'tokenEstimators' | 'modelPricing' | 'ecosystems'>, sessionFile: string, preloadedContent?: string, preloadedParsedJson?: unknown): Promise<ModelUsage> {
 	const modelUsage: ModelUsage = {};
 	if (deps.ecosystems) {
@@ -2519,22 +2545,7 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 	}
 	try {
 		const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
-		if (isUuidPointerFile(fileContent)) { return modelUsage; }
-		const isJsonl = sessionFile.endsWith('.jsonl') || isJsonlContent(fileContent);
-		if (isJsonl) {
-			// Copilot CLI events.jsonl: prefer exact per-model usage from the OpenTelemetry
-			// file export (when enabled) over the ratio-based estimate below.
-			if (extractCopilotCliSessionId(sessionFile)) {
-				const otel = await getCopilotCliOtelUsage(sessionFile);
-				if (otel && Object.keys(otel.modelUsage).length > 0) { return otel.modelUsage; }
-			}
-			const lines = fileContent.trim().split('\n');
-			const result = _gmusProcessJsonlContent(lines, modelUsage, deps);
-			return result ?? modelUsage;
-		}
-		const parsed: unknown = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
-		if (!isParsedSessionJson(parsed)) { deps.warn(`Unexpected session format in ${sessionFile}`); return modelUsage; }
-		_gmusProcessJsonRequests(parsed, modelUsage, deps);
+		return await _gmusResolveFromContent(sessionFile, fileContent, modelUsage, deps, preloadedParsedJson);
 	} catch (error) {
 		deps.warn(`Error getting model usage from ${sessionFile}: ${error}`);
 	}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6216,56 +6216,41 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.log(`🧭 [Tool Curation Trace] ${stage} ${details}`);
 	}
 
-	private async handleAnalysisMessage(message: any): Promise<void> {
-		switch (message.command) {
-			case 'refresh':
-				await this.dispatch('refresh:analysis', () => this.refreshAnalysisPanel());
-				break;
-			case 'analyseRepository':
-				await this.dispatch('analyseRepository', () => this.handleAnalyseRepository(message.workspacePath));
-				break;
-			case 'analyseAllRepositories':
-				await this.dispatch('analyseAllRepositories', () => this.handleAnalyseAllRepositories());
-				break;
-			case 'openCopilotChatWithPrompt':
-				await this.dispatch('openCopilotChatWithPrompt', () =>
-					vscode.commands.executeCommand('workbench.action.chat.open', { query: message.prompt, isNewChat: true })
-				);
-				break;
-			case 'suppressUnknownTool': {
+	private async _handleOpenSessionFile(message: any): Promise<void> {
+		if (!message.file) { return; }
+		await this.dispatch('openSessionFile:analysis', async () => {
+			try { await this.showLogViewer(message.file); }
+			catch { vscode.window.showErrorMessage('Could not open log viewer: ' + message.file); }
+		});
+	}
+
+	private _getAnalysisMessageHandlers(): Record<string, (message: any) => Promise<void> | void> {
+		return {
+			refresh: () => this.dispatch('refresh:analysis', () => this.refreshAnalysisPanel()),
+			analyseRepository: (message) => this.dispatch('analyseRepository', () => this.handleAnalyseRepository(message.workspacePath)),
+			analyseAllRepositories: () => this.dispatch('analyseAllRepositories', () => this.handleAnalyseAllRepositories()),
+			openCopilotChatWithPrompt: (message) => this.dispatch('openCopilotChatWithPrompt', () =>
+				vscode.commands.executeCommand('workbench.action.chat.open', { query: message.prompt, isNewChat: true })
+			),
+			suppressUnknownTool: (message) => {
 				const toolName = message.toolName as string;
-				if (toolName) { await this._handleSuppressUnknownTool(toolName); }
-				break;
-			}
-			case 'loadRepoPrStats':
-				await this.dispatch('loadRepoPrStats', () => this.loadRepoPrStats());
-				break;
-			case 'loadAgentSessions':
-				await this.dispatch('loadAgentSessions', () => this.loadAgentSessions());
-				break;
-			case 'loadRecentSessions':
-				await this.dispatch('loadRecentSessions', () => this.loadRecentSessions(Number(message.days)));
-				break;
-			case 'openSessionFile':
-				if (message.file) {
-					await this.dispatch('openSessionFile:analysis', async () => {
-						try { await this.showLogViewer(message.file); }
-						catch { vscode.window.showErrorMessage('Could not open log viewer: ' + message.file); }
-					});
-				}
-				break;
-			case 'insightAction':
-					await this.dispatch(`insightAction:${message.id ?? ''}`, () => this.handleInsightAction(message));
-					break;
-			case 'traceUsageCuration':
-				this._logTraceCuration(message);
-				break;
-			case 'saveSessionColumnSettings':
-				await this.dispatch('saveSessionColumnSettings', () =>
-					this.context.globalState.update('usage.sessionColumnSettings', message.settings)
-				);
-				break;
-		}
+				return toolName ? this._handleSuppressUnknownTool(toolName) : undefined;
+			},
+			loadRepoPrStats: () => this.dispatch('loadRepoPrStats', () => this.loadRepoPrStats()),
+			loadAgentSessions: () => this.dispatch('loadAgentSessions', () => this.loadAgentSessions()),
+			loadRecentSessions: (message) => this.dispatch('loadRecentSessions', () => this.loadRecentSessions(Number(message.days))),
+			openSessionFile: (message) => this._handleOpenSessionFile(message),
+			insightAction: (message) => this.dispatch(`insightAction:${message.id ?? ''}`, () => this.handleInsightAction(message)),
+			traceUsageCuration: (message) => this._logTraceCuration(message),
+			saveSessionColumnSettings: (message) => this.dispatch('saveSessionColumnSettings', () =>
+				this.context.globalState.update('usage.sessionColumnSettings', message.settings)
+			),
+		};
+	}
+
+	private async handleAnalysisMessage(message: any): Promise<void> {
+		const handler = this._getAnalysisMessageHandlers()[message.command];
+		if (handler) { await handler(message); }
 	}
 
 	private async handleInsightAction(message: any): Promise<void> {
@@ -8950,12 +8935,42 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     return result;
   }
 
-  private async diagHandleDeleteWorktree(message: any): Promise<void> {
+  /**
+   * Removes a worktree, escalating through a fallback chain: plain removal, then (with user
+   * confirmation) a force removal if uncommitted/untracked changes block it, then an OS-level
+   * directory-removal fallback for git-for-windows junction/long-path failures. Returns the
+   * final result, or `undefined` if the user declined the force-delete confirmation.
+   */
+  private async _removeWorktreeWithFallback(mainRepoRoot: string, worktreePath: string): Promise<{ ok: boolean; stderr: string } | undefined> {
+    let result = await this.removeGitWorktree(mainRepoRoot, worktreePath, false);
+    if (!result.ok && /modified or untracked/i.test(result.stderr)) {
+      const forceChoice = await vscode.window.showWarningMessage(
+        `"${worktreePath}" has uncommitted or untracked changes.`,
+        { modal: true, detail: "Force-deleting will permanently discard those changes — this cannot be undone. Committed history elsewhere in the repository is not affected." },
+        "Force Delete",
+      );
+      if (forceChoice !== "Force Delete") { return undefined; }
+      result = await this.removeGitWorktree(mainRepoRoot, worktreePath, true);
+    }
+
+    if (!result.ok && this.isWorktreeDirectoryRemovalFailure(result.stderr)) {
+      result = await this.removeWorktreeDirectoryFallback(mainRepoRoot, worktreePath);
+    }
+    return result;
+  }
+
+  /** Parse and normalize the delete-worktree webview message's fields, defaulting missing ones. */
+  private _parseDeleteWorktreeMessage(message: any): { worktreePath: string; branch: string; repoLabel: string; pushed: "yes" | "no" | "?" } {
     const worktreePath = typeof message?.path === "string" ? message.path.trim() : "";
-    if (!worktreePath) { return; }
     const branch = typeof message?.branch === "string" && message.branch ? message.branch : "?";
     const repoLabel = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : path.basename(path.dirname(worktreePath));
     const pushed = message?.pushed === "yes" || message?.pushed === "no" ? message.pushed : "?";
+    return { worktreePath, branch, repoLabel, pushed };
+  }
+
+  private async diagHandleDeleteWorktree(message: any): Promise<void> {
+    const { worktreePath, branch, repoLabel, pushed } = this._parseDeleteWorktreeMessage(message);
+    if (!worktreePath) { return; }
 
     if (!(await this.confirmDeleteWorktree(worktreePath, branch, repoLabel, pushed))) { return; }
 
@@ -8965,20 +8980,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       return;
     }
 
-    let result = await this.removeGitWorktree(mainRepoRoot, worktreePath, false);
-    if (!result.ok && /modified or untracked/i.test(result.stderr)) {
-      const forceChoice = await vscode.window.showWarningMessage(
-        `"${worktreePath}" has uncommitted or untracked changes.`,
-        { modal: true, detail: "Force-deleting will permanently discard those changes — this cannot be undone. Committed history elsewhere in the repository is not affected." },
-        "Force Delete",
-      );
-      if (forceChoice !== "Force Delete") { return; }
-      result = await this.removeGitWorktree(mainRepoRoot, worktreePath, true);
-    }
-
-    if (!result.ok && this.isWorktreeDirectoryRemovalFailure(result.stderr)) {
-      result = await this.removeWorktreeDirectoryFallback(mainRepoRoot, worktreePath);
-    }
+    const result = await this._removeWorktreeWithFallback(mainRepoRoot, worktreePath);
+    if (!result) { return; }
 
     if (!result.ok) {
       vscode.window.showErrorMessage(`Could not delete worktree: ${result.stderr || "unknown error"}`);
@@ -9906,16 +9909,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
 		</html>`;
   }
 
-  private getUsageAnalysisHtml(
-    webview: vscode.Webview,
-    stats: UsageAnalysisStats | null,
-  ): string {
-    const nonce = getNonce();
-    const scriptUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "usage.js"),
-    );
-
-    // Detect user's locale for number formatting
+  /** Detect the user's locale for number formatting, logging each candidate source. */
+  private _detectUsageAnalysisLocale(stats: UsageAnalysisStats | null): string {
     const localeFromEnv =
       process.env.LC_ALL || process.env.LC_NUMERIC || process.env.LANG;
     const vscodeLanguage = vscode.env.language; // e.g., 'en', 'nl', 'de'
@@ -9927,19 +9922,23 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     );
     this.log(`[Locale Detection] Intl default: ${intlLocale}`);
 
-    const detectedLocale = (stats?.locale) || localeFromEnv || intlLocale;
+    const detectedLocale = stats?.locale || localeFromEnv || intlLocale;
     this.log(`[Usage Analysis] Extension detected locale: ${detectedLocale}`);
     this.log(
       `[Usage Analysis] Test format 1234567.89: ${new Intl.NumberFormat(detectedLocale).format(1234567.89)}`,
     );
+    return detectedLocale;
+  }
 
+  /** Build the JSON-serialized initial payload injected into the usage analysis webview. */
+  private _buildUsageAnalysisInitialData(stats: UsageAnalysisStats | null, detectedLocale: string): string {
+    if (!stats) { return 'null'; }
     const suppressedUnknownTools = vscode.workspace
       .getConfiguration('aiEngineeringFluency')
       .get<string[]>('suppressedUnknownTools', []);
-
     const sessionColumnSettings = this.context.globalState.get('usage.sessionColumnSettings', {});
 
-    const initialData = stats ? JSON.stringify({
+    return JSON.stringify({
       today: stats.today,
       last30Days: stats.last30Days,
       month: stats.month,
@@ -9958,7 +9957,20 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       sessionColumnSettings,
       copilotApiBalance: this._buildCopilotApiBalance(),
       monthBillingGroupCosts: this.lastDetailedStats?.month.billingGroupCosts ?? null,
-    }).replace(/</g, "\\u003c") : 'null';
+    }).replace(/</g, "\\u003c");
+  }
+
+  private getUsageAnalysisHtml(
+    webview: vscode.Webview,
+    stats: UsageAnalysisStats | null,
+  ): string {
+    const nonce = getNonce();
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "usage.js"),
+    );
+
+    const detectedLocale = this._detectUsageAnalysisLocale(stats);
+    const initialData = this._buildUsageAnalysisInitialData(stats, detectedLocale);
 
     return `<!DOCTYPE html>
 		<html lang="en">


### PR DESCRIPTION
## Summary
- `npm run lint` (the eslint check CI actually runs, via `vscode-extension`'s script covering `src` and `../src`) flagged 5 pre-existing complexity warnings. This PR extracts helper functions to bring each under the threshold, with no behavior changes:
  - `getModelUsageFromSession` (src/usageAnalysis.ts) — split content-resolution logic into `_gmusResolveFromContent` / `_gmusResolveJsonl`
  - `handleAnalysisMessage` — replaced the switch statement with a command→handler lookup map
  - `diagHandleDeleteWorktree` — extracted message parsing (`_parseDeleteWorktreeMessage`) and the removal fallback chain (`_removeWorktreeWithFallback`)
  - `getUsageAnalysisHtml` — split out locale detection (`_detectUsageAnalysisLocale`) and initial-data JSON building (`_buildUsageAnalysisInitialData`)
- Also confirmed `npm run lint:json` is clean. `cli/`'s `lint` script isn't wired into CI (and eslint isn't even installed there), and `lint:css` has ~100 pre-existing, CI-unrelated stylelint errors — both left untouched as out of scope.

## Test plan
- [x] `npm run lint` in `vscode-extension` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` in `vscode-extension` — clean
- [x] `npm run test:node` in `vscode-extension` — all suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)