### PR TITLE
Add task classification and stacked bar chart by task category

### DIFF
--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -92,7 +92,7 @@ function fmtKey(d: Date): string {
 }
 
 function emptyEntry(date: string): DailyTokenStats {
-	return { date, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} };
+	return { date, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {}, taskCategoryUsage: {} };
 }
 
 function mergeUsageGroup(
@@ -134,6 +134,8 @@ function mergeInto(target: DailyTokenStats, src: DailyTokenStats): void {
 	addModelUsage(target.modelUsage, src.modelUsage);
 	mergeUsageGroup(target.editorUsage, src.editorUsage);
 	mergeUsageGroup(target.repositoryUsage, src.repositoryUsage);
+	if (!target.taskCategoryUsage) { target.taskCategoryUsage = {}; }
+	mergeUsageGroup(target.taskCategoryUsage, src.taskCategoryUsage ?? {});
 	if (src.linesAdded !== undefined) { target.linesAdded = (target.linesAdded ?? 0) + src.linesAdded; }
 	if (src.linesRemoved !== undefined) { target.linesRemoved = (target.linesRemoved ?? 0) + src.linesRemoved; }
 	mergeLanguageUsage(target, src);
@@ -361,7 +363,13 @@ function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 	});
 	const editorCostDatasets = buildEditorCostDatasets(entries, deps);
 	const billingGroupCostDatasets = buildBillingGroupCostDatasets(entries, deps);
