### PR TITLE
fix(copilot-cli): use authoritative session-store.db billing data for exact usage

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -13,7 +13,7 @@ import { isMcpTool, extractMcpServerName } from '../../src/workspaceHelpers';
 import { resolveFileUri } from '../../src/workspacePathResolver';
 import { parseSessionFileContent } from '../../src/sessionParser';
 import { estimateTokensFromText, getModelFromRequest, isJsonlContent, estimateTokensFromJsonlSession, calculateEstimatedCost, extractAllTokensFromDebugLog } from '../../src/tokenEstimation';
-import { extractCopilotCliSessionId, getCopilotCliOtelUsage } from '../../src/copilotCliOtel';
+import { extractCopilotCliSessionId, getCopilotCliExactUsage } from '../../src/copilotCliOtel';
 import { extractDailyFractions } from '../../src/dailyAttribution';
 import { toLocalDayKey } from '../../src/utils/dayKeys';
 import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
@@ -320,8 +320,8 @@ export async function processSessionFile(filePath: string, verbose = false): Pro
 		let fileModelUsage: ModelUsage = {};
 
 		if (isJsonl) {
-			const otelUsage = extractCopilotCliSessionId(filePath) ? await getCopilotCliOtelUsage(filePath) : null;
-			const result = estimateTokensFromJsonlSession(content, otelUsage);
+			const exactUsage = extractCopilotCliSessionId(filePath) ? await getCopilotCliExactUsage(filePath) : null;
+			const result = estimateTokensFromJsonlSession(content, exactUsage);
 			// Prefer actualTokens (from session.shutdown modelMetrics) over estimated tokens,
 			// matching VS Code's logic: actualTokens > 0 ? actualTokens : estimatedTokens
 			tokens = result.actualTokens > 0 ? result.actualTokens : result.tokens;

--- a/src/adapters/copilotCliAdapter.ts
+++ b/src/adapters/copilotCliAdapter.ts
@@ -25,7 +25,7 @@ import type {
 	UsageAnalysisAdapterContext,
 } from '../ecosystemAdapter';
 import { CopilotCliStoreAccess, isMicrosoftScoutCwd } from '../copilotCliStore';
-import { getCopilotCliOtelUsage } from '../copilotCliOtel';
+import { getCopilotCliExactUsage } from '../copilotCliOtel';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
 import { normalizePath } from '../utils/pathUtils';
@@ -101,12 +101,17 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		return fs.promises.stat(sessionFile);
 	}
 
-	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
-		// session-store.db does not store token counts (see getModelUsage() below for the
-		// full schema rationale — chat-only sessions have no token/model data to surface).
-		// OpenTelemetry file export (when enabled) gives exact numbers for the same session UUID.
-		const otel = await getCopilotCliOtelUsage(sessionFile);
-		if (otel) { return { tokens: otel.actualTokens, thinkingTokens: 0, actualTokens: otel.actualTokens }; }
+	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens?: number }> {
+		// Prefer exact billing rows from session-store.db; fall back to OTel file export.
+		const exact = await getCopilotCliExactUsage(sessionFile);
+		if (exact) {
+			return {
+				tokens: exact.actualTokens,
+				thinkingTokens: 0,
+				actualTokens: exact.actualTokens,
+				cacheReadTokens: exact.cacheReadTokens,
+			};
+		}
 		return { tokens: 0, thinkingTokens: 0, actualTokens: 0 };
 	}
 
@@ -117,14 +122,14 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		return 0;
 	}
 
-	// session-store.db has no model or token columns at all (sessions: id, cwd, repository,
-	// branch, summary, created_at, updated_at; turns: session_id, turn_index, user_message,
-	// assistant_response, timestamp — verified directly against the SQLite schema). Chat-only
-	// sessions therefore have no data to attribute per model from the DB alone; OpenTelemetry
-	// file export (when enabled) fills that gap with exact numbers for the same session UUID.
+	// session-store.db now contains an `assistant_usage_events` table with exact per-LLM-call
+	// billing data (model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+	// total_nano_aiu), keyed by the same session UUID used in events.jsonl paths and DB-only
+	// virtual paths. This is the authoritative source for both worktree and chat-only sessions;
+	// OpenTelemetry file export (when enabled) is used only as a fallback.
 	async getModelUsage(sessionFile: string): Promise<ModelUsage> {
-		const otel = await getCopilotCliOtelUsage(sessionFile);
-		return otel?.modelUsage ?? {};
+		const exact = await getCopilotCliExactUsage(sessionFile);
+		return exact?.modelUsage ?? {};
 	}
 
 	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {

--- a/src/copilotCliOtel.ts
+++ b/src/copilotCliOtel.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { Worker } from 'worker_threads';
 import type { ModelUsage } from './types';
+import { CopilotCliStoreAccess } from './copilotCliStore';
 
 /** Per-session usage aggregated from OTel `chat <model>` spans. */
 export interface CopilotCliOtelSessionUsage {
@@ -423,6 +424,47 @@ export async function getCopilotCliOtelUsage(sessionFile: string): Promise<Copil
 	if (!sessionId) { return null; }
 	const index = await loadCopilotCliOtelIndex();
 	return index.get(sessionId) ?? null;
+}
+
+// Shared store access for exact billing lookups. The instance caches the SQLite DB
+// by mtime/size, so repeated lookups across many sessions reuse the same in-memory DB.
+const cliStoreAccess = new CopilotCliStoreAccess();
+
+/**
+ * Looks up exact usage from `session-store.db`'s `assistant_usage_events` billing
+ * table for a Copilot CLI session file. Returns null when the DB/table is missing,
+ * the session has no rows, or the path is not a Copilot CLI session.
+ *
+ * This table is the authoritative source used by Copilot CLI's own usage display:
+ * it contains one row per LLM API call with exact input/output/cache tokens and
+ * nano-AIU cost. It is available for both worktree-backed sessions (events.jsonl)
+ * and DB-only chat sessions, and unlike `session.shutdown` events it is written
+ * even for sessions that do not shut down cleanly.
+ */
+export async function getCopilotCliStoreUsage(
+	sessionFile: string,
+	storeAccess: CopilotCliStoreAccess = cliStoreAccess,
+): Promise<CopilotCliOtelSessionUsage | null> {
+	const sessionId = extractCopilotCliSessionId(sessionFile);
+	if (!sessionId) { return null; }
+	const usage = await storeAccess.getSessionUsage(sessionId);
+	if (!usage) { return null; }
+	return usage;
+}
+
+/**
+ * Returns the most authoritative exact usage data available for a Copilot CLI session.
+ * Prefers the always-available `assistant_usage_events` table in session-store.db;
+ * falls back to the opt-in OpenTelemetry file export when the DB has no billing rows.
+ * Returns null for non-CLI paths or when no exact data is available.
+ */
+export async function getCopilotCliExactUsage(
+	sessionFile: string,
+	storeAccess: CopilotCliStoreAccess = cliStoreAccess,
+): Promise<CopilotCliOtelSessionUsage | null> {
+	const storeUsage = await getCopilotCliStoreUsage(sessionFile, storeAccess);
+	if (storeUsage) { return storeUsage; }
+	return getCopilotCliOtelUsage(sessionFile);
 }
 
 /** Whether the OTel export directory exists, how many export files it holds, and how many distinct sessions they cover. */

--- a/src/copilotCliStore.ts
+++ b/src/copilotCliStore.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import initSqlJs from 'sql.js';
+import type { ModelUsage } from './types';
 import { toLocalDayKey } from './utils/dayKeys';
 
 // Access SqlJsStatic and Database via the globally declared initSqlJs namespace
@@ -82,6 +83,7 @@ type CliStoreTurnCountsCacheEntry = { mtimeMs: number; size: number; byId: Map<s
 export class CopilotCliStoreAccess {
 	private _sqlJsModule: SqlJsStatic | null = null;
 	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
+	private _initSqlJsFn: typeof initSqlJs;
 	private _dbCache: Map<string, CliStoreDbCacheEntry> = new Map();
 	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
 	// Bulk-loaded caches keyed by dbPath, invalidated on the same mtime/size basis
@@ -91,6 +93,10 @@ export class CopilotCliStoreAccess {
 	private _sessionsCacheInflight: Map<string, Promise<Map<string, CliStoreSession>>> = new Map();
 	private _turnCountsCache: Map<string, CliStoreTurnCountsCacheEntry> = new Map();
 	private _turnCountsCacheInflight: Map<string, Promise<Map<string, number>>> = new Map();
+
+	constructor(initSqlJsFn?: typeof initSqlJs) {
+		this._initSqlJsFn = initSqlJsFn ?? initSqlJs;
+	}
 
 	dispose(): void {
 		for (const entry of this._dbCache.values()) {
@@ -348,7 +354,7 @@ export class CopilotCliStoreAccess {
 				try {
 					wasmBinary = await fs.promises.readFile(wasmPath);
 				} catch { /* WASM file not present — proceed without pre-loaded binary */ }
-				const module = await initSqlJs(wasmBinary ? { wasmBinary: wasmBinary.buffer as ArrayBuffer } : undefined);
+				const module = await this._initSqlJsFn(wasmBinary ? { wasmBinary: wasmBinary.buffer as ArrayBuffer } : undefined);
 				this._sqlJsModule = module;
 				return module;
 			})().catch(err => {
@@ -442,6 +448,57 @@ export class CopilotCliStoreAccess {
 		if (!sessionId) { return 0; }
 		const byId = await this.getTurnCountsMap(dbPath);
 		return byId.get(sessionId) ?? 0;
+	}
+
+	/**
+	 * Returns exact per-model token/cost usage from the `assistant_usage_events`
+	 * billing table for a session UUID. Returns null when the table is missing,
+	 * the session has no rows, or the DB cannot be read.
+	 *
+	 * `input_tokens` already includes cache-write creation tokens, matching the
+	 * `inputTokens` meaning used elsewhere. `cache_read_tokens` is tracked
+	 * separately and exposed as `cachedReadTokens`; `cache_write_tokens` is
+	 * exposed as `cacheCreationTokens`. `total_nano_aiu` is summed to
+	 * `nanoAiu` so callers can compute exact dollar cost.
+	 */
+	async getSessionUsage(sessionId: string): Promise<{ modelUsage: ModelUsage; actualTokens: number; cacheReadTokens: number; nanoAiu: number } | null> {
+		const dbPath = this.getDbPath();
+		const db = await this.getDb(dbPath);
+		if (!db) { return null; }
+		try {
+			const result = db.exec(
+				'SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_nano_aiu FROM assistant_usage_events WHERE session_id = ?',
+				[sessionId],
+			);
+			if (!result.length) { return null; }
+			const cols = result[0].columns;
+			const modelUsage: ModelUsage = {};
+			let actualTokens = 0;
+			let cacheReadTokens = 0;
+			let nanoAiu = 0;
+			for (const row of result[0].values) {
+				const obj: Record<string, unknown> = {};
+				cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+				const model = typeof obj.model === 'string' ? obj.model : 'unknown';
+				const input = typeof obj.input_tokens === 'number' ? obj.input_tokens : 0;
+				const output = typeof obj.output_tokens === 'number' ? obj.output_tokens : 0;
+				const cacheRead = typeof obj.cache_read_tokens === 'number' ? obj.cache_read_tokens : 0;
+				const cacheWrite = typeof obj.cache_write_tokens === 'number' ? obj.cache_write_tokens : 0;
+				const nano = typeof obj.total_nano_aiu === 'number' ? obj.total_nano_aiu : 0;
+				if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0 }; }
+				modelUsage[model].inputTokens += input;
+				modelUsage[model].outputTokens += output;
+				if (cacheRead > 0) { modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + cacheRead; }
+				if (cacheWrite > 0) { modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + cacheWrite; }
+				actualTokens += input + output;
+				cacheReadTokens += cacheRead;
+				nanoAiu += nano;
+			}
+			if (actualTokens === 0 && cacheReadTokens === 0 && nanoAiu === 0) { return null; }
+			return { modelUsage, actualTokens, cacheReadTokens, nanoAiu };
+		} catch {
+			return null;
+		}
 	}
 
 	/**

--- a/src/tokenEstimation.ts
+++ b/src/tokenEstimation.ts
@@ -696,21 +696,22 @@ export function selectTokenEstimationStrategy(lines: string[]): TokenEstimationS
  * Estimate tokens from a JSONL session file (used by Copilot CLI/Agent mode and VS Code incremental format)
  * Each line is a separate JSON object representing an event in the session.
  *
- * `otelUsage`, when supplied by the caller (resolved via getCopilotCliOtelUsage against
+ * `exactUsage`, when supplied by the caller (resolved via getCopilotCliExactUsage against
  * the session's file path), overrides actualTokens/cacheReadTokens/copilotNanoAiu with
- * exact counts from the Copilot CLI OpenTelemetry file export instead of the ratio-based
- * estimate below — the same "exact data wins" precedent as a session.shutdown event.
+ * exact counts from the Copilot CLI `assistant_usage_events` billing table or the
+ * OpenTelemetry file export instead of the ratio-based estimate below — the same
+ * "exact data wins" precedent as a session.shutdown event.
  */
-export function estimateTokensFromJsonlSession(fileContent: string, otelUsage?: CopilotCliOtelSessionUsage | null): TokenEstimationResult {
+export function estimateTokensFromJsonlSession(fileContent: string, exactUsage?: CopilotCliOtelSessionUsage | null): TokenEstimationResult {
 	const lines = fileContent.trim().split('\n');
 	const strategy = selectTokenEstimationStrategy(lines);
 	const result = strategy.estimate(lines);
-	if (otelUsage) {
+	if (exactUsage) {
 		return {
 			...result,
-			actualTokens: otelUsage.actualTokens,
-			cacheReadTokens: otelUsage.cacheReadTokens,
-			copilotNanoAiu: otelUsage.nanoAiu || result.copilotNanoAiu,
+			actualTokens: exactUsage.actualTokens,
+			cacheReadTokens: exactUsage.cacheReadTokens,
+			copilotNanoAiu: exactUsage.nanoAiu || result.copilotNanoAiu,
 		};
 	}
 	return result;

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -35,7 +35,7 @@ import {
 	buildReasoningEffortTimeline,
 	extractResponseItemText,
 } from './tokenEstimation';
-import { extractCopilotCliSessionId, getCopilotCliOtelUsage } from './copilotCliOtel';
+import { extractCopilotCliSessionId, getCopilotCliExactUsage } from './copilotCliOtel';
 import { getModelBillingProvider } from './chartDataBuilder';
 import {
 	getModeType,
@@ -2508,13 +2508,14 @@ function _gmusProcessJsonRequests(sessionContent: ParsedSessionJson, modelUsage:
 	}
 }
 
-/** Resolve model usage for a JSONL-format session, preferring exact OTel usage when available. */
+/** Resolve model usage for a JSONL-format session, preferring exact billing usage when available. */
 async function _gmusResolveJsonl(sessionFile: string, fileContent: string, modelUsage: ModelUsage, deps: GmusDeps): Promise<ModelUsage> {
-	// Copilot CLI events.jsonl: prefer exact per-model usage from the OpenTelemetry
-	// file export (when enabled) over the ratio-based estimate below.
+	// Copilot CLI events.jsonl: prefer exact per-model usage from the
+	// session-store.db assistant_usage_events billing table, falling back to the
+	// opt-in OpenTelemetry file export and finally the ratio-based estimate below.
 	if (extractCopilotCliSessionId(sessionFile)) {
-		const otel = await getCopilotCliOtelUsage(sessionFile);
-		if (otel && Object.keys(otel.modelUsage).length > 0) { return otel.modelUsage; }
+		const exact = await getCopilotCliExactUsage(sessionFile);
+		if (exact && Object.keys(exact.modelUsage).length > 0) { return exact.modelUsage; }
 	}
 	const lines = fileContent.trim().split('\n');
 	const result = _gmusProcessJsonlContent(lines, modelUsage, deps);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -99,7 +99,7 @@ import { PiDataAccess } from '../../src/pi';
 import { getVSCodeUserPaths } from '../../src/adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from '../../src/jetbrains';
-import { extractCopilotCliSessionId, getCopilotCliOtelUsage, getCopilotCliOtelStatus, loadCopilotCliOtelIndex } from '../../src/copilotCliOtel';
+import { extractCopilotCliSessionId, getCopilotCliExactUsage, getCopilotCliOtelStatus, getCopilotCliOtelUsage, loadCopilotCliOtelIndex } from '../../src/copilotCliOtel';
 import { createWakeupGate } from './utils/promises';
 
 // --- Session parsing & token estimation ---
@@ -5790,8 +5790,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFilePath, 'utf8');
 			if (this.isUuidPointerFile(fileContent)) { return { tokens: 0, thinkingTokens: 0, actualTokens: 0 }; }
 			if (sessionFilePath.endsWith('.jsonl') || this.isJsonlContent(fileContent)) {
-				const otelUsage = extractCopilotCliSessionId(sessionFilePath) ? await getCopilotCliOtelUsage(sessionFilePath) : null;
-				return this.estimateTokensFromJsonlSession(fileContent, otelUsage);
+				const exactUsage = extractCopilotCliSessionId(sessionFilePath) ? await getCopilotCliExactUsage(sessionFilePath) : null;
+				return this.estimateTokensFromJsonlSession(fileContent, exactUsage);
 			}
 			const sessionContent = preloadedParsedJson !== undefined ? preloadedParsedJson : JSON.parse(fileContent);
 			return this.estimateTokensFromJsonSession(sessionContent);
@@ -5866,8 +5866,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return 0;
 	}
 
-	private estimateTokensFromJsonlSession(fileContent: string, otelUsage?: Awaited<ReturnType<typeof getCopilotCliOtelUsage>>): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number; copilotNanoAiu: number; truncationCount?: number; messagesRemovedByTruncation?: number; maxRequestInputTokens?: number; contextTier?: string } {
-		return _estimateTokensFromJsonlSession(fileContent, otelUsage);
+	private estimateTokensFromJsonlSession(fileContent: string, exactUsage?: Awaited<ReturnType<typeof getCopilotCliExactUsage>>): { tokens: number; thinkingTokens: number; actualTokens: number; cacheReadTokens: number; copilotNanoAiu: number; truncationCount?: number; messagesRemovedByTruncation?: number; maxRequestInputTokens?: number; contextTier?: string } {
+		return _estimateTokensFromJsonlSession(fileContent, exactUsage);
 	}
 
 	/**

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -761,7 +761,7 @@ function buildActualTokensCard(data: SessionLogData, stats: SummaryStats): strin
 		return `<div class="summary-card">
 <div class="summary-label">✅ Actual Tokens</div>
 <div class="summary-value">${formatCompact(sessionActualTokens)}</div>
-<div class="summary-sub">${data.editorName === 'Mistral Vibe' ? 'From session data' : 'Total from session shutdown event'}</div>
+<div class="summary-sub">${data.editorName === 'Mistral Vibe' ? 'From session data' : 'Actual API tokens from Copilot CLI usage data'}</div>
 </div>`;
 	}
 	return '';
@@ -795,7 +795,7 @@ function buildDebugTokenCards(data: SessionLogData): string {
 
 function buildCachedTokensCard(data: SessionLogData): string {
 	if ((data.cachedTokens ?? 0) <= 0) { return ''; }
-	return `<div class="summary-card" title="Tokens served from the provider's prompt cache. Cached tokens are billed at a lower rate and reduce latency. Source: session.shutdown modelMetrics.">
+	return `<div class="summary-card" title="Tokens served from the provider's prompt cache. Cached tokens are billed at a lower rate and reduce latency. Source: Copilot CLI usage data (assistant_usage_events).">
 <div class="summary-label">💾 Cached Input</div>
 <div class="summary-value">${formatCompact(data.cachedTokens!)}</div>
 <div class="summary-sub">Prompt tokens served from cache</div>

--- a/vscode-extension/test/unit/copilotCliOtel.test.ts
+++ b/vscode-extension/test/unit/copilotCliOtel.test.ts
@@ -4,13 +4,65 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import type initSqlJs from 'sql.js';
+
+import { CopilotCliStoreAccess } from '../../../src/copilotCliStore';
 import {
 	extractCopilotCliSessionId,
 	getCopilotCliOtelUsage,
+	getCopilotCliStoreUsage,
+	getCopilotCliExactUsage,
 	loadCopilotCliOtelIndex,
 	clearCopilotCliOtelCache,
 	expireCopilotCliOtelCacheForTests,
 } from '../../../src/copilotCliOtel';
+
+type StoreRow = {
+	session_id: string;
+	model: string;
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_tokens: number;
+	cache_write_tokens: number;
+	total_nano_aiu: number;
+};
+
+/**
+ * Builds a fake sql.js factory backed by the supplied rows. We avoid the real sql.js WASM
+ * in unit tests because loading it causes a Windows UV handle assertion on forced process
+ * exit (see copilotCliAdapter.test.ts for the same workaround).
+ */
+function createFakeSqlJs(rows: StoreRow[]): typeof initSqlJs {
+	return (() => Promise.resolve({
+		Database: class FakeDatabase {
+			constructor(_data?: Uint8Array | number[]) { /* rows come from closure, not serialized file */ }
+
+			run(_sql: string, _params?: unknown[]): void { /* no-op — tests only read */ }
+
+			exec(sql: string, params?: unknown[]): initSqlJs.QueryResult[] {
+				if (sql.includes('assistant_usage_events') && params && params.length > 0) {
+					const sessionId = params[0] as string;
+					const matches = rows.filter(r => r.session_id === sessionId);
+					return [{
+						columns: ['model', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_write_tokens', 'total_nano_aiu'],
+						values: matches.map(r => [
+							r.model,
+							r.input_tokens,
+							r.output_tokens,
+							r.cache_read_tokens,
+							r.cache_write_tokens,
+							r.total_nano_aiu,
+						]),
+					}];
+				}
+				return [];
+			}
+
+			export(): Uint8Array { return new Uint8Array(); }
+			close(): void { /* no-op */ }
+		},
+	})) as unknown as typeof initSqlJs;
+}
 
 const SESSION_ID = 'a19abe35-b44e-4713-bf70-27f015393772';
 const SESSION_ID_2 = 'b28cf946-c55b-5824-cf81-38f126404883';
@@ -33,6 +85,18 @@ function eventsJsonlPath(homeDir: string, sessionId: string): string {
 
 function dbVirtualPath(homeDir: string, sessionId: string): string {
 	return path.join(homeDir, '.copilot', 'session-store.db') + `#${sessionId}`;
+}
+
+/**
+ * Creates a CopilotCliStoreAccess instance seeded with the supplied assistant_usage_events
+ * rows. Uses a fake sql.js implementation so tests don't load the real WASM. Writes a dummy
+ * session-store.db file so getDb()/statDb() succeeds without touching the real sql.js WASM.
+ */
+function createStoreAccess(homeDir: string, rows: StoreRow[]): CopilotCliStoreAccess {
+	const dbPath = path.join(homeDir, '.copilot', 'session-store.db');
+	fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+	fs.writeFileSync(dbPath, Buffer.alloc(0));
+	return new CopilotCliStoreAccess(createFakeSqlJs(rows));
 }
 
 function chatSpan(sessionId: string, overrides: Record<string, unknown> = {}): string {
@@ -206,5 +270,62 @@ test('loadCopilotCliOtelIndex: a shrunken (rotated/truncated) export triggers a 
 		const after = await loadCopilotCliOtelIndex();
 		assert.equal(after.get(SESSION_ID), undefined, 'the pre-rotation session should be gone after a rebuild');
 		assert.equal(after.get(SESSION_ID_2)?.actualTokens, 110, 'the post-rotation session should be parsed fresh');
+	});
+});
+
+test('getCopilotCliStoreUsage: reads exact usage from assistant_usage_events', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const storeAccess = createStoreAccess(homeDir, [
+			{ session_id: SESSION_ID, model: 'claude-sonnet-5', input_tokens: 100, output_tokens: 10, cache_read_tokens: 80, cache_write_tokens: 15, total_nano_aiu: 12345 },
+			{ session_id: SESSION_ID, model: 'claude-sonnet-5', input_tokens: 50, output_tokens: 5, cache_read_tokens: 40, cache_write_tokens: 5, total_nano_aiu: 6000 },
+		]);
+
+		const usage = await getCopilotCliStoreUsage(eventsJsonlPath(homeDir, SESSION_ID), storeAccess);
+		assert.ok(usage);
+		assert.equal(usage!.actualTokens, 165);
+		assert.equal(usage!.cacheReadTokens, 120);
+		assert.equal(usage!.nanoAiu, 18345);
+		assert.equal(usage!.modelUsage['claude-sonnet-5'].inputTokens, 150);
+		assert.equal(usage!.modelUsage['claude-sonnet-5'].outputTokens, 15);
+		assert.equal(usage!.modelUsage['claude-sonnet-5'].cachedReadTokens, 120);
+		assert.equal(usage!.modelUsage['claude-sonnet-5'].cacheCreationTokens, 20);
+	});
+});
+
+test('getCopilotCliStoreUsage: returns null when assistant_usage_events has no rows for the session', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const storeAccess = createStoreAccess(homeDir, [
+			{ session_id: SESSION_ID_2, model: 'claude-sonnet-5', input_tokens: 100, output_tokens: 10, cache_read_tokens: 0, cache_write_tokens: 0, total_nano_aiu: 12345 },
+		]);
+
+		const usage = await getCopilotCliStoreUsage(eventsJsonlPath(homeDir, SESSION_ID), storeAccess);
+		assert.equal(usage, null);
+	});
+});
+
+test('getCopilotCliExactUsage: prefers session-store.db over OTel file export', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const otelDir = path.join(homeDir, '.copilot', 'otel');
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID, { 'gen_ai.usage.input_tokens': 999, 'github.copilot.nano_aiu': 999999 })]);
+		const storeAccess = createStoreAccess(homeDir, [
+			{ session_id: SESSION_ID, model: 'claude-sonnet-5', input_tokens: 100, output_tokens: 10, cache_read_tokens: 0, cache_write_tokens: 0, total_nano_aiu: 12345 },
+		]);
+
+		const usage = await getCopilotCliExactUsage(eventsJsonlPath(homeDir, SESSION_ID), storeAccess);
+		assert.ok(usage);
+		assert.equal(usage!.actualTokens, 110, 'should use store data, not OTel');
+		assert.equal(usage!.nanoAiu, 12345);
+	});
+});
+
+test('getCopilotCliExactUsage: falls back to OTel file export when session-store.db has no billing rows', async (t) => {
+	await withHomedir(t, async (homeDir) => {
+		const otelDir = path.join(homeDir, '.copilot', 'otel');
+		writeOtelSpans(otelDir, [chatSpan(SESSION_ID)]);
+		const storeAccess = createStoreAccess(homeDir, []);
+
+		const usage = await getCopilotCliExactUsage(eventsJsonlPath(homeDir, SESSION_ID), storeAccess);
+		assert.ok(usage);
+		assert.equal(usage!.actualTokens, 110);
 	});
 });

