### PR TITLE
Improve toolNames.json duplicate prevention

### DIFF
--- a/.claude/agents/tool-names.md
+++ b/.claude/agents/tool-names.md
@@ -134,6 +134,12 @@ When adding a new tool to `toolNames.json`, also determine if it belongs in `aut
 - Insert new non-MCP entries alphabetically or near logically related tools
 - Never remove existing entries
 - **Case-insensitive deduplication**: Before adding a new tool ID, check whether a lowercase (or differently-cased) variant already exists. If `grep` is already mapped, do **not** add `Grep`. If `tool_search` is already mapped, do **not** add `ToolSearch`. The lookup code handles exact-match only, so capitalized variants do map differently — but if both would resolve to the *exact same friendly name*, skip the duplicate. Only add a capitalized variant when it has a meaningfully different name or the lowercase form does not exist at all.
+- **Canonical deduplication**: Tool IDs can arrive in many equivalent forms (different MCP server registrations or separator styles). Before adding a new ID, run `.github/scripts/toolnames_utils.py` and check whether the new ID normalizes to the same canonical key as an existing entry. If it does, **do not add it** — the existing entry already covers it. Common equivalent families include:
+  - GitHub MCP: `mcp_github_github_*` ↔ `mcp_io_github_git_*` ↔ `github-mcp-server-*` ↔ `mcp_github_mcp_s2_*` ↔ `mcp_github_mcp_se_*`
+  - Context7: `context7-*` ↔ `mcp_context7_*` ↔ `mcp__context7__*` ↔ `mcp_io_github_ups_*`
+  - Playwright: `mcp_microsoft_pla_*` ↔ `mcp_playwright_*` ↔ `mcp__playwright__*` ↔ `microsoft_playwright-mcp-*`
+  - Tavily: `mcp_tavily_*` ↔ `mcp_tavily-mcp_*` ↔ `io_github_tavily-ai_tavily-mcp-*`
+  - Claude Browser: `mcp__claude-in-chrome__*` ↔ `mcp__claude_browser__*` ↔ `mcp__Claude_Browser__*`
 
 ### Validation
 

--- a/.github/agents/tool-names.agent.md
+++ b/.github/agents/tool-names.agent.md
@@ -157,6 +157,12 @@ When adding a new tool to `toolNames.json`, also determine if it belongs in `aut
 - Insert new non-MCP entries alphabetically or near logically related tools
 - Never remove existing entries
 - **Case-insensitive deduplication**: Before adding a new tool ID, check whether a lowercase (or differently-cased) variant already exists. If `grep` is already mapped, do **not** add `Grep`. If `tool_search` is already mapped, do **not** add `ToolSearch`. The lookup code handles exact-match only, so capitalized variants do map differently — but if both would resolve to the *exact same friendly name*, skip the duplicate. Only add a capitalized variant when it has a meaningfully different name or the lowercase form does not exist at all.
+- **Canonical deduplication**: Tool IDs can arrive in many equivalent forms (different MCP server registrations or separator styles). Before adding a new ID, run `.github/scripts/toolnames_utils.py` and check whether the new ID normalizes to the same canonical key as an existing entry. If it does, **do not add it** — the existing entry already covers it. Common equivalent families include:
+  - GitHub MCP: `mcp_github_github_*` ↔ `mcp_io_github_git_*` ↔ `github-mcp-server-*` ↔ `mcp_github_mcp_s2_*` ↔ `mcp_github_mcp_se_*`
+  - Context7: `context7-*` ↔ `mcp_context7_*` ↔ `mcp__context7__*` ↔ `mcp_io_github_ups_*`
+  - Playwright: `mcp_microsoft_pla_*` ↔ `mcp_playwright_*` ↔ `mcp__playwright__*` ↔ `microsoft_playwright-mcp-*`
+  - Tavily: `mcp_tavily_*` ↔ `mcp_tavily-mcp_*` ↔ `io_github_tavily-ai_tavily-mcp-*`
+  - Claude Browser: `mcp__claude-in-chrome__*` ↔ `mcp__claude_browser__*` ↔ `mcp__Claude_Browser__*`
 
 ### Validation
 

