### PR TITLE
Add Sessions histogram metric to Chart view

### DIFF
--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -159,15 +159,20 @@ function fmtWeekLabel(monday: Date): string {
 
 function buildDailyBuckets(fullDailyStats: DailyTokenStats[], now: Date): BucketEntry[] {
 	const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-	const thirtyDaysAgoStr = fmtKey(thirtyDaysAgo);
+	let startDate = new Date(thirtyDaysAgo);
+	for (const day of fullDailyStats) {
+		const d = new Date(day.date + 'T00:00:00');
+		if (d < startDate) { startDate = d; }
+	}
+	const startStr = fmtKey(startDate);
 	const todayStr = fmtKey(now);
 	const bucketMap = new Map<string, BucketEntry>();
-	for (let cursor = new Date(thirtyDaysAgo); cursor <= now; cursor.setDate(cursor.getDate() + 1)) {
+	for (let cursor = new Date(startDate); cursor <= now; cursor.setDate(cursor.getDate() + 1)) {
 		const key = fmtKey(new Date(cursor));
 		bucketMap.set(key, { key, label: key, stats: emptyEntry(key) });
 	}
 	for (const day of fullDailyStats) {
-		if (day.date >= thirtyDaysAgoStr && day.date <= todayStr) {
+		if (day.date >= startStr && day.date <= todayStr) {
 			const bucket = bucketMap.get(day.date);
 			if (bucket) { mergeInto(bucket.stats, day); }
 		}
@@ -177,9 +182,18 @@ function buildDailyBuckets(fullDailyStats: DailyTokenStats[], now: Date): Bucket
 
 function buildWeeklyBuckets(fullDailyStats: DailyTokenStats[], now: Date): BucketEntry[] {
 	const thisMonday = getMondayOfWeek(now);
-	const bucketMap = new Map<string, BucketEntry>();
+	let earliestMonday = new Date(thisMonday);
 	for (let w = 5; w >= 0; w--) {
 		const monday = new Date(thisMonday); monday.setDate(thisMonday.getDate() - w * 7);
+		if (monday < earliestMonday) { earliestMonday = monday; }
+	}
+	for (const day of fullDailyStats) {
+		const monday = getMondayOfWeek(new Date(day.date + "T00:00:00"));
+		if (monday < earliestMonday) { earliestMonday = monday; }
+	}
+	const bucketMap = new Map<string, BucketEntry>();
+	for (let cursor = new Date(earliestMonday); cursor <= thisMonday; cursor.setDate(cursor.getDate() + 7)) {
+		const monday = new Date(cursor);
 		const key = fmtKey(monday);
 		bucketMap.set(key, { key, label: fmtWeekLabel(monday), stats: emptyEntry(key) });
 	}
@@ -193,8 +207,19 @@ function buildWeeklyBuckets(fullDailyStats: DailyTokenStats[], now: Date): Bucke
 
 function buildMonthlyBuckets(fullDailyStats: DailyTokenStats[], now: Date): BucketEntry[] {
 	const bucketMap = new Map<string, BucketEntry>();
-	for (let m = 11; m >= 0; m--) {
-		const monthDate = new Date(now.getFullYear(), now.getMonth() - m, 1);
+	let earliestYear = now.getFullYear();
+	let earliestMonth = now.getMonth() - 11;
+	while (earliestMonth < 0) { earliestYear--; earliestMonth += 12; }
+	for (const day of fullDailyStats) {
+		const [year, month] = day.date.split('-').map(Number);
+		if (year < earliestYear || (year === earliestYear && month - 1 < earliestMonth)) {
+			earliestYear = year;
+			earliestMonth = month - 1;
+		}
+	}
+	const monthsCount = (now.getFullYear() - earliestYear) * 12 + (now.getMonth() - earliestMonth);
+	for (let i = 0; i <= monthsCount; i++) {
+		const monthDate = new Date(earliestYear, earliestMonth + i, 1);
 		const key = `${monthDate.getFullYear()}-${String(monthDate.getMonth() + 1).padStart(2, "0")}`;
 		const label = monthDate.toLocaleDateString("en-US", { month: "short", year: "numeric" });
 		bucketMap.set(key, { key, label, stats: emptyEntry(key) });
@@ -392,7 +417,9 @@ function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilde
 
 /**
  * Aggregate daily token stats into the chart payload used by the chart webview.
- * Produces daily (last 30 days), weekly (last 6 weeks), and monthly (last 12 months) period data.
+ * Produces daily, weekly, and monthly period data covering at least the recent default
+ * window (30 days / 6 weeks / 12 months) and extending back to the earliest available
+ * session so the "All time" time-window option can display the full history.
  */
 export function buildChartData(fullDailyStats: DailyTokenStats[], deps: ChartDataBuilderDeps): ChartDataPayload {
 	const now = deps.now ?? new Date();

--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -253,6 +253,74 @@ function buildModelDatasets(entries: DailyTokenStats[], deps: ChartDataBuilderDe
 	return datasets;
 }
 
+/** Builds session-count datasets split by model. */
+function buildModelSessionsDatasets(entries: DailyTokenStats[]) {
+	const allModels = new Set<string>();
+	entries.forEach(e => Object.keys(e.modelUsage).forEach(m => allModels.add(m)));
+	const modelSessionTotals = new Map<string, number>();
+	for (const model of allModels) {
+		const total = entries.reduce((sum, e) => sum + (e.modelUsage[model]?.sessions ?? 0), 0);
+		modelSessionTotals.set(model, total);
+	}
+	const sortedModels = Array.from(allModels).sort((a, b) => (modelSessionTotals.get(b) || 0) - (modelSessionTotals.get(a) || 0));
+	const topModels = sortedModels.slice(0, 5);
+	const otherModels = sortedModels.slice(5);
+	const datasets = topModels.map((model, idx) => {
+		const color = getModelColor(idx);
+		return { label: getModelDisplayName(model), data: entries.map(e => e.modelUsage[model]?.sessions ?? 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
+	});
+	if (otherModels.length > 0) {
+		datasets.push({ label: 'Other models', data: entries.map(e => otherModels.reduce((sum, m) => sum + (e.modelUsage[m]?.sessions ?? 0), 0)), backgroundColor: 'rgba(150, 150, 150, 0.5)', borderColor: 'rgba(150, 150, 150, 0.8)', borderWidth: 1 });
+	}
+	return datasets;
+}
+
+/** Builds session-count datasets split by editor. */
+function buildEditorSessionsDatasets(entries: DailyTokenStats[]) {
+	const allEditors = new Set<string>();
+	entries.forEach(e => Object.keys(e.editorUsage).forEach(ed => allEditors.add(ed)));
+	const editorSessionTotals = new Map<string, number>();
+	for (const editor of allEditors) {
+		const total = entries.reduce((sum, e) => sum + (e.editorUsage[editor]?.sessions ?? 0), 0);
+		editorSessionTotals.set(editor, total);
+	}
+	const sortedEditors = Array.from(allEditors).sort((a, b) => (editorSessionTotals.get(b) || 0) - (editorSessionTotals.get(a) || 0));
+	return sortedEditors.map((editor, idx) => {
+		const color = getModelColor(idx);
+		return { label: editor, data: entries.map(e => e.editorUsage[editor]?.sessions ?? 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
+	});
+}
+
+/** Aggregates per-editor-model session counts up to billing provider groups. */
+function aggregateBillingGroupSessions(entry: DailyTokenStats): Record<string, number> {
+	const result: Record<string, number> = {};
+	const editorModelUsage = entry.editorModelUsage;
+	if (!editorModelUsage) { return result; }
+	for (const [editor, modelUsage] of Object.entries(editorModelUsage)) {
+		for (const [modelId, usage] of Object.entries(modelUsage)) {
+			const group = getBillingGroup(editor, modelId);
+			result[group] = (result[group] ?? 0) + (usage.sessions ?? 0);
+		}
+	}
+	return result;
+}
+
+/** Builds session-count datasets split by billing provider. */
+function buildProviderSessionsDatasets(entries: DailyTokenStats[]) {
+	const allGroups = new Set<string>();
+	entries.forEach(e => Object.keys(aggregateBillingGroupSessions(e)).forEach(g => allGroups.add(g)));
+	const groupTotals = new Map<string, number>();
+	for (const group of allGroups) {
+		const total = entries.reduce((sum, e) => sum + (aggregateBillingGroupSessions(e)[group] ?? 0), 0);
+		groupTotals.set(group, total);
+	}
+	const sortedGroups = Array.from(allGroups).sort((a, b) => (groupTotals.get(b) || 0) - (groupTotals.get(a) || 0));
+	return sortedGroups.map((group, idx) => {
+		const color = getModelColor(idx);
+		return { label: group, data: entries.map(e => aggregateBillingGroupSessions(e)[group] ?? 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
+	});
+}
+
 /**
  * Builds cost datasets split by editor/hosting surface.
  * Each dataset holds per-bucket estimated costs for one editor type, using the
@@ -389,13 +457,16 @@ function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 	});
 	const editorCostDatasets = buildEditorCostDatasets(entries, deps);
 	const billingGroupCostDatasets = buildBillingGroupCostDatasets(entries, deps);
+	const modelSessionsDatasets = buildModelSessionsDatasets(entries);
+	const editorSessionsDatasets = buildEditorSessionsDatasets(entries);
+	const providerSessionsDatasets = buildProviderSessionsDatasets(entries);
 	const allTaskCategories = new Set<string>();
 	entries.forEach(e => Object.keys(e.taskCategoryUsage ?? {}).forEach(tc => allTaskCategories.add(tc)));
 	const taskCategoryDatasets = Array.from(allTaskCategories).map((category, idx) => {
 		const color = getModelColor(idx);
 		return { label: category, data: entries.map(e => e.taskCategoryUsage?.[category]?.tokens || 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
 	});
-	return { labels, periodKeys, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, taskCategoryDatasets };
+	return { labels, periodKeys, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, modelSessionsDatasets, editorSessionsDatasets, providerSessionsDatasets, taskCategoryDatasets };
 }
 
 function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilderDeps) {

--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -320,6 +320,7 @@ function buildBillingGroupCostDatasets(entries: DailyTokenStats[], deps: ChartDa
 function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 	const entries = buckets.map(b => b.stats);
 	const labels = buckets.map(b => b.label);
+	const periodKeys = buckets.map(b => b.key);
 	const tokensData = entries.map(e => e.tokens);
 	const sessionsData = entries.map(e => e.sessions);
 	const modelDatasets = buildModelDatasets(entries, deps);
@@ -369,7 +370,7 @@ function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 		const color = getModelColor(idx);
 		return { label: category, data: entries.map(e => e.taskCategoryUsage?.[category]?.tokens || 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
 	});
-	return { labels, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, taskCategoryDatasets };
+	return { labels, periodKeys, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, taskCategoryDatasets };
 }
 
 function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilderDeps) {

--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -453,9 +453,17 @@ function addToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: n
 	if (!entry.repositoryUsage[repository]) { entry.repositoryUsage[repository] = { tokens: 0, sessions: 0 }; }
 	entry.repositoryUsage[repository].tokens += tokens; entry.repositoryUsage[repository].sessions += 1;
 	addModelUsage(entry.modelUsage, modelUsage);
+	for (const model of Object.keys(modelUsage)) {
+		if (!entry.modelUsage[model].sessions) { entry.modelUsage[model].sessions = 0; }
+		entry.modelUsage[model].sessions += 1;
+	}
 	if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
 	if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
 	addModelUsage(entry.editorModelUsage[editorType], modelUsage);
+	for (const model of Object.keys(modelUsage)) {
+		if (!entry.editorModelUsage[editorType][model].sessions) { entry.editorModelUsage[editorType][model].sessions = 0; }
+		entry.editorModelUsage[editorType][model].sessions += 1;
+	}
 }
 
 function accumulatePeriod(acc: PeriodAccumulator, tokens: number, estimated: number, actual: number, thinking: number, cached: number, interactions: number, countSession: boolean, editorType: string, modelUsage: ModelUsage, copilotExactCostDollars?: number): void {

--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -59,6 +59,9 @@ target[model].cachedReadTokens = (target[model].cachedReadTokens ?? 0) + usage.c
 if (usage.cacheCreationTokens !== undefined) {
 target[model].cacheCreationTokens = (target[model].cacheCreationTokens ?? 0) + usage.cacheCreationTokens;
 }
+if (usage.sessions !== undefined) {
+target[model].sessions = (target[model].sessions ?? 0) + usage.sessions;
+}
 }
 }
 
@@ -99,6 +102,7 @@ export function reconcileModelUsageToTotal(modelUsage: ModelUsage, targetInputTo
 			inputTokens, outputTokens,
 			...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * inputScale) } : {}),
 			...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(usage.cacheCreationTokens * inputScale) } : {}),
+			...(usage.sessions !== undefined ? { sessions: usage.sessions } : {}),
 		};
 	}
 	const residualInput = targetInputTokens - scaledInputTotal;
@@ -243,9 +247,17 @@ function _apsBumpDailyEntry(entry: DailyTokenStats, tokens: number, interactions
 	entry.repositoryUsage[repository].tokens += tokens;
 	entry.repositoryUsage[repository].sessions += 1;
 	addModelUsage(entry.modelUsage, modelUsage);
+	for (const model of Object.keys(modelUsage)) {
+		if (!entry.modelUsage[model].sessions) { entry.modelUsage[model].sessions = 0; }
+		entry.modelUsage[model].sessions += 1;
+	}
 	if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
 	if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
 	addModelUsage(entry.editorModelUsage[editorType], modelUsage);
+	for (const model of Object.keys(modelUsage)) {
+		if (!entry.editorModelUsage[editorType][model].sessions) { entry.editorModelUsage[editorType][model].sessions = 0; }
+		entry.editorModelUsage[editorType][model].sessions += 1;
+	}
 }
 
 function _apsBumpPeriod(acc: PeriodAccumulator, f: ApsDayFields, freshSession: boolean): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,9 +164,14 @@ export interface DailyTokenStats {
   taskCategoryUsage?: { [category: string]: { tokens: number; sessions: number } };
 }
 
+/** Time-window selector options available in the Chart view. */
+export type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth';
+
 /** Aggregated data for one time window (day/week/month) in the chart. */
 export interface ChartPeriodData {
   labels: string[];
+  /** ISO date keys for each bar, used for time-window filtering. Day=YYYY-MM-DD, week=Monday YYYY-MM-DD, month=YYYY-MM. */
+  periodKeys: string[];
   tokensData: number[];
   sessionsData: number[];
   modelDatasets: object[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export interface ModelUsage {
      * the standard `cacheCreationCostPerMillion` (5-minute) rate.
      */
     cacheCreation1hTokens?: number;
+    /** Number of sessions that used this model in the aggregated period. */
+    sessions?: number;
   };
 }
 
@@ -211,6 +213,12 @@ export interface ChartPeriodData {
    * Copilot group uses AI-Credit pricing; all others use direct provider pricing.
    */
   billingGroupCostDatasets?: object[];
+  /** Session-count datasets split by model — one stacked-bar dataset per model. */
+  modelSessionsDatasets?: object[];
+  /** Session-count datasets split by editor — one stacked-bar dataset per editor. */
+  editorSessionsDatasets?: object[];
+  /** Session-count datasets split by billing provider — one stacked-bar dataset per provider group. */
+  providerSessionsDatasets?: object[];
   /** Token datasets split by task category (e.g. "Coding", "Debugging", "Testing") — one stacked-bar dataset per category. */
   taskCategoryDatasets?: object[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,7 @@ export interface DailyTokenStats {
 }
 
 /** Time-window selector options available in the Chart view. */
-export type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth';
+export type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth' | 'allTime';
 
 /** Aggregated data for one time window (day/week/month) in the chart. */
 export interface ChartPeriodData {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -28,6 +28,7 @@ import type {
   DetailedStats,
   DailyTokenStats,
   ChartDataPayload,
+  ChartTimeWindow,
   SessionFileCache,
   DailyRollupEntry,
   CustomizationFileEntry,
@@ -484,6 +485,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private lastChartView: 'total' | 'model' | 'editor' | 'repository' | 'cost' = 'total';
 	private lastChartMetric: string = 'tokens';
 	private lastChartSplit: string = 'total';
+	private lastChartTimeWindow: ChartTimeWindow = 'last30';
 	private lastUsageAnalysisStats: UsageAnalysisStats | undefined;
 	private lastDashboardData: any | undefined;
 	/** Insight engine: persisted state for all surfaced insights. */
@@ -6154,6 +6156,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (await this.dispatchSharedCommand(message)) { return; }
 			if (message.command === 'refresh') { await this.dispatch('refresh:chart', () => this.refreshChartPanel()); }
 			if (message.command === 'setPeriodPreference') { this.setChartPeriodPreference(message.period); }
+			if (message.command === 'setTimeWindowPreference') { this.setChartTimeWindowPreference(message.timeWindow); }
 			if (message.command === 'setViewPreference') { this.setChartViewPreference(message); }
 		});
 
@@ -6180,6 +6183,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private setChartPeriodPreference(period: string): void {
 		if (period === 'day' || period === 'week' || period === 'month') { this.lastChartPeriod = period; }
+	}
+
+	private setChartTimeWindowPreference(timeWindow: string): void {
+		const valid: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth'];
+		if (valid.includes(timeWindow as ChartTimeWindow)) { this.lastChartTimeWindow = timeWindow as ChartTimeWindow; }
 	}
 
 	private setChartViewPreference(message: any): void {
@@ -9915,7 +9923,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       vscode.Uri.joinPath(this.extensionUri, "dist", "webview", "chart.js"),
     );
 
-    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit, monthlyBudget: this.getEffectiveMonthlyBudget() };
+    const chartData = { ...this.buildChartData(dailyStats), periodsReady, initialPeriod: this.lastChartPeriod, initialTimeWindow: this.lastChartTimeWindow, initialView: this.lastChartView, initialMetric: this.lastChartMetric, initialSplit: this.lastChartSplit, monthlyBudget: this.getEffectiveMonthlyBudget() };
 
     const initialData = JSON.stringify(chartData).replace(/</g, "\\u003c");
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3379,9 +3379,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 		entry.repositoryUsage[repository].tokens += tokens;
 		entry.repositoryUsage[repository].sessions += 1;
 		addModelUsage(entry.modelUsage, modelUsage);
+		for (const model of Object.keys(modelUsage)) {
+			if (!entry.modelUsage[model].sessions) { entry.modelUsage[model].sessions = 0; }
+			entry.modelUsage[model].sessions += 1;
+		}
 		if (!entry.editorModelUsage) { entry.editorModelUsage = {}; }
 		if (!entry.editorModelUsage[editorType]) { entry.editorModelUsage[editorType] = {}; }
 		addModelUsage(entry.editorModelUsage[editorType], modelUsage);
+		for (const model of Object.keys(modelUsage)) {
+			if (!entry.editorModelUsage[editorType][model].sessions) { entry.editorModelUsage[editorType][model].sessions = 0; }
+			entry.editorModelUsage[editorType][model].sessions += 1;
+		}
 		if (taskCategory) {
 			if (!entry.taskCategoryUsage) { entry.taskCategoryUsage = {}; }
 			if (!entry.taskCategoryUsage[taskCategory]) { entry.taskCategoryUsage[taskCategory] = { tokens: 0, sessions: 0 }; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6186,7 +6186,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private setChartTimeWindowPreference(timeWindow: string): void {
-		const valid: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth'];
+		const valid: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
 		if (valid.includes(timeWindow as ChartTimeWindow)) { this.lastChartTimeWindow = timeWindow as ChartTimeWindow; }
 	}
 

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -49,6 +49,7 @@ type ChartPeriodData = {
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
+type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth';
 
 type InitialChartData = {
 	labels: string[];
@@ -70,8 +71,9 @@ type InitialChartData = {
 	periodsReady?: boolean;
 	hasLocData?: boolean;
 	initialPeriod?: ChartPeriod;
+	initialTimeWindow?: ChartTimeWindow;
 	initialView?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
-	initialMetric?: 'tokens' | 'output' | 'cost';
+	initialMetric?: 'tokens' | 'output' | 'cost' | 'sessions';
 	initialSplit?: 'total' | 'model' | 'editor' | 'repository' | 'language';
 	monthlyBudget?: number;
 	periods?: {
@@ -103,9 +105,10 @@ async function loadChartModule(): Promise<void> {
 	const mod = await import('chart.js/auto');
 	Chart = mod.default;
 }
-let currentMetric: 'tokens' | 'output' | 'cost' = 'tokens';
+let currentMetric: 'tokens' | 'output' | 'cost' | 'sessions' = 'tokens';
 let currentSplit: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' | 'taskCategory' = 'total';
 let currentPeriod: ChartPeriod = 'day';
+let currentTimeWindow: ChartTimeWindow = 'last30';
 // Stores state to restore after a background data update re-initializes the chart
 let pendingMetric: typeof currentMetric | null = null;
 let pendingSplit: typeof currentSplit | null = null;
@@ -116,7 +119,8 @@ let currentDisplayMode: DisplayMode = 'actual';
 
 type ChartWebviewState = {
 	period: ChartPeriod;
-	metric: 'tokens' | 'output' | 'cost';
+	timeWindow: ChartTimeWindow;
+	metric: 'tokens' | 'output' | 'cost' | 'sessions';
 	split: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' | 'taskCategory';
 	displayMode: DisplayMode;
 	/** @deprecated Use metric + split instead. Kept for migration of old saved state. */
@@ -125,14 +129,144 @@ type ChartWebviewState = {
 
 const chartState = createViewStateManager<ChartWebviewState>(vscode, {
 	period: 'day',
+	timeWindow: 'last30',
 	metric: 'tokens',
 	split: 'total',
 	displayMode: 'actual',
 });
 
 function saveWebviewState(): void {
-	chartState.save({ period: currentPeriod, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode });
+	chartState.save({ period: currentPeriod, timeWindow: currentTimeWindow, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode });
 }
+
+const TIME_WINDOW_LABELS: Record<ChartTimeWindow, string> = {
+	today: 'Today',
+	last7: 'Last 7 days',
+	last30: 'Last 30 days',
+	currentMonth: 'Current month',
+};
+
+function getWindowStartDate(timeWindow: ChartTimeWindow, now: Date): string {
+	const y = now.getFullYear();
+	const m = now.getMonth();
+	const d = now.getDate();
+	switch (timeWindow) {
+		case 'today':
+			return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+		case 'last7': {
+			const start = new Date(y, m, d - 6);
+			return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-${String(start.getDate()).padStart(2, '0')}`;
+		}
+		case 'last30': {
+			const start = new Date(y, m, d - 29);
+			return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-${String(start.getDate()).padStart(2, '0')}`;
+		}
+		case 'currentMonth':
+			return `${y}-${String(m + 1).padStart(2, '0')}-01`;
+	}
+}
+
+function getWindowStartMonth(timeWindow: ChartTimeWindow, now: Date): string {
+	const y = now.getFullYear();
+	const m = now.getMonth();
+	if (timeWindow === 'currentMonth') {
+		return `${y}-${String(m + 1).padStart(2, '0')}`;
+	}
+	// For today/last7/last30, include the current month and previous month if needed.
+	const start = new Date(y, m, timeWindow === 'today' ? 1 : timeWindow === 'last7' ? -5 : -29);
+	return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function sliceByIndices<T>(arr: T[] | undefined, indices: number[]): T[] | undefined {
+	if (!arr) { return undefined; }
+	return indices.map(i => arr[i]);
+}
+
+function sliceDatasetsByIndices(datasets: object[] | undefined, indices: number[]): object[] | undefined {
+	if (!datasets) { return undefined; }
+	return datasets.map(ds => {
+		const d = ds as { data: number[] };
+		return { ...d, data: indices.map(i => d.data[i]) };
+	});
+}
+
+function getFilterStartKey(timeWindow: ChartTimeWindow, periodType: ChartPeriod, now: Date): string {
+	return periodType === 'month' ? getWindowStartMonth(timeWindow, now) : getWindowStartDate(timeWindow, now);
+}
+
+function buildCoreFilteredPeriod(period: ChartPeriodData, indices: number[]): ChartPeriodData {
+	const totalTokens = indices.reduce((sum, i) => sum + period.tokensData[i], 0);
+	const totalSessions = indices.reduce((sum, i) => sum + period.sessionsData[i], 0);
+	const costData = sliceByIndices(period.costData, indices) as number[];
+	const totalCost = costData.reduce((a, b) => a + b, 0);
+	return {
+		labels: indices.map(i => period.labels[i]),
+		periodKeys: indices.map(i => period.periodKeys[i]),
+		tokensData: indices.map(i => period.tokensData[i]),
+		sessionsData: indices.map(i => period.sessionsData[i]),
+		modelDatasets: sliceDatasetsByIndices(period.modelDatasets, indices) as ModelDataset[],
+		editorDatasets: sliceDatasetsByIndices(period.editorDatasets, indices) as EditorDataset[],
+		repositoryDatasets: sliceDatasetsByIndices(period.repositoryDatasets, indices) as RepositoryDataset[],
+		periodCount: indices.length,
+		totalTokens,
+		totalSessions,
+		avgPerPeriod: indices.length > 0 ? Math.round(totalTokens / indices.length) : 0,
+		costData,
+		totalCost,
+		avgCostPerPeriod: indices.length > 0 ? totalCost / indices.length : 0,
+	};
+}
+
+function copyFilteredLocFields(source: ChartPeriodData, target: ChartPeriodData, indices: number[]): void {
+	const locData = sliceByIndices(source.locData, indices);
+	const linesAddedData = sliceByIndices(source.linesAddedData, indices);
+	const linesRemovedData = sliceByIndices(source.linesRemovedData, indices);
+
+	if (locData) { target.locData = locData as number[]; }
+	if (linesAddedData) { target.linesAddedData = linesAddedData as number[]; }
+	if (linesRemovedData) { target.linesRemovedData = linesRemovedData as number[]; }
+	if (source.totalLinesAdded !== undefined) { target.totalLinesAdded = (linesAddedData as number[] ?? []).reduce((a, b) => a + b, 0); }
+	if (source.totalLinesRemoved !== undefined) { target.totalLinesRemoved = (linesRemovedData as number[] ?? []).reduce((a, b) => a + b, 0); }
+	if (source.avgLocPerPeriod !== undefined) {
+		target.avgLocPerPeriod = locData && locData.length > 0 ? (locData as number[]).reduce((a, b) => a + b, 0) / locData.length : 0;
+	}
+}
+
+function copyFilteredDatasetFields(source: ChartPeriodData, target: ChartPeriodData, indices: number[]): void {
+	const datasetFields: Array<{ key: keyof ChartPeriodData; source: object[] | undefined }> = [
+		{ key: 'languageDatasets', source: source.languageDatasets },
+		{ key: 'locEditorDatasets', source: source.locEditorDatasets },
+		{ key: 'locRepositoryDatasets', source: source.locRepositoryDatasets },
+		{ key: 'editorCostDatasets', source: source.editorCostDatasets },
+		{ key: 'billingGroupCostDatasets', source: source.billingGroupCostDatasets },
+		{ key: 'taskCategoryDatasets', source: source.taskCategoryDatasets },
+	];
+	for (const { key, source: ds } of datasetFields) {
+		if (ds) { (target as Record<string, object[]>)[key] = sliceDatasetsByIndices(ds, indices) as object[]; }
+	}
+}
+
+function copyFilteredOptionalFields(source: ChartPeriodData, target: ChartPeriodData, indices: number[]): void {
+	copyFilteredLocFields(source, target, indices);
+	copyFilteredDatasetFields(source, target, indices);
+}
+
+function filterPeriodByTimeWindow(period: ChartPeriodData, timeWindow: ChartTimeWindow, periodType: ChartPeriod): ChartPeriodData {
+	if (timeWindow === 'last30' && periodType === 'day') {
+		return period;
+	}
+	const startKey = getFilterStartKey(timeWindow, periodType, new Date());
+	const indices: number[] = [];
+	for (let i = 0; i < period.periodKeys.length; i++) {
+		if (period.periodKeys[i] >= startKey) { indices.push(i); }
+	}
+	if (indices.length === 0) { return period; }
+
+	const filtered = buildCoreFilteredPeriod(period, indices);
+	copyFilteredOptionalFields(period, filtered, indices);
+	return filtered;
+}
+
 const ROLLING_WINDOW: Record<ChartPeriod, number> = { day: 7, week: 4, month: 3 };
 
 function computeRollingAverage(data: number[], window: number): number[] {
@@ -149,8 +283,16 @@ function getRollingLabel(): string {
 	return `${w}-${unit} rolling avg`;
 }
 
+function getTimeWindowSuffix(): string {
+	if (currentTimeWindow === 'last30') { return ''; }
+	return ` — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
+}
+
 function getChartTitle(): string {
 	const periodMeta = PERIOD_LABELS[currentPeriod];
+	if (currentMetric === 'sessions') {
+		return `Sessions — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
+	}
 	if (currentMetric === 'cost') {
 		let titleText: string;
 		if (currentSplit === 'editor') {
@@ -163,39 +305,43 @@ function getChartTitle(): string {
 		if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 			titleText += ` (${getRollingLabel()})`;
 		}
-		return titleText;
+		return titleText + getTimeWindowSuffix();
 	}
 	if (currentMetric === 'output') {
-		return periodMeta.outputTitle;
+		return periodMeta.outputTitle + getTimeWindowSuffix();
 	}
 	let titleText = periodMeta.title;
 	if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 		titleText += ` (${getRollingLabel()})`;
 	}
-	return titleText;
+	return titleText + getTimeWindowSuffix();
 }
 
 /** Returns period data for the current period, falling back to legacy flat fields. */
 function getActivePeriodData(data: InitialChartData): ChartPeriodData {
+	let period: ChartPeriodData;
 	if (data.periods) {
-		return data.periods[currentPeriod];
+		period = data.periods[currentPeriod];
+	} else {
+		// Fallback for backward compat (no periods field)
+		period = {
+			labels: data.labels,
+			periodKeys: data.labels,
+			tokensData: data.tokensData,
+			sessionsData: data.sessionsData,
+			modelDatasets: data.modelDatasets,
+			editorDatasets: data.editorDatasets,
+			repositoryDatasets: data.repositoryDatasets,
+			periodCount: data.dailyCount,
+			totalTokens: data.totalTokens,
+			totalSessions: data.totalSessions,
+			avgPerPeriod: data.avgTokensPerDay,
+			costData: [],
+			totalCost: 0,
+			avgCostPerPeriod: 0,
+		};
 	}
-	// Fallback for backward compat (no periods field)
-	return {
-		labels: data.labels,
-		tokensData: data.tokensData,
-		sessionsData: data.sessionsData,
-		modelDatasets: data.modelDatasets,
-		editorDatasets: data.editorDatasets,
-		repositoryDatasets: data.repositoryDatasets,
-		periodCount: data.dailyCount,
-		totalTokens: data.totalTokens,
-		totalSessions: data.totalSessions,
-		avgPerPeriod: data.avgTokensPerDay,
-		costData: [],
-		totalCost: 0,
-		avgCostPerPeriod: 0,
-	};
+	return filterPeriodByTimeWindow(period, currentTimeWindow, currentPeriod);
 }
 
 const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string; costTitle: string; avgCostLabel: string; outputTitle: string; avgLocLabel: string }> = {
@@ -205,6 +351,7 @@ const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countL
 };
 
 function isComboSupported(metric: string, split: string): boolean {
+	if (metric === 'sessions') { return split === 'total'; }
 	if (metric === 'cost') { return split === 'total' || split === 'editor' || split === 'provider'; }
 	if (metric === 'output') { return split !== 'model' && split !== 'provider' && split !== 'taskCategory'; }
 	return split !== 'language' && split !== 'provider';
@@ -222,21 +369,33 @@ function buildChartHeader(data: InitialChartData): HTMLElement {
 	return header;
 }
 
+function getSummaryTotal(periodData: ChartPeriodData): { label: string; value: string } {
+	switch (currentMetric) {
+		case 'cost': return { label: 'Total Cost (est.)', value: `$${periodData.totalCost.toFixed(2)}` };
+		case 'output': return { label: 'Total Lines (AI)', value: ((periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0)).toLocaleString() };
+		case 'sessions': return { label: 'Total Sessions', value: periodData.totalSessions.toLocaleString() };
+		default: return { label: 'Total Tokens', value: formatCompact(periodData.totalTokens) };
+	}
+}
+
+function getSummaryAverage(periodData: ChartPeriodData, periodMeta: typeof PERIOD_LABELS[ChartPeriod]): { label: string; value: string } {
+	switch (currentMetric) {
+		case 'cost': return { label: periodMeta.avgCostLabel, value: `$${periodData.avgCostPerPeriod.toFixed(2)}` };
+		case 'output': return { label: periodMeta.avgLocLabel, value: Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString() };
+		case 'sessions': return { label: `Avg Sessions / ${periodMeta.countLabel.replace('Total ', '')}`, value: Math.round(periodData.totalSessions / (periodData.periodCount || 1)).toLocaleString() };
+		default: return { label: periodMeta.avgLabel, value: formatCompact(periodData.avgPerPeriod) };
+	}
+}
+
 function buildSummaryCards(periodData: ChartPeriodData, periodMeta: typeof PERIOD_LABELS[ChartPeriod]): HTMLElement {
-	const totalLabel = currentMetric === 'cost' ? 'Total Cost (est.)' : currentMetric === 'output' ? 'Total Lines (AI)' : 'Total Tokens';
-	const totalValue = currentMetric === 'cost' ? `$${periodData.totalCost.toFixed(2)}`
-		: currentMetric === 'output' ? ((periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0)).toLocaleString()
-		: formatCompact(periodData.totalTokens);
-	const avgLabel = currentMetric === 'cost' ? periodMeta.avgCostLabel : currentMetric === 'output' ? periodMeta.avgLocLabel : periodMeta.avgLabel;
-	const avgValue = currentMetric === 'cost' ? `$${periodData.avgCostPerPeriod.toFixed(2)}`
-		: currentMetric === 'output' ? Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString()
-		: formatCompact(periodData.avgPerPeriod);
+	const total = getSummaryTotal(periodData);
+	const average = getSummaryAverage(periodData, periodMeta);
 	const cards = el('div', 'cards');
 	cards.id = 'summary-cards';
 	cards.append(
 		buildCard('card-period-count', periodMeta.countLabel, periodData.periodCount.toLocaleString()),
-		buildCard('card-total-tokens', totalLabel, totalValue),
-		buildCard('card-avg-tokens', avgLabel, avgValue),
+		buildCard('card-total-tokens', total.label, total.value),
+		buildCard('card-avg-tokens', average.label, average.value),
 		buildCard('card-total-sessions', 'Total Sessions', periodData.totalSessions.toLocaleString()),
 	);
 	return cards;
@@ -260,6 +419,21 @@ function buildPeriodToggles(periodsReady: boolean): HTMLElement {
 
 function buildChartControls(data: InitialChartData): HTMLElement {
 	const toggles = el('div', 'chart-controls');
+
+	const windowGroup = el('div', 'control-group');
+	const windowSelect = document.createElement('select');
+	windowSelect.id = 'time-window-select';
+	windowSelect.className = 'time-window-select';
+	const windows: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth'];
+	windows.forEach(w => {
+		const option = document.createElement('option');
+		option.value = w;
+		option.textContent = TIME_WINDOW_LABELS[w];
+		if (w === currentTimeWindow) { option.selected = true; }
+		windowSelect.append(option);
+	});
+	windowGroup.append(windowSelect);
+
 	const metricGroup = el('div', 'control-group');
 	const tokensBtn = el('button', `toggle${currentMetric === 'tokens' ? ' active' : ''}`, 'Tokens');
 	tokensBtn.id = 'metric-tokens';
@@ -268,7 +442,9 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 	if (!data.hasLocData) { outputBtn.title = 'No edit data available yet (VS Code edit/agent sessions only)'; }
 	const costBtn = el('button', `toggle${currentMetric === 'cost' ? ' active' : ''}`, '💰 Cost');
 	costBtn.id = 'metric-cost';
-	metricGroup.append(tokensBtn, outputBtn, costBtn);
+	const sessionsBtn = el('button', `toggle${currentMetric === 'sessions' ? ' active' : ''}`, '📊 Sessions');
+	sessionsBtn.id = 'metric-sessions';
+	metricGroup.append(tokensBtn, outputBtn, costBtn, sessionsBtn);
 	const splitGroup = el('div', 'control-group');
 	const mkSplit = (id: string, split: string, label: string) => {
 		const supported = isComboSupported(currentMetric, split);
@@ -281,12 +457,12 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 		mkSplit('split-editor', 'editor', 'By Editor'), mkSplit('split-provider', 'provider', '🏷️ By Provider'),
 		mkSplit('split-repository', 'repository', 'By Repository'), mkSplit('split-language', 'language', 'By Language'),
 		mkSplit('split-taskcategory', 'taskCategory', 'By Task'));
-	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output';
+	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output' && currentMetric !== 'sessions';
 	const rollingBtn = el('button', `toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicable ? '' : ' hidden'}`, '📈 Rolling Avg');
 	rollingBtn.id = 'view-rolling';
 	const rollingGroup = el('div', 'control-group');
 	rollingGroup.append(rollingBtn);
-	toggles.append(metricGroup, el('div', 'control-group-separator'), splitGroup, el('div', 'control-group-separator'), rollingGroup);
+	toggles.append(windowGroup, el('div', 'control-group-separator'), metricGroup, el('div', 'control-group-separator'), splitGroup, el('div', 'control-group-separator'), rollingGroup);
 	return toggles;
 }
 
@@ -373,17 +549,10 @@ function updateSummaryCards(data: InitialChartData): void {
 
 	updateCard('card-period-count', periodMeta.countLabel, periodData.periodCount.toLocaleString());
 
-	if (currentMetric === 'cost') {
-		updateCard('card-total-tokens', 'Total Cost (est.)', `$${periodData.totalCost.toFixed(2)}`);
-		updateCard('card-avg-tokens', periodMeta.avgCostLabel, `$${periodData.avgCostPerPeriod.toFixed(2)}`);
-	} else if (currentMetric === 'output') {
-		const totalLines = (periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0);
-		updateCard('card-total-tokens', 'Total Lines (AI)', totalLines.toLocaleString());
-		updateCard('card-avg-tokens', periodMeta.avgLocLabel, Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString());
-	} else {
-		updateCard('card-total-tokens', 'Total Tokens', formatCompact(periodData.totalTokens));
-		updateCard('card-avg-tokens', periodMeta.avgLabel, formatCompact(periodData.avgPerPeriod));
-	}
+	const total = getSummaryTotal(periodData);
+	const average = getSummaryAverage(periodData, periodMeta);
+	updateCard('card-total-tokens', total.label, total.value);
+	updateCard('card-avg-tokens', average.label, average.value);
 
 	updateCard('card-total-sessions', null, periodData.totalSessions.toLocaleString());
 
@@ -431,11 +600,16 @@ function wireInteractions(data: InitialChartData): void {
 		btn?.addEventListener('click', () => { void switchPeriod(period, data); });
 	});
 
+	// Time window selector
+	const timeWindowSelect = document.getElementById('time-window-select') as HTMLSelectElement | null;
+	timeWindowSelect?.addEventListener('change', () => { void switchTimeWindow(timeWindowSelect.value as ChartTimeWindow, data); });
+
 	// Chart metric toggle buttons
 	const metricButtons: Array<{ id: string; metric: typeof currentMetric }> = [
 		{ id: 'metric-tokens', metric: 'tokens' },
 		{ id: 'metric-output', metric: 'output' },
 		{ id: 'metric-cost',   metric: 'cost'   },
+		{ id: 'metric-sessions', metric: 'sessions' },
 	];
 	metricButtons.forEach(({ id, metric }) => {
 		const btn = document.getElementById(id);
@@ -530,8 +704,10 @@ async function switchMetric(metric: typeof currentMetric, data: InitialChartData
 	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; }
 	// When switching to tokens, disable language split
 	if (metric === 'tokens' && currentSplit === 'language') { currentSplit = 'total'; }
+	// Sessions only supports the total split
+	if (metric === 'sessions') { currentSplit = 'total'; }
 	currentMetric = metric;
-	const rollingApplicable = currentSplit === 'total' && metric !== 'output';
+	const rollingApplicable = currentSplit === 'total' && metric !== 'output' && metric !== 'sessions';
 	if (!rollingApplicable) { currentDisplayMode = 'actual'; }
 	vscode.postMessage({ command: 'setViewPreference', metric: currentMetric, split: currentSplit });
 	saveWebviewState();
@@ -547,7 +723,17 @@ async function switchMetric(metric: typeof currentMetric, data: InitialChartData
 	await reinitChart(data);
 }
 
+async function switchTimeWindow(timeWindow: ChartTimeWindow, data: InitialChartData): Promise<void> {
+	if (currentTimeWindow === timeWindow) { return; }
+	currentTimeWindow = timeWindow;
+	vscode.postMessage({ command: 'setTimeWindowPreference', timeWindow });
+	saveWebviewState();
+	updateSummaryCards(data);
+	await reinitChart(data);
+}
+
 function isSplitSupported(metric: typeof currentMetric, split: typeof currentSplit): boolean {
+	if (metric === 'sessions') { return split === 'total'; }
 	return (metric === 'cost' && (split === 'total' || split === 'editor' || split === 'provider')) ||
 		(metric === 'output' && split !== 'model' && split !== 'provider' && split !== 'taskCategory') ||
 		(metric === 'tokens' && split !== 'language' && split !== 'provider');
@@ -607,7 +793,7 @@ function setActivePeriod(period: ChartPeriod): void {
 }
 
 function setActiveMetric(metric: typeof currentMetric): void {
-	(['metric-tokens', 'metric-output', 'metric-cost'] as const).forEach(id => {
+	(['metric-tokens', 'metric-output', 'metric-cost', 'metric-sessions'] as const).forEach(id => {
 		const btn = document.getElementById(id);
 		if (!btn) { return; }
 		btn.classList.toggle('active', id === `metric-${metric}`);
@@ -689,6 +875,20 @@ function buildBaseOptions(c: ChartColors) {
 			tooltip: { backgroundColor: c.bgColor, titleColor: c.textColor, bodyColor: c.textColor, borderColor: c.borderColor, borderWidth: 1, padding: 10, displayColors: true }
 		},
 		scales: { x: { grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } } } as const
+	};
+}
+
+function buildSessionsViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+	return {
+		type: 'bar' as const,
+		data: { labels: period.labels, datasets: [
+			{ label: 'Sessions', data: period.sessionsData, backgroundColor: 'rgba(137, 180, 250, 0.7)', borderColor: 'rgba(137, 180, 250, 1)', borderWidth: 1, borderRadius: 4 }
+		] },
+		options: { ...baseOptions, plugins: { ...baseOptions.plugins, legend: { display: false } },
+			scales: { x: { grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
+				y: { type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => Number(value).toLocaleString() }, title: { display: true, text: 'Sessions', color: c.textColor, font: { size: 12, weight: 'bold' } } }
+			}
+		}
 	};
 }
 
@@ -964,6 +1164,7 @@ function buildStackedViewConfig(view: string, period: ChartPeriodData, baseOptio
 }
 
 function resolveChartView(metric: typeof currentMetric, split: typeof currentSplit): string {
+	if (metric === 'sessions') { return 'sessions'; }
 	if (metric === 'tokens') {
 		if (split === 'model') { return 'model'; }
 		if (split === 'editor') { return 'editor'; }
@@ -984,6 +1185,7 @@ function createConfig(data: InitialChartData): ChartConfig {
 	const view = resolveChartView(currentMetric, currentSplit);
 	const c = getChartColors();
 	const baseOptions = buildBaseOptions(c);
+	if (view === 'sessions') { return buildSessionsViewConfig(period, baseOptions, c); }
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
 	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }
 	if (view === 'cost-editor') { return buildCostEditorViewConfig(period, baseOptions, c); }
@@ -1008,6 +1210,7 @@ function restoreChartState(initialData: InitialChartData): void {
 	const saved = chartState.restore();
 	if (!vscode.getState()) {
 		if (initialData.initialPeriod) { currentPeriod = initialData.initialPeriod; }
+		if (initialData.initialTimeWindow) { currentTimeWindow = initialData.initialTimeWindow; }
 		if (initialData.initialMetric) { currentMetric = initialData.initialMetric; }
 		if (initialData.initialSplit) { currentSplit = initialData.initialSplit; }
 		else if (initialData.initialView) {
@@ -1017,6 +1220,7 @@ function restoreChartState(initialData: InitialChartData): void {
 		return;
 	}
 	currentPeriod = saved.period;
+	currentTimeWindow = saved.timeWindow ?? 'last30';
 	currentDisplayMode = saved.displayMode;
 	if (saved.view && !saved.metric) {
 		const m = migrateViewKey(saved.view);

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -300,7 +300,11 @@ function getSessionsChartTitle(): string {
 		case 'model': return 'Sessions by Model';
 		case 'editor': return 'Sessions by Editor';
 		case 'provider': return 'Sessions by Provider';
-		default: return 'Sessions';
+		default: {
+			let title = 'Sessions';
+			if (currentDisplayMode === 'rolling') { title += ` (${getRollingLabel()})`; }
+			return title;
+		}
 	}
 }
 
@@ -489,7 +493,7 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 		mkSplit('split-editor', 'editor', 'By Editor'), mkSplit('split-provider', 'provider', '🏷️ By Provider'),
 		mkSplit('split-repository', 'repository', 'By Repository'), mkSplit('split-language', 'language', 'By Language'),
 		mkSplit('split-taskcategory', 'taskCategory', 'By Task'));
-	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output' && currentMetric !== 'sessions';
+	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output';
 	const rollingBtn = el('button', `toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicable ? '' : ' hidden'}`, '📈 Rolling Avg');
 	rollingBtn.id = 'view-rolling';
 	const rollingGroup = el('div', 'control-group');
@@ -739,7 +743,7 @@ async function switchMetric(metric: typeof currentMetric, data: InitialChartData
 	if (currentMetric === metric) { return; }
 	clampSplitForMetric(metric);
 	currentMetric = metric;
-	const rollingApplicable = currentSplit === 'total' && metric !== 'output' && metric !== 'sessions';
+	const rollingApplicable = currentSplit === 'total' && metric !== 'output';
 	if (!rollingApplicable) { currentDisplayMode = 'actual'; }
 	vscode.postMessage({ command: 'setViewPreference', metric: currentMetric, split: currentSplit });
 	saveWebviewState();
@@ -914,13 +918,32 @@ function buildBaseOptions(c: ChartColors, periodsReady: boolean) {
 	};
 }
 
+function resolveSessionsDatasets(view: string, period: ChartPeriodData): ModelDataset[] | undefined {
+	if (view === 'sessions-model') { return period.modelSessionsDatasets ?? period.modelDatasets; }
+	if (view === 'sessions-editor') { return period.editorSessionsDatasets ?? period.editorDatasets; }
+	if (view === 'sessions-provider') { return period.providerSessionsDatasets ?? period.billingGroupCostDatasets ?? []; }
+	return undefined;
+}
+
+function buildSessionsTotalDataset(period: ChartPeriodData): any {
+	const isRolling = currentDisplayMode === 'rolling';
+	return {
+		label: isRolling ? getRollingLabel() : 'Sessions',
+		data: isRolling ? computeRollingAverage(period.sessionsData, ROLLING_WINDOW[currentPeriod]) : period.sessionsData,
+		backgroundColor: isRolling ? 'rgba(137, 180, 250, 0.15)' : 'rgba(137, 180, 250, 0.7)',
+		borderColor: 'rgba(137, 180, 250, 1)',
+		borderWidth: isRolling ? 2 : 1,
+		borderRadius: isRolling ? undefined : 4,
+		type: isRolling ? 'line' as const : undefined,
+		tension: isRolling ? 0.4 : undefined,
+		fill: isRolling ? false : undefined
+	};
+}
+
 function buildSessionsViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
-	const datasets = view === 'sessions-model' ? (period.modelSessionsDatasets ?? period.modelDatasets)
-		: view === 'sessions-editor' ? (period.editorSessionsDatasets ?? period.editorDatasets)
-			: view === 'sessions-provider' ? (period.providerSessionsDatasets ?? period.billingGroupCostDatasets ?? [])
-				: undefined;
+	const datasets = resolveSessionsDatasets(view, period);
 	const isStacked = !!datasets;
-	const seriesDatasets = isStacked ? datasets as ModelDataset[] : [{ label: 'Sessions', data: period.sessionsData, backgroundColor: 'rgba(137, 180, 250, 0.7)', borderColor: 'rgba(137, 180, 250, 1)', borderWidth: 1, borderRadius: 4 }];
+	const seriesDatasets = isStacked ? datasets as ModelDataset[] : [buildSessionsTotalDataset(period)];
 	return {
 		type: 'bar' as const,
 		data: { labels: period.labels, datasets: seriesDatasets as any },

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -289,18 +289,12 @@ function getRollingLabel(): string {
 	return `${w}-${unit} rolling avg`;
 }
 
-function getTimeWindowSuffix(): string {
-	if (currentTimeWindow === 'last30') { return ''; }
-	return ` — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
-}
-
 function getSessionsChartTitle(): string {
-	const suffix = ` — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
 	switch (currentSplit) {
-		case 'model': return `Sessions by Model${suffix}`;
-		case 'editor': return `Sessions by Editor${suffix}`;
-		case 'provider': return `Sessions by Provider${suffix}`;
-		default: return `Sessions${suffix}`;
+		case 'model': return 'Sessions by Model';
+		case 'editor': return 'Sessions by Editor';
+		case 'provider': return 'Sessions by Provider';
+		default: return 'Sessions';
 	}
 }
 
@@ -321,16 +315,16 @@ function getChartTitle(): string {
 		if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 			titleText += ` (${getRollingLabel()})`;
 		}
-		return titleText + getTimeWindowSuffix();
+		return titleText;
 	}
 	if (currentMetric === 'output') {
-		return periodMeta.outputTitle + getTimeWindowSuffix();
+		return periodMeta.outputTitle;
 	}
 	let titleText = periodMeta.title;
 	if (currentDisplayMode === 'rolling' && currentSplit === 'total') {
 		titleText += ` (${getRollingLabel()})`;
 	}
-	return titleText + getTimeWindowSuffix();
+	return titleText;
 }
 
 function getAggregationIndicator(): string {
@@ -894,6 +888,7 @@ function buildBaseOptions(c: ChartColors) {
 		responsive: true, maintainAspectRatio: false,
 		interaction: { mode: 'index' as const, intersect: false },
 		plugins: {
+			title: { display: true, text: TIME_WINDOW_LABELS[currentTimeWindow], color: c.textColor, font: { size: 14, weight: 'bold' }, padding: { top: 4, bottom: 12 } },
 			legend: { position: 'top' as const, labels: { color: c.textColor, font: { size: 12 } } },
 			tooltip: { backgroundColor: c.bgColor, titleColor: c.textColor, bodyColor: c.textColor, borderColor: c.borderColor, borderWidth: 1, padding: 10, displayColors: true }
 		},

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -46,6 +46,9 @@ type ChartPeriodData = {
 	avgLocPerPeriod?: number;
 	editorCostDatasets?: ModelDataset[];
 	billingGroupCostDatasets?: ModelDataset[];
+	modelSessionsDatasets?: ModelDataset[];
+	editorSessionsDatasets?: ModelDataset[];
+	providerSessionsDatasets?: ModelDataset[];
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
@@ -245,6 +248,9 @@ function copyFilteredDatasetFields(source: ChartPeriodData, target: ChartPeriodD
 		{ key: 'locRepositoryDatasets', source: source.locRepositoryDatasets },
 		{ key: 'editorCostDatasets', source: source.editorCostDatasets },
 		{ key: 'billingGroupCostDatasets', source: source.billingGroupCostDatasets },
+		{ key: 'modelSessionsDatasets', source: source.modelSessionsDatasets },
+		{ key: 'editorSessionsDatasets', source: source.editorSessionsDatasets },
+		{ key: 'providerSessionsDatasets', source: source.providerSessionsDatasets },
 		{ key: 'taskCategoryDatasets', source: source.taskCategoryDatasets },
 	];
 	for (const { key, source: ds } of datasetFields) {
@@ -897,9 +903,9 @@ function buildBaseOptions(c: ChartColors) {
 }
 
 function buildSessionsViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
-	const datasets = view === 'sessions-model' ? period.modelDatasets
-		: view === 'sessions-editor' ? period.editorDatasets
-			: view === 'sessions-provider' ? (period.billingGroupCostDatasets ?? [])
+	const datasets = view === 'sessions-model' ? (period.modelSessionsDatasets ?? period.modelDatasets)
+		: view === 'sessions-editor' ? (period.editorSessionsDatasets ?? period.editorDatasets)
+			: view === 'sessions-provider' ? (period.providerSessionsDatasets ?? period.billingGroupCostDatasets ?? [])
 				: undefined;
 	const isStacked = !!datasets;
 	const seriesDatasets = isStacked ? datasets as ModelDataset[] : [{ label: 'Sessions', data: period.sessionsData, backgroundColor: 'rgba(137, 180, 250, 0.7)', borderColor: 'rgba(137, 180, 250, 1)', borderWidth: 1, borderRadius: 4 }];

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -423,27 +423,30 @@ function buildSummaryCards(periodData: ChartPeriodData, periodMeta: typeof PERIO
 
 function buildPeriodToggles(periodsReady: boolean): HTMLElement {
 	const periodToggles = el('div', 'period-controls');
-	const dayBtn = el('button', `toggle${currentPeriod === 'day' ? ' active' : ''}`, '📅 By Day');
+	const label = el('span', 'period-controls-label', 'Aggregate by');
+	const dayBtn = el('button', `toggle${currentPeriod === 'day' ? ' active' : ''}`, 'Day');
 	dayBtn.id = 'period-day';
 	dayBtn.title = 'Aggregate data by day';
-	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, periodsReady ? '🗓️ By Week' : '🗓️ By Week ⌛');
+	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, 'Week');
 	weekBtn.id = 'period-week';
 	weekBtn.title = 'Aggregate data by week';
-	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, periodsReady ? '📆 By Month' : '📆 By Month ⌛');
+	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, 'Month');
 	monthBtn.id = 'period-month';
 	monthBtn.title = 'Aggregate data by month';
 	if (!periodsReady) {
-		(weekBtn as HTMLButtonElement).disabled = true; weekBtn.title = 'Loading historical data…';
-		(monthBtn as HTMLButtonElement).disabled = true; monthBtn.title = 'Loading historical data…';
+		(weekBtn as HTMLButtonElement).disabled = true; weekBtn.title = 'Loading historical data for weekly aggregation…';
+		(monthBtn as HTMLButtonElement).disabled = true; monthBtn.title = 'Loading historical data for monthly aggregation…';
 	}
-	periodToggles.append(dayBtn, weekBtn, monthBtn);
+	periodToggles.append(label, dayBtn, weekBtn, monthBtn);
 	return periodToggles;
 }
 
 function buildChartControls(data: InitialChartData): HTMLElement {
 	const toggles = el('div', 'chart-controls');
+	const periodsReady = data.periodsReady !== false;
 
 	const windowGroup = el('div', 'control-group');
+	windowGroup.append(el('span', 'control-label', 'Time window:'));
 	const windowSelect = document.createElement('select');
 	windowSelect.id = 'time-window-select';
 	windowSelect.className = 'time-window-select';
@@ -453,9 +456,15 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 		option.value = w;
 		option.textContent = TIME_WINDOW_LABELS[w];
 		if (w === currentTimeWindow) { option.selected = true; }
+		if (w === 'allTime' && !periodsReady) { option.disabled = true; }
 		windowSelect.append(option);
 	});
 	windowGroup.append(windowSelect);
+	if (!periodsReady) {
+		const loadingNote = el('span', 'loading-note', 'Loading history…');
+		loadingNote.title = 'Full history is still loading. "All time" and weekly/monthly aggregation are not available yet.';
+		windowGroup.append(loadingNote);
+	}
 
 	const metricGroup = el('div', 'control-group');
 	const tokensBtn = el('button', `toggle${currentMetric === 'tokens' ? ' active' : ''}`, 'Tokens');
@@ -889,12 +898,15 @@ function getChartColors(): ChartColors {
 	};
 }
 
-function buildBaseOptions(c: ChartColors) {
+function buildBaseOptions(c: ChartColors, periodsReady: boolean) {
+	const title = !periodsReady && currentTimeWindow === 'allTime'
+		? `${TIME_WINDOW_LABELS[currentTimeWindow]} (loading history…)`
+		: TIME_WINDOW_LABELS[currentTimeWindow];
 	return {
 		responsive: true, maintainAspectRatio: false,
 		interaction: { mode: 'index' as const, intersect: false },
 		plugins: {
-			title: { display: true, text: TIME_WINDOW_LABELS[currentTimeWindow], color: c.textColor, font: { size: 14, weight: 'bold' }, padding: { top: 4, bottom: 12 } },
+			title: { display: true, text: title, color: c.textColor, font: { size: 14, weight: 'bold' }, padding: { top: 4, bottom: 12 } },
 			legend: { position: 'top' as const, labels: { color: c.textColor, font: { size: 12 } } },
 			tooltip: { backgroundColor: c.bgColor, titleColor: c.textColor, bodyColor: c.textColor, borderColor: c.borderColor, borderWidth: 1, padding: 10, displayColors: true }
 		},
@@ -1223,7 +1235,8 @@ function createConfig(data: InitialChartData): ChartConfig {
 	const period = getActivePeriodData(data);
 	const view = resolveChartView(currentMetric, currentSplit);
 	const c = getChartColors();
-	const baseOptions = buildBaseOptions(c);
+	const periodsReady = data.periodsReady !== false;
+	const baseOptions = buildBaseOptions(c, periodsReady);
 	if (view.startsWith('sessions')) { return buildSessionsViewConfig(view, period, baseOptions, c); }
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
 	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -49,7 +49,7 @@ type ChartPeriodData = {
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
-type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth';
+type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth' | 'allTime';
 
 type InitialChartData = {
 	labels: string[];
@@ -365,9 +365,9 @@ function getActivePeriodData(data: InitialChartData): ChartPeriodData {
 }
 
 const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string; aggregationLabel: string; costTitle: string; avgCostLabel: string; outputTitle: string; avgLocLabel: string }> = {
-	day:   { title: 'Token Usage – Last 30 Days',  footer: 'Day-by-day token usage for the last 30 days',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day',   aggregationLabel: 'Aggregated by Day',   costTitle: 'Est. Cost – Last 30 Days',  avgCostLabel: 'Avg Cost / Day',   outputTitle: 'Lines of Code – Last 30 Days',  avgLocLabel: 'Avg Lines / Day'   },
-	week:  { title: 'Token Usage – Last 6 Weeks',  footer: 'Week-by-week token usage for the last 6 weeks', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week',  aggregationLabel: 'Aggregated by Week',  costTitle: 'Est. Cost – Last 6 Weeks',  avgCostLabel: 'Avg Cost / Week',  outputTitle: 'Lines of Code – Last 6 Weeks',  avgLocLabel: 'Avg Lines / Week'  },
-	month: { title: 'Token Usage – Last 12 Months', footer: 'Monthly token usage for the last 12 months',   countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month', aggregationLabel: 'Aggregated by Month', costTitle: 'Est. Cost – Last 12 Months', avgCostLabel: 'Avg Cost / Month', outputTitle: 'Lines of Code – Last 12 Months', avgLocLabel: 'Avg Lines / Month' },
+	day:   { title: 'Token Usage',  footer: 'Day-by-day token usage',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day',   aggregationLabel: 'Aggregated by Day',   costTitle: 'Est. Cost',  avgCostLabel: 'Avg Cost / Day',   outputTitle: 'Lines of Code',  avgLocLabel: 'Avg Lines / Day'   },
+	week:  { title: 'Token Usage',  footer: 'Week-by-week token usage', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week',  aggregationLabel: 'Aggregated by Week',  costTitle: 'Est. Cost',  avgCostLabel: 'Avg Cost / Week',  outputTitle: 'Lines of Code',  avgLocLabel: 'Avg Lines / Week'  },
+	month: { title: 'Token Usage', footer: 'Monthly token usage',       countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month', aggregationLabel: 'Aggregated by Month', costTitle: 'Est. Cost', avgCostLabel: 'Avg Cost / Month', outputTitle: 'Lines of Code', avgLocLabel: 'Avg Lines / Month' },
 };
 
 function isComboSupported(metric: string, split: string): boolean {

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -966,16 +966,34 @@ function buildSessionsTotalDataset(period: ChartPeriodData): any {
 	};
 }
 
+function buildSessionsProjectionDataset(period: ChartPeriodData): any | null {
+	const lastIdx = period.sessionsData.length - 1;
+	if (lastIdx < 0) { return null; }
+	const projExtra = computeProjectionExtra(period.sessionsData[lastIdx], getCurrentPeriodFraction(currentPeriod));
+	if (projExtra === null) { return null; }
+	return {
+		label: PROJECTION_LABELS[currentPeriod],
+		data: period.sessionsData.map((_: number, i: number) => i === lastIdx ? Math.round(projExtra) : 0),
+		backgroundColor: 'rgba(137, 180, 250, 0.25)',
+		borderColor: 'rgba(137, 180, 250, 0.5)',
+		borderWidth: 1
+	};
+}
+
 function buildSessionsViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
 	const datasets = resolveSessionsDatasets(view, period);
 	const isStacked = !!datasets;
-	const seriesDatasets = isStacked ? datasets as ModelDataset[] : [buildSessionsTotalDataset(period)];
+	const isRolling = !isStacked && currentDisplayMode === 'rolling';
+	const projDs = !isStacked && !isRolling ? buildSessionsProjectionDataset(period) : null;
+	const showLegend = isStacked || !!projDs;
+	const stackAxes = isStacked || !!projDs;
+	const seriesDatasets = isStacked ? datasets as ModelDataset[] : [buildSessionsTotalDataset(period), ...(projDs ? [projDs] : [])];
 	return {
 		type: 'bar' as const,
 		data: { labels: period.labels, datasets: seriesDatasets as any },
-		options: { ...baseOptions, plugins: { ...baseOptions.plugins, legend: { display: isStacked, position: 'top' as const, labels: { color: c.textColor, font: { size: 12 } } }, tooltip: { ...baseOptions.plugins.tooltip, callbacks: { label: (ctx: any) => ` ${ctx.dataset.label}: ${Number(ctx.parsed.y).toLocaleString()} sessions` } } },
-			scales: { x: { stacked: isStacked, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
-				y: { stacked: isStacked, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => Number(value).toLocaleString() }, title: { display: true, text: 'Sessions', color: c.textColor, font: { size: 12, weight: 'bold' } } }
+		options: { ...baseOptions, plugins: { ...baseOptions.plugins, legend: { display: showLegend, position: 'top' as const, labels: { color: c.textColor, font: { size: 12 } } }, tooltip: { ...baseOptions.plugins.tooltip, callbacks: { label: (ctx: any) => ` ${ctx.dataset.label}: ${Number(ctx.parsed.y).toLocaleString()} sessions` } } },
+			scales: { x: { stacked: stackAxes, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
+				y: { stacked: stackAxes, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => Number(value).toLocaleString() }, title: { display: true, text: 'Sessions', color: c.textColor, font: { size: 12, weight: 'bold' } } }
 			}
 		}
 	};

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -516,12 +516,15 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 	const periodsReady = data.periodsReady !== false;
 
 	const scopeRow = el('div', 'chart-controls-row scope-row');
-	scopeRow.append(buildTimeWindowControl(periodsReady), el('div', 'control-group-separator'), buildPeriodToggles(periodsReady));
+	scopeRow.append(buildTimeWindowControl(periodsReady), el('div', 'control-group-separator'), buildPeriodToggles(periodsReady), el('div', 'control-group-separator'), buildRollingControl());
 
-	const viewRow = el('div', 'chart-controls-row view-row');
-	viewRow.append(buildMetricControl(data), el('div', 'control-group-separator'), buildSplitControl(), el('div', 'control-group-separator'), buildRollingControl());
+	const metricRow = el('div', 'chart-controls-row metric-row');
+	metricRow.append(buildMetricControl(data));
 
-	controls.append(scopeRow, viewRow);
+	const splitRow = el('div', 'chart-controls-row split-row');
+	splitRow.append(buildSplitControl());
+
+	controls.append(scopeRow, metricRow, splitRow);
 	return controls;
 }
 

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -445,12 +445,9 @@ function buildPeriodToggles(periodsReady: boolean): HTMLElement {
 	return periodToggles;
 }
 
-function buildChartControls(data: InitialChartData): HTMLElement {
-	const toggles = el('div', 'chart-controls');
-	const periodsReady = data.periodsReady !== false;
-
-	const windowGroup = el('div', 'control-group');
-	windowGroup.append(el('span', 'control-label', 'Time window:'));
+function buildTimeWindowControl(periodsReady: boolean): HTMLElement {
+	const group = el('div', 'control-group');
+	group.append(el('span', 'control-label', 'Time window:'));
 	const windowSelect = document.createElement('select');
 	windowSelect.id = 'time-window-select';
 	windowSelect.className = 'time-window-select';
@@ -463,14 +460,18 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 		if (w === 'allTime' && !periodsReady) { option.disabled = true; }
 		windowSelect.append(option);
 	});
-	windowGroup.append(windowSelect);
+	group.append(windowSelect);
 	if (!periodsReady) {
 		const loadingNote = el('span', 'loading-note', 'Loading history…');
 		loadingNote.title = 'Full history is still loading. "All time" and weekly/monthly aggregation are not available yet.';
-		windowGroup.append(loadingNote);
+		group.append(loadingNote);
 	}
+	return group;
+}
 
-	const metricGroup = el('div', 'control-group');
+function buildMetricControl(data: InitialChartData): HTMLElement {
+	const group = el('div', 'control-group');
+	group.append(el('span', 'control-label', 'Metric:'));
 	const tokensBtn = el('button', `toggle${currentMetric === 'tokens' ? ' active' : ''}`, 'Tokens');
 	tokensBtn.id = 'metric-tokens';
 	const outputBtn = el('button', `toggle${currentMetric === 'output' ? ' active' : ''}${!data.hasLocData ? ' dim' : ''}`, '✏️ Output');
@@ -480,8 +481,13 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 	costBtn.id = 'metric-cost';
 	const sessionsBtn = el('button', `toggle${currentMetric === 'sessions' ? ' active' : ''}`, '📊 Sessions');
 	sessionsBtn.id = 'metric-sessions';
-	metricGroup.append(tokensBtn, outputBtn, costBtn, sessionsBtn);
-	const splitGroup = el('div', 'control-group');
+	group.append(tokensBtn, outputBtn, costBtn, sessionsBtn);
+	return group;
+}
+
+function buildSplitControl(): HTMLElement {
+	const group = el('div', 'control-group');
+	group.append(el('span', 'control-label', 'Split:'));
 	const mkSplit = (id: string, split: string, label: string) => {
 		const supported = isComboSupported(currentMetric, split);
 		const btn = el('button', `toggle${currentSplit === split ? ' active' : ''}${!supported ? ' disabled' : ''}`, label);
@@ -489,17 +495,34 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 		if (!supported) { (btn as HTMLButtonElement).disabled = true; btn.title = `Not available for ${currentMetric} metric`; }
 		return btn;
 	};
-	splitGroup.append(mkSplit('split-total', 'total', 'Total'), mkSplit('split-model', 'model', 'By Model'),
+	group.append(mkSplit('split-total', 'total', 'Total'), mkSplit('split-model', 'model', 'By Model'),
 		mkSplit('split-editor', 'editor', 'By Editor'), mkSplit('split-provider', 'provider', '🏷️ By Provider'),
 		mkSplit('split-repository', 'repository', 'By Repository'), mkSplit('split-language', 'language', 'By Language'),
 		mkSplit('split-taskcategory', 'taskCategory', 'By Task'));
+	return group;
+}
+
+function buildRollingControl(): HTMLElement {
+	const group = el('div', 'control-group');
 	const rollingApplicable = currentSplit === 'total' && currentMetric !== 'output';
 	const rollingBtn = el('button', `toggle${currentDisplayMode === 'rolling' ? ' active' : ''}${rollingApplicable ? '' : ' hidden'}`, '📈 Rolling Avg');
 	rollingBtn.id = 'view-rolling';
-	const rollingGroup = el('div', 'control-group');
-	rollingGroup.append(rollingBtn);
-	toggles.append(windowGroup, el('div', 'control-group-separator'), metricGroup, el('div', 'control-group-separator'), splitGroup, el('div', 'control-group-separator'), rollingGroup);
-	return toggles;
+	group.append(rollingBtn);
+	return group;
+}
+
+function buildChartControls(data: InitialChartData): HTMLElement {
+	const controls = el('div', 'chart-controls');
+	const periodsReady = data.periodsReady !== false;
+
+	const scopeRow = el('div', 'chart-controls-row scope-row');
+	scopeRow.append(buildTimeWindowControl(periodsReady), el('div', 'control-group-separator'), buildPeriodToggles(periodsReady));
+
+	const viewRow = el('div', 'chart-controls-row view-row');
+	viewRow.append(buildMetricControl(data), el('div', 'control-group-separator'), buildSplitControl(), el('div', 'control-group-separator'), buildRollingControl());
+
+	controls.append(scopeRow, viewRow);
+	return controls;
 }
 
 function renderLayout(data: InitialChartData): void {
@@ -516,7 +539,7 @@ function renderLayout(data: InitialChartData): void {
 	const editorCards = buildEditorCards(data.editorTotalsMap);
 	if (editorCards) { summarySection.append(editorCards); }
 	const chartSectionHeader = el('div', 'chart-section-header');
-	chartSectionHeader.append(iconHeading('h3', 'graph-line', 'Charts'), buildPeriodToggles(data.periodsReady !== false));
+	chartSectionHeader.append(iconHeading('h3', 'graph-line', 'Charts'));
 	const canvasWrap = el('div', 'canvas-wrap');
 	const canvas = document.createElement('canvas'); canvas.id = 'token-chart'; canvasWrap.append(canvas);
 	const heatmapContainer = el('div', 'heatmap-container hidden');

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -144,6 +144,7 @@ const TIME_WINDOW_LABELS: Record<ChartTimeWindow, string> = {
 	last7: 'Last 7 days',
 	last30: 'Last 30 days',
 	currentMonth: 'Current month',
+	allTime: 'All time',
 };
 
 function getWindowStartDate(timeWindow: ChartTimeWindow, now: Date): string {
@@ -163,10 +164,15 @@ function getWindowStartDate(timeWindow: ChartTimeWindow, now: Date): string {
 		}
 		case 'currentMonth':
 			return `${y}-${String(m + 1).padStart(2, '0')}-01`;
+		case 'allTime':
+			return '0000-00-00';
 	}
 }
 
 function getWindowStartMonth(timeWindow: ChartTimeWindow, now: Date): string {
+	if (timeWindow === 'allTime') {
+		return '0000-00';
+	}
 	const y = now.getFullYear();
 	const m = now.getMonth();
 	if (timeWindow === 'currentMonth') {
@@ -288,10 +294,20 @@ function getTimeWindowSuffix(): string {
 	return ` — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
 }
 
+function getSessionsChartTitle(): string {
+	const suffix = ` — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
+	switch (currentSplit) {
+		case 'model': return `Sessions by Model${suffix}`;
+		case 'editor': return `Sessions by Editor${suffix}`;
+		case 'provider': return `Sessions by Provider${suffix}`;
+		default: return `Sessions${suffix}`;
+	}
+}
+
 function getChartTitle(): string {
 	const periodMeta = PERIOD_LABELS[currentPeriod];
 	if (currentMetric === 'sessions') {
-		return `Sessions — ${TIME_WINDOW_LABELS[currentTimeWindow]}`;
+		return getSessionsChartTitle();
 	}
 	if (currentMetric === 'cost') {
 		let titleText: string;
@@ -315,6 +331,10 @@ function getChartTitle(): string {
 		titleText += ` (${getRollingLabel()})`;
 	}
 	return titleText + getTimeWindowSuffix();
+}
+
+function getAggregationIndicator(): string {
+	return PERIOD_LABELS[currentPeriod].aggregationLabel;
 }
 
 /** Returns period data for the current period, falling back to legacy flat fields. */
@@ -344,14 +364,14 @@ function getActivePeriodData(data: InitialChartData): ChartPeriodData {
 	return filterPeriodByTimeWindow(period, currentTimeWindow, currentPeriod);
 }
 
-const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string; costTitle: string; avgCostLabel: string; outputTitle: string; avgLocLabel: string }> = {
-	day:   { title: 'Token Usage – Last 30 Days',  footer: 'Day-by-day token usage for the last 30 days',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day',   costTitle: 'Est. Cost – Last 30 Days',  avgCostLabel: 'Avg Cost / Day',   outputTitle: 'Lines of Code – Last 30 Days',  avgLocLabel: 'Avg Lines / Day'   },
-	week:  { title: 'Token Usage – Last 6 Weeks',  footer: 'Week-by-week token usage for the last 6 weeks', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week',  costTitle: 'Est. Cost – Last 6 Weeks',  avgCostLabel: 'Avg Cost / Week',  outputTitle: 'Lines of Code – Last 6 Weeks',  avgLocLabel: 'Avg Lines / Week'  },
-	month: { title: 'Token Usage – Last 12 Months', footer: 'Monthly token usage for the last 12 months',   countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month', costTitle: 'Est. Cost – Last 12 Months', avgCostLabel: 'Avg Cost / Month', outputTitle: 'Lines of Code – Last 12 Months', avgLocLabel: 'Avg Lines / Month' },
+const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countLabel: string; avgLabel: string; aggregationLabel: string; costTitle: string; avgCostLabel: string; outputTitle: string; avgLocLabel: string }> = {
+	day:   { title: 'Token Usage – Last 30 Days',  footer: 'Day-by-day token usage for the last 30 days',   countLabel: 'Total Days',   avgLabel: 'Avg Tokens / Day',   aggregationLabel: 'Aggregated by Day',   costTitle: 'Est. Cost – Last 30 Days',  avgCostLabel: 'Avg Cost / Day',   outputTitle: 'Lines of Code – Last 30 Days',  avgLocLabel: 'Avg Lines / Day'   },
+	week:  { title: 'Token Usage – Last 6 Weeks',  footer: 'Week-by-week token usage for the last 6 weeks', countLabel: 'Total Weeks',  avgLabel: 'Avg Tokens / Week',  aggregationLabel: 'Aggregated by Week',  costTitle: 'Est. Cost – Last 6 Weeks',  avgCostLabel: 'Avg Cost / Week',  outputTitle: 'Lines of Code – Last 6 Weeks',  avgLocLabel: 'Avg Lines / Week'  },
+	month: { title: 'Token Usage – Last 12 Months', footer: 'Monthly token usage for the last 12 months',   countLabel: 'Total Months', avgLabel: 'Avg Tokens / Month', aggregationLabel: 'Aggregated by Month', costTitle: 'Est. Cost – Last 12 Months', avgCostLabel: 'Avg Cost / Month', outputTitle: 'Lines of Code – Last 12 Months', avgLocLabel: 'Avg Lines / Month' },
 };
 
 function isComboSupported(metric: string, split: string): boolean {
-	if (metric === 'sessions') { return split === 'total'; }
+	if (metric === 'sessions') { return split === 'total' || split === 'model' || split === 'editor' || split === 'provider'; }
 	if (metric === 'cost') { return split === 'total' || split === 'editor' || split === 'provider'; }
 	if (metric === 'output') { return split !== 'model' && split !== 'provider' && split !== 'taskCategory'; }
 	return split !== 'language' && split !== 'provider';
@@ -403,12 +423,15 @@ function buildSummaryCards(periodData: ChartPeriodData, periodMeta: typeof PERIO
 
 function buildPeriodToggles(periodsReady: boolean): HTMLElement {
 	const periodToggles = el('div', 'period-controls');
-	const dayBtn = el('button', `toggle${currentPeriod === 'day' ? ' active' : ''}`, '📅 Day');
+	const dayBtn = el('button', `toggle${currentPeriod === 'day' ? ' active' : ''}`, '📅 By Day');
 	dayBtn.id = 'period-day';
-	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, periodsReady ? '🗓️ Week' : '🗓️ Week ⌛');
+	dayBtn.title = 'Aggregate data by day';
+	const weekBtn = el('button', `toggle${currentPeriod === 'week' ? ' active' : ''}`, periodsReady ? '🗓️ By Week' : '🗓️ By Week ⌛');
 	weekBtn.id = 'period-week';
-	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, periodsReady ? '📆 Month' : '📆 Month ⌛');
+	weekBtn.title = 'Aggregate data by week';
+	const monthBtn = el('button', `toggle${currentPeriod === 'month' ? ' active' : ''}`, periodsReady ? '📆 By Month' : '📆 By Month ⌛');
 	monthBtn.id = 'period-month';
+	monthBtn.title = 'Aggregate data by month';
 	if (!periodsReady) {
 		(weekBtn as HTMLButtonElement).disabled = true; weekBtn.title = 'Loading historical data…';
 		(monthBtn as HTMLButtonElement).disabled = true; monthBtn.title = 'Loading historical data…';
@@ -424,7 +447,7 @@ function buildChartControls(data: InitialChartData): HTMLElement {
 	const windowSelect = document.createElement('select');
 	windowSelect.id = 'time-window-select';
 	windowSelect.className = 'time-window-select';
-	const windows: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth'];
+	const windows: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
 	windows.forEach(w => {
 		const option = document.createElement('option');
 		option.value = w;
@@ -490,7 +513,7 @@ function renderLayout(data: InitialChartData): void {
 	const chartSection = el('div', 'section');
 	chartSection.append(chartSectionHeader, chartShell);
 	const footer = el('div', 'footer',
-		`${periodMeta.footer}\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`);
+		`${periodMeta.footer} (${periodMeta.aggregationLabel})\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`);
 	footer.id = 'chart-footer';
 	const container = el('div', 'container');
 	container.append(buildChartHeader(data), summarySection, chartSection, footer);
@@ -561,7 +584,7 @@ function updateSummaryCards(data: InitialChartData): void {
 
 	const footer = document.getElementById('chart-footer');
 	if (footer) {
-		footer.textContent = `${periodMeta.footer}\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`;
+		footer.textContent = `${periodMeta.footer} (${periodMeta.aggregationLabel})\nLast updated: ${new Date(data.lastUpdated).toLocaleString()}\nUpdates automatically every 5 minutes.`;
 	}
 }
 
@@ -696,16 +719,16 @@ async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promis
 	chart = new Chart(ctx, createConfig(data));
 }
 
+function clampSplitForMetric(metric: typeof currentMetric): void {
+	if (metric === 'cost' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; return; }
+	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; return; }
+	if (metric === 'tokens' && currentSplit === 'language') { currentSplit = 'total'; return; }
+	if (metric === 'sessions' && currentSplit !== 'total' && currentSplit !== 'model' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; }
+}
+
 async function switchMetric(metric: typeof currentMetric, data: InitialChartData): Promise<void> {
 	if (currentMetric === metric) { return; }
-	// When switching to cost, keep editor/provider split if active; otherwise fall back to total
-	if (metric === 'cost' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; }
-	// When switching to output, disable unsupported splits
-	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; }
-	// When switching to tokens, disable language split
-	if (metric === 'tokens' && currentSplit === 'language') { currentSplit = 'total'; }
-	// Sessions only supports the total split
-	if (metric === 'sessions') { currentSplit = 'total'; }
+	clampSplitForMetric(metric);
 	currentMetric = metric;
 	const rollingApplicable = currentSplit === 'total' && metric !== 'output' && metric !== 'sessions';
 	if (!rollingApplicable) { currentDisplayMode = 'actual'; }
@@ -733,7 +756,7 @@ async function switchTimeWindow(timeWindow: ChartTimeWindow, data: InitialChartD
 }
 
 function isSplitSupported(metric: typeof currentMetric, split: typeof currentSplit): boolean {
-	if (metric === 'sessions') { return split === 'total'; }
+	if (metric === 'sessions') { return split === 'total' || split === 'model' || split === 'editor' || split === 'provider'; }
 	return (metric === 'cost' && (split === 'total' || split === 'editor' || split === 'provider')) ||
 		(metric === 'output' && split !== 'model' && split !== 'provider' && split !== 'taskCategory') ||
 		(metric === 'tokens' && split !== 'language' && split !== 'provider');
@@ -878,15 +901,19 @@ function buildBaseOptions(c: ChartColors) {
 	};
 }
 
-function buildSessionsViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+function buildSessionsViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+	const datasets = view === 'sessions-model' ? period.modelDatasets
+		: view === 'sessions-editor' ? period.editorDatasets
+			: view === 'sessions-provider' ? (period.billingGroupCostDatasets ?? [])
+				: undefined;
+	const isStacked = !!datasets;
+	const seriesDatasets = isStacked ? datasets as ModelDataset[] : [{ label: 'Sessions', data: period.sessionsData, backgroundColor: 'rgba(137, 180, 250, 0.7)', borderColor: 'rgba(137, 180, 250, 1)', borderWidth: 1, borderRadius: 4 }];
 	return {
 		type: 'bar' as const,
-		data: { labels: period.labels, datasets: [
-			{ label: 'Sessions', data: period.sessionsData, backgroundColor: 'rgba(137, 180, 250, 0.7)', borderColor: 'rgba(137, 180, 250, 1)', borderWidth: 1, borderRadius: 4 }
-		] },
-		options: { ...baseOptions, plugins: { ...baseOptions.plugins, legend: { display: false } },
-			scales: { x: { grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
-				y: { type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => Number(value).toLocaleString() }, title: { display: true, text: 'Sessions', color: c.textColor, font: { size: 12, weight: 'bold' } } }
+		data: { labels: period.labels, datasets: seriesDatasets as any },
+		options: { ...baseOptions, plugins: { ...baseOptions.plugins, legend: { display: isStacked, position: 'top' as const, labels: { color: c.textColor, font: { size: 12 } } }, tooltip: { ...baseOptions.plugins.tooltip, callbacks: { label: (ctx: any) => ` ${ctx.dataset.label}: ${Number(ctx.parsed.y).toLocaleString()} sessions` } } },
+			scales: { x: { stacked: isStacked, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
+				y: { stacked: isStacked, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => Number(value).toLocaleString() }, title: { display: true, text: 'Sessions', color: c.textColor, font: { size: 12, weight: 'bold' } } }
 			}
 		}
 	};
@@ -1163,20 +1190,31 @@ function buildStackedViewConfig(view: string, period: ChartPeriodData, baseOptio
 	};
 }
 
+function resolveTokensView(split: typeof currentSplit): string {
+	if (split === 'model') { return 'model'; }
+	if (split === 'editor') { return 'editor'; }
+	if (split === 'repository') { return 'repository'; }
+	if (split === 'taskCategory') { return 'taskCategory'; }
+	return 'total';
+}
+
+function resolveCostView(split: typeof currentSplit): string {
+	if (split === 'editor') { return 'cost-editor'; }
+	if (split === 'provider') { return 'cost-provider'; }
+	return 'cost';
+}
+
+function resolveSessionsView(split: typeof currentSplit): string {
+	if (split === 'model') { return 'sessions-model'; }
+	if (split === 'editor') { return 'sessions-editor'; }
+	if (split === 'provider') { return 'sessions-provider'; }
+	return 'sessions';
+}
+
 function resolveChartView(metric: typeof currentMetric, split: typeof currentSplit): string {
-	if (metric === 'sessions') { return 'sessions'; }
-	if (metric === 'tokens') {
-		if (split === 'model') { return 'model'; }
-		if (split === 'editor') { return 'editor'; }
-		if (split === 'repository') { return 'repository'; }
-		if (split === 'taskCategory') { return 'taskCategory'; }
-		return 'total';
-	}
-	if (metric === 'cost') {
-		if (split === 'editor') { return 'cost-editor'; }
-		if (split === 'provider') { return 'cost-provider'; }
-		return 'cost';
-	}
+	if (metric === 'sessions') { return resolveSessionsView(split); }
+	if (metric === 'tokens') { return resolveTokensView(split); }
+	if (metric === 'cost') { return resolveCostView(split); }
 	return `output-${split}`;
 }
 
@@ -1185,7 +1223,7 @@ function createConfig(data: InitialChartData): ChartConfig {
 	const view = resolveChartView(currentMetric, currentSplit);
 	const c = getChartColors();
 	const baseOptions = buildBaseOptions(c);
-	if (view === 'sessions') { return buildSessionsViewConfig(period, baseOptions, c); }
+	if (view.startsWith('sessions')) { return buildSessionsViewConfig(view, period, baseOptions, c); }
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
 	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }
 	if (view === 'cost-editor') { return buildCostEditorViewConfig(period, baseOptions, c); }

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -179,19 +179,22 @@ body {
 }
 
 .period-controls .toggle {
-	font-size: 11px;
-	padding: 4px 9px;
+	padding: 6px 10px;
 }
 
 .toggle {
 	background: var(--button-secondary-bg);
 	border: 1px solid var(--border-subtle);
 	color: var(--text-primary);
-	padding: 8px 12px;
+	padding: 6px 12px;
 	border-radius: 6px;
 	font-size: 12px;
 	cursor: pointer;
 	transition: all 0.15s ease;
+	min-height: 30px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .toggle.active {
@@ -255,10 +258,11 @@ body {
 	border: 1px solid var(--border-subtle);
 	color: var(--text-primary);
 	border-radius: 6px;
-	padding: 5px 10px;
+	padding: 6px 10px;
 	font-size: 12px;
 	cursor: pointer;
 	outline: none;
+	min-height: 30px;
 }
 
 .time-window-select:focus {

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -219,6 +219,26 @@ body {
 	background: var(--button-secondary-bg);
 }
 
+.time-window-select {
+	background: var(--button-secondary-bg);
+	border: 1px solid var(--border-subtle);
+	color: var(--text-primary);
+	border-radius: 6px;
+	padding: 5px 10px;
+	font-size: 12px;
+	cursor: pointer;
+	outline: none;
+}
+
+.time-window-select:focus {
+	border-color: var(--button-bg);
+}
+
+.time-window-select option {
+	background: var(--bg-secondary);
+	color: var(--text-primary);
+}
+
 /* Language Heatmap */
 .heatmap-container {
 	position: relative;

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -120,11 +120,22 @@ body {
 
 .chart-controls {
 	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	margin-bottom: 12px;
+}
+
+.chart-controls-row {
+	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-	gap: 12px;
-	margin-bottom: 8px;
-	justify-content: center;
+	gap: 10px;
+	justify-content: flex-start;
+}
+
+.scope-row {
+	padding-bottom: 10px;
+	border-bottom: 1px solid var(--border-subtle);
 }
 
 .control-group {

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -133,6 +133,18 @@ body {
 	align-items: center;
 }
 
+.control-label {
+	font-size: 11px;
+	color: var(--text-secondary);
+}
+
+.loading-note {
+	font-size: 11px;
+	color: var(--text-secondary);
+	margin-left: 4px;
+	white-space: nowrap;
+}
+
 .control-group-separator {
 	width: 1px;
 	height: 20px;
@@ -145,6 +157,12 @@ body {
 	display: flex;
 	gap: 4px;
 	align-items: center;
+}
+
+.period-controls-label {
+	font-size: 11px;
+	color: var(--text-secondary);
+	margin-right: 4px;
 }
 
 .period-controls .toggle {

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -131,11 +131,13 @@ body {
 	align-items: center;
 	gap: 10px;
 	justify-content: flex-start;
-}
-
-.scope-row {
 	padding-bottom: 10px;
 	border-bottom: 1px solid var(--border-subtle);
+}
+
+.chart-controls-row:last-child {
+	padding-bottom: 0;
+	border-bottom: none;
 }
 
 .control-group {

--- a/vscode-extension/test/unit/chartDataBuilder.test.ts
+++ b/vscode-extension/test/unit/chartDataBuilder.test.ts
@@ -1,7 +1,8 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { getModelBillingProvider, getBillingGroup, COPILOT_EDITOR_NAMES } from '../../../src/chartDataBuilder';
+import { buildChartData, getModelBillingProvider, getBillingGroup, COPILOT_EDITOR_NAMES } from '../../../src/chartDataBuilder';
+import type { DailyTokenStats } from '../../../src/types';
 
 // ── getModelBillingProvider ───────────────────────────────────────────────────
 
@@ -112,4 +113,71 @@ test('COPILOT_EDITOR_NAMES includes Visual Studio', () => {
 
 test('COPILOT_EDITOR_NAMES includes JetBrains', () => {
 	assert.ok(COPILOT_EDITOR_NAMES.has('JetBrains'));
+});
+
+// ── buildChartData sessions splits ────────────────────────────────────────────
+
+const testDailyStats: DailyTokenStats[] = [
+	{
+		date: '2025-01-01',
+		tokens: 1000,
+		sessions: 2,
+		interactions: 10,
+		modelUsage: {
+			'gpt-4o': { inputTokens: 400, outputTokens: 100, sessions: 1 },
+			'claude-3-5-sonnet': { inputTokens: 300, outputTokens: 200, sessions: 1 },
+		},
+		editorUsage: { 'VS Code': { tokens: 1000, sessions: 2 } },
+		repositoryUsage: { 'owner/repo': { tokens: 1000, sessions: 2 } },
+		editorModelUsage: {
+			'VS Code': {
+				'gpt-4o': { inputTokens: 400, outputTokens: 100, sessions: 1 },
+				'claude-3-5-sonnet': { inputTokens: 300, outputTokens: 200, sessions: 1 },
+			},
+		},
+	},
+	{
+		date: '2025-01-02',
+		tokens: 500,
+		sessions: 1,
+		interactions: 5,
+		modelUsage: { 'gpt-4o': { inputTokens: 300, outputTokens: 200, sessions: 1 } },
+		editorUsage: { 'VS Code': { tokens: 500, sessions: 1 } },
+		repositoryUsage: { 'owner/repo': { tokens: 500, sessions: 1 } },
+		editorModelUsage: {
+			'VS Code': { 'gpt-4o': { inputTokens: 300, outputTokens: 200, sessions: 1 } },
+		},
+	},
+];
+
+const testDeps = {
+	getRepoDisplayName: (url: string) => url,
+	calculateEstimatedCost: () => 0,
+	backendConfigured: false,
+	compactNumbers: false,
+	now: new Date('2025-01-15T12:00:00Z'),
+};
+
+test('buildChartData builds non-empty model session datasets', () => {
+	const data = buildChartData(testDailyStats, testDeps);
+	assert.ok(data.periods.day.modelSessionsDatasets);
+	assert.equal(data.periods.day.modelSessionsDatasets.length, 2);
+	const totals = data.periods.day.modelSessionsDatasets.map((d: any) => d.data.reduce((a: number, b: number) => a + b, 0)).sort((a: number, b: number) => a - b);
+	assert.deepEqual(totals, [1, 2]);
+});
+
+test('buildChartData builds non-empty editor session datasets', () => {
+	const data = buildChartData(testDailyStats, testDeps);
+	const vsCodeDataset = data.periods.day.editorSessionsDatasets?.find((d: any) => d.label === 'VS Code');
+	assert.ok(vsCodeDataset, 'expected VS Code session dataset');
+	assert.equal((vsCodeDataset as any).data.reduce((a: number, b: number) => a + b, 0), 3);
+});
+
+test('buildChartData builds non-empty provider session datasets', () => {
+	const data = buildChartData(testDailyStats, testDeps);
+	assert.ok(data.periods.day.providerSessionsDatasets);
+	assert.ok(data.periods.day.providerSessionsDatasets!.length > 0);
+	const copilotDataset = data.periods.day.providerSessionsDatasets!.find((d: any) => d.label === 'GitHub Copilot');
+	assert.ok(copilotDataset, 'expected GitHub Copilot provider session dataset');
+	assert.equal((copilotDataset as any).data.reduce((a: number, b: number) => a + b, 0), 3);
 });

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -991,3 +991,45 @@ const result = aggregatePeriodStats([input], ranges);
 assert.deepEqual(result.monthStats.modelUsageNoExact, {}, 'Gemini CLI rollup must not feed the Copilot estimate');
 assert.deepEqual(result.monthStats.modelUsage['gemini-2.5-pro'], { inputTokens: 300, outputTokens: 100 });
 });
+
+// ── per-model / per-provider session counts ───────────────────────────────────
+
+test('aggregatePeriodStats: fallback path increments per-model and per-editor-model session counts', () => {
+const ranges = makeRanges('2025-03-15');
+const usage: ModelUsage = {
+'gpt-4o': { inputTokens: 400, outputTokens: 100 },
+'claude-3-5-sonnet': { inputTokens: 200, outputTokens: 100 },
+};
+const input: SessionAggregateInput = {
+editorType: 'VS Code',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+lastInteraction: '2025-03-15T10:00:00.000Z',
+sessionData: makeSession({ modelUsage: usage, interactions: 3 }),
+};
+const result = aggregatePeriodStats([input], ranges);
+const day = result.dailyStatsMap.get('2025-03-15')!;
+assert.equal(day.modelUsage['gpt-4o']?.sessions, 1);
+assert.equal(day.modelUsage['claude-3-5-sonnet']?.sessions, 1);
+assert.equal(day.editorModelUsage!['VS Code']['gpt-4o']?.sessions, 1);
+assert.equal(day.editorModelUsage!['VS Code']['claude-3-5-sonnet']?.sessions, 1);
+assert.equal(day.editorUsage['VS Code']?.sessions, 1);
+});
+
+test('aggregatePeriodStats: rollup path increments per-model and per-editor-model session counts', () => {
+const ranges = makeRanges('2025-03-15');
+const usage: ModelUsage = { 'gpt-4o': { inputTokens: 300, outputTokens: 100 } };
+const input: SessionAggregateInput = {
+editorType: 'VS Code',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+sessionData: makeSession({
+dailyRollups: {
+'2025-03-15': { tokens: 400, actualTokens: 0, thinkingTokens: 0, interactions: 2, modelUsage: usage },
+},
+}),
+};
+const result = aggregatePeriodStats([input], ranges);
+const day = result.dailyStatsMap.get('2025-03-15')!;
+assert.equal(day.modelUsage['gpt-4o']?.sessions, 1);
+assert.equal(day.editorModelUsage!['VS Code']['gpt-4o']?.sessions, 1);
+assert.equal(day.editorUsage['VS Code']?.sessions, 1);
+});


### PR DESCRIPTION
Implements the histogram view requested in #1456 by extending the existing Chart webview with a new **Sessions** metric, so users can see AI session volume over time alongside tokens, cost, and output.

### What's new

- **Sessions metric** in the Chart view, with the same time-window selector as other metrics (Today, Last 7 days, Last 30 days, Current month, All time).
- **All time** window that renders the full available history instead of a fixed 30-day window.
- **Model / Editor / Provider splits** for Sessions, matching the splits available for tokens and cost.
- **Rolling average** for the Sessions total chart.
- **Current-period projection** for Sessions total, showing a projected full day/week/month value on the current incomplete period.
- **Reorganized chart controls** into three logical rows: scope (time window + aggregate by + rolling), metric, and split.

### Bug fixes

- Fixed per-model and per-provider session counts in both the extension's daily aggregation and the shared `aggregatePeriodStats` helper, which were causing the by-model and by-provider Sessions charts to render empty.

### Tests

- Added regression tests in `chartDataBuilder.test.ts` verifying session-count datasets are built correctly.
- Added regression tests in `statsHelpers.test.ts` verifying per-model/editor/provider session counts through the shared aggregation path.

Relates to #1456.