### PR TITLE
feat(codexcli): add OpenAI Codex CLI ecosystem support

### DIFF
--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -106,6 +106,9 @@ export function getEditorSourceFromPath(filePath: string): string {
 	if (normalized.includes('/.copilot/session-state/')) { return 'Copilot CLI'; }
 	if (normalized.includes('/.crush/crush.db#')) { return 'Crush'; }
 	if (normalized.includes('/opencode/')) { return 'OpenCode'; }
+	// OpenAI Codex CLI (~/.codex): must be checked before the generic 'code'-based
+	// fallbacks below ('codex' contains 'code' and would misclassify as VS Code).
+	if (normalized.includes('/.codex/')) { return 'Codex CLI'; }
 	// Kiro CLI (~/.kiro/sessions/cli) and Kiro IDE (kiro.kiroagent global storage) are separate editors.
 	if (normalized.includes('/.kiro/sessions/cli/')) { return 'Kiro CLI'; }
 	if (normalized.includes('/kiro.kiroagent/workspace-sessions/')) { return 'Kiro'; }

--- a/docs/logFilesSchema/codex-cli-session-format.md
+++ b/docs/logFilesSchema/codex-cli-session-format.md
@@ -1,0 +1,88 @@
+# OpenAI Codex CLI session format
+
+Codex CLI (https://github.com/openai/codex, Rust `codex-rs`) stores its data under
+`$CODEX_HOME` (default `~/.codex` on every platform, including Windows).
+
+Adapter: `src/adapters/codexCliAdapter.ts` (id `codexcli`, display name **Codex CLI**),
+data access: `src/codexcli.ts`.
+
+## Storage layout
+
+| Path | Contents |
+|---|---|
+| `~/.codex/sessions/YYYY/MM/DD/rollout-<ISO-ts>-<uuid>.jsonl` | Rollout session files (primary source) |
+| `~/.codex/archived_sessions/...` | Same layout, after the user archives a thread |
+| `~/.codex/state_<N>.sqlite` | SQLite state DB (`sqlx` migrations; N is the schema generation — `state_5.sqlite` as of CLI ~0.115). Contains the `threads` registry |
+| `~/.codex/logs_<N>.sqlite` | Diagnostic tracing only (`logs` table: ts, level, target, feedback_log_body, thread_id). **No usage data** — not read by the adapter |
+| `~/.codex/models_cache.json` | Model catalog (`models[].slug` / `display_name`, reasoning levels). Slugs match the model ids used in rollouts/threads, so no mapping is needed |
+
+## `threads` table (state_&lt;N&gt;.sqlite)
+
+Confirmed against a live `state_5.sqlite` (22 sqlx migrations):
+
+```
+id TEXT PK, rollout_path TEXT, created_at INTEGER, updated_at INTEGER, source TEXT,
+model_provider TEXT, cwd TEXT, title TEXT, sandbox_policy TEXT, approval_mode TEXT,
+tokens_used INTEGER, has_user_event INTEGER, archived INTEGER, archived_at INTEGER,
+git_sha TEXT, git_branch TEXT, git_origin_url TEXT, cli_version TEXT,
+first_user_message TEXT, agent_nickname TEXT, agent_role TEXT, memory_mode TEXT,
+model TEXT, reasoning_effort TEXT, agent_path TEXT
+```
+
+`rollout_path` points at the thread's rollout file. When that file is missing, the row
+alone still provides `tokens_used` (real total), `model`, `title`, `cwd` and timestamps;
+the adapter exposes such rows via a virtual path `<state_db>#<thread_id>`
+(e.g. `C:\Users\alice\.codex\state_5.sqlite#019d0233-...`), mirroring the
+OpenCode/Crush/Devin CLI `db#id` convention.
+
+`created_at`/`updated_at` unit (seconds vs milliseconds) could not be confirmed against
+live rows (the observed DB's threads table was empty — Codex had been used through the
+`codex app-server` and rollout files had been cleaned up); the adapter treats values
+as **seconds** unless > 1e12.
+
+Other tables (`thread_dynamic_tools`, `stage1_outputs`, `jobs`, `agent_jobs`,
+`agent_job_items`, `thread_spawn_edges`, `backfill_state`) are not needed for usage
+tracking.
+
+## Rollout JSONL format
+
+One JSON object per line: `{ "timestamp": "<ISO 8601>", "type": "<kind>", "payload": {...} }`.
+
+| `type` | Payload |
+|---|---|
+| `session_meta` | `{ id, timestamp, cwd, originator ("codex_cli_rs"), cli_version, instructions, git }` (first line) |
+| `turn_context` | `{ cwd, approval_policy, sandbox_policy, model, effort, summary }` — tracks the active model |
+| `response_item` | `{ type: message \| reasoning \| function_call \| function_call_output \| local_shell_call \| custom_tool_call \| web_search_call, ... }`. Messages: `{ role, content: [{type: input_text\|output_text, text}] }` |
+| `event_msg` | `{ type: token_count \| user_message \| agent_message \| ... }` |
+| `compacted` | history compaction marker |
+
+`token_count` events carry **cumulative** usage in `payload.info.total_token_usage`:
+`{ input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens }`
+(plus `last_token_usage` and `model_context_window`). Older builds inline the same fields
+directly on the payload. A legacy pre-wrapper format (each line is the raw response item;
+bare session-meta first line) also exists; both are handled.
+
+## How the adapter computes stats
+
+- **Discovery**: glob `sessions/` + `archived_sessions/` for `rollout-*.jsonl`, then add
+  `threads` rows — resolved to `rollout_path` when the file exists, else virtual DB paths.
+  Duplicates are removed by the thread/session uuid embedded in the rollout filename.
+- **Tokens**: per-model deltas between successive cumulative `token_count` snapshots
+  (clamped at 0 so compaction resets can't go negative); `reasoning_output_tokens` →
+  thinking tokens. Fallback: ~4 chars/token estimate over message text. DB-only threads:
+  `tokens_used` (attributed to `model` as input tokens — only a single total is stored).
+- **Interactions**: `response_item` user messages, excluding system-injected payloads that
+  start with tags like `<user_instructions>` / `<environment_context>`. Falls back to
+  `event_msg`/`user_message` events for legacy files; DB-only threads report 1 when
+  `has_user_event`/`first_user_message` is set.
+- **Turns / usage analysis**: user message + following assistant/tool activity per turn;
+  tool names from `function_call.name`, `local_shell_call` → `shell`,
+  `web_search_call` → `web_search`; model switching from `turn_context`.
+
+## Known limitations
+
+- sql.js reads only the main DB file, so thread rows still in an un-checkpointed `-wal`
+  are invisible until Codex checkpoints (same as all sql.js-based adapters).
+- On machines where rollout files were removed and the `threads` table is empty (observed
+  on one live install), no historical sessions can be recovered — `logs_<N>.sqlite`
+  contains thread ids but no usage data.

--- a/src/adapters/adapterRegistry.ts
+++ b/src/adapters/adapterRegistry.ts
@@ -29,6 +29,7 @@ import { CursorDataAccess } from '../cursor';
 import { KiroDataAccess } from '../kiro';
 import { KiroCliDataAccess } from '../kirocli';
 import { DevinCliDataAccess } from '../devinCli';
+import { CodexCliDataAccess } from '../codexcli';
 
 import { OpenCodeAdapter } from './openCodeAdapter';
 import { CrushAdapter } from './crushAdapter';
@@ -48,6 +49,7 @@ import { JetBrainsAdapter } from './jetbrainsAdapter';
 import { KiroAdapter } from './kiroAdapter';
 import { KiroCliAdapter } from './kiroCliAdapter';
 import { DevinCliAdapter } from './devinCliAdapter';
+import { CodexCliAdapter } from './codexCliAdapter';
 
 /** Data-access instances and callbacks required to build the adapter registry. */
 export interface AdapterRegistryDeps {
@@ -66,6 +68,7 @@ cursor: CursorDataAccess;
 kiro: KiroDataAccess;
 kiroCli: KiroCliDataAccess;
 devinCli: DevinCliDataAccess;
+codexCli: CodexCliDataAccess;
 /** Estimates token count from raw text for a given model. */
 estimateTokens: (text: string, model?: string) => number;
 /** Returns true when the tool name identifies an MCP server tool. */
@@ -107,6 +110,7 @@ cursor: new CursorDataAccess(extensionUri),
 kiro: new KiroDataAccess(),
 kiroCli: new KiroCliDataAccess(),
 devinCli: new DevinCliDataAccess(),
+codexCli: new CodexCliDataAccess(),
 };
 }
 
@@ -141,6 +145,7 @@ new CursorAdapter(deps.cursor),
 new KiroAdapter(deps.kiro),
 new KiroCliAdapter(deps.kiroCli),
 new DevinCliAdapter(deps.devinCli),
+new CodexCliAdapter(deps.codexCli),
 // Copilot Chat / CLI adapters: discovery-only. Their handles() returns
 // false so processSessionFile() falls through to the shared parser path
 // for VS Code Copilot Chat and CLI files. See issue #654.

--- a/src/adapters/codexCliAdapter.ts
+++ b/src/adapters/codexCliAdapter.ts
@@ -1,0 +1,195 @@
+import * as fs from 'fs';
+import type { ChatTurn, ModelUsage, SessionUsageAnalysis } from '../types';
+import type {
+	CandidatePath,
+	DiscoveryResult,
+	IAnalyzableEcosystem,
+	IDiscoverableEcosystem,
+	IEcosystemAdapter,
+	UsageAnalysisAdapterContext,
+} from '../ecosystemAdapter';
+import type { CodexCliDataAccess, CodexRolloutSummary } from '../codexcli';
+import { createEmptyContextRefs } from '../tokenEstimation';
+import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
+
+/**
+ * Adapter for the OpenAI Codex CLI (terminal coding agent, https://github.com/openai/codex).
+ *
+ * Sessions come from two sources handled by CodexCliDataAccess (see src/codexcli.ts for the
+ * full schema writeup): rollout JSONL files under ~/.codex/sessions/ (real per-event data,
+ * including cumulative token_count usage events), and rows in the ~/.codex/state_<N>.sqlite
+ * `threads` table exposed as virtual `<state_db>#<thread_id>` paths when the rollout file
+ * referenced by `rollout_path` no longer exists on disk (those rows still carry real
+ * `tokens_used` totals, model, title, cwd and timestamps).
+ */
+export class CodexCliAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
+	readonly id = 'codexcli';
+	readonly displayName = 'Codex CLI';
+
+	constructor(private readonly codexCli: CodexCliDataAccess) {}
+
+	handles(sessionFile: string): boolean {
+		return this.codexCli.isCodexCliSessionFile(sessionFile);
+	}
+
+	getBackingPath(sessionFile: string): string {
+		return this.codexCli.getBackingPath(sessionFile);
+	}
+
+	async stat(sessionFile: string): Promise<fs.Stats> {
+		return this.codexCli.statSessionFile(sessionFile);
+	}
+
+	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
+		const result = await this.codexCli.getTokens(sessionFile);
+		return { ...result, actualTokens: result.tokens };
+	}
+
+	async countInteractions(sessionFile: string): Promise<number> {
+		return this.codexCli.countInteractions(sessionFile);
+	}
+
+	async getModelUsage(sessionFile: string): Promise<ModelUsage> {
+		return this.codexCli.getModelUsage(sessionFile);
+	}
+
+	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+		return this.codexCli.getMeta(sessionFile);
+	}
+
+	getEditorRoot(_sessionFile: string): string {
+		return this.codexCli.getCodexHome();
+	}
+
+	async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
+		const candidatePaths = this.getCandidatePaths();
+		const sessionFiles: string[] = [];
+		try {
+			const { files, rolloutCount, dbOnlyCount } = await this.codexCli.discoverSessions();
+			if (files.length > 0) {
+				log(`📄 Found ${files.length} Codex CLI session(s) (${rolloutCount} rollout file(s), ${dbOnlyCount} DB-only thread(s))`);
+			}
+			sessionFiles.push(...files);
+		} catch (e) {
+			log(`Could not read Codex CLI sessions: ${e}`);
+		}
+		return { sessionFiles, candidatePaths };
+	}
+
+	getCandidatePaths(): CandidatePath[] {
+		return [
+			{ path: this.codexCli.getSessionsDir(), source: 'Codex CLI (sessions)' },
+			{ path: this.codexCli.getArchivedSessionsDir(), source: 'Codex CLI (archived sessions)' },
+			{ path: this.codexCli.getStateDbPath(), source: 'Codex CLI (state db)' },
+		];
+	}
+
+	async getDailyFractions(sessionFile: string): Promise<Record<string, number>> {
+		return this.codexCli.getDailyFractions(sessionFile);
+	}
+
+	async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
+		if (this.codexCli.isVirtualThreadPath(sessionFile)) {
+			return this.buildDbThreadTurns(sessionFile);
+		}
+		const summary = await this.codexCli.getRolloutSummary(sessionFile);
+		const totals = this.codexCli.computeTokenTotals(summary);
+		const turns = summary.userMessages.map((user, i) => this.buildRolloutTurn(summary, i, user));
+		return { turns, actualTokens: totals.totalTokens > 0 ? totals.totalTokens : undefined };
+	}
+
+	/** DB-only threads carry no message data — surface a single summary turn when possible. */
+	private async buildDbThreadTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
+		const thread = await this.codexCli.readThread(sessionFile);
+		if (!thread) { return { turns: [] }; }
+		const userMessage = thread.first_user_message?.trim() || '';
+		if (!userMessage) { return { turns: [], actualTokens: thread.tokens_used || undefined }; }
+		const created = this.codexCli.toMillis(thread.created_at);
+		return {
+			turns: [{
+				turnNumber: 1,
+				timestamp: created ? new Date(created).toISOString() : null,
+				mode: 'cli',
+				userMessage,
+				assistantResponse: '',
+				model: thread.model || null,
+				toolCalls: [],
+				contextReferences: createEmptyContextRefs(),
+				mcpTools: [],
+				inputTokensEstimate: Math.ceil(userMessage.length / 4),
+				outputTokensEstimate: 0,
+				thinkingTokensEstimate: 0,
+			}],
+			actualTokens: thread.tokens_used || undefined,
+		};
+	}
+
+	/** Build one turn: the i-th user message plus assistant/tool activity until the next user message. */
+	private buildRolloutTurn(summary: CodexRolloutSummary, index: number, user: { text: string; timestamp: string | null }): ChatTurn {
+		const nextUserTs = summary.userMessages[index + 1]?.timestamp ?? null;
+		const inWindow = (ts: string | null): boolean => {
+			if (!user.timestamp) { return index === summary.userMessages.length - 1; }
+			if (!ts) { return false; }
+			return ts >= user.timestamp && (nextUserTs === null || ts < nextUserTs);
+		};
+		const assistantInTurn = summary.assistantMessages.filter(m => inWindow(m.timestamp));
+		const assistantText = assistantInTurn.map(m => m.text).join('\n');
+		const model = assistantInTurn.length > 0
+			? assistantInTurn[assistantInTurn.length - 1].model
+			: (summary.models[summary.models.length - 1] ?? null);
+		return {
+			turnNumber: index + 1,
+			timestamp: user.timestamp,
+			mode: 'cli',
+			userMessage: user.text,
+			assistantResponse: assistantText,
+			model: model === 'unknown' ? null : model,
+			toolCalls: summary.toolCalls.filter(t => inWindow(t.timestamp)).map(t => ({ toolName: t.name })),
+			contextReferences: createEmptyContextRefs(),
+			mcpTools: [],
+			inputTokensEstimate: Math.ceil(user.text.length / 4),
+			outputTokensEstimate: Math.ceil(assistantText.length / 4),
+			thinkingTokensEstimate: 0,
+		};
+	}
+
+	async analyzeUsage(sessionFile: string, ctx: UsageAnalysisAdapterContext): Promise<SessionUsageAnalysis> {
+		const analysis = createEmptySessionUsageAnalysis();
+		if (this.codexCli.isVirtualThreadPath(sessionFile)) {
+			return this.analyzeDbThread(sessionFile, ctx, analysis);
+		}
+		const summary = await this.codexCli.getRolloutSummary(sessionFile);
+		analysis.modeUsage.cli += summary.userMessages.length;
+		analysis.toolCalls.total = summary.toolCalls.length;
+		for (const tc of summary.toolCalls) {
+			const name = ctx.toolNameMap[tc.name] || tc.name;
+			analysis.toolCalls.byTool[name] = (analysis.toolCalls.byTool[name] || 0) + 1;
+		}
+		// One request per assistant message, attributed to the model active at that point.
+		const models = summary.assistantMessages.map(m => m.model).filter(m => m !== 'unknown');
+		this.applyModelStats(models.length > 0 ? models : summary.models, analysis, ctx);
+		return analysis;
+	}
+
+	private async analyzeDbThread(sessionFile: string, ctx: UsageAnalysisAdapterContext, analysis: SessionUsageAnalysis): Promise<SessionUsageAnalysis> {
+		const thread = await this.codexCli.readThread(sessionFile);
+		if (!thread) { return analysis; }
+		const interactions = await this.codexCli.countInteractions(sessionFile);
+		analysis.modeUsage.cli += interactions;
+		if (thread.model) { this.applyModelStats([thread.model], analysis, ctx); }
+		return analysis;
+	}
+
+	private applyModelStats(models: string[], analysis: SessionUsageAnalysis, ctx: UsageAnalysisAdapterContext): void {
+		const uniqueModels = [...new Set(models)];
+		analysis.modelSwitching.uniqueModels = uniqueModels;
+		analysis.modelSwitching.modelCount = uniqueModels.length;
+		analysis.modelSwitching.totalRequests = models.length;
+		let switchCount = 0;
+		for (let i = 1; i < models.length; i++) {
+			if (models[i] !== models[i - 1]) { switchCount++; }
+		}
+		analysis.modelSwitching.switchCount = switchCount;
+		applyModelTierClassification(ctx.modelPricing, uniqueModels, models, analysis);
+	}
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -15,4 +15,5 @@ export { JetBrainsAdapter } from './jetbrainsAdapter';
 export { PiAdapter } from './piAdapter';
 export { KiroAdapter } from './kiroAdapter';
 export { KiroCliAdapter } from './kiroCliAdapter';