-	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets };
+	const allTaskCategories = new Set<string>();
+	entries.forEach(e => Object.keys(e.taskCategoryUsage ?? {}).forEach(tc => allTaskCategories.add(tc)));
+	const taskCategoryDatasets = Array.from(allTaskCategories).map((category, idx) => {
+		const color = getModelColor(idx);
+		return { label: category, data: entries.map(e => e.taskCategoryUsage?.[category]?.tokens || 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
+	});
+	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, taskCategoryDatasets };
 }
 
 function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilderDeps) {
@@ -403,6 +411,7 @@ export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDat
 		modelDatasets: dailyPeriod.modelDatasets,
 		editorDatasets: dailyPeriod.editorDatasets,
 		repositoryDatasets: dailyPeriod.repositoryDatasets,
+		taskCategoryDatasets: dailyPeriod.taskCategoryDatasets,
 		editorTotalsMap,
 		repositoryTotalsMap,
 		dailyCount: dailyPeriod.periodCount,

--- a/src/taskClassification.ts
+++ b/src/taskClassification.ts
@@ -1,0 +1,172 @@
+/**
+ * Task classification — buckets a session into a single dominant task category
+ * using keyword + tool-usage heuristics (issue #1650).
+ *
+ * Design notes:
+ * - `classifySessionTask()` is a pure function operating on a small, adapter-agnostic
+ *   input shape (`TaskClassificationInput`) so it can run over data already produced
+ *   by the existing parsing/enrichment pipeline (`usageAnalysis.ts`'s `toolCalls.byTool`,
+ *   or the log viewer's `ChatTurn[]`) without re-parsing session files.
+ * - Two builder helpers adapt the existing shared types to that input:
+ *   - `buildClassificationInputFromUsageAnalysis()` — lightweight path used during
+ *     session caching (`getSessionFileDataCached`). Only tool names + the session
+ *     title (already extracted for free during metadata parsing) are available, so
+ *     terminal command text isn't inspected here.
+ *   - `buildClassificationInputFromChatTurns()` — richer path used by the log viewer,
+ *     where full per-turn user text and tool-call arguments (e.g. terminal commands)
+ *     are already reconstructed.
+ * - Priority order (most specific → least specific) is intentionally pragmatic:
+ *   terminal-command keyword matches (Git Ops / Build-Deploy / Testing) win over
+ *   generic tool-based categories because they're stronger, less ambiguous signals.
+ *   Keyword-based categories (Debugging / Refactoring / Feature Dev) only apply when
+ *   there IS tool activity (so plain chit-chat mentioning "fix" isn't miscategorized).
+ *   Conversation is the fallback only when there are zero tool calls and no strong
+ *   keyword match fired.
+ */
+
+import type { SessionUsageAnalysis, ChatTurn } from './types';
+
+export type TaskCategory =
+	| 'Coding'
+	| 'Debugging'
+	| 'Feature Dev'
+	| 'Refactoring'
+	| 'Testing'
+	| 'Exploration'
+	| 'Planning'
+	| 'Delegation'
+	| 'Git Ops'
+	| 'Build/Deploy'
+	| 'Brainstorming'
+	| 'Conversation';
+
+/** Adapter-agnostic input for `classifySessionTask()`. */
+export interface TaskClassificationInput {
+	/** Tool names invoked during the session (e.g. `toolCalls.byTool` keys, or per-turn tool names). */
+	toolNames: string[];
+	/** Raw command/argument text passed to terminal-style tool calls, when available. */
+	terminalCommands?: string[];
+	/** Free-form text to scan for intent keywords — session title, first user message, or concatenated user messages. */
+	userText?: string;
+}
+
+const EDIT_TOOL_PATTERN = /edit|write|create_?file|replace_?string|str_replace|apply_?patch|patch/i;
+const READ_TOOL_PATTERN = /read_?file|grep_?search|file_?search|search|glob|list_dir|websearch|fetch/i;
+const TERMINAL_TOOL_PATTERN = /terminal|bash|shell|run_?command/i;
+const PLANNING_TOOL_PATTERN = /todo|task[-_]?create|enterplanmode|\bplan\b/i;
+const DELEGATION_TOOL_PATTERN = /subagent|sub[-_]?agent|agent[-_]?spawn|delegate/i;
+const TEST_TOOL_PATTERN = /run_?tests?|pytest|vitest|jest/i;
+
+const GIT_KEYWORD_PATTERN = /\bgit\s+(push|commit|merge|pull|rebase|checkout|clone)\b/i;
+const BUILD_KEYWORD_PATTERN = /\b(npm\s+run\s+build|docker\s+(build|run|compose)|pm2|webpack|esbuild|make\s+build|deploy(ment)?)\b/i;
+const TEST_KEYWORD_PATTERN = /\b(pytest|vitest|jest|npm\s+(run\s+)?test|go\s+test|dotnet\s+test|mocha)\b/i;
+const DEBUG_KEYWORD_PATTERN = /\b(fix(ing|ed)?|bug|error|debug(ging)?|broken|crash(ing|ed)?|fail(ing|ed|ure)?|issue)\b/i;
+const REFACTOR_KEYWORD_PATTERN = /\b(refactor(ing)?|rename|simplify|restructure|clean\s?up)\b/i;
+const FEATURE_KEYWORD_PATTERN = /\b(add|create|implement|build|new feature)\b/i;
+const PLANNING_KEYWORD_PATTERN = /\b(plan|roadmap|outline|todo list|task list)\b/i;
+const BRAINSTORM_KEYWORD_PATTERN = /\b(brainstorm|what if|design|explore ideas?|thinking about)\b/i;
+
+/** Derived boolean/text signals used by the priority checks below. Kept in one place so each check function stays small. */
+interface ClassificationSignals {
+	hasToolCalls: boolean;
+	hasEditTools: boolean;
+	hasReadTools: boolean;
+	hasTerminalTools: boolean;
+	hasPlanningTools: boolean;
+	hasDelegationTools: boolean;
+	hasTestTools: boolean;
+	terminalText: string;
+	userText: string;
+}
+
+function deriveSignals(input: TaskClassificationInput): ClassificationSignals {
+	const toolNames = (input.toolNames ?? []).map(t => t.toLowerCase());
+	return {
+		hasToolCalls: toolNames.length > 0,
+		hasEditTools: toolNames.some(t => EDIT_TOOL_PATTERN.test(t)),
+		hasReadTools: toolNames.some(t => READ_TOOL_PATTERN.test(t)),
+		hasTerminalTools: toolNames.some(t => TERMINAL_TOOL_PATTERN.test(t)),
+		hasPlanningTools: toolNames.some(t => PLANNING_TOOL_PATTERN.test(t)),
+		hasDelegationTools: toolNames.some(t => DELEGATION_TOOL_PATTERN.test(t)),
+		hasTestTools: toolNames.some(t => TEST_TOOL_PATTERN.test(t)),
+		terminalText: (input.terminalCommands ?? []).join(' ').toLowerCase(),
+		userText: (input.userText ?? '').toLowerCase(),
+	};
+}
+
+/** Priority 1-5: strong, unambiguous terminal-command and dedicated-tool signals. */
+function classifyByToolAndTerminalSignals(s: ClassificationSignals): TaskCategory | null {
+	if (GIT_KEYWORD_PATTERN.test(s.terminalText)) { return 'Git Ops'; }
+	if (BUILD_KEYWORD_PATTERN.test(s.terminalText)) { return 'Build/Deploy'; }
+	if (TEST_KEYWORD_PATTERN.test(s.terminalText) || s.hasTestTools) { return 'Testing'; }
+	if (s.hasDelegationTools) { return 'Delegation'; }
+	if (s.hasPlanningTools) { return 'Planning'; }
+	return null;
+}
+
+/** Priority 6-8: keyword matches that only count as a signal when there IS tool activity (not idle chatter). */
+function classifyByActivityKeywords(s: ClassificationSignals): TaskCategory | null {
+	if (!s.hasToolCalls) { return null; }
+	if (DEBUG_KEYWORD_PATTERN.test(s.userText)) { return 'Debugging'; }
+	// Checked before Feature Dev since "refactor" is the more specific term.
+	if (REFACTOR_KEYWORD_PATTERN.test(s.userText)) { return 'Refactoring'; }
+	if (FEATURE_KEYWORD_PATTERN.test(s.userText)) { return 'Feature Dev'; }
+	return null;
+}
+
+/** Priority 9-13: remaining fallbacks — planning-by-keyword, exploration, coding, brainstorming, conversation. */
+function classifyByFallback(s: ClassificationSignals): TaskCategory {
+	// Planning by keyword — only when no edit tools contradict it.
+	if (!s.hasEditTools && PLANNING_KEYWORD_PATTERN.test(s.userText)) { return 'Planning'; }
+	// Exploration — only read/search tool calls, no edits or terminal usage.
+	if (s.hasToolCalls && s.hasReadTools && !s.hasEditTools && !s.hasTerminalTools) { return 'Exploration'; }
+	// Coding — edit/write tool calls present, no stronger signal matched above.
+	if (s.hasEditTools) { return 'Coding'; }
+	// Brainstorming — no tool calls (or only exploration) + brainstorming keywords.
+	if ((!s.hasToolCalls || s.hasReadTools) && BRAINSTORM_KEYWORD_PATTERN.test(s.userText)) { return 'Brainstorming'; }
+	// Conversation — fallback when there are zero tool calls and no keyword matched.
+	if (!s.hasToolCalls) { return 'Conversation'; }
+	// Any remaining tool-call session with no stronger signal (e.g. terminal-only, no keyword match).
+	return 'Coding';
+}
+
+/** Classifies a session into a single dominant `TaskCategory` using keyword + tool-usage heuristics. */
+export function classifySessionTask(input: TaskClassificationInput): TaskCategory {
+	const signals = deriveSignals(input);
+	return classifyByToolAndTerminalSignals(signals) ?? classifyByActivityKeywords(signals) ?? classifyByFallback(signals);
+}
+
+/**
+ * Lightweight builder used during session caching (`getSessionFileDataCached`).
+ * Only tool names (from `toolCalls.byTool`) and the already-extracted session title
+ * are available at this stage — no raw terminal command text.
+ */
+export function buildClassificationInputFromUsageAnalysis(
+	usageAnalysis: Pick<SessionUsageAnalysis, 'toolCalls'> | undefined,
+	userText?: string | null
+): TaskClassificationInput {
+	const toolNames = usageAnalysis ? Object.keys(usageAnalysis.toolCalls?.byTool ?? {}) : [];
+	return { toolNames, userText: userText ?? undefined };
+}
+
+/**
+ * Richer builder used by the log viewer, where full per-turn user messages and
+ * tool-call arguments (e.g. terminal commands) are already reconstructed as `ChatTurn[]`.
+ */
+export function buildClassificationInputFromChatTurns(turns: ChatTurn[]): TaskClassificationInput {
+	const toolNames: string[] = [];
+	const terminalCommands: string[] = [];
+	const userTextParts: string[] = [];
+	for (const turn of turns) {
+		if (turn.userMessage) { userTextParts.push(turn.userMessage); }
+		for (const tc of turn.toolCalls ?? []) {
+			toolNames.push(tc.toolName);
+			if (tc.arguments && TERMINAL_TOOL_PATTERN.test(tc.toolName.toLowerCase())) {
+				terminalCommands.push(tc.arguments);
+			}
+		}
+	}
+	return { toolNames, terminalCommands, userText: userTextParts.join(' ') };
+}
+
+export default { classifySessionTask, buildClassificationInputFromUsageAnalysis, buildClassificationInputFromChatTurns };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@
  * Extracted from extension.ts to reduce file size and improve reusability.
  */
 
+import type { TaskCategory } from './taskClassification';
+
 /**
  * Character-to-token ratio for a specific AI model.
  * The value is a multiplier applied to the character count to estimate token count
@@ -158,6 +160,8 @@ export interface DailyTokenStats {
    * model usage aggregated from all sessions of that editor type on that day.
    */
   editorModelUsage?: { [editor: string]: ModelUsage };
+  /** Per-task-category token/session breakdown for this day, keyed by `TaskCategory` (e.g. "Coding", "Debugging"). */
+  taskCategoryUsage?: { [category: string]: { tokens: number; sessions: number } };
 }
 
 /** Aggregated data for one time window (day/week/month) in the chart. */
