### PR TITLE
Migrate sharing-server Azure deploy to new tenant via OIDC

### DIFF
--- a/.github/workflows/sharing-server-bootstrap.yml
+++ b/.github/workflows/sharing-server-bootstrap.yml
@@ -1,0 +1,83 @@
+name: Bootstrap Sharing Server Terraform State
+
+# One-off, manually-triggered workflow. Creates the storage account + blob
+# container that sharing-server-deploy.yml uses as its Terraform remote state
+# backend. Run this once per environment (e.g. after migrating to a new Azure
+# subscription/tenant) before pointing TF_STATE_* variables at it — the main
+# deploy workflow's `terraform init` will fail until this backend exists.
+#
+# Uses local Terraform state (see sharing-server/infra/bootstrap/main.tf) since
+# it can't depend on the backend it's creating. Re-running this after the
+# storage account already exists will try to create a second one — it isn't
+# idempotent across runs, so only run it when you actually need a new backend.
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'GitHub Environment to authenticate as (must already have the Azure OIDC federated credential configured)'
+        type: choice
+        options:
+          - testing
+          - production
+        required: true
+      resource_group_name:
+        description: 'Existing Azure resource group to create the state storage account in'
+        type: string
+        required: true
+      location:
+        description: 'Azure region'
+        type: string
+        default: 'westeurope'
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    name: Create Terraform state storage (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write # required to request the OIDC token for Azure federated login
+    env:
+      ARM_CLIENT_ID:       ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_TENANT_ID:       ${{ secrets.AZURE_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_USE_OIDC:        "true"
+      TF_VAR_resource_group_name: ${{ inputs.resource_group_name }}
+      TF_VAR_location:            ${{ inputs.location }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+
+      - name: Terraform init (local state)
+        working-directory: sharing-server/infra/bootstrap
+        run: terraform init
+
+      - name: Terraform apply
+        working-directory: sharing-server/infra/bootstrap
+        run: terraform apply -auto-approve
+
+      - name: Output created resources
+        working-directory: sharing-server/infra/bootstrap
+        run: |
+          {
+            echo "## Terraform state storage created"
+            echo ""
+            echo "| Variable | Value |"
+            echo "|---|---|"
+            echo "| \`TF_STATE_RESOURCE_GROUP\` | \`$(terraform output -raw resource_group_name)\` |"
+            echo "| \`TF_STATE_STORAGE_ACCOUNT\` | \`$(terraform output -raw storage_account_name)\` |"
+            echo "| \`TF_STATE_CONTAINER\` | \`$(terraform output -raw container_name)\` |"
+            echo ""
+            echo "Set these as environment-scoped variables on the \`${{ inputs.environment }}\` GitHub Environment, then re-run the deploy workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sharing-server-cleanup.yml
+++ b/.github/workflows/sharing-server-cleanup.yml
@@ -27,11 +27,13 @@ jobs:
     environment: testing
     permissions:
       contents: read
+      id-token: write # required to request the OIDC token for Azure federated login
+    # Auth is via OIDC federated credentials (no client secret).
     env:
       ARM_CLIENT_ID:       ${{ secrets.AZURE_CLIENT_ID }}
-      ARM_CLIENT_SECRET:   ${{ secrets.AZURE_CLIENT_SECRET }}
       ARM_TENANT_ID:       ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_USE_OIDC:        "true"
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -90,7 +92,11 @@ jobs:
       # terraform destroy. We must unbind all hostnames and delete all certs first.
       - name: Azure CLI login
         if: steps.prereqs.outputs.configured == 'true'
-        run: az login --service-principal -u "$ARM_CLIENT_ID" -p "$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID" --output none
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id:       ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id:       ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Pre-destroy - unbind custom domains and delete managed certs
         if: steps.prereqs.outputs.configured == 'true'

--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -167,12 +167,14 @@ jobs:
       url:  ${{ steps.app-url.outputs.url }}
     permissions:
       contents: read
+      id-token: write # required to request the OIDC token for Azure federated login
     # ARM_* env vars are read by both the AzureRM Terraform backend and provider.
+    # Auth is via OIDC federated credentials (no client secret).
     env:
       ARM_CLIENT_ID:       ${{ secrets.AZURE_CLIENT_ID }}
-      ARM_CLIENT_SECRET:   ${{ secrets.AZURE_CLIENT_SECRET }}
       ARM_TENANT_ID:       ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_USE_OIDC:        "true"
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -206,6 +208,17 @@ jobs:
             -backend-config="container_name=${{ vars.TF_STATE_CONTAINER }}" \
             -backend-config="key=${{ needs.setup.outputs.state_key }}"
 
+      # Azure CLI login (OIDC federated credential) — needed by the `az containerapp`
+      # calls below for custom domain/cert reconciliation. Terraform itself
+      # authenticates separately via ARM_USE_OIDC and does not need this login.
+      - name: Azure Login
+        if: steps.prereqs.outputs.configured == 'true'
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id:       ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id:       ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Reconcile custom domain Terraform state
         # Custom domains (and their managed certs) are only meaningful on stable, long-lived
         # environments (production). Per-branch testing environments each get a unique ACA FQDN
@@ -227,9 +240,6 @@ jobs:
           TF_VAR_min_replicas:           ${{ needs.setup.outputs.min_replicas }}
           TF_VAR_custom_domain:          ${{ vars.SHARING_CUSTOM_DOMAIN }}
         run: |
-          az login --service-principal -u "$ARM_CLIENT_ID" -p "$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID" --output none
-          az account set --subscription "$ARM_SUBSCRIPTION_ID"
-
           ENV_NAME="${TF_VAR_app_name}-env"
           EXPECTED_CERT_NAME="sharing-cert"
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,13 @@ jetbrains-plugin/.gradle/
 **/idea-sandbox/
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+
+# Terraform (local runs only — CI uses ephemeral runners and a remote backend,
+# but local bootstrap runs like sharing-server/infra/bootstrap leave these
+# behind; state files can contain plaintext secrets, never commit them)
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.*
+**/*.tfplan
+crash.log
+crash.*.log

--- a/sharing-server/infra/bootstrap/.terraform.lock.hcl
+++ b/sharing-server/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:4BEgtU/crlkbMduT7tm8Sp3+C+1RBfrpUIlTBM/wtMc=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/sharing-server/infra/bootstrap/main.tf
+++ b/sharing-server/infra/bootstrap/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # Deliberately no remote backend here. This config creates the storage account
+  # that the main sharing-server/infra config uses as ITS backend, so it can't
+  # depend on that backend without a circular bootstrap problem. State is local
+  # to the CI run and discarded afterward — this is a run-once-per-environment
+  # bootstrap, not something reconciled on every deploy. If you ever need to
+  # change these resources again, re-run with `terraform import` first.
+}
+
+provider "azurerm" {
+  features {}
+  use_oidc                        = true
+  resource_provider_registrations = "none"
+}
+
+data "azurerm_resource_group" "this" {
+  name = var.resource_group_name
+}
+
+# Storage account names must be globally unique, 3-24 chars, lowercase alphanumeric only.
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  keepers = {
+    resource_group_name = var.resource_group_name
+  }
+}
+
+resource "azurerm_storage_account" "tfstate" {
+  name                     = "sharingtfstate${random_string.suffix.result}"
+  resource_group_name      = data.azurerm_resource_group.this.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+
+  blob_properties {
+    versioning_enabled = true # protects Terraform state from accidental overwrite/corruption
+  }
+}
+
+resource "azurerm_storage_container" "tfstate" {
+  name                  = var.container_name
+  storage_account_id    = azurerm_storage_account.tfstate.id
+  container_access_type = "private"
+}

--- a/sharing-server/infra/bootstrap/outputs.tf
+++ b/sharing-server/infra/bootstrap/outputs.tf
@@ -1,0 +1,11 @@
+output "resource_group_name" {
+  value = var.resource_group_name
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.tfstate.name
+}
+
+output "container_name" {
+  value = azurerm_storage_container.tfstate.name
+}

--- a/sharing-server/infra/bootstrap/variables.tf
+++ b/sharing-server/infra/bootstrap/variables.tf
@@ -1,0 +1,16 @@
+variable "resource_group_name" {
+  description = "Existing Azure resource group to create the Terraform state storage account in"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region (e.g. westeurope)"
+  type        = string
+  default     = "westeurope"
+}
+
+variable "container_name" {
+  description = "Blob container name used to store the main Terraform state file"
+  type        = string
+  default     = "tfstate"
+}

--- a/sharing-server/infra/providers.tf
+++ b/sharing-server/infra/providers.tf
@@ -26,8 +26,9 @@ provider "azurerm" {
   # Authentication is via GitHub Actions OIDC federated credentials using ARM_*
   # environment variables set by the workflow (ARM_CLIENT_ID, ARM_TENANT_ID,
   # ARM_SUBSCRIPTION_ID, ARM_USE_OIDC=true). No client secret is stored.
+  # use_oidc is intentionally not hardcoded here so a local run (without
+  # ARM_USE_OIDC set) falls back to the ambient `az login` session instead.
   # The SP has Contributor on the RG only, not subscription-level permissions,
   # so we disable automatic resource provider registration.
-  use_oidc                        = true
   resource_provider_registrations = "none"
 }

--- a/sharing-server/infra/providers.tf
+++ b/sharing-server/infra/providers.tf
@@ -23,10 +23,11 @@ terraform {
 
 provider "azurerm" {
   features {}
-  # Authentication is via service principal client secret using ARM_* environment
-  # variables set by the workflow (ARM_CLIENT_ID, ARM_CLIENT_SECRET,
-  # ARM_TENANT_ID, ARM_SUBSCRIPTION_ID).
+  # Authentication is via GitHub Actions OIDC federated credentials using ARM_*
+  # environment variables set by the workflow (ARM_CLIENT_ID, ARM_TENANT_ID,
+  # ARM_SUBSCRIPTION_ID, ARM_USE_OIDC=true). No client secret is stored.
   # The SP has Contributor on the RG only, not subscription-level permissions,
   # so we disable automatic resource provider registration.
+  use_oidc                        = true
   resource_provider_registrations = "none"
 }


### PR DESCRIPTION
## Summary
- Switches sharing-server Azure deploy (Terraform + az CLI) from service-principal client-secret auth to GitHub Actions OIDC federated credentials
- Adds a reusable Terraform state-storage bootstrap (`sharing-server/infra/bootstrap/`) used to provision fresh state backends in the new subscription/tenant
- Points `testing` and `production` GitHub Environments at new resource groups/state storage in the new Azure subscription (`rg-copilot-token-usage-test` / `rg-copilot-token-usage-prod`)
- `production`'s `SHARING_CUSTOM_DOMAIN` is temporarily unset so this first deploy creates base infra without attempting custom-domain cert provisioning (DNS cutover happens separately)

## Test plan
- [x] Verified full deploy pipeline (OIDC login → terraform init/plan/apply → health check) against the new tenant on the `testing` environment
- [ ] Verify `production` deploy creates the container app successfully
- [ ] Manually copy `sharing.db` from the old tenant's prod file share before/around DNS cutover
- [ ] Re-add `SHARING_CUSTOM_DOMAIN` and update DNS once ready, then redeploy to provision the managed cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)