+export { CodexCliAdapter } from './codexCliAdapter';
 

--- a/src/codexcli.ts
+++ b/src/codexcli.ts
@@ -1,0 +1,808 @@
+/**
+ * CodexCliDataAccess — reads session data for the OpenAI Codex CLI (https://github.com/openai/codex).
+ *
+ * Codex CLI stores its data under `$CODEX_HOME` (default `~/.codex` on every platform):
+ *
+ *   1. Rollout session files (primary, when present):
+ *        ~/.codex/sessions/YYYY/MM/DD/rollout-<ISO-timestamp>-<uuid>.jsonl
+ *        ~/.codex/archived_sessions/... (same layout, after `/archive`)
+ *      JSONL, one JSON object per line:
+ *        { "timestamp": "<ISO 8601>", "type": "<kind>", "payload": { ... } }
+ *      Line kinds observed/documented in codex-rs:
+ *        - session_meta:  payload { id, timestamp, cwd, originator, cli_version, instructions, git }
+ *        - turn_context:  payload { cwd, approval_policy, sandbox_policy, model, effort, summary }
+ *        - response_item: payload { type: message|reasoning|function_call|function_call_output|
+ *                                   local_shell_call|custom_tool_call|web_search_call, ... }
+ *        - event_msg:     payload { type: token_count|user_message|agent_message|..., ... }
+ *          token_count carries CUMULATIVE usage in payload.info.total_token_usage:
+ *            { input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens }
+ *          (older builds inline the same fields directly on the payload).
+ *        - compacted:     history compaction marker.
+ *      A legacy (pre-wrapper) format exists where each line IS the response item and the first
+ *      line is the session meta object — both are handled defensively.
+ *
+ *   2. SQLite state DB (fallback + registry): ~/.codex/state_<N>.sqlite (N = schema generation;
+ *      state_5.sqlite as of Codex CLI ~0.115). Read via sql.js like the other DB-backed adapters.
+ *      `threads` table columns (confirmed against a live state_5.sqlite):
+ *        id, rollout_path, created_at, updated_at, source, model_provider, cwd, title,
+ *        sandbox_policy, approval_mode, tokens_used, has_user_event, archived, archived_at,
+ *        git_sha, git_branch, git_origin_url, cli_version, first_user_message, agent_nickname,
+ *        agent_role, memory_mode, model, reasoning_effort, agent_path
+ *      `rollout_path` points at the rollout file for the thread. When that file is missing
+ *      (deleted, or the machine only has the DB), the thread row alone still provides
+ *      tokens_used / model / title / cwd / timestamps, exposed via a virtual path:
+ *        <state_db_path>#<thread_id>   e.g. C:\Users\alice\.codex\state_5.sqlite#019d0233-...
+ *      (mirrors the OpenCode/Crush/Devin CLI `db#id` convention).
+ *
+ *   Also present but NOT used here: logs_<N>.sqlite (diagnostic tracing only — no per-session
+ *   usage data) and models_cache.json (model catalog; slugs match the model ids already used
+ *   in rollouts/threads, so no mapping is needed).
+ *
+ * Timestamp units: rollout lines use ISO 8601 strings. threads.created_at / updated_at are
+ * epoch integers whose unit could not be confirmed against live rows (the observed DB had an
+ * empty threads table); values are treated as SECONDS unless > 1e12 (then milliseconds).
+ *
+ * Known limitation: sql.js reads only the main DB file, so thread rows still sitting in an
+ * un-checkpointed `-wal` file are not visible until Codex checkpoints them (same limitation
+ * as every other sql.js-based adapter in this repo).
+ */
+/// <reference types="sql.js" />
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import initSqlJs from 'sql.js';
+import type { ModelUsage } from './types';
+import { normalizePath } from './utils/pathUtils';
+import { toLocalDayKey } from './utils/dayKeys';
+
+type SqlJsStatic = initSqlJs.SqlJsStatic;
+type SqlDatabase = initSqlJs.Database;
+
+type DbCacheEntry = { db: SqlDatabase; mtimeMs: number; size: number };
+
+/** Matches rollout session filenames: rollout-2026-03-19T12-00-00-<uuid>.jsonl */
+const ROLLOUT_FILE_RE = /^rollout-.*\.jsonl$/i;
+/** Extracts the thread/session uuid from a rollout filename. */
+const ROLLOUT_UUID_RE = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i;
+/** Matches virtual thread paths that point into a state_<N>.sqlite DB. */
+const STATE_DB_VIRTUAL_RE = /\/state_\d+\.sqlite#/i;
+/** Newest schema generation observed at implementation time (used only as a diagnostics fallback). */
+const DEFAULT_STATE_DB_NAME = 'state_5.sqlite';
+/** System-injected user messages start with these XML-ish tags and are not real user turns. */
+const SYNTHETIC_USER_TAG_RE = /^\s*<(user_instructions|environment_context|turn_context|permissions|ide_context|system_instructions)\b/i;
+
+/** Row from the `threads` table (subset used by this adapter). */
+export interface CodexThread {
+	id: string;
+	rollout_path: string | null;
+	created_at: number | null;
+	updated_at: number | null;
+	cwd: string | null;
+	title: string | null;
+	tokens_used: number | null;
+	has_user_event: number | null;
+	archived: number | null;
+	first_user_message: string | null;
+	model: string | null;
+}
+
+/** One parsed rollout JSONL line, normalised across new and legacy formats. */
+export interface CodexRolloutLine {
+	timestamp: string | null;
+	kind: string;
+	payload: Record<string, unknown>;
+}
+
+/** Cumulative token usage snapshot from a token_count event. */
+interface TokenSnapshot {
+	input: number;
+	cachedInput: number;
+	output: number;
+	reasoning: number;
+	model: string;
+}
+
+/** Aggregated view of one rollout file, consumed by the adapter. */
+export interface CodexRolloutSummary {
+	sessionId: string | null;
+	cwd: string | null;
+	firstTimestamp: string | null;
+	lastTimestamp: string | null;
+	/** Genuine user messages (system-injected instruction/context payloads filtered out). */
+	userMessages: { text: string; timestamp: string | null }[];
+	assistantMessages: { text: string; timestamp: string | null; model: string }[];
+	toolCalls: { name: string; timestamp: string | null }[];
+	/** Cumulative usage snapshots in file order, tagged with the model active at that point. */
+	tokenSnapshots: TokenSnapshot[];
+	/** Total characters of reasoning summary text (for thinking-token estimation fallback). */
+	reasoningChars: number;
+	/** Models seen in turn_context order (deduplicated, first-seen order). */
+	models: string[];
+}
+
+/** Sums per-model input/output deltas across cumulative snapshots (reset-safe). */
+export interface CodexTokenTotals {
+	perModel: { [model: string]: { inputTokens: number; outputTokens: number } };
+	totalTokens: number;
+	thinkingTokens: number;
+}
+
+export class CodexCliDataAccess {
+	private _sqlJsModule: SqlJsStatic | null = null;
+	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
+	private _dbCache: Map<string, DbCacheEntry> = new Map();
+	private _dbCacheInflight: Map<string, Promise<SqlDatabase | null>> = new Map();
+	/** Parsed-rollout cache keyed by file path, invalidated on mtime/size change (bounded). */
+	private _rolloutCache: Map<string, { mtimeMs: number; size: number; summary: CodexRolloutSummary }> = new Map();
+	private static readonly ROLLOUT_CACHE_MAX = 64;
+	/** Test-only override for the Codex home directory. */
+	private _codexHomeOverride: string | null = null;
+
+	dispose(): void {
+		for (const entry of this._dbCache.values()) {
+			try { entry.db.close(); } catch { /* ignore */ }
+		}
+		this._dbCache.clear();
+		this._dbCacheInflight.clear();
+		this._rolloutCache.clear();
+		this._sqlJsInitPromise = null;
+	}
+
+	// ── Paths ───────────────────────────────────────────────────────────────
+
+	/** Codex home: $CODEX_HOME or ~/.codex (same on every platform). */
+	getCodexHome(): string {
+		if (this._codexHomeOverride) { return this._codexHomeOverride; }
+		const envHome = process.env['CODEX_HOME'];
+		if (envHome && envHome.trim()) { return envHome; }
+		return path.join(os.homedir(), '.codex');
+	}
+
+	/** Test-only: override the Codex home directory. */
+	setCodexHomeOverrideForTests(dir: string | null): void {
+		this._codexHomeOverride = dir;
+		this._rolloutCache.clear();
+	}
+
+	getSessionsDir(): string {
+		return path.join(this.getCodexHome(), 'sessions');
+	}
+
+	getArchivedSessionsDir(): string {
+		return path.join(this.getCodexHome(), 'archived_sessions');
+	}
+
+	/**
+	 * Absolute path to the newest state_<N>.sqlite in the Codex home.
+	 * Falls back to the newest known default name when none exists yet
+	 * (so diagnostics can still display the expected location).
+	 */
+	getStateDbPath(): string {
+		const home = this.getCodexHome();
+		let best: { n: number; name: string } | null = null;
+		try {
+			for (const name of fs.readdirSync(home)) {
+				const m = /^state_(\d+)\.sqlite$/i.exec(name);
+				if (m) {
+					const n = parseInt(m[1], 10);
+					if (!best || n > best.n) { best = { n, name }; }
+				}
+			}
+		} catch { /* home missing — fall through to default */ }
+		return path.join(home, best ? best.name : DEFAULT_STATE_DB_NAME);
+	}
+
+	// ── Path classification ─────────────────────────────────────────────────
+
+	/**
+	 * Returns true for any path owned by this adapter:
+	 *  - rollout JSONL files under the Codex home (sessions/ or archived_sessions/)
+	 *  - virtual thread paths <state_db>#<thread_id>
+	 */
+	isCodexCliSessionFile(filePath: string): boolean {
+		const norm = normalizePath(filePath).toLowerCase();
+		const home = normalizePath(this.getCodexHome()).toLowerCase();
+		const inCodexHome = norm.includes('/.codex/') || norm.startsWith(home + '/');
+		if (!inCodexHome) { return false; }
+		if (STATE_DB_VIRTUAL_RE.test(norm)) { return true; }
+		return ROLLOUT_FILE_RE.test(path.basename(norm));
+	}
+
+	/** Returns true when the path is a virtual DB-thread path (as opposed to a rollout file). */
+	isVirtualThreadPath(filePath: string): boolean {
+		return STATE_DB_VIRTUAL_RE.test(normalizePath(filePath));
+	}
+
+	/** Extract the real state DB path from a virtual thread path. */
+	getDbPathFromVirtual(virtualPath: string): string {
+		const idx = virtualPath.lastIndexOf('.sqlite#');
+		if (idx === -1) { return virtualPath; }
+		return virtualPath.substring(0, idx + '.sqlite'.length);
+	}
+
+	/** Extract the thread id from a virtual thread path. */
+	getThreadId(virtualPath: string): string | null {
+		const idx = virtualPath.lastIndexOf('.sqlite#');
+		if (idx === -1) { return null; }
+		const id = virtualPath.substring(idx + '.sqlite#'.length);
+		return id || null;
+	}
+
+	/** Build a virtual thread path for a thread id. */
+	virtualPath(threadId: string): string {
+		return `${this.getStateDbPath()}#${threadId}`;
+	}
+
+	/** Real backing file for a session path (rollout file itself, or the state DB). */
+	getBackingPath(sessionFile: string): string {
+		return this.isVirtualThreadPath(sessionFile) ? this.getDbPathFromVirtual(sessionFile) : sessionFile;
+	}
+
+	/** Stat the backing file for a session path. */
+	async statSessionFile(sessionFile: string): Promise<fs.Stats> {
+		return fs.promises.stat(this.getBackingPath(sessionFile));
+	}
+
+	// ── sql.js boilerplate (same pattern as crush.ts / devinCli.ts) ─────────
+
+	async initSqlJs(): Promise<SqlJsStatic> {
+		if (this._sqlJsModule) { return this._sqlJsModule; }
+		if (!this._sqlJsInitPromise) {
+			this._sqlJsInitPromise = (async () => {
+				const wasmPath = path.join(__dirname, 'sql-wasm.wasm');
+				let wasmBinary: Uint8Array | undefined;
+				try {
+					wasmBinary = await fs.promises.readFile(wasmPath);
+				} catch { /* WASM file not present — proceed without pre-loaded binary */ }
+				const module = await initSqlJs(wasmBinary ? { wasmBinary: wasmBinary.buffer as ArrayBuffer } : undefined);
+				this._sqlJsModule = module;
+				return module;
+			})().catch(err => {
+				this._sqlJsInitPromise = null;
+				throw err;
+			});
+		}
+		return this._sqlJsInitPromise;
+	}
+
+	private closeDb(db: SqlDatabase): void {
+		try { db.close(); } catch { /* ignore */ }
+	}
+
+	private isMissingFileError(error: unknown): boolean {
+		const code = (error as NodeJS.ErrnoException)?.code;
+		return code === 'ENOENT' || code === 'ENOTDIR';
+	}
+
+	private async statDb(dbPath: string): Promise<fs.Stats | null> {
+		try {
+			return await fs.promises.stat(dbPath);
+		} catch (error) {
+			if (this.isMissingFileError(error) && this._dbCache.has(dbPath)) {
+				this.closeDb(this._dbCache.get(dbPath)!.db);
+				this._dbCache.delete(dbPath);
+			}
+			return null;
+		}
+	}
+
+	private sameDbStats(left: fs.Stats, right: fs.Stats): boolean {
+		return left.mtimeMs === right.mtimeMs && left.size === right.size;
+	}
+
+	private async refreshDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
+		let db: SqlDatabase;
+		try {
+			const SQL = await this.initSqlJs();
+			const buffer = await fs.promises.readFile(dbPath);
+			db = new SQL.Database(buffer);
+		} catch {
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+		const currentStats = await this.statDb(dbPath);
+		if (!currentStats || !this.sameDbStats(stats, currentStats)) {
+			this.closeDb(db);
+			return this._dbCache.get(dbPath)?.db ?? null;
+		}
+		const existing = this._dbCache.get(dbPath);
+		if (existing) { this.closeDb(existing.db); }
+		this._dbCache.set(dbPath, { db, mtimeMs: stats.mtimeMs, size: stats.size });
+		return db;
+	}
+
+	/** Cached SQL.Database, re-opened only on mtime/size change; single-flight deduplicated. */
+	private async getDb(dbPath: string): Promise<SqlDatabase | null> {
+		const stats = await this.statDb(dbPath);
+		if (!stats) { return this._dbCache.get(dbPath)?.db ?? null; }
+		const cached = this._dbCache.get(dbPath);
+		if (cached && cached.mtimeMs === stats.mtimeMs && cached.size === stats.size) { return cached.db; }
+		const cacheKey = `${dbPath}:${stats.mtimeMs}:${stats.size}`;
+		const inflight = this._dbCacheInflight.get(cacheKey);
+		if (inflight) { return inflight; }
+		const createDbPromise = this.refreshDb(dbPath, stats);
+		this._dbCacheInflight.set(cacheKey, createDbPromise);
+		try {
+			return await createDbPromise;
+		} finally {
+			if (this._dbCacheInflight.get(cacheKey) === createDbPromise) {
+				this._dbCacheInflight.delete(cacheKey);
+			}
+		}
+	}
+
+	private rowsToObjects(result: initSqlJs.QueryExecResult[]): Record<string, unknown>[] {
+		if (result.length === 0) { return []; }
+		const { columns, values } = result[0];
+		return values.map(row => {
+			const obj: Record<string, unknown> = {};
+			columns.forEach((c, i) => { obj[c] = row[i]; });
+			return obj;
+		});
+	}
+
+	// ── Threads table access ────────────────────────────────────────────────
+
+	/** Read all thread rows (including archived — they still represent real usage). */
+	async readAllThreads(): Promise<CodexThread[]> {
+		const db = await this.getDb(this.getStateDbPath());
+		if (!db) { return []; }
+		try {
+			const result = db.exec(
+				`SELECT id, rollout_path, created_at, updated_at, cwd, title, tokens_used,
+				        has_user_event, archived, first_user_message, model
+				 FROM threads ORDER BY updated_at DESC`,
+			);
+			return this.rowsToObjects(result) as unknown as CodexThread[];
+		} catch {
+			return [];
+		}
+	}
+
+	/** Read one thread row for a virtual thread path. */
+	async readThread(virtualPath: string): Promise<CodexThread | null> {
+		const threadId = this.getThreadId(virtualPath);
+		if (!threadId) { return null; }
+		const db = await this.getDb(this.getDbPathFromVirtual(virtualPath));
+		if (!db) { return null; }
+		try {
+			const result = db.exec(
+				`SELECT id, rollout_path, created_at, updated_at, cwd, title, tokens_used,
+				        has_user_event, archived, first_user_message, model
+				 FROM threads WHERE id = ?`,
+				[threadId],
+			);
+			const rows = this.rowsToObjects(result);
+			return rows.length > 0 ? rows[0] as unknown as CodexThread : null;
+		} catch {
+			return null;
+		}
+	}
+
+	/** Epoch seconds-vs-milliseconds heuristic (threads table unit unconfirmed — see file header). */
+	toMillis(epoch: number | null | undefined): number | null {
+		if (typeof epoch !== 'number' || !Number.isFinite(epoch) || epoch <= 0) { return null; }
+		return epoch > 1e12 ? epoch : epoch * 1000;
+	}
+
+	// ── Discovery ───────────────────────────────────────────────────────────
+
+	/** Recursively collect rollout-*.jsonl files under a directory (depth-bounded). */
+	private async collectRolloutFiles(dir: string, depth = 0, out: string[] = []): Promise<string[]> {
+		if (depth > 5) { return out; }
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		} catch {
+			return out;
+		}
+		for (const entry of entries) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await this.collectRolloutFiles(full, depth + 1, out);
+			} else if (ROLLOUT_FILE_RE.test(entry.name)) {
+				out.push(full);
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * Discover all Codex CLI sessions:
+	 *  1. rollout files under sessions/ and archived_sessions/
+	 *  2. threads-table rows — resolved to their rollout_path when that file exists,
+	 *     otherwise exposed as a virtual <state_db>#<thread_id> path.
+	 * Threads whose id already matches a discovered rollout file are skipped (dedupe).
+	 */
+	async discoverSessions(): Promise<{ files: string[]; rolloutCount: number; dbOnlyCount: number }> {
+		const files: string[] = [];
+		const seenPaths = new Set<string>();
+		const seenThreadIds = new Set<string>();
+
+		const rollouts = [
+			...await this.collectRolloutFiles(this.getSessionsDir()),
+			...await this.collectRolloutFiles(this.getArchivedSessionsDir()),
+		];
+		for (const file of rollouts) {
+			const key = normalizePath(file).toLowerCase();
+			if (seenPaths.has(key)) { continue; }
+			seenPaths.add(key);
+			files.push(file);
+			const uuid = ROLLOUT_UUID_RE.exec(file);
+			if (uuid) { seenThreadIds.add(uuid[1].toLowerCase()); }
+		}
+		const rolloutCount = files.length;
+
+		let dbOnlyCount = 0;
+		for (const thread of await this.readAllThreads()) {
+			if (!thread.id || seenThreadIds.has(thread.id.toLowerCase())) { continue; }
+			seenThreadIds.add(thread.id.toLowerCase());
+			const resolved = this.resolveThreadPath(thread, seenPaths);
+			if (!resolved) { continue; }
+			files.push(resolved.path);
+			if (resolved.dbOnly) { dbOnlyCount++; }
+		}
+		return { files, rolloutCount, dbOnlyCount };
+	}
+
+	/** Resolve a thread row to its rollout file when it exists, else its virtual DB path. */
+	private resolveThreadPath(thread: CodexThread, seenPaths: Set<string>): { path: string; dbOnly: boolean } | null {
+		if (thread.rollout_path && fs.existsSync(thread.rollout_path)) {
+			const key = normalizePath(thread.rollout_path).toLowerCase();
+			if (seenPaths.has(key)) { return null; }
+			seenPaths.add(key);
+			return { path: thread.rollout_path, dbOnly: false };
+		}
+		return { path: this.virtualPath(thread.id), dbOnly: true };
+	}
+
+	// ── Rollout parsing ─────────────────────────────────────────────────────
+
+	/**
+	 * Normalise one parsed JSONL object across the current wrapper format and the
+	 * legacy formats (raw response items; bare session-meta first line).
+	 */
+	normalizeRolloutLine(obj: Record<string, unknown>): CodexRolloutLine | null {
+		const timestamp = typeof obj['timestamp'] === 'string' ? obj['timestamp'] as string : null;
+		const type = typeof obj['type'] === 'string' ? obj['type'] as string : null;
+		const payload = obj['payload'];
+		if (type && typeof payload === 'object' && payload !== null) {
+			return { timestamp, kind: type, payload: payload as Record<string, unknown> };
+		}
+		// Legacy: the line itself is a response item ({type:'message',role:...} etc.).
+		if (type) {
+			return { timestamp, kind: 'response_item', payload: obj };
+		}
+		// Legacy: bare session meta first line ({id, timestamp, instructions, ...}).
+		if (typeof obj['id'] === 'string' && ('instructions' in obj || 'cwd' in obj || 'git' in obj)) {
+			return { timestamp, kind: 'session_meta', payload: obj };
+		}
+		return null;
+	}
+
+	/** Extract the concatenated text from a response-item message content array. */
+	private extractMessageText(payload: Record<string, unknown>): string {
+		const content = payload['content'];
+		if (typeof content === 'string') { return content; }
+		if (!Array.isArray(content)) { return ''; }
+		return content
+			.filter((c): c is Record<string, unknown> => typeof c === 'object' && c !== null)
+			.filter(c => typeof c['text'] === 'string' &&
+				(c['type'] === 'input_text' || c['type'] === 'output_text' || c['type'] === 'text' || c['type'] === undefined))
+			.map(c => c['text'] as string)
+			.join('\n');
+	}
+
+	/** Extract a cumulative usage snapshot from a token_count event payload (both shapes). */
+	private extractTokenSnapshot(payload: Record<string, unknown>, model: string): TokenSnapshot | null {
+		const info = payload['info'];
+		const usageHolder = (typeof info === 'object' && info !== null)
+			? (info as Record<string, unknown>)['total_token_usage'] ?? info
+			: payload;
+		if (typeof usageHolder !== 'object' || usageHolder === null) { return null; }
+		const usage = usageHolder as Record<string, unknown>;
+		const num = (k: string): number => typeof usage[k] === 'number' && Number.isFinite(usage[k] as number) ? usage[k] as number : 0;
+		const input = num('input_tokens');
+		const output = num('output_tokens');
+		if (input === 0 && output === 0 && num('total_tokens') === 0) { return null; }
+		return {
+			input,
+			cachedInput: num('cached_input_tokens'),
+			output,
+			reasoning: num('reasoning_output_tokens'),
+			model,
+		};
+	}
+
+	private toolNameForResponseItem(itemType: string, payload: Record<string, unknown>): string | null {
+		if (itemType === 'function_call' || itemType === 'custom_tool_call') {
+			return typeof payload['name'] === 'string' && payload['name'] ? payload['name'] as string : 'unknown';
+		}
+		if (itemType === 'local_shell_call') { return 'shell'; }
+		if (itemType === 'web_search_call') { return 'web_search'; }
+		return null;
+	}
+
+	private applyMessageItem(line: CodexRolloutLine, summary: CodexRolloutSummary, currentModel: string): void {
+		const role = line.payload['role'];
+		const text = this.extractMessageText(line.payload);
+		if (!text) { return; }
+		if (role === 'user' && !SYNTHETIC_USER_TAG_RE.test(text)) {
+			summary.userMessages.push({ text, timestamp: line.timestamp });
+		} else if (role === 'assistant') {
+			summary.assistantMessages.push({ text, timestamp: line.timestamp, model: currentModel });
+		}
+	}
+
+	private applyReasoningItem(payload: Record<string, unknown>, summary: CodexRolloutSummary): void {
+		const summaries = Array.isArray(payload['summary']) ? payload['summary'] : [];
+		for (const s of summaries) {
+			if (typeof s === 'object' && s !== null && typeof (s as Record<string, unknown>)['text'] === 'string') {
+				summary.reasoningChars += ((s as Record<string, unknown>)['text'] as string).length;
+			}
+		}
+	}
+
+	private applyResponseItem(line: CodexRolloutLine, summary: CodexRolloutSummary, currentModel: string): void {
+		const p = line.payload;
+		const itemType = typeof p['type'] === 'string' ? p['type'] as string : '';
+		if (itemType === 'message') {
+			this.applyMessageItem(line, summary, currentModel);
+			return;
+		}
+		if (itemType === 'reasoning') {
+			this.applyReasoningItem(p, summary);
+			return;
+		}
+		const toolName = this.toolNameForResponseItem(itemType, p);
+		if (toolName) { summary.toolCalls.push({ name: toolName, timestamp: line.timestamp }); }
+	}
+
+	private applyEventMsg(line: CodexRolloutLine, summary: CodexRolloutSummary, currentModel: string): void {
+		const p = line.payload;
+		const eventType = p['type'];
+		if (eventType === 'token_count') {
+			const snapshot = this.extractTokenSnapshot(p, currentModel);
+			if (snapshot) { summary.tokenSnapshots.push(snapshot); }
+		}
+	}
+
+	/** Fallback user-turn counting from event_msg user_message events (legacy files without response items). */
+	private countEventMsgUserMessages(lines: CodexRolloutLine[]): { text: string; timestamp: string | null }[] {
+		const result: { text: string; timestamp: string | null }[] = [];
+		for (const line of lines) {
+			if (line.kind !== 'event_msg' || line.payload['type'] !== 'user_message') { continue; }
+			const message = line.payload['message'];
+			if (typeof message === 'string' && message && !SYNTHETIC_USER_TAG_RE.test(message)) {
+				result.push({ text: message, timestamp: line.timestamp });
+			}
+		}
+		return result;
+	}
+
+	/** Parse a rollout file into normalised lines (invalid/partial lines skipped). */
+	async readRolloutLines(filePath: string): Promise<CodexRolloutLine[]> {
+		let content: string;
+		try {
+			content = await fs.promises.readFile(filePath, 'utf8');
+		} catch {
+			return [];
+		}
+		const lines: CodexRolloutLine[] = [];
+		for (const raw of content.split('\n')) {
+			const trimmed = raw.trim();
+			if (!trimmed) { continue; }
+			try {
+				const obj = JSON.parse(trimmed);
+				if (typeof obj !== 'object' || obj === null) { continue; }
+				const normalized = this.normalizeRolloutLine(obj as Record<string, unknown>);
+				if (normalized) { lines.push(normalized); }
+			} catch { /* truncated/partial line — skip */ }
+		}
+		return lines;
+	}
+
+	/** Parse + summarise a rollout file (cached by mtime/size). */
+	async getRolloutSummary(filePath: string): Promise<CodexRolloutSummary> {
+		let stats: fs.Stats | null = null;
+		try { stats = await fs.promises.stat(filePath); } catch { /* missing */ }
+		if (stats) {
+			const cached = this._rolloutCache.get(filePath);
+			if (cached && cached.mtimeMs === stats.mtimeMs && cached.size === stats.size) {
+				return cached.summary;
+			}
+		}
+		const summary = this.buildRolloutSummary(await this.readRolloutLines(filePath));
+		if (stats) {
+			if (this._rolloutCache.size >= CodexCliDataAccess.ROLLOUT_CACHE_MAX) {
+				const oldest = this._rolloutCache.keys().next().value;
+				if (oldest !== undefined) { this._rolloutCache.delete(oldest); }
+			}
+			this._rolloutCache.set(filePath, { mtimeMs: stats.mtimeMs, size: stats.size, summary });
+		}
+		return summary;
+	}
+
+	private buildRolloutSummary(lines: CodexRolloutLine[]): CodexRolloutSummary {
+		const summary: CodexRolloutSummary = {
+			sessionId: null, cwd: null, firstTimestamp: null, lastTimestamp: null,
+			userMessages: [], assistantMessages: [], toolCalls: [],
+			tokenSnapshots: [], reasoningChars: 0, models: [],
+		};
+		let currentModel = 'unknown';
+		for (const line of lines) {
+			if (line.timestamp) {
+				if (!summary.firstTimestamp) { summary.firstTimestamp = line.timestamp; }
+				summary.lastTimestamp = line.timestamp;
+			}
+			currentModel = this.applyRolloutLine(line, summary, currentModel);
+		}
+		if (summary.userMessages.length === 0) {
+			summary.userMessages = this.countEventMsgUserMessages(lines);
+		}
+		return summary;
+	}
+
+	private applyRolloutLine(line: CodexRolloutLine, summary: CodexRolloutSummary, currentModel: string): string {
+		if (line.kind === 'session_meta') {
+			const p = line.payload;
+			if (typeof p['id'] === 'string') { summary.sessionId = p['id'] as string; }
+			if (typeof p['cwd'] === 'string') { summary.cwd = p['cwd'] as string; }
+			return currentModel;
+		}
+		if (line.kind === 'turn_context') {
+			const model = line.payload['model'];
+			if (typeof model === 'string' && model) {
+				if (!summary.models.includes(model)) { summary.models.push(model); }
+				return model;
+			}
+			return currentModel;
+		}
+		if (line.kind === 'response_item') { this.applyResponseItem(line, summary, currentModel); }
+		else if (line.kind === 'event_msg') { this.applyEventMsg(line, summary, currentModel); }
+		return currentModel;
+	}
+
+	// ── Token / usage computation ───────────────────────────────────────────
+
+	/**
+	 * Compute per-model token totals from cumulative snapshots by summing successive
+	 * deltas (negative deltas — e.g. after compaction resets — are clamped to 0,
+	 * and a reset re-baselines from the new snapshot).
+	 */
+	computeTokenTotals(summary: CodexRolloutSummary): CodexTokenTotals {
+		const perModel: CodexTokenTotals['perModel'] = {};
+		let thinking = 0;
+		let prev: TokenSnapshot | null = null;
+		for (const snap of summary.tokenSnapshots) {
+			const dInput = prev ? Math.max(0, snap.input - prev.input) : snap.input;
+			const dOutput = prev ? Math.max(0, snap.output - prev.output) : snap.output;
+			const dReasoning = prev ? Math.max(0, snap.reasoning - prev.reasoning) : snap.reasoning;
+			if (dInput > 0 || dOutput > 0) {
+				const entry = perModel[snap.model] ?? (perModel[snap.model] = { inputTokens: 0, outputTokens: 0 });
+				entry.inputTokens += dInput;
+				entry.outputTokens += dOutput;
+			}
+			thinking += dReasoning;
+			prev = snap;
+		}
+		const totalTokens = Object.values(perModel).reduce((sum, u) => sum + u.inputTokens + u.outputTokens, 0);
+		return { perModel, totalTokens, thinkingTokens: thinking };
+	}
+
+	private estimateTextTokens(text: string): number {
+		return text ? Math.ceil(text.length / 4) : 0;
+	}
+
+	/** Fallback ~4 chars/token estimate over all message + reasoning text. */
+	private estimateRolloutTokens(summary: CodexRolloutSummary): { input: number; output: number; thinking: number } {
+		let input = 0;
+		let output = 0;
+		for (const m of summary.userMessages) { input += this.estimateTextTokens(m.text); }
+		for (const m of summary.assistantMessages) { output += this.estimateTextTokens(m.text); }
+		const thinking = Math.ceil(summary.reasoningChars / 4);
+		return { input, output, thinking };
+	}
+
+	/** Session token counts. Rollouts: real token_count data (estimate fallback). DB threads: tokens_used. */
+	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number }> {
+		if (this.isVirtualThreadPath(sessionFile)) {
+			const thread = await this.readThread(sessionFile);
+			const tokens = typeof thread?.tokens_used === 'number' ? thread.tokens_used : 0;
+			return { tokens, thinkingTokens: 0 };
+		}
+		const summary = await this.getRolloutSummary(sessionFile);
+		const totals = this.computeTokenTotals(summary);
+		if (totals.totalTokens > 0) {
+			return { tokens: totals.totalTokens, thinkingTokens: totals.thinkingTokens };
+		}
+		const est = this.estimateRolloutTokens(summary);
+		return { tokens: est.input + est.output + est.thinking, thinkingTokens: est.thinking };
+	}
+
+	/** Count genuine user turns. DB-only threads expose no message data → 1 if any user event, else 0. */
+	async countInteractions(sessionFile: string): Promise<number> {
+		if (this.isVirtualThreadPath(sessionFile)) {
+			const thread = await this.readThread(sessionFile);
+			if (!thread) { return 0; }
+			const hasUser = thread.has_user_event === 1 ||
+				(typeof thread.first_user_message === 'string' && thread.first_user_message.trim().length > 0);
+			return hasUser ? 1 : 0;
+		}
+		const summary = await this.getRolloutSummary(sessionFile);
+		return summary.userMessages.length;
+	}
+
+	/** Per-model usage. Rollouts: real per-model deltas. DB threads: all tokens on the thread's model. */
+	async getModelUsage(sessionFile: string): Promise<ModelUsage> {
+		if (this.isVirtualThreadPath(sessionFile)) {
+			const thread = await this.readThread(sessionFile);
+			const tokens = typeof thread?.tokens_used === 'number' ? thread.tokens_used : 0;
+			if (tokens === 0) { return {}; }
+			const model = thread?.model || 'unknown';
+			// Only a single total is stored; agent sessions are heavily input-dominated,
+			// so the total is attributed to inputTokens (conservative for cost estimates).
+			return { [model]: { inputTokens: tokens, outputTokens: 0 } };
+		}
+		const summary = await this.getRolloutSummary(sessionFile);
+		const totals = this.computeTokenTotals(summary);
+		if (totals.totalTokens > 0) { return totals.perModel; }
+		const est = this.estimateRolloutTokens(summary);
+		if (est.input + est.output + est.thinking === 0) { return {}; }
+		const model = summary.models[summary.models.length - 1] || 'unknown';
+		return { [model]: { inputTokens: est.input, outputTokens: est.output + est.thinking } };
+	}
+
+	/** Session metadata (title, first/last interaction, workspace path). */
+	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+		if (this.isVirtualThreadPath(sessionFile)) {
+			return this.getThreadMeta(sessionFile);
+		}
+		const summary = await this.getRolloutSummary(sessionFile);
+		const title = summary.userMessages[0]?.text.split('\n')[0].slice(0, 100);
+		return {
+			title: title || undefined,
+			firstInteraction: summary.firstTimestamp,
+			lastInteraction: summary.lastTimestamp,
+			workspacePath: summary.cwd || undefined,
+		};
+	}
+
+	private async getThreadMeta(virtualPath: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+		const thread = await this.readThread(virtualPath);
+		const created = this.toMillis(thread?.created_at);
+		const updated = this.toMillis(thread?.updated_at);
+		return {
+			title: thread?.title || thread?.first_user_message?.slice(0, 100) || undefined,
+			firstInteraction: created ? new Date(created).toISOString() : null,
+			lastInteraction: updated ? new Date(updated).toISOString() : null,
+			workspacePath: thread?.cwd || undefined,
+		};
+	}
+
+	/** Per-local-day fractions for multi-day attribution. */
+	async getDailyFractions(sessionFile: string): Promise<Record<string, number>> {
+		if (this.isVirtualThreadPath(sessionFile)) {
+			const thread = await this.readThread(sessionFile);
+			const millis = this.toMillis(thread?.updated_at) ?? this.toMillis(thread?.created_at);
+			return { [toLocalDayKey(millis ? new Date(millis) : new Date())]: 1.0 };
+		}
+		const summary = await this.getRolloutSummary(sessionFile);
+		const counts: Record<string, number> = {};
+		let total = 0;
+		for (const m of [...summary.userMessages, ...summary.assistantMessages]) {
+			if (!m.timestamp) { continue; }
+			const d = new Date(m.timestamp);
+			if (isNaN(d.getTime())) { continue; }
+			const key = toLocalDayKey(d);
+			counts[key] = (counts[key] || 0) + 1;
+			total++;
+		}
+		if (total === 0) {
+			const fallback = summary.lastTimestamp ? new Date(summary.lastTimestamp) : new Date();
+			return { [toLocalDayKey(isNaN(fallback.getTime()) ? new Date() : fallback)]: 1.0 };
+		}
+		const fractions: Record<string, number> = {};
+		for (const [day, count] of Object.entries(counts)) { fractions[day] = count / total; }
+		return fractions;
+	}
+}

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -471,6 +471,10 @@ function isVSCodeRoot(lower: string): boolean {
  */
 function detectToolEditorFromRootPath(lower: string): string | undefined {
 	if (lower.includes('opencode')) { return 'OpenCode'; }
+	// OpenAI Codex CLI home (~/.codex). The dot-prefix keeps this from colliding with
+	// the generic 'code' substring checks further down ('.codex' never matches '/code/'
+	// or endsWith('code')), but it must still run before isVSCodeRoot for clarity.
+	if (lower.includes('.codex')) { return 'Codex CLI'; }
 	// Kiro CLI root (~/.kiro) must be checked before the Kiro IDE root — both
 	// contain 'kiro' but only the CLI root has the dot-prefixed folder.
 	if (lower.includes('/.kiro')) { return 'Kiro CLI'; }
@@ -988,6 +992,25 @@ export function detectClaudeCodeEditorVariant(filePath: string): string {
 }
 
 /**
+ * Detect terminal CLI agents with dedicated data stores from a lower-cased normalised path.
+ * @internal
+ */
+function detectCliAgentStoreFromPath(lowerPath: string): string | undefined {
+	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
+	// Devin CLI virtual paths: <...>/devin/cli/sessions.db#<id>. Checked here (not merely
+	// the generic 'devin' substring match in detectIDEEditorSource) so it always wins over
+	// the desktop app's devin:// scheme / Windsurf family checks, which are handled earlier
+	// in getEditorTypeFromPath/detectEditorSource before this function is even called.
+	if (lowerPath.includes('devin/cli/sessions.db#')) { return 'Devin CLI'; }
+	// OpenAI Codex CLI: rollout JSONL files under ~/.codex/sessions|archived_sessions and
+	// virtual thread paths ~/.codex/state_<N>.sqlite#<thread-id>. Must be detected here,
+	// before the loose 'code' substring fallbacks in detectIDEEditorSource /
+	// detectVSCodeVariantFromPath ('codex' contains 'code' and would misclassify as VS Code).
+	if (lowerPath.includes('/.codex/')) { return 'Codex CLI'; }
+	return undefined;
+}
+
+/**
  * Detect tool-specific (non-VS Code family) editors from a lower-cased normalised path.
  * Returns the editor name or undefined if none matched.
  * @internal
@@ -1000,12 +1023,8 @@ function detectToolEditorFromPath(
 	const copilotFamily = detectCopilotFamilyFromPath(lowerPath);
 	if (copilotFamily) { return copilotFamily; }
 	if (isOpenCodeSessionFile?.(filePath)) { return 'OpenCode'; }
-	if (lowerPath.includes('/.crush/crush.db#')) { return 'Crush'; }
-	// Devin CLI virtual paths: <...>/devin/cli/sessions.db#<id>. Checked here (not merely
-	// the generic 'devin' substring match in detectIDEEditorSource) so it always wins over
-	// the desktop app's devin:// scheme / Windsurf family checks, which are handled earlier
-	// in getEditorTypeFromPath/detectEditorSource before this function is even called.
-	if (lowerPath.includes('devin/cli/sessions.db#')) { return 'Devin CLI'; }
+	const cliAgent = detectCliAgentStoreFromPath(lowerPath);
+	if (cliAgent) { return cliAgent; }
 	// Cursor virtual paths must be checked before the generic /cursor/ match in detectVSCodeVariantFromPath.
 	if (lowerPath.includes('/cursor/user/globalstorage/state.vscdb#')) { return 'Cursor'; }
 	if (lowerPath.includes('/.pi/agent/sessions/')) { return 'Pi'; }

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -12,6 +12,7 @@ export const EDITOR_ICON_MAP: Record<string, string> = {
 	'Claude Code CLI': '🟠',
 	'Claude Desktop': '🟠',
 	'Claude Desktop Cowork': '🟠',
+	'Codex CLI': '🌀',
 	'Continue': '▶️',
 	'Copilot CLI': '🤖',
 	'Crush': '🦾',

--- a/vscode-extension/test/unit/codexCli.test.ts
+++ b/vscode-extension/test/unit/codexCli.test.ts
@@ -1,0 +1,300 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CodexCliDataAccess } from '../../../src/codexcli';
+
+const ROLLOUT_UUID = '019d0233-2d86-7c21-b13a-8fa9578d3a0d';
+const DB_ONLY_UUID = '019d0236-27fa-71e0-9ade-ae3682565e7b';
+
+/** Build a realistic new-format rollout JSONL fixture with two user turns and a model switch. */
+function rolloutFixtureLines(): string[] {
+	const line = (timestamp: string, type: string, payload: unknown) => JSON.stringify({ timestamp, type, payload });
+	return [
+		line('2026-03-19T12:00:00.000Z', 'session_meta', {
+			id: ROLLOUT_UUID, timestamp: '2026-03-19T12:00:00.000Z', cwd: 'C:\\repo\\project',
+			originator: 'codex_cli_rs', cli_version: '0.115.0', instructions: null,
+		}),
+		line('2026-03-19T12:00:01.000Z', 'turn_context', { cwd: 'C:\\repo\\project', model: 'gpt-5.4', effort: 'medium' }),
+		// Synthetic instruction payloads arrive as user messages and must be filtered out.
+		line('2026-03-19T12:00:02.000Z', 'response_item', {
+			type: 'message', role: 'user',
+			content: [{ type: 'input_text', text: '<user_instructions>Always be terse</user_instructions>' }],
+		}),
+		line('2026-03-19T12:00:02.500Z', 'response_item', {
+			type: 'message', role: 'user',
+			content: [{ type: 'input_text', text: '<environment_context>cwd: C:\\repo</environment_context>' }],
+		}),
+		line('2026-03-19T12:00:03.000Z', 'response_item', {
+			type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Fix the login bug' }],
+		}),
+		line('2026-03-19T12:00:04.000Z', 'response_item', {
+			type: 'reasoning', summary: [{ type: 'summary_text', text: 'Analysing the login flow first' }], content: null,
+		}),
+		line('2026-03-19T12:00:05.000Z', 'response_item', {
+			type: 'function_call', name: 'shell', arguments: '{"command":["grep","login"]}', call_id: 'c1',
+		}),
+		line('2026-03-19T12:00:06.000Z', 'response_item', { type: 'function_call_output', call_id: 'c1', output: 'ok' }),
+		line('2026-03-19T12:00:07.000Z', 'response_item', {
+			type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Fixed the null check.' }],
+		}),
+		line('2026-03-19T12:00:08.000Z', 'event_msg', {
+			type: 'token_count',
+			info: {
+				total_token_usage: { input_tokens: 1000, cached_input_tokens: 800, output_tokens: 200, reasoning_output_tokens: 50, total_tokens: 1200 },
+				last_token_usage: { input_tokens: 1000, cached_input_tokens: 800, output_tokens: 200, reasoning_output_tokens: 50, total_tokens: 1200 },
+				model_context_window: 272000,
+			},
+		}),
+		// Second turn the next day on a different model.
+		line('2026-03-20T09:00:00.000Z', 'turn_context', { cwd: 'C:\\repo\\project', model: 'gpt-5.4-codex', effort: 'high' }),
+		line('2026-03-20T09:00:01.000Z', 'response_item', {
+			type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Now add tests' }],
+		}),
+		line('2026-03-20T09:00:02.000Z', 'response_item', {
+			type: 'web_search_call', action: { type: 'search', query: 'jest login test' },
+		}),
+		line('2026-03-20T09:00:03.000Z', 'response_item', {
+			type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Added two tests.' }],
+		}),
+		line('2026-03-20T09:00:04.000Z', 'event_msg', {
+			type: 'token_count',
+			info: {
+				total_token_usage: { input_tokens: 3000, cached_input_tokens: 2500, output_tokens: 500, reasoning_output_tokens: 80, total_tokens: 3500 },
+				last_token_usage: { input_tokens: 2000, cached_input_tokens: 1700, output_tokens: 300, reasoning_output_tokens: 30, total_tokens: 2300 },
+				model_context_window: 272000,
+			},
+		}),
+	];
+}
+
+function createHarness() {
+	const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codexcli-'));
+	const dayDir = path.join(tmpHome, 'sessions', '2026', '03', '19');
+	fs.mkdirSync(dayDir, { recursive: true });
+	const rolloutPath = path.join(dayDir, `rollout-2026-03-19T12-00-00-${ROLLOUT_UUID}.jsonl`);
+	fs.writeFileSync(rolloutPath, rolloutFixtureLines().join('\n') + '\n');
+	// Older-generation DB left behind + current one: getStateDbPath must pick the highest N.
+	fs.writeFileSync(path.join(tmpHome, 'state_3.sqlite'), 'stub');
+	const dbPath = path.join(tmpHome, 'state_5.sqlite');
+	fs.writeFileSync(dbPath, 'stub');
+
+	type Row = { columns: string[]; values: unknown[][] };
+	const threadColumns = ['id', 'rollout_path', 'created_at', 'updated_at', 'cwd', 'title', 'tokens_used',
+		'has_user_event', 'archived', 'first_user_message', 'model'];
+	// Thread 1 duplicates the rollout file (must be deduped); thread 2 has a stale rollout_path (DB-only).
+	const threadRows: Row = {
+		columns: threadColumns,
+		values: [
+			[ROLLOUT_UUID, rolloutPath, 1774000000, 1774003600, 'C:\\repo\\project', 'Fix the login bug', 3500, 1, 0, 'Fix the login bug', 'gpt-5.4'],
+			[DB_ONLY_UUID, path.join(tmpHome, 'sessions', 'gone.jsonl'), 1774100000, 1774103600, 'C:\\repo\\other', 'Refactor auth', 4200, 1, 0, 'Refactor the auth module', 'gpt-5.4-codex'],
+		],
+	};
+
+	class FakeDatabase {
+		exec(query: string, params?: unknown[]): Row[] {
+			if (query.includes('FROM threads WHERE id')) {
+				const id = params?.[0];
+				const match = threadRows.values.filter(v => v[0] === id);
+				return match.length > 0 ? [{ columns: threadRows.columns, values: match }] : [];
+			}
+			if (query.includes('FROM threads')) { return [threadRows]; }
+			return [];
+		}
+		close(): void { /* noop */ }
+	}
+
+	const access = new CodexCliDataAccess();
+	(access as any).initSqlJs = async () => ({ Database: FakeDatabase });
+	access.setCodexHomeOverrideForTests(tmpHome);
+
+	return {
+		access, tmpHome, dbPath, rolloutPath,
+		cleanup: () => { access.dispose(); fs.rmSync(tmpHome, { recursive: true, force: true }); },
+	};
+}
+
+test('getCodexHome defaults to ~/.codex and honours the test override', () => {
+	const access = new CodexCliDataAccess();
+	if (!process.env['CODEX_HOME']) {
+		assert.equal(normalize(access.getCodexHome()), normalize(path.join(os.homedir(), '.codex')));
+	}
+	access.setCodexHomeOverrideForTests('/tmp/custom-codex');
+	assert.equal(access.getCodexHome(), '/tmp/custom-codex');
+});
+
+function normalize(p: string): string { return p.replace(/\\/g, '/').toLowerCase(); }
+
+test('getStateDbPath picks the highest-numbered state_<N>.sqlite', () => {
+	const harness = createHarness();
+	try {
+		assert.equal(harness.access.getStateDbPath(), harness.dbPath);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('isCodexCliSessionFile recognises rollouts and virtual thread paths, rejects other files', () => {
+	const access = new CodexCliDataAccess();
+	const home = path.join(os.homedir(), '.codex');
+	const rollout = path.join(home, 'sessions', '2026', '03', '19', `rollout-2026-03-19T12-00-00-${ROLLOUT_UUID}.jsonl`);
+	assert.ok(access.isCodexCliSessionFile(rollout));
+	assert.ok(access.isCodexCliSessionFile(rollout.replace(/\\/g, '/')));
+	assert.ok(access.isCodexCliSessionFile(path.join(home, `state_5.sqlite#${ROLLOUT_UUID}`)));
+	assert.ok(!access.isCodexCliSessionFile(path.join(home, 'logs_1.sqlite')));
+	assert.ok(!access.isCodexCliSessionFile(path.join(home, 'models_cache.json')));
+	assert.ok(!access.isCodexCliSessionFile(path.join(os.homedir(), '.crush', 'crush.db#abc')));
+});
+
+test('virtual path helpers round-trip db path and thread id', () => {
+	const harness = createHarness();
+	try {
+		const vp = harness.access.virtualPath(DB_ONLY_UUID);
+		assert.equal(vp, `${harness.dbPath}#${DB_ONLY_UUID}`);
+		assert.ok(harness.access.isVirtualThreadPath(vp));
+		assert.equal(harness.access.getDbPathFromVirtual(vp), harness.dbPath);
+		assert.equal(harness.access.getThreadId(vp), DB_ONLY_UUID);
+		assert.equal(harness.access.getBackingPath(vp), harness.dbPath);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('discoverSessions finds rollout files and adds DB-only threads as virtual paths (deduped)', async () => {
+	const harness = createHarness();
+	try {
+		const { files, rolloutCount, dbOnlyCount } = await harness.access.discoverSessions();
+		assert.equal(rolloutCount, 1);
+		assert.equal(dbOnlyCount, 1);
+		assert.equal(files.length, 2);
+		assert.ok(files.includes(harness.rolloutPath));
+		assert.ok(files.includes(`${harness.dbPath}#${DB_ONLY_UUID}`));
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getTokens sums per-model deltas from cumulative token_count snapshots', async () => {
+	const harness = createHarness();
+	try {
+		const result = await harness.access.getTokens(harness.rolloutPath);
+		assert.equal(result.tokens, 3500); // final cumulative input 3000 + output 500
+		assert.equal(result.thinkingTokens, 80);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('countInteractions counts genuine user messages, filtering synthetic instruction payloads', async () => {
+	const harness = createHarness();
+	try {
+		assert.equal(await harness.access.countInteractions(harness.rolloutPath), 2);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getModelUsage attributes snapshot deltas to the model active at each snapshot', async () => {
+	const harness = createHarness();
+	try {
+		const usage = await harness.access.getModelUsage(harness.rolloutPath);
+		assert.deepEqual(usage['gpt-5.4'], { inputTokens: 1000, outputTokens: 200 });
+		assert.deepEqual(usage['gpt-5.4-codex'], { inputTokens: 2000, outputTokens: 300 });
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getMeta extracts title, timestamps and cwd from the rollout', async () => {
+	const harness = createHarness();
+	try {
+		const meta = await harness.access.getMeta(harness.rolloutPath);
+		assert.equal(meta.title, 'Fix the login bug');
+		assert.equal(meta.firstInteraction, '2026-03-19T12:00:00.000Z');
+		assert.equal(meta.lastInteraction, '2026-03-20T09:00:04.000Z');
+		assert.equal(meta.workspacePath, 'C:\\repo\\project');
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getDailyFractions splits across the two local days of the session', async () => {
+	const harness = createHarness();
+	try {
+		const fractions = await harness.access.getDailyFractions(harness.rolloutPath);
+		const total = Object.values(fractions).reduce((s, f) => s + f, 0);
+		assert.ok(Math.abs(total - 1) < 1e-9);
+		assert.equal(Object.keys(fractions).length, 2);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('DB-only virtual threads expose tokens_used, metadata and a single interaction', async () => {
+	const harness = createHarness();
+	try {
+		const vp = `${harness.dbPath}#${DB_ONLY_UUID}`;
+		const tokens = await harness.access.getTokens(vp);
+		assert.equal(tokens.tokens, 4200);
+		assert.equal(await harness.access.countInteractions(vp), 1);
+		const usage = await harness.access.getModelUsage(vp);
+		assert.deepEqual(usage['gpt-5.4-codex'], { inputTokens: 4200, outputTokens: 0 });
+		const meta = await harness.access.getMeta(vp);
+		assert.equal(meta.title, 'Refactor auth');
+		assert.equal(meta.workspacePath, 'C:\\repo\\other');
+		// created_at 1774100000 is epoch seconds → must be converted to ms (not year 1970 / 58043).
+		assert.ok(meta.firstInteraction!.startsWith('2026-'));
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('toMillis treats small epochs as seconds and large ones as milliseconds', () => {
+	const access = new CodexCliDataAccess();
+	assert.equal(access.toMillis(1774000000), 1774000000000);
+	assert.equal(access.toMillis(1774000000000), 1774000000000);
+	assert.equal(access.toMillis(null), null);
+	assert.equal(access.toMillis(0), null);
+});
+
+test('normalizeRolloutLine handles legacy unwrapped response items and bare session meta', () => {
+	const access = new CodexCliDataAccess();
+	const legacyItem = access.normalizeRolloutLine({ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] });
+	assert.equal(legacyItem?.kind, 'response_item');
+	assert.equal((legacyItem?.payload as any).role, 'user');
+	const legacyMeta = access.normalizeRolloutLine({ id: ROLLOUT_UUID, timestamp: '2025-01-01T00:00:00Z', instructions: null });
+	assert.equal(legacyMeta?.kind, 'session_meta');
+	assert.equal(access.normalizeRolloutLine({ foo: 'bar' }), null);
+});
+
+test('token_count events with inline usage fields (older builds) are still parsed', async () => {
+	const harness = createHarness();
+	try {
+		const extra = path.join(harness.tmpHome, 'sessions', '2026', '03', '19', `rollout-2026-03-19T13-00-00-119d0233-2d86-7c21-b13a-8fa9578d3a0d.jsonl`);
+		fs.writeFileSync(extra, [
+			JSON.stringify({ timestamp: '2026-03-19T13:00:00.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] } }),
+			JSON.stringify({ timestamp: '2026-03-19T13:00:01.000Z', type: 'event_msg', payload: { type: 'token_count', input_tokens: 500, cached_input_tokens: 0, output_tokens: 100, reasoning_output_tokens: 10, total_tokens: 600 } }),
+		].join('\n'));
+		const tokens = await harness.access.getTokens(extra);
+		assert.equal(tokens.tokens, 600);
+		assert.equal(tokens.thinkingTokens, 10);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('rollouts without token_count events fall back to a text-length estimate', async () => {
+	const harness = createHarness();
+	try {
+		const extra = path.join(harness.tmpHome, 'sessions', '2026', '03', '19', `rollout-2026-03-19T14-00-00-229d0233-2d86-7c21-b13a-8fa9578d3a0d.jsonl`);
+		fs.writeFileSync(extra, [
+			JSON.stringify({ timestamp: '2026-03-19T14:00:00.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'a'.repeat(400) }] } }),
+			JSON.stringify({ timestamp: '2026-03-19T14:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'b'.repeat(200) }] } }),
+		].join('\n'));
+		const tokens = await harness.access.getTokens(extra);
+		assert.equal(tokens.tokens, 150); // (400 + 200) / 4
+	} finally {
+		harness.cleanup();
+	}
+});

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -28,6 +28,7 @@ import { AntigravityAdapter } from '../../../src/adapters/antigravityAdapter';
 import { KiroAdapter } from '../../../src/adapters/kiroAdapter';
 import { KiroCliAdapter } from '../../../src/adapters/kiroCliAdapter';
 import { DevinCliAdapter } from '../../../src/adapters/devinCliAdapter';
+import { CodexCliAdapter } from '../../../src/adapters/codexCliAdapter';
 
 import { OpenCodeDataAccess } from '../../../src/opencode';
 import { CrushDataAccess } from '../../../src/crush';
@@ -42,6 +43,7 @@ import { AntigravityDataAccess } from '../../../src/antigravity';
 import { KiroDataAccess } from '../../../src/kiro';
 import { KiroCliDataAccess } from '../../../src/kirocli';
 import { DevinCliDataAccess } from '../../../src/devinCli';
+import { CodexCliDataAccess } from '../../../src/codexcli';
 
 // Stub functions for adapters requiring callbacks
 const noopEstimateTokens = (_text: string, _model?: string) => 0;
@@ -62,6 +64,7 @@ const antigravityDA = new AntigravityDataAccess();
 const kiroDA = new KiroDataAccess();
 const kiroCliDA = new KiroCliDataAccess();
 const devinCliDA = new DevinCliDataAccess();
+const codexCliDA = new CodexCliDataAccess();
 
 const openCodeAdapter = new OpenCodeAdapter(openCodeDA);
 const crushAdapter = new CrushAdapter(crushDA);
@@ -78,22 +81,24 @@ const antigravityAdapter = new AntigravityAdapter(antigravityDA);
 const kiroAdapter = new KiroAdapter(kiroDA);
 const kiroCliAdapter = new KiroCliAdapter(kiroCliDA);
 const devinCliAdapter = new DevinCliAdapter(devinCliDA);
+const codexCliAdapter = new CodexCliAdapter(codexCliDA);
 
 const allAdapters: IEcosystemAdapter[] = [
     openCodeAdapter, crushAdapter, continueAdapter, eclipseAdapter,
     claudeCodeAdapter, claudeDesktopAdapter, visualStudioAdapter, mistralVibeAdapter, geminiCliAdapter,
     copilotChatAdapter, copilotCliAdapter, antigravityAdapter, kiroAdapter, kiroCliAdapter, devinCliAdapter,
+    codexCliAdapter,
 ];
 
 // ---------------------------------------------------------------------------
 // isDiscoverable type guard
 // ---------------------------------------------------------------------------
 
-test('isDiscoverable: returns true for all 15 adapters', () => {
+test('isDiscoverable: returns true for all 16 adapters', () => {
     for (const adapter of allAdapters) {
         assert.ok(isDiscoverable(adapter), `Expected ${adapter.id} to be discoverable`);
     }
-    assert.equal(allAdapters.length, 15);
+    assert.equal(allAdapters.length, 16);
 });
 
 test('isDiscoverable: returns false for plain IEcosystemAdapter without discover()', () => {
@@ -128,6 +133,7 @@ test('adapter IDs are stable lowercase identifiers', () => {
     assert.equal(kiroAdapter.id, 'kiro');
     assert.equal(kiroCliAdapter.id, 'kirocli');
     assert.equal(devinCliAdapter.id, 'devincli');
+    assert.equal(codexCliAdapter.id, 'codexcli');
 });
 
 // ---------------------------------------------------------------------------
@@ -255,6 +261,23 @@ test('DevinCliAdapter.handles: rejects unrelated paths and the Devin desktop dev
     assert.ok(!devinCliAdapter.handles('devin://trajectory/abc123'));
     assert.ok(!devinCliAdapter.handles(path.join(os.homedir(), '.crush', 'crush.db#abc')));
     assert.ok(!devinCliAdapter.handles(path.join(os.homedir(), '.continue', 'sessions', 'abc.json')));
+});
+
+test('CodexCliAdapter.handles: recognises rollout files and state-db virtual thread paths', () => {
+    const rollout = path.join(codexCliDA.getSessionsDir(), '2026', '03', '19', 'rollout-2026-03-19T12-00-00-019d0233-2d86-7c21-b13a-8fa9578d3a0d.jsonl');
+    assert.ok(codexCliAdapter.handles(rollout));
+    const archived = path.join(codexCliDA.getArchivedSessionsDir(), '2026', '03', '19', 'rollout-2026-03-19T12-00-00-019d0233-2d86-7c21-b13a-8fa9578d3a0d.jsonl');
+    assert.ok(codexCliAdapter.handles(archived));
+    const virtual = codexCliDA.virtualPath('019d0233-2d86-7c21-b13a-8fa9578d3a0d');
+    assert.ok(codexCliAdapter.handles(virtual));
+    assert.ok(codexCliAdapter.handles(virtual.replace(/\//g, '\\')));
+});
+
+test('CodexCliAdapter.handles: rejects unrelated paths (incl. the logs db and other adapters)', () => {
+    assert.ok(!codexCliAdapter.handles(path.join(os.homedir(), '.codex', 'logs_1.sqlite')));
+    assert.ok(!codexCliAdapter.handles(path.join(os.homedir(), '.codex', 'models_cache.json')));
+    assert.ok(!codexCliAdapter.handles(path.join(os.homedir(), '.crush', 'crush.db#abc')));
+    assert.ok(!codexCliAdapter.handles(path.join(os.homedir(), '.continue', 'sessions', 'abc.json')));
 });
 
 test('KiroAdapter.handles: recognises kiro.kiroagent workspace-sessions paths', () => {

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -266,6 +266,11 @@ test('getEditorNameFromRoot: Devin CLI config dir returns "Devin CLI" (distinct 
     assert.equal(getEditorNameFromRoot('C:\\Users\\user\\AppData\\Roaming\\devin\\cli'), 'Devin CLI');
     assert.equal(getEditorNameFromRoot('/home/user/.local/share/devin/cli'), 'Devin CLI');
 });
+
+test('getEditorNameFromRoot: Codex CLI home (~/.codex) returns "Codex CLI", not VS Code', () => {
+    assert.equal(getEditorNameFromRoot('C:\\Users\\user\\.codex'), 'Codex CLI');
+    assert.equal(getEditorNameFromRoot('/home/user/.codex'), 'Codex CLI');
+});
 // ── Mutation-killing tests ──────────────────────────────────────────────
 
 import {
@@ -456,6 +461,13 @@ test('detectEditorSource: detects Devin (Cognition Labs fork/rebrand of Windsurf
 test('detectEditorSource: detects Devin CLI virtual sessions.db paths (distinct from the desktop app)', () => {
         const p = 'C:\\Users\\alice\\AppData\\Roaming\\devin\\cli\\sessions.db#sess-abc123';
         assert.equal(detectEditorSource(p), 'Devin CLI');
+});
+
+test('detectEditorSource: detects Codex CLI rollout files and virtual thread paths (not VS Code, despite the "code" substring)', () => {
+        const rollout = 'C:\\Users\\alice\\.codex\\sessions\\2026\\03\\19\\rollout-2026-03-19T12-00-00-019d0233-2d86-7c21-b13a-8fa9578d3a0d.jsonl';
+        assert.equal(detectEditorSource(rollout), 'Codex CLI');
+        const virtual = '/home/alice/.codex/state_5.sqlite#019d0233-2d86-7c21-b13a-8fa9578d3a0d';
+        assert.equal(detectEditorSource(virtual), 'Codex CLI');
 });
 
 test('detectEditorSource: detects VSCodium', () => {
@@ -1353,6 +1365,13 @@ test('getEditorTypeFromPath: devin:// URI returns Devin', () => {
 test('getEditorTypeFromPath: Devin CLI sessions.db virtual path returns "Devin CLI"', () => {
     const p = 'C:\\Users\\alice\\AppData\\Roaming\\devin\\cli\\sessions.db#sess-abc123';
     assert.equal(getEditorTypeFromPath(p), 'Devin CLI');
+});
+
+test('getEditorTypeFromPath: Codex CLI rollout and virtual thread paths return "Codex CLI"', () => {
+    const rollout = 'C:\\Users\\alice\\.codex\\archived_sessions\\2026\\03\\19\\rollout-2026-03-19T12-00-00-019d0233-2d86-7c21-b13a-8fa9578d3a0d.jsonl';
+    assert.equal(getEditorTypeFromPath(rollout), 'Codex CLI');
+    const virtual = 'C:\\Users\\alice\\.codex\\state_5.sqlite#019d0233-2d86-7c21-b13a-8fa9578d3a0d';
+    assert.equal(getEditorTypeFromPath(virtual), 'Codex CLI');
 });
 
 test('getEditorTypeFromPath: isGeminiCliPath requires all three conditions (missing /chats/session-)', () => {


### PR DESCRIPTION
Adds OpenAI Codex CLI as a tracked ecosystem (closes #1493).

## Data sources
Codex stores threads in `~/.codex/state_<N>.sqlite` (sqlx; `threads` table with `rollout_path`, `tokens_used`, `model`, `cwd`, title, git metadata) pointing at rollout JSONL files (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`) whose `token_count` events carry cumulative real token usage. The adapter supports **both**: rollout files for per-model deltas/turns/tool calls, and DB-only threads (virtual `<state_db>#<thread_id>` paths) as a graceful fallback. `CODEX_HOME` is honored; highest-numbered `state_<N>.sqlite` wins.

## Changes
- New `src/codexcli.ts` (`CodexCliDataAccess`, sql.js pattern from devinCli/crush; reset-safe cumulative-delta math, legacy format handling, mtime-keyed cache) and `src/adapters/codexCliAdapter.ts` (id `codexcli`, `IEcosystemAdapter` + `IDiscoverableEcosystem` + `IAnalyzableEcosystem`, `buildTurns`, `getDailyFractions`)
- Detection: `workspaceHelpers.ts` (new `detectCliAgentStoreFromPath` guarding `/.codex/` before loose `code` substring matches) and `cli/src/analysis.ts`
- `editorIcons.ts`: 🌀 for Codex CLI
- 15 new unit tests + adapter/workspace-helper test updates; schema doc in `docs/logFilesSchema/codex-cli-session-format.md`

## Verification
- `npm run compile`: 0 errors; `npm run test:node`: 86 suites pass; CLI build + 23/23 unit tests
- End-to-end with a synthetic rollout under a scratch `CODEX_HOME`: diagnostics + stats report 1 session / 14.5K tokens exactly
- Caveat: `threads.created_at/updated_at` unit assumed seconds (local `threads` table was empty); re-verify on a machine with populated rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)