### PR TITLE
chore: minor version bump across all deployment surfaces

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.2.13",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.1.3
+pluginVersion = 0.2.0
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.0.15"
+              Version="1.1.0"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@azure/arm-resources": "^7.0.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — minor version bump (all surfaces)

Per explicit request, this bumps the **minor** version (patch reset to 0) for all four packaged/released components in this repo, regardless of whether each has changes since its last release tag/version.

| Component | Version file | Old version | New version |
|-----------|--------------|-------------|--------------|
| VS Code extension | `vscode-extension/package.json` | 0.13.0 | 0.14.0 |
| CLI | `cli/package.json` | 0.2.13 | 0.3.0 |
| Visual Studio extension | `visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest` (`Identity.Version`) | 1.0.15 | 1.1.0 |
| JetBrains plugin | `jetbrains-plugin/gradle.properties` (`pluginVersion`) | 0.1.3 | 0.2.0 |

`package-lock.json` was also updated for `vscode-extension/` and `cli/` (npm keeps these in sync automatically with `npm version`).

### Not bumped (not a versioned release surface)
- `desktop/package.json` (0.1.0) — no CI/publish workflow exists for this component.
- `sharing-server/package.json` (0.1.0) — deployed as a continuously-running service (`sharing-server-deploy.yml`); its `package.json` version is not read by any publish/tag workflow.

### CHANGELOG files
Not touched — `vscode-extension/CHANGELOG.md`, `cli/CHANGELOG.md`, and `visualstudio-extension/CHANGELOG.md` are auto-synced from GitHub release notes by `sync-release-notes.yml`, not hand-edited during version bumps.

### After merging, run these workflows

1. **Extensions - Release** (`release.yml`) — Actions → Run workflow (on `main`)
   - Publishes VS Code extension **v0.14.0** and Visual Studio extension **v1.1.0**.
   - Since *both* were bumped in this PR, run with defaults (`vscode_only=false`, `vs_only=false`) so both get built and published, with `publish_marketplace=true`.
2. **CLI - Publish to npm and GitHub** (`cli-publish.yml`) — do **not** use `workflow_dispatch` (it re-bumps the version itself). Instead push a tag matching the merged version:
   ```bash
   git fetch origin main
   git tag -a cli/v0.3.0 origin/main -m "Release cli/v0.3.0"
   git push origin cli/v0.3.0
   ```
3. **JetBrains Plugin - Publish** (`jetbrains-publish.yml`) — push a matching tag (tag convention `jetbrains/v<version>`, must match `pluginVersion` in `gradle.properties`):
   ```bash
   git fetch origin main
   git tag -a jetbrains/v0.2.0 origin/main -m "Release jetbrains/v0.2.0"
   git push origin jetbrains/v0.2.0
   ```
   Or trigger via `workflow_dispatch` with `publish_marketplace: true` if a tag-driven publish isn't desired.