--- a/vscode-extension/test/unit/copilotCliOtel.test.ts
+++ b/vscode-extension/test/unit/copilotCliOtel.test.ts
@@ -39,7 +39,7 @@ function createFakeSqlJs(rows: StoreRow[]): typeof initSqlJs {
 
 			run(_sql: string, _params?: unknown[]): void { /* no-op — tests only read */ }
 
-			exec(sql: string, params?: unknown[]): initSqlJs.QueryResult[] {
+			exec(sql: string, params?: unknown[]): initSqlJs.QueryExecResult[] {
 				if (sql.includes('assistant_usage_events') && params && params.length > 0) {
 					const sessionId = params[0] as string;
 					const matches = rows.filter(r => r.session_id === sessionId);


### PR DESCRIPTION
Fixes #1610

Copilot CLI sessions were reporting inflated/estimated token counts and missing per-model cost attribution because the extension relied on session.shutdown events and ratio-based estimates. The CLI's own usage display sources assistant_usage_events in ~/.copilot/session-store.db, which contains exact per-LLM-call input/output/cache tokens and nano-AIU.

Changes:
- Add CopilotCliStoreAccess.getSessionUsage() to query assistant_usage_events by session UUID.
- Add getCopilotCliExactUsage() that prefers store billing rows and falls back to the opt-in OTel file export.
- Route token counting, model attribution, and cost estimation through the new exact-usage path for both events.jsonl and DB-only sessions.
- Update log viewer labels to stop misattributing actual/cached tokens to session.shutdown.
- Add unit tests covering store usage, store-over-OTel preference, and OTel fallback.