@@ -202,6 +206,8 @@ export interface ChartPeriodData {
    * Copilot group uses AI-Credit pricing; all others use direct provider pricing.
    */
   billingGroupCostDatasets?: object[];
+  /** Token datasets split by task category (e.g. "Coding", "Debugging", "Testing") — one stacked-bar dataset per category. */
+  taskCategoryDatasets?: object[];
 }
 
 /** Shape of the data payload sent to the chart webview (via window.__INITIAL_CHART__ or postMessage). */
@@ -214,6 +220,7 @@ export interface ChartDataPayload {
   editorTotalsMap: Record<string, number>;
   repositoryDatasets: object[];
   repositoryTotalsMap: Record<string, number>;
+  taskCategoryDatasets?: object[];
   dailyCount: number;
   totalTokens: number;
   avgTokensPerDay: number;
@@ -276,6 +283,8 @@ export interface SessionFileCache {
   maxRequestInputTokens?: number;
   /** Copilot CLI context tier from session.start/resume/model_change events (e.g. "default"). */
   contextTier?: string;
+  /** Dominant task category for this session (e.g. "Coding", "Debugging"), computed once via `classifySessionTask()`. */
+  taskCategory?: TaskCategory;
   /** Per-UTC-day token/interaction breakdown (keyed by YYYY-MM-DD UTC). Used for consistent daily stats. */
   dailyRollups?: { [utcDayKey: string]: DailyRollupEntry };
   linesAdded?: number;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -179,6 +179,9 @@ import {
 // --- Chart building ---
 import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceForBillingGroup } from '../../src/chartDataBuilder';
 
+// --- Task classification ---
+import { classifySessionTask, buildClassificationInputFromUsageAnalysis, type TaskCategory } from '../../src/taskClassification';
+
 // --- Stats helpers ---
 import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, type SessionAggregateInput } from '../../src/statsHelpers';
 
@@ -380,7 +383,7 @@ interface WorktreeScanResult {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 59; // Detect Auto model and Foundry local models from request-level fields
+	private static readonly CACHE_VERSION = 60; // Added taskCategory (task classification, issue #1650)
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';
@@ -3333,7 +3336,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (dayKey < cutoffUtcStartKey) { continue; }
 			const dayTokens = (dayRollup.actualTokens > 0 ? dayRollup.actualTokens : dayRollup.tokens);
 			const dailyEntry = this.getOrCreateDailyEntry(dailyStatsMap, dayKey);
-			this.addUsageToDailyEntry(dailyEntry, dayTokens, dayRollup.interactions, editorType, repository, dayRollup.modelUsage);
+			this.addUsageToDailyEntry(dailyEntry, dayTokens, dayRollup.interactions, editorType, repository, dayRollup.modelUsage, sessionData.taskCategory);
 			if (!lastDayKey || dayKey > lastDayKey) { lastDayKey = dayKey; }
 		}
 		if (lastDayKey && (sessionData.linesAdded ?? 0) + (sessionData.linesRemoved ?? 0) > 0) {
@@ -3349,7 +3352,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const dateKey = toLocalDayKey(lastActivity);
 		if (dateKey < cutoffUtcStartKey) { return; }
 		const dailyEntry = this.getOrCreateDailyEntry(dailyStatsMap, dateKey);
-		this.addUsageToDailyEntry(dailyEntry, tokens, sessionData.interactions, editorType, repository, sessionData.modelUsage);
+		this.addUsageToDailyEntry(dailyEntry, tokens, sessionData.interactions, editorType, repository, sessionData.modelUsage, sessionData.taskCategory);
 		if ((sessionData.linesAdded ?? 0) + (sessionData.linesRemoved ?? 0) > 0) {
 			this.addLocToDailyEntry(dailyEntry, sessionData.linesAdded ?? 0, sessionData.linesRemoved ?? 0, editorType, repository, sessionData.languageUsage);
 		}
@@ -3357,12 +3360,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private getOrCreateDailyEntry(dailyStatsMap: Map<string, DailyTokenStats>, dateKey: string): DailyTokenStats {
 		if (!dailyStatsMap.has(dateKey)) {
-			dailyStatsMap.set(dateKey, { date: dateKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
+			dailyStatsMap.set(dateKey, { date: dateKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {}, taskCategoryUsage: {} });
 		}
 		return dailyStatsMap.get(dateKey)!;
 	}
 
-	private addUsageToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: number, editorType: string, repository: string, modelUsage: any): void {
+	private addUsageToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: number, editorType: string, repository: string, modelUsage: any, taskCategory?: TaskCategory): void {
 		entry.tokens += tokens;
 		entry.sessions += 1;
 		entry.interactions += interactions;
@@ -3376,6 +3379,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
 		if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
 		addModelUsage(entry.editorModelUsage[editorType], modelUsage);
+		if (taskCategory) {
+			if (!entry.taskCategoryUsage) { entry.taskCategoryUsage = {}; }
+			if (!entry.taskCategoryUsage[taskCategory]) { entry.taskCategoryUsage[taskCategory] = { tokens: 0, sessions: 0 }; }
+			entry.taskCategoryUsage[taskCategory].tokens += tokens;
+			entry.taskCategoryUsage[taskCategory].sessions += 1;
+		}
 	}
 
 	private addLocToDailyEntry(entry: DailyTokenStats, linesAdded: number, linesRemoved: number, editorType: string, repository: string, languageUsage?: any): void {
@@ -4641,10 +4650,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const copilotNanoAiu = debugLogTokens?.copilotNanoAiu ?? tokenResult.copilotNanoAiu ?? 0;
 		const copilotExactCostDollars = copilotNanoAiu > 0 ? copilotNanoAiu * NANO_AIU_TO_DOLLARS : undefined;
 		const optionals = this.buildOptionalSessionFields(tokenResult, debugLogTokens, finalCacheReadTokens, copilotExactCostDollars, dailyRollups, usageAnalysis);
+		// Classified once per session (not per-render) using tool names from usageAnalysis and the
+		// already-extracted session title — see src/taskClassification.ts for the heuristic + rationale.
+		const taskCategory = classifySessionTask(buildClassificationInputFromUsageAnalysis(usageAnalysis, sessionMeta.title));
 		return {
 			tokens: tokenResult.tokens, interactions, modelUsage: resolvedModelUsage, mtime, size: fileSize,
 			usageAnalysis, title: sessionMeta.title, firstInteraction: sessionMeta.firstInteraction,
-			lastInteraction: sessionMeta.lastInteraction, actualTokens: resolvedActualTokens,
+			lastInteraction: sessionMeta.lastInteraction, actualTokens: resolvedActualTokens, taskCategory,
 			// Repository is discovered separately by getSessionFileDetails() (via content-reference
 			// git-root lookup) and is not recomputed here. Without preserving it, every cache-miss
 			// rebuild of this entry (e.g. an actively-edited session whose file keeps changing)

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -27,6 +27,7 @@ type ChartPeriodData = {
 	modelDatasets: ModelDataset[];
 	editorDatasets: EditorDataset[];
 	repositoryDatasets: RepositoryDataset[];
+	taskCategoryDatasets?: ModelDataset[];
 	periodCount: number;
 	totalTokens: number;
 	totalSessions: number;
@@ -103,7 +104,7 @@ async function loadChartModule(): Promise<void> {
 	Chart = mod.default;
 }
 let currentMetric: 'tokens' | 'output' | 'cost' = 'tokens';
-let currentSplit: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' = 'total';
+let currentSplit: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' | 'taskCategory' = 'total';
 let currentPeriod: ChartPeriod = 'day';
 // Stores state to restore after a background data update re-initializes the chart
 let pendingMetric: typeof currentMetric | null = null;
@@ -116,7 +117,7 @@ let currentDisplayMode: DisplayMode = 'actual';
 type ChartWebviewState = {
 	period: ChartPeriod;
 	metric: 'tokens' | 'output' | 'cost';
-	split: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider';
+	split: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' | 'taskCategory';
 	displayMode: DisplayMode;
 	/** @deprecated Use metric + split instead. Kept for migration of old saved state. */
 	view?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
@@ -205,7 +206,7 @@ const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countL
 
 function isComboSupported(metric: string, split: string): boolean {
 	if (metric === 'cost') { return split === 'total' || split === 'editor' || split === 'provider'; }
-	if (metric === 'output') { return split !== 'model' && split !== 'provider'; }
+	if (metric === 'output') { return split !== 'model' && split !== 'provider' && split !== 'taskCategory'; }
 	return split !== 'language' && split !== 'provider';
 }
 
@@ -278,7 +279,8 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 	};
 	splitGroup.append(mkSplit('split-total', 'total', 'Total'), mkSplit('split-model', 'model', 'By Model'),
 		mkSplit('split-editor', 'editor', 'By Editor'), mkSplit('split-provider', 'provider', '🏷️ By Provider'),
-		mkSplit('split-repository', 'repository', 'By Repository'), mkSplit('split-language', 'language', 'By Language'));
+		mkSplit('split-repository', 'repository', 'By Repository'), mkSplit('split-language', 'language', 'By Language'),
+		mkSplit('split-taskcategory', 'taskCategory', 'By Task'));
 	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output';
 	const rollingBtn = el('button', `toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicable ? '' : ' hidden'}`, '📈 Rolling Avg');
 	rollingBtn.id = 'view-rolling';
@@ -448,6 +450,7 @@ function wireInteractions(data: InitialChartData): void {
 		{ id: 'split-repository', split: 'repository' },
 		{ id: 'split-language',   split: 'language'   },
 		{ id: 'split-provider',   split: 'provider'   },
+		{ id: 'split-taskcategory', split: 'taskCategory' },
 	];
 	splitButtons.forEach(({ id, split }) => {
 		const btn = document.getElementById(id);
@@ -546,7 +549,7 @@ async function switchMetric(metric: typeof currentMetric, data: InitialChartData
 
 function isSplitSupported(metric: typeof currentMetric, split: typeof currentSplit): boolean {
 	return (metric === 'cost' && (split === 'total' || split === 'editor' || split === 'provider')) ||
-		(metric === 'output' && split !== 'model' && split !== 'provider') ||
+		(metric === 'output' && split !== 'model' && split !== 'provider' && split !== 'taskCategory') ||
 		(metric === 'tokens' && split !== 'language' && split !== 'provider');
 }
 
@@ -612,7 +615,7 @@ function setActiveMetric(metric: typeof currentMetric): void {
 }
 
 function setActiveSplit(split: typeof currentSplit): void {
-	(['split-total', 'split-model', 'split-editor', 'split-repository', 'split-language', 'split-provider'] as const).forEach(id => {
+	(['split-total', 'split-model', 'split-editor', 'split-repository', 'split-language', 'split-provider', 'split-taskcategory'] as const).forEach(id => {
 		const btn = document.getElementById(id);
 		if (!btn) { return; }
 		btn.classList.toggle('active', id === `split-${split}`);
@@ -627,6 +630,7 @@ function updateSplitButtonStates(): void {
 		{ id: 'split-repository', split: 'repository' },
 		{ id: 'split-language',   split: 'language'   },
 		{ id: 'split-provider',   split: 'provider'   },
+		{ id: 'split-taskcategory', split: 'taskCategory' },
 	];
 	splits.forEach(({ id, split }) => {
 		const btn = document.getElementById(id) as HTMLButtonElement | null;
@@ -940,7 +944,7 @@ function refreshHeatmapView(data: InitialChartData): void {
 }
 
 function buildStackedViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
-	const datasets = view === 'model' ? period.modelDatasets : view === 'repository' ? period.repositoryDatasets : period.editorDatasets;
+	const datasets = view === 'model' ? period.modelDatasets : view === 'repository' ? period.repositoryDatasets : view === 'taskCategory' ? (period.taskCategoryDatasets ?? []) : period.editorDatasets;
 	const lastIdx = period.tokensData.length - 1;
 	const projExtra = lastIdx >= 0 ? computeProjectionExtra(period.tokensData[lastIdx], getCurrentPeriodFraction(currentPeriod)) : null;
 	const projDs = projExtra !== null ? [{ label: PROJECTION_LABELS[currentPeriod], data: period.tokensData.map((_: number, i: number) => i === lastIdx ? Math.round(projExtra) : 0), backgroundColor: 'rgba(200, 200, 200, 0.25)', borderColor: 'rgba(200, 200, 200, 0.5)', borderWidth: 1 }] : [];
@@ -964,6 +968,7 @@ function resolveChartView(metric: typeof currentMetric, split: typeof currentSpl
 		if (split === 'model') { return 'model'; }
 		if (split === 'editor') { return 'editor'; }
 		if (split === 'repository') { return 'repository'; }
+		if (split === 'taskCategory') { return 'taskCategory'; }
 		return 'total';
 	}
 	if (metric === 'cost') {

--- a/vscode-extension/test/unit/taskClassification.test.ts
+++ b/vscode-extension/test/unit/taskClassification.test.ts
@@ -1,0 +1,136 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import taskClassificationDefault, {
+	classifySessionTask,
+	buildClassificationInputFromUsageAnalysis,
+	buildClassificationInputFromChatTurns,
+} from '../../../src/taskClassification';
+import type { ChatTurn, ContextReferenceUsage, SessionUsageAnalysis } from '../../../src/types';
+
+function emptyContextRefs(): ContextReferenceUsage {
+	return {
+		file: 0, selection: 0, implicitSelection: 0, symbol: 0, codebase: 0, workspace: 0,
+		terminal: 0, vscode: 0, terminalLastCommand: 0, terminalSelection: 0, clipboard: 0,
+		changes: 0, outputPanel: 0, problemsPanel: 0, pullRequest: 0,
+		byKind: {}, copilotInstructions: 0, agentsMd: 0, byPath: {},
+	};
+}
+
+function makeTurn(overrides: Partial<ChatTurn>): ChatTurn {
+	return {
+		turnNumber: 1,
+		timestamp: null,
+		mode: 'agent',
+		userMessage: '',
+		assistantResponse: '',
+		model: null,
+		toolCalls: [],
+		contextReferences: emptyContextRefs(),
+		mcpTools: [],
+		inputTokensEstimate: 0,
+		outputTokensEstimate: 0,
+		thinkingTokensEstimate: 0,
+		...overrides,
+	};
+}
+
+// ── classifySessionTask: one example per TaskCategory ─────────────────────────
+
+test('classifySessionTask: Git Ops — terminal git command wins over everything else', () => {
+	assert.equal(classifySessionTask({ toolNames: ['run_in_terminal'], terminalCommands: ['git push origin main'] }), 'Git Ops');
+});
+
+test('classifySessionTask: Build/Deploy — docker build terminal command', () => {
+	assert.equal(classifySessionTask({ toolNames: ['run_in_terminal'], terminalCommands: ['docker build -t app .'] }), 'Build/Deploy');
+});
+
+test('classifySessionTask: Testing — test-runner terminal command', () => {
+	assert.equal(classifySessionTask({ toolNames: ['run_in_terminal'], terminalCommands: ['npm test'] }), 'Testing');
+});
+
+test('classifySessionTask: Testing — dedicated test tool call', () => {
+	assert.equal(classifySessionTask({ toolNames: ['run_tests'] }), 'Testing');
+});
+
+test('classifySessionTask: Delegation — sub-agent tool call', () => {
+	assert.equal(classifySessionTask({ toolNames: ['delegate_task'] }), 'Delegation');
+});
+
+test('classifySessionTask: Planning — dedicated planning/todo tool call', () => {
+	assert.equal(classifySessionTask({ toolNames: ['todo_write'] }), 'Planning');
+});
+
+test('classifySessionTask: Debugging — edit tool + bug/fix keywords', () => {
+	assert.equal(classifySessionTask({ toolNames: ['edit_file'], userText: 'fix the bug in the parser' }), 'Debugging');
+});
+
+test('classifySessionTask: Refactoring — edit tool + refactor keywords', () => {
+	assert.equal(classifySessionTask({ toolNames: ['edit_file'], userText: 'refactor the module to simplify duplicate logic' }), 'Refactoring');
+});
+
+test('classifySessionTask: Feature Dev — edit tool + add/implement keywords', () => {
+	assert.equal(classifySessionTask({ toolNames: ['create_file'], userText: 'add a new feature to export CSV data' }), 'Feature Dev');
+});
+
+test('classifySessionTask: Planning — planning keywords without edit tools', () => {
+	assert.equal(classifySessionTask({ toolNames: ['read_file'], userText: 'help me outline a roadmap for next quarter' }), 'Planning');
+});
+
+test('classifySessionTask: Exploration — only read/search tool calls', () => {
+	assert.equal(classifySessionTask({ toolNames: ['read_file', 'grep_search'] }), 'Exploration');
+});
+
+test('classifySessionTask: Coding — edit tool calls, no stronger signal', () => {
+	assert.equal(classifySessionTask({ toolNames: ['edit_file'] }), 'Coding');
+});
+
+test('classifySessionTask: Brainstorming — no tool calls, brainstorming keywords', () => {
+	assert.equal(classifySessionTask({ toolNames: [], userText: 'brainstorm some ideas for the new architecture' }), 'Brainstorming');
+});
+
+test('classifySessionTask: Conversation — no tool calls, no keyword match', () => {
+	assert.equal(classifySessionTask({ toolNames: [], userText: 'thanks so much, that really helped me understand' }), 'Conversation');
+});
+
+// ── buildClassificationInputFromUsageAnalysis ─────────────────────────────────
+
+test('buildClassificationInputFromUsageAnalysis: extracts tool names from byTool keys and passes through title', () => {
+	const usageAnalysis = { toolCalls: { total: 2, byTool: { edit_file: 1, read_file: 1 } } } as unknown as Pick<SessionUsageAnalysis, 'toolCalls'>;
+	const result = buildClassificationInputFromUsageAnalysis(usageAnalysis, 'Fix a bug in the parser');
+	assert.deepEqual([...result.toolNames].sort(), ['edit_file', 'read_file']);
+	assert.equal(result.userText, 'Fix a bug in the parser');
+	assert.equal(result.terminalCommands, undefined);
+});
+
+test('buildClassificationInputFromUsageAnalysis: handles missing usageAnalysis/title gracefully', () => {
+	const result = buildClassificationInputFromUsageAnalysis(undefined, undefined);
+	assert.deepEqual(result.toolNames, []);
+	assert.equal(result.userText, undefined);
+});
+
+// ── buildClassificationInputFromChatTurns ─────────────────────────────────────
+
+test('buildClassificationInputFromChatTurns: collects tool names, terminal commands, and joined user text', () => {
+	const turns: ChatTurn[] = [
+		makeTurn({ userMessage: 'please fix this', toolCalls: [{ toolName: 'edit_file' }] }),
+		makeTurn({ userMessage: 'and run the tests', toolCalls: [{ toolName: 'run_in_terminal', arguments: 'npm test' }] }),
+	];
+	const result = buildClassificationInputFromChatTurns(turns);
+	assert.deepEqual(result.toolNames, ['edit_file', 'run_in_terminal']);
+	assert.deepEqual(result.terminalCommands, ['npm test']);
+	assert.equal(result.userText, 'please fix this and run the tests');
+});
+
+test('buildClassificationInputFromChatTurns: empty turns array yields empty input', () => {
+	const result = buildClassificationInputFromChatTurns([]);
+	assert.deepEqual(result.toolNames, []);
+	assert.deepEqual(result.terminalCommands, []);
+	assert.equal(result.userText, '');
+});
+
+test('default export bundles all three functions', () => {
+	assert.equal(taskClassificationDefault.classifySessionTask, classifySessionTask);
+	assert.equal(taskClassificationDefault.buildClassificationInputFromUsageAnalysis, buildClassificationInputFromUsageAnalysis);
+	assert.equal(taskClassificationDefault.buildClassificationInputFromChatTurns, buildClassificationInputFromChatTurns);
+});


### PR DESCRIPTION
## Summary

Implements task classification for sessions and a new stacked bar chart showing task-category distribution over time, per #1650.

- Add `src/taskClassification.ts` — `classifySessionTask()` heuristic classifier covering 12 task categories: Coding, Debugging, Feature Dev, Refactoring, Testing, Exploration, Planning, Delegation, Git Ops, Build/Deploy, Brainstorming, Conversation.
- Compute `taskCategory` once per session during parsing/caching (`buildSessionDataObject` in `extension.ts`), bump `CACHE_VERSION` 59→60 to invalidate stale cache entries.
- Thread `taskCategory` through daily aggregation and `chartDataBuilder.ts` (`taskCategoryDatasets`), mirroring the existing `editorDatasets` pattern.
- Add task category as a new stacked-bar split option in the webview chart (`vscode-extension/src/webview/chart/main.ts`), reusing the existing metric×split toggle infrastructure. Currently tokens-metric only (no cost/session-count split yet — see open question below).
- Add unit tests covering one example per category (`vscode-extension/test/unit/taskClassification.test.ts`).

## Decisions made
- Priority order in `classifySessionTask`: terminal commands (Git Ops → Build/Deploy → Testing) > dedicated tools (Delegation → Planning) > keyword+tool-activity (Debugging → Refactoring → Feature Dev) > fallbacks (Planning-by-keyword → Exploration → Coding → Brainstorming → Conversation).
- Classification runs during parsing/caching (not per-render in the webview), per the issue's guidance to avoid re-classifying on every render.
- Dominant/single category per session (no partial credit split).

## Follow-up (not in this PR)
- Task-category chart split currently supports tokens only; extending to cost/session-count would need additional dataset building in `chartDataBuilder.ts`.

## Validation
- `npm run compile` → 0 errors, 0 warnings
- `npm run test:node` → all suites pass, including the new test file

Closes #1650