### PR TITLE
ci: skip sharing-server deploy when the push has no sharing-server changes

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -3,6 +3,12 @@ name: Deploy Sharing Server
 # Triggers on any push that touches the sharing server or this workflow file.
 # main  → production environment  (sharing-server-prod)
 # branch → testing environment    (sharing-test-<slug><hash>)
+#
+# NOTE: on.push.paths cannot compute a diff for the first push of a new branch
+# (the event's `before` SHA is all zeros), so GitHub triggers this workflow for
+# every new branch regardless of paths. The `changes` job below re-checks with
+# a real git diff and skips the whole deploy pipeline when the sharing server
+# is untouched.
 on:
   push:
     branches: ["**"]
@@ -29,10 +35,61 @@ permissions:
   contents: read
 
 jobs:
+  # ── Verify the push actually changed sharing-server files ────────────────────
+  # Guards against the new-branch path-filter gap described in the header note.
+  changes:
+    name: Check for sharing-server changes
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.diff.outputs.deploy }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Diff changed paths against the push base
+        id: diff
+        env:
+          EVENT_NAME:     ${{ github.event_name }}
+          BEFORE:         ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — deploying." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          BASE="$BEFORE"
+          if [[ "$BASE" =~ ^0+$ ]] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            # New branch or rewritten history: compare against the merge-base with the default branch
+            BASE=$(git merge-base "origin/${DEFAULT_BRANCH:-main}" HEAD || true)
+          fi
+          if [[ -z "$BASE" ]]; then
+            # No base determinable — fail open so a real change is never skipped
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Could not determine a diff base — deploying to be safe." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" HEAD | grep -qE '^(sharing-server/|\.github/workflows/sharing-server-deploy\.yml)'; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "No sharing-server changes between \`${BASE}\` and \`${GITHUB_SHA}\` — skipping deployment." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   # ── Compute environment metadata ─────────────────────────────────────────────
   setup:
     name: Compute deployment environment
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.deploy == 'true'
     outputs:
       app_name:           ${{ steps.env.outputs.app_name }}
       state_key:          ${{ steps.env.outputs.state_key }}


### PR DESCRIPTION
Every new branch push was creating a `Deploy Sharing Server` run (stuck `waiting` on environment approval) even when the branch never touched the sharing server — see e.g. the July 14–15 runs for `copilot/*` and `rajbos-*` branches.

## Root cause
`on.push.paths` cannot compute a diff for the **first push of a new branch**: the push event's `before` SHA is all zeros, so GitHub triggers the workflow regardless of path filters. The filters work fine for subsequent pushes.

## Fix
A new lightweight `changes` gate job re-checks with a real git diff before anything else runs:
- normal pushes: diff `before..HEAD`
- new branches / rewritten history: diff against the merge-base with the default branch
- no base determinable: **fail open** (deploy) so a real change is never silently skipped
- `workflow_dispatch`: always deploys

`setup` now needs `changes` with `if: deploy == 'true'`, so `build` and `deploy` cascade-skip too — no more container builds or dangling environment-approval prompts for unrelated branches. Same paths are matched as the trigger filter (`sharing-server/**` + the workflow file itself).

Validated with `actionlint` (clean). Follows the workflow security conventions: pinned action SHAs, harden-runner, `${{ }}` values passed via `env` instead of inline script interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)