### PR TITLE
Fix: Input tokens can exceed Total tokens in the details webview

### DIFF
--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -63,6 +63,54 @@ target[model].cacheCreationTokens = (target[model].cacheCreationTokens ?? 0) + u
 }
 
 /**
+ * Rescales a per-model usage breakdown so its input/output totals match an
+ * authoritative target (e.g. a debug log or OTel export), while preserving each
+ * model's relative share of the original breakdown.
+ *
+ * Needed because "Total tokens" and the per-model `modelUsage` map used for the
+ * "Input tokens" / "Output tokens" rows and cost estimates are sometimes derived
+ * from different sources that don't always agree — e.g. a debug log's per-request
+ * `model` attribute can be missing on some requests, so the per-model breakdown
+ * undercounts relative to the debug log's own total. Left unreconciled, Input +
+ * Output can end up higher or lower than Total in the UI, and cost estimates
+ * (computed from `modelUsage`) inherit the same drift.
+ *
+ * Any target total not covered by the known models — because `modelUsage` has no
+ * usable per-model split at all, or due to rounding — is attributed to a
+ * synthetic `unknown` bucket (consistent with how `calculateEstimatedCost`
+ * already treats unpriced/unrecognized models: it appears in totals but
+ * contributes $0 to cost) so Input + Output always equals the target total.
+ */
+export function reconcileModelUsageToTotal(modelUsage: ModelUsage, targetInputTokens: number, targetOutputTokens: number): ModelUsage {
+	if (targetInputTokens + targetOutputTokens <= 0) { return modelUsage; }
+	const currentInput = Object.values(modelUsage).reduce((s, u) => s + u.inputTokens, 0);
+	const currentOutput = Object.values(modelUsage).reduce((s, u) => s + u.outputTokens, 0);
+	const inputScale = currentInput > 0 ? targetInputTokens / currentInput : 0;
+	const outputScale = currentOutput > 0 ? targetOutputTokens / currentOutput : 0;
+	const result: ModelUsage = {};
+	let scaledInputTotal = 0;
+	let scaledOutputTotal = 0;
+	for (const [model, usage] of Object.entries(modelUsage)) {
+		const inputTokens = Math.round(usage.inputTokens * inputScale);
+		const outputTokens = Math.round(usage.outputTokens * outputScale);
+		scaledInputTotal += inputTokens;
+		scaledOutputTotal += outputTokens;
+		result[model] = {
+			inputTokens, outputTokens,
+			...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * inputScale) } : {}),
+			...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(usage.cacheCreationTokens * inputScale) } : {}),
+		};
+	}
+	const residualInput = targetInputTokens - scaledInputTotal;
+	const residualOutput = targetOutputTokens - scaledOutputTotal;
+	if (residualInput !== 0 || residualOutput !== 0) {
+		const unknown = result.unknown ?? { inputTokens: 0, outputTokens: 0 };
+		result.unknown = { ...unknown, inputTokens: unknown.inputTokens + residualInput, outputTokens: unknown.outputTokens + residualOutput };
+	}
+	return result;
+}
+
+/**
  * Merges `source` language usage into `target` (in-place).
  */
 export function addLanguageUsage(target: LanguageUsage, source: LanguageUsage): void {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -180,7 +180,7 @@ import {
 import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceForBillingGroup } from '../../src/chartDataBuilder';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, type SessionAggregateInput } from '../../src/statsHelpers';
+import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, type SessionAggregateInput } from '../../src/statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -4665,14 +4665,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this._cacheHits++;
 			return null;
 		}
-		let supplementModelUsage = cached.modelUsage;
-		let supplementDailyRollups = cached.dailyRollups;
-		if (Object.keys(debugLogTokens.modelBreakdown).length > 0) {
-			supplementModelUsage = _scdlBuildFromBreakdown(debugLogTokens.modelBreakdown);
-			if (cached.dailyRollups) {
-				supplementDailyRollups = _scdlDistributeToDays(cached.dailyRollups, supplementModelUsage) ?? cached.dailyRollups;
-			}
-		}
+		const breakdownUsage = Object.keys(debugLogTokens.modelBreakdown).length > 0
+			? _scdlBuildFromBreakdown(debugLogTokens.modelBreakdown)
+			: cached.modelUsage;
+		// Reconcile to the debug log's totals even when the breakdown is missing or
+		// partial (e.g. some requests lack a `model` attribute), so Input+Output
+		// never drifts from Total — see reconcileModelUsageToTotal for why.
+		const supplementModelUsage = reconcileModelUsageToTotal(breakdownUsage, debugLogTokens.inputTokens, debugLogTokens.outputTokens);
+		const supplementDailyRollups = cached.dailyRollups
+			? (_scdlDistributeToDays(cached.dailyRollups, supplementModelUsage) ?? cached.dailyRollups)
+			: cached.dailyRollups;
 		const supplemented: SessionFileCache = {
 			...cached, modelUsage: supplementModelUsage, dailyRollups: supplementDailyRollups,
 			actualTokens: debugLogTokens.inputTokens + debugLogTokens.outputTokens,
@@ -4822,11 +4824,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private applyDebugLogModelBreakdown(modelUsage: ModelUsage, debugLogTokens: { inputTokens: number; outputTokens: number; modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }> } | null | undefined, dailyRollups: { [utcDayKey: string]: DailyRollupEntry }, totalInteractions: number): ModelUsage {
-		if (!debugLogTokens || Object.keys(debugLogTokens.modelBreakdown).length === 0) { return modelUsage; }
-		const resolvedModelUsage: ModelUsage = {};
+		if (!debugLogTokens || debugLogTokens.inputTokens + debugLogTokens.outputTokens === 0) { return modelUsage; }
+		const breakdownUsage: ModelUsage = {};
 		for (const [model, bd] of Object.entries(debugLogTokens.modelBreakdown)) {
-			resolvedModelUsage[model] = { inputTokens: bd.inputTokens, outputTokens: bd.outputTokens, ...(bd.cachedTokens > 0 ? { cachedReadTokens: bd.cachedTokens } : {}) };
+			breakdownUsage[model] = { inputTokens: bd.inputTokens, outputTokens: bd.outputTokens, ...(bd.cachedTokens > 0 ? { cachedReadTokens: bd.cachedTokens } : {}) };
 		}
+		// Reconcile against the debug log's own totals even when the breakdown is
+		// missing or partial (e.g. some requests lack a `model` attribute), so
+		// Input+Output never drifts from Total — see reconcileModelUsageToTotal.
+		const resolvedModelUsage = reconcileModelUsageToTotal(
+			Object.keys(breakdownUsage).length > 0 ? breakdownUsage : modelUsage,
+			debugLogTokens.inputTokens,
+			debugLogTokens.outputTokens,
+		);
 		for (const [dayKey, dayRollup] of Object.entries(dailyRollups)) {
 			const fraction = totalInteractions > 0 ? dayRollup.interactions / totalInteractions : 1;
 			dailyRollups[dayKey].modelUsage = this.scaledModelUsage(resolvedModelUsage, fraction);

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -8,6 +8,7 @@ computeUtcDateRanges,
 aggregatePeriodStats,
 computeSessionTotalTokens,
 computeSessionDurationMs,
+reconcileModelUsageToTotal,
 type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../../src/statsHelpers';
@@ -164,6 +165,68 @@ test('addModelUsage: source with empty object is a no-op', () => {
 const target: ModelUsage = { 'gpt-4': { inputTokens: 100, outputTokens: 50 } };
 addModelUsage(target, {});
 assert.deepEqual(target, { 'gpt-4': { inputTokens: 100, outputTokens: 50 } });
+});
+
+// ── reconcileModelUsageToTotal ──────────────────────────────────────────────
+
+test('reconcileModelUsageToTotal: returns modelUsage unchanged when target totals are zero', () => {
+const modelUsage: ModelUsage = { 'gpt-4': { inputTokens: 100, outputTokens: 50 } };
+const result = reconcileModelUsageToTotal(modelUsage, 0, 0);
+assert.deepEqual(result, modelUsage);
+});
+
+test('reconcileModelUsageToTotal: no-op when the breakdown already matches the target (regression for the Input > Total bug)', () => {
+// The bug this guards: Input/Output tokens (from modelUsage) must never exceed
+// Total tokens (the debug-log/actualTokens total) in the details webview table.
+const modelUsage: ModelUsage = { 'gpt-4': { inputTokens: 100, outputTokens: 50 } };
+const result = reconcileModelUsageToTotal(modelUsage, 100, 50);
+assert.deepEqual(result, { 'gpt-4': { inputTokens: 100, outputTokens: 50 } });
+});
+
+test('reconcileModelUsageToTotal: scales a single model proportionally down to the target total', () => {
+// Stale pre-debug-log estimate overcounted input tokens (111 vs the debug log's
+// authoritative 90) — this is the exact shape of the reported "Input > Total" bug.
+const modelUsage: ModelUsage = { 'gpt-4': { inputTokens: 111, outputTokens: 40 } };
+const result = reconcileModelUsageToTotal(modelUsage, 90, 30);
+assert.deepEqual(result, { 'gpt-4': { inputTokens: 90, outputTokens: 30 } });
+});
+
+test('reconcileModelUsageToTotal: preserves relative shares across multiple models', () => {
+const modelUsage: ModelUsage = {
+'gpt-4': { inputTokens: 300, outputTokens: 100 },
+'claude-3-5-sonnet': { inputTokens: 100, outputTokens: 100 },
+};
+// Target is double the current total (400 input / 200 output).
+const result = reconcileModelUsageToTotal(modelUsage, 800, 400);
+assert.deepEqual(result['gpt-4'], { inputTokens: 600, outputTokens: 200 });
+assert.deepEqual(result['claude-3-5-sonnet'], { inputTokens: 200, outputTokens: 200 });
+});
+
+test('reconcileModelUsageToTotal: scales cachedReadTokens and cacheCreationTokens using the input scale factor', () => {
+const modelUsage: ModelUsage = {
+'claude-3-5-sonnet': { inputTokens: 200, outputTokens: 50, cachedReadTokens: 80, cacheCreationTokens: 20 },
+};
+const result = reconcileModelUsageToTotal(modelUsage, 100, 50);
+assert.deepEqual(result['claude-3-5-sonnet'], {
+inputTokens: 100, outputTokens: 50, cachedReadTokens: 40, cacheCreationTokens: 10,
+});
+});
+
+test('reconcileModelUsageToTotal: attributes the whole target to an "unknown" bucket when modelUsage has no usable breakdown', () => {
+const result = reconcileModelUsageToTotal({}, 100, 50);
+assert.deepEqual(result, { unknown: { inputTokens: 100, outputTokens: 50 } });
+});
+
+test('reconcileModelUsageToTotal: sum of reconciled models always equals the target totals (no silent drift)', () => {
+const modelUsage: ModelUsage = {
+'gpt-4': { inputTokens: 37, outputTokens: 11 },
+'claude-3-5-sonnet': { inputTokens: 53, outputTokens: 29 },
+};
+const result = reconcileModelUsageToTotal(modelUsage, 1000, 333);
+const totalInput = Object.values(result).reduce((s, u) => s + u.inputTokens, 0);
+const totalOutput = Object.values(result).reduce((s, u) => s + u.outputTokens, 0);
+assert.strictEqual(totalInput, 1000);
+assert.strictEqual(totalOutput, 333);
 });
 
 // ── addEditorUsage ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

On the details page, "Input tokens" could show a higher value than "Total tokens" for the same period, which shouldn't be possible since Total = Input + Output + Thinking.

Root cause: "Total tokens" and "Input/Output tokens" were populated from two independently-computed sources that were never reconciled:
- **Total tokens** uses the Copilot Chat debug log's own `inputTokens + outputTokens`, summed across *every* `llm_request` event.
- **Input/Output tokens** sum a per-model `modelUsage` breakdown, which is only populated for events that have a non-empty `attrs.model` field. Events missing that field still count toward the debug log's totals but silently dropped out of the per-model breakdown — so the two numbers could diverge in either direction.

The same stale/unreconciled `modelUsage` also feeds `calculateEstimatedCost()`, so the "Estimated cost (UBB)" figures could drift by the same margin.

## Changes

- `src/statsHelpers.ts`: added `reconcileModelUsageToTotal()` — a pure helper that rescales a per-model usage breakdown to match an authoritative target total, preserving each model's relative share. Any amount that can't be attributed to a known model (empty/partial breakdown, or rounding) is swept into a synthetic `unknown` bucket so Input+Output always equals the target exactly (consistent with how `calculateEstimatedCost` already treats unpriced models — visible in totals, $0 cost).
- `vscode-extension/src/extension.ts`: `applyDebugLogModelBreakdown()` and `supplementCacheWithDebugLog()` now always reconcile `modelUsage` against the debug log's totals, even when the per-model breakdown is missing or partial. Previously they silently kept the stale pre-debug-log estimate in that case.
- `vscode-extension/test/unit/statsHelpers.test.ts`: 7 new unit tests for `reconcileModelUsageToTotal`, including a direct regression test for the "Input > Total" shape reported.

## Notes for reviewers

- This fixes the computation going forward (new syncs / cache rebuilds). Existing cached session entries won't retroactively update until they're naturally rebuilt.
- Full unit test suite (`npm run test:node`) and `eslint` pass locally.

## Test plan

- [x] `npm run test:node` — all suites pass, including the 7 new `reconcileModelUsageToTotal` tests
- [x] `tsc --noEmit` — no type errors
- [x] `eslint` on changed files — no issues
- [ ] Manual verification in the details webview once cache rebuilds with the fix (Total should always equal Input+Output+Thinking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)