--- a/.github/prompts/sync-toolnames.prompt.md
+++ b/.github/prompts/sync-toolnames.prompt.md
@@ -16,7 +16,11 @@ Scan `microsoft/vscode-copilot-chat` repo for model-facing tool identifiers, com
      - `export enum ContributedToolName { ... }` (string literal values)
    - Ignore TypeScript keys (enum member names). Only collect the **string values** (the model-facing tool names).
 3. In *this* repo, load the existing mapping file `src/toolNames.json`. Treat its top-level keys as the set of already-known tool IDs.
-4. Compute `missing = (upstreamToolIds - existingMappingKeys)`.
+4. Normalize and deduplicate before computing missing:
+   - Use the helper at `.github/scripts/toolnames_utils.py` (or replicate its canonicalization rules) to canonicalize both upstream tool IDs and existing mapping keys.
+   - Equivalent forms (e.g. `mcp_github_github_*` ↔ `mcp_io_github_git_*` ↔ `github-mcp-server-*`, `context7-*` ↔ `mcp_context7_*`, Playwright/Tavily/Claude Browser prefix variants) must collapse to the same canonical key.
+   - Compute `missing = upstream IDs whose canonical form is not already present in the existing mapping`.
+   - Skip any upstream ID whose generated friendly name already exists as a value in `toolNames.json`.
    - Deduplicate.
    - Sort ascending (stable, locale-insensitive).
 5. For each missing tool ID, generate a default friendly name:

--- a/.github/scripts/toolnames_utils.py
+++ b/.github/scripts/toolnames_utils.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Shared helpers for detecting duplicate-like entries in src/toolNames.json.
+
+Tool IDs can arrive in many equivalent forms (different MCP server registrations,
+dash vs underscore vs dot separators, truncated server names). This module
+normalizes those forms so callers can flag duplicates before they are injected.
+"""
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# Longest prefix first so the most specific rule wins.
+_CANONICAL_PREFIX_RULES: list[tuple[str, str]] = [
+    # GitHub MCP server registrations (local stdio, remote, GitHub-official server)
+    ("mcp.io.github.git.", "github_"),
+    ("mcp_io_github_git_", "github_"),
+    ("mcp.github.github.", "github_"),
+    ("mcp_github_github_", "github_"),
+    ("github-mcp-server-", "github_"),
+    ("mcp_github_mcp_s2_", "github_"),
+    ("mcp_github_mcp_se_", "github_"),
+    # Context7 / UPS docs
+    ("mcp__plugin_context7_context7__", "context7_"),
+    ("mcp__context7__", "context7_"),
+    ("mcp_context7_", "context7_"),
+    ("mcp_io_github_ups_", "context7_"),
+    ("context7-", "context7_"),
+    # Playwright MCP
+    ("mcp__microsoft_playwright-mcp__", "playwright_"),
+    ("microsoft_playwright-mcp-", "playwright_"),
+    ("mcp__playwright__", "playwright_"),
+    ("mcp_playwright_", "playwright_"),
+    ("mcp_microsoft_pla_", "playwright_"),
+    # Tavily MCP
+    ("io_github_tavily-ai_tavily-mcp-", "tavily_"),
+    ("mcp_tavily-mcp_", "tavily_"),
+    ("mcp_tavily_", "tavily_"),
+    # Claude Browser MCP
+    ("mcp__claude-in-chrome__", "claude_browser_"),
+    ("mcp__claude_browser__", "claude_browser_"),
+    ("mcp__Claude_Browser__", "claude_browser_"),
+]
+
+
+def _normalize_separators(value: str) -> str:
+    """Replace separators that tooling uses interchangeably with underscores."""
+    return value.replace(".", "_").replace("-", "_")
+
+
+def canonicalize_tool_id(tool_id: str) -> str:
+    """Return a canonical form of a tool ID for duplicate comparison.
+
+    The result is not meant to be displayed; it is a stable key used to decide
+    whether two tool IDs are likely the same tool under different registrations.
+    """
+    lowered = tool_id.lower()
+    for prefix, replacement in _CANONICAL_PREFIX_RULES:
+        if lowered.startswith(prefix):
+            action = tool_id[len(prefix):]
+            return replacement + _normalize_separators(action)
+    return _normalize_separators(tool_id)
+
+
+def _normalize_friendly_name(name: str) -> str:
+    """Normalize a friendly name so trivial spacing/casing differences match."""
+    return re.sub(r"\s+", " ", name.strip().lower())
+
+
+def find_matches_for_new_tool(
+    tool_id: str, existing: dict[str, str]
+) -> dict[str, list[tuple[str, str]]]:
+    """Check whether a new tool ID is already represented in the mapping.
+
+    Returns a dict with keys:
+      - exact: same key exists
+      - case_variant: same key with different casing
+      - canonical_equivalent: different key that normalizes to the same canonical form
+    """
+    result: dict[str, list[tuple[str, str]]] = {
+        "exact": [],
+        "case_variant": [],
+        "canonical_equivalent": [],
+    }
+
+    if tool_id in existing:
+        result["exact"].append((tool_id, existing[tool_id]))
+        return result
+
+    lower_tool_id = tool_id.lower()
+    for existing_id, friendly in existing.items():
+        if existing_id.lower() == lower_tool_id:
+            result["case_variant"].append((existing_id, friendly))
+
+    canonical = canonicalize_tool_id(tool_id)
+    for existing_id, friendly in existing.items():
+        if existing_id.lower() == lower_tool_id:
+            continue
+        if canonicalize_tool_id(existing_id) == canonical:
+            result["canonical_equivalent"].append((existing_id, friendly))
+
+    return result
+
+
+def find_friendly_duplicates(
+    friendly_name: str, existing: dict[str, str]
+) -> list[tuple[str, str]]:
+    """Return existing entries whose friendly name matches the proposed one."""
+    normalized = _normalize_friendly_name(friendly_name)
+    return [
+        (existing_id, friendly)
+        for existing_id, friendly in existing.items()
+        if _normalize_friendly_name(friendly) == normalized
+    ]
+
+
+def find_duplicate_groups(
+    tool_names: dict[str, str]
+) -> tuple[dict[str, list[tuple[str, str]]], dict[str, list[tuple[str, str]]]]:
+    """Find groups of entries that look like duplicates.
+
+    Returns two dicts:
+    - strict_duplicates: entries with the same normalized friendly name.
+      These are unambiguous duplicates.
+    - canonical_equivalents: entries that normalize to the same canonical key
+      but have different friendly names. These are likely the same tool from
+      different MCP server registrations, but may be intentional (e.g. local
+      vs remote server labels).
+    """
+    by_canonical: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    by_friendly: dict[str, list[tuple[str, str]]] = defaultdict(list)
+
+    for tool_id, friendly in tool_names.items():
+        entry = (tool_id, friendly)
+        by_canonical[canonicalize_tool_id(tool_id)].append(entry)
+        by_friendly[_normalize_friendly_name(friendly)].append(entry)
+
+    strict_duplicates = {
+        f"strict-{i + 1}": sorted(group)
+        for i, group in enumerate(by_friendly.values())
+        if len(group) > 1
+    }
+
+    # Canonical equivalents: same canonical key, different friendly name, and
+    # not already covered by a strict duplicate group.
+    strict_entries = {
+        entry
+        for group in strict_duplicates.values()
+        for entry in group
+    }
+    canonical_equivalents: dict[str, list[tuple[str, str]]] = {}
+    for i, group in enumerate(by_canonical.values()):
+        if len(group) < 2:
+            continue
+        filtered = sorted(entry for entry in group if entry not in strict_entries)
+        if len(filtered) > 1:
+            canonical_equivalents[f"canonical-{i + 1}"] = filtered
+
+    return strict_duplicates, canonical_equivalents
+
+
+def load_tool_names(path: Path | str) -> dict[str, str]:
+    with open(path, "r", encoding="utf-8") as f:
+        data: dict[str, Any] = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"toolNames.json must be a JSON object, got {type(data).__name__}")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def _group_key(group: list[tuple[str, str]]) -> frozenset[tuple[str, str]]:
+    return frozenset(group)
+
+
+def find_new_duplicate_groups(
+    head_tool_names: dict[str, str],
+    base_tool_names: dict[str, str]
+) -> tuple[dict[str, list[tuple[str, str]]], dict[str, list[tuple[str, str]]]]:
+    """Return duplicate groups present in head but not entirely present in base."""
+    head_strict, head_canonical = find_duplicate_groups(head_tool_names)
+    base_strict, base_canonical = find_duplicate_groups(base_tool_names)
+
+    base_strict_keys = {_group_key(g) for g in base_strict.values()}
+    base_canonical_keys = {_group_key(g) for g in base_canonical.values()}
+
+    new_strict = {
+        label: group
+        for label, group in head_strict.items()
+        if _group_key(group) not in base_strict_keys
+    }
+    new_canonical = {
+        label: group
+        for label, group in head_canonical.items()
+        if _group_key(group) not in base_canonical_keys
+    }
+    return new_strict, new_canonical
+
+
+def _print_report(
+    strict_duplicates: dict[str, list[tuple[str, str]]],
+    canonical_equivalents: dict[str, list[tuple[str, str]]]
+) -> None:
+    if strict_duplicates:
+        print(f"Found {len(strict_duplicates)} group(s) with the same friendly name:")
+        for label, group in sorted(strict_duplicates.items()):
+            print(f"\n{label}:")
+            for tool_id, friendly in group:
+                print(f"  {tool_id!r} -> {friendly!r}")
+
+    if canonical_equivalents:
+        print(
+            f"\nFound {len(canonical_equivalents)} group(s) of likely equivalent "
+            "tool IDs (different friendly names):"
+        )
+        for label, group in sorted(canonical_equivalents.items()):
+            print(f"\n{label}:")
+            for tool_id, friendly in group:
+                print(f"  {tool_id!r} -> {friendly!r}")
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    tool_names_path = repo_root / "src" / "toolNames.json"
+    tool_names = load_tool_names(tool_names_path)
+
+    import argparse
+    parser = argparse.ArgumentParser(description="Lint src/toolNames.json for duplicates.")
+    parser.add_argument(
+        "--base",
+        type=Path,
+        help="Path to a base toolNames.json. When provided, only duplicates "
+             "introduced relative to the base are reported."
+    )
+    args = parser.parse_args()
+
+    if args.base:
+        base_tool_names = load_tool_names(args.base)
+        strict_duplicates, canonical_equivalents = find_new_duplicate_groups(
+            tool_names, base_tool_names
+        )
+    else:
+        strict_duplicates, canonical_equivalents = find_duplicate_groups(tool_names)
+
+    if not strict_duplicates and not canonical_equivalents:
+        print("No duplicate-like entries found.")
+        return 0
+
+    _print_report(strict_duplicates, canonical_equivalents)
+
+    # Treat strict duplicates as a failing condition for CI; canonical
+    # equivalents are surfaced but do not fail the build on their own.
+    return 1 if strict_duplicates else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -57,6 +57,9 @@ jobs:
           import re
           import sys
           
+          sys.path.insert(0, ".github/scripts")
+          from toolnames_utils import find_matches_for_new_tool
+          
           issue_body = os.environ.get("ISSUE_BODY", "")
           issue_number = os.environ.get("ISSUE_NUMBER", "")
           repo = os.environ.get("REPO", "")
@@ -92,20 +95,20 @@ jobs:
               already_added = []
               needs_adding = []
               case_variants = []
+              canonical_equivalents = []
           
               for tool in tools:
-                  if tool in known_tools:
+                  matches = find_matches_for_new_tool(tool, known_tools)
+                  if matches["exact"]:
                       already_added.append((tool, known_tools[tool]))
+                  elif matches["case_variant"]:
+                      existing_id, friendly = matches["case_variant"][0]
+                      case_variants.append((tool, existing_id, friendly))
+                  elif matches["canonical_equivalent"]:
+                      existing_id, friendly = matches["canonical_equivalent"][0]
+                      canonical_equivalents.append((tool, existing_id, friendly))
                   else:
-                      # Case-insensitive check: if a differently-cased variant already
-                      # exists with the same friendly name, flag it as a case variant
-                      # rather than a missing entry — it should NOT be added separately.
-                      lower_tool = tool.lower()
-                      case_match = next((k for k in known_tools if k.lower() == lower_tool), None)
-                      if case_match and known_tools[case_match] == known_tools.get(tool, known_tools[case_match]):
-                          case_variants.append((tool, case_match, known_tools[case_match]))
-                      else:
-                          needs_adding.append(tool)
+                      needs_adding.append(tool)
           
               lines = ["## 🔍 Toolnames Checkup", ""]
               lines.append("Checked the tool names in this issue against `src/toolNames.json` on the `main` branch:")
@@ -132,6 +135,18 @@ jobs:
                       lines.append(f"| `{tool}` | `{existing}` | {friendly} |")
                   lines.append("")
           
+              if canonical_equivalents:
+                  lines.append("### ⚠️ Equivalent to an existing entry — do not add")
+                  lines.append("")
+                  lines.append("These tool names normalize to the same canonical form as an existing entry (e.g. different MCP server registration or separator style).")
+                  lines.append("**Do not add a separate entry** — the existing entry covers this tool.")
+                  lines.append("")
+                  lines.append("| Tool Name (from issue) | Existing Entry | Friendly Name |")
+                  lines.append("| --- | --- | --- |")
+                  for tool, existing, friendly in canonical_equivalents:
+                      lines.append(f"| `{tool}` | `{existing}` | {friendly} |")
+                  lines.append("")
+          
               if needs_adding:
                   lines.append("### ❌ Not yet in `toolNames.json`")
                   lines.append("")
@@ -141,10 +156,11 @@ jobs:
                       lines.append(f"| `{tool}` |")
                   lines.append("")
           
-              if already_added and not needs_adding and not case_variants:
+              has_issues = case_variants or canonical_equivalents
+              if already_added and not needs_adding and not has_issues:
                   lines.append("> **All tool names in this issue are already mapped.** This issue may be a duplicate — consider closing it.")
-              elif case_variants and not needs_adding:
-                  lines.append("> **All unmapped tool names are case variants of existing entries.** No new entries should be added. Consider closing this issue.")
+              elif has_issues and not needs_adding:
+                  lines.append("> **All unmapped tool names are variants of existing entries.** No new entries should be added. Consider closing this issue.")
               elif needs_adding:
                   lines.append(f"> **{len(needs_adding)} tool name(s) still need to be added.** Please use the `tool-names` custom agent or update `src/toolNames.json` manually.")
           
@@ -215,6 +231,9 @@ jobs:
           python3 - << 'PYEOF'
           import json, os, re, sys
 
+          sys.path.insert(0, ".github/scripts")
+          from toolnames_utils import find_matches_for_new_tool
+
           issue_body = os.environ.get("ISSUE_BODY", "")
           MAX_BODY_LEN = 100_000
           if len(issue_body) > MAX_BODY_LEN:
@@ -237,11 +256,15 @@ jobs:
 
           missing = []
           for tool in tools:
-              if tool not in known_tools:
-                  lower = tool.lower()
-                  case_match = next((k for k in known_tools if k.lower() == lower), None)
-                  if not case_match:
-                      missing.append(tool)
+              matches = find_matches_for_new_tool(tool, known_tools)
+              if not (matches["exact"] or matches["case_variant"] or matches["canonical_equivalent"]):
+                  missing.append(tool)
+              elif matches["canonical_equivalent"]:
+                  existing_id, friendly = matches["canonical_equivalent"][0]
+                  print(
+                      f"Skipping {tool!r} — canonical equivalent of {existing_id!r} ({friendly})",
+                      file=sys.stderr
+                  )
 
           print(f"Missing tools: {missing}", file=sys.stderr)
           with open("/tmp/missing-tools.json", "w") as f:
@@ -433,6 +456,9 @@ jobs:
           python3 - << 'PYEOF'
           import json, re, sys
 
+          sys.path.insert(0, ".github/scripts")
+          from toolnames_utils import find_friendly_duplicates, find_matches_for_new_tool
+
           TOOLNAMES_FILE = "src/toolNames.json"
 
           with open("/tmp/slm-names.json") as f:
@@ -447,11 +473,26 @@ jobs:
 
           to_add = {}
           for tool_id, friendly_name in new_entries.items():
-              if tool_id in known_tools:
+              matches = find_matches_for_new_tool(tool_id, known_tools)
+              if matches["exact"]:
                   print(f"Skipping {tool_id!r} — already present", file=sys.stderr)
                   continue
-              if any(k.lower() == tool_id.lower() for k in known_tools):
-                  print(f"Skipping {tool_id!r} — case variant present", file=sys.stderr)
+              if matches["case_variant"]:
+                  existing_id = matches["case_variant"][0][0]
+                  print(f"Skipping {tool_id!r} — case variant of {existing_id!r}", file=sys.stderr)
+                  continue
+              if matches["canonical_equivalent"]:
+                  existing_id = matches["canonical_equivalent"][0][0]
+                  print(f"Skipping {tool_id!r} — canonical equivalent of {existing_id!r}", file=sys.stderr)
+                  continue
+              friendly_dups = find_friendly_duplicates(friendly_name, known_tools)
+              if friendly_dups:
+                  existing_id, existing_friendly = friendly_dups[0]
+                  print(
+                      f"Skipping {tool_id!r} — friendly name '{friendly_name}' already used by "
+                      f"{existing_id!r} ({existing_friendly})",
+                      file=sys.stderr
+                  )
                   continue
               to_add[tool_id] = friendly_name
 

--- a/.github/workflows/lint-toolnames.yml
+++ b/.github/workflows/lint-toolnames.yml
@@ -1,0 +1,71 @@
+name: Lint Tool Names
+
+# Prevent duplicate-like entries from being added to src/toolNames.json.
+# The script flags:
+#   - strict duplicates: multiple keys mapping to the same friendly name
+#   - canonical equivalents: same tool under different MCP registrations
+#
+# Strict duplicates fail the build; canonical equivalents are reported as
+# warnings for human review.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/toolNames.json"
+      - ".github/scripts/toolnames_utils.py"
+      - ".github/workflows/lint-toolnames.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/toolNames.json"
+      - ".github/scripts/toolnames_utils.py"
+      - ".github/workflows/lint-toolnames.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: lint-toolnames-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check for duplicate-like entries
+        id: check
+        run: |
+          # Only fail on duplicates newly introduced by this change; the file
+          # already contains historical duplicates that need a separate cleanup.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BASE_SHA="${{ github.event.before }}"
+          else
+            BASE_SHA=""
+          fi
+
+          if [ -n "$BASE_SHA" ]; then
+            git show "${BASE_SHA}:src/toolNames.json" > /tmp/toolNames-base.json
+            python3 .github/scripts/toolnames_utils.py --base /tmp/toolNames-base.json
+          else
+            python3 .github/scripts/toolnames_utils.py
+          fi
+
+      - name: Report canonical equivalents as warnings
+        if: failure() || success()
+        run: |
+          # Re-run the check without the base filter so canonical equivalents
+          # are visible in the log even when no new strict duplicates exist.
+          python3 .github/scripts/toolnames_utils.py || true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ reports/mutation/
 .github/scripts/models.txt
 .github/scripts/scraper.log
 .github/scripts/scraped-models.json
+.github/scripts/__pycache__/
 example.json
 log-example.txt
 eslint-all.txt

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -620,14 +620,58 @@ export function isMcpTool(toolName: string): boolean {
 /**
  * Normalize an MCP tool name so that equivalent tools from different servers
  * (local stdio vs remote) are counted under a single canonical key in "By Tool" views.
- * Maps mcp_github_github_<action> → mcp_io_github_git_<action>.
+ *
+ * Each rule maps a known equivalent prefix to a canonical prefix. Rules are
+ * evaluated in order; the first match wins.
+ */
+const MCP_NORMALIZATION_RULES: readonly [string, string][] = [
+	// GitHub MCP (remote / server-name variants → local stdio form).
+	['mcp_github_github_', 'mcp_io_github_git_'],
+	['github-mcp-server-', 'mcp_io_github_git_'],
+	['mcp_github_mcp_s2_', 'mcp_io_github_git_'],
+	['mcp_github_mcp_se_', 'mcp_io_github_git_'],
+	['mcp.github.github.', 'mcp.io.github.git.'],
+
+	// Context7 / UPS docs.
+	['mcp__plugin_context7_context7__', 'context7-'],
+	['mcp__context7__', 'context7-'],
+	['mcp_context7_', 'context7-'],
+	['mcp_io_github_ups_', 'context7-'],
+
+	// Playwright MCP.
+	['mcp__microsoft_playwright-mcp__', 'microsoft_playwright-mcp-'],
+	['mcp__playwright__', 'microsoft_playwright-mcp-'],
+	['mcp_playwright_', 'microsoft_playwright-mcp-'],
+	['mcp_microsoft_pla_', 'microsoft_playwright-mcp-'],
+
+	// Tavily MCP.
+	['mcp_tavily-mcp_', 'io_github_tavily-ai_tavily-mcp-'],
+	['mcp_tavily_', 'io_github_tavily-ai_tavily-mcp-'],
+
+	// Claude Browser MCP.
+	['mcp__claude-in-chrome__', 'mcp__claude_browser__'],
+	['mcp__Claude_Browser__', 'mcp__claude_browser__'],
+];
+
+/**
+ * Normalize an MCP tool name so that equivalent tools from different servers
+ * (local stdio vs remote) are counted under a single canonical key in "By Tool" views.
+ *
+ * Known equivalent prefix families that collapse to a single canonical form:
+ * - GitHub MCP: mcp_github_github_, mcp_io_github_git_, github-mcp-server-,
+ *   mcp_github_mcp_s2_, mcp_github_mcp_se_, mcp.github.github., mcp.io.github.git.
+ * - Context7: context7-, mcp_context7_, mcp__context7__, mcp__plugin_context7_context7__,
+ *   mcp_io_github_ups_
+ * - Playwright: mcp_microsoft_pla_, microsoft_playwright-mcp-, mcp__playwright__,
+ *   mcp_playwright_, mcp__microsoft_playwright-mcp__
+ * - Tavily: mcp_tavily-mcp_, io_github_tavily-ai_tavily-mcp-, mcp_tavily_
+ * - Claude Browser: mcp__claude-in-chrome__, mcp__claude_browser__, mcp__Claude_Browser__
  */
 export function normalizeMcpToolName(toolName: string): string {
-	if (toolName.startsWith('mcp_github_github_')) {
-		return 'mcp_io_github_git_' + toolName.substring('mcp_github_github_'.length);
-	}
-	if (toolName.startsWith('mcp.github.github.')) {
-		return 'mcp.io.github.git.' + toolName.substring('mcp.github.github.'.length);
+	for (const [prefix, canonicalPrefix] of MCP_NORMALIZATION_RULES) {
+		if (toolName.startsWith(prefix)) {
+			return canonicalPrefix + toolName.substring(prefix.length);
+		}
 	}
 	return toolName;
 }

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -162,6 +162,72 @@ test('normalizeMcpToolName: mcp.github.github. prefix maps to mcp.io.github.git.
     );
 });
 
+test('normalizeMcpToolName: github-mcp-server- prefix maps to mcp_io_github_git_', () => {
+    assert.equal(
+        normalizeMcpToolName('github-mcp-server-list_issues'),
+        'mcp_io_github_git_list_issues'
+    );
+});
+
+test('normalizeMcpToolName: mcp_github_mcp_s2_ prefix maps to mcp_io_github_git_', () => {
+    assert.equal(
+        normalizeMcpToolName('mcp_github_mcp_s2_issue_read'),
+        'mcp_io_github_git_issue_read'
+    );
+});
+
+test('normalizeMcpToolName: context7 prefix variants normalize to context7-', () => {
+    assert.equal(
+        normalizeMcpToolName('mcp_context7_query-docs'),
+        'context7-query-docs'
+    );
+    assert.equal(
+        normalizeMcpToolName('mcp__context7__query-docs'),
+        'context7-query-docs'
+    );
+    assert.equal(
+        normalizeMcpToolName('mcp_io_github_ups_resolve-library-id'),
+        'context7-resolve-library-id'
+    );
+});
+
+test('normalizeMcpToolName: playwright prefix variants normalize to microsoft_playwright-mcp-', () => {
+    assert.equal(
+        normalizeMcpToolName('mcp_playwright_browser_click'),
+        'microsoft_playwright-mcp-browser_click'
+    );
+    assert.equal(
+        normalizeMcpToolName('mcp__microsoft_playwright-mcp__browser_click'),
+        'microsoft_playwright-mcp-browser_click'
+    );
+    assert.equal(
+        normalizeMcpToolName('mcp_microsoft_pla_browser_click'),
+        'microsoft_playwright-mcp-browser_click'
+    );
+});
+
+test('normalizeMcpToolName: tavily prefix variants normalize to io_github_tavily-ai_tavily-mcp-', () => {
+    assert.equal(
+        normalizeMcpToolName('mcp_tavily_tavily_search'),
+        'io_github_tavily-ai_tavily-mcp-tavily_search'
+    );
+    assert.equal(
+        normalizeMcpToolName('mcp_tavily-mcp_tavily_search'),
+        'io_github_tavily-ai_tavily-mcp-tavily_search'
+    );
+});
+
+test('normalizeMcpToolName: claude browser prefix variants normalize to mcp__claude_browser__', () => {
+    assert.equal(
+        normalizeMcpToolName('mcp__claude-in-chrome__navigate'),
+        'mcp__claude_browser__navigate'
+    );
+    assert.equal(
+        normalizeMcpToolName('mcp__Claude_Browser__navigate'),
+        'mcp__claude_browser__navigate'
+    );
+});
+
 test('normalizeMcpToolName: other tool names pass through unchanged', () => {
     assert.equal(normalizeMcpToolName('mcp_io_github_git_list_issues'), 'mcp_io_github_git_list_issues');
     assert.equal(normalizeMcpToolName('editFiles'), 'editFiles');


### PR DESCRIPTION
`src/toolNames.json` has grown to 1,136 entries, with 111 groups sharing the same friendly name across different keys. The current tooling only catches exact and case-variant matches, so equivalent tool IDs from different MCP server registrations keep being added.

This change tightens the injection process at every entry point:

- Adds `.github/scripts/toolnames_utils.py`, a shared utility that canonicalizes tool IDs and detects strict duplicates (same friendly name) and canonical equivalents (same normalized prefix family).
- Adds `.github/workflows/lint-toolnames.yml`, a CI check that fails PRs introducing new strict duplicates. It compares against the PR base or previous commit so the existing historical duplicates do not block merges.
- Updates `.github/workflows/check-toolnames.yml` so the `Toolnames checkup` labeler reports canonical equivalents and the `add-toolnames-with-slm` job skips near-duplicates before calling the model.
- Updates `.github/prompts/sync-toolnames.prompt.md` to require canonicalizing upstream IDs before computing missing entries.
- Expands `normalizeMcpToolName` in `src/workspaceHelpers.ts` to cover Context7, Playwright, Tavily, Claude Browser, and additional GitHub MCP prefix variants, so usage views already group equivalent tools.
- Adds unit tests for the new normalization mappings.
- Updates the `tool-names` custom agent docs in both `.github/agents/` and `.claude/agents/` mirrors with canonical deduplication guidance.

The existing duplicate groups in `toolNames.json` are intentionally left in place; a separate cleanup PR can remove them once this prevention tooling is in place.