### PR TITLE
Show net session duration, keep wall-clock time for future use

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -580,6 +580,8 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 						editor: data.editorSource,
 						models: Object.keys(data.modelUsage),
 						lastActivity: data.lastModified.toISOString(),
+						...(analysis.sessionDuration?.totalDurationMs !== undefined ? { durationMs: analysis.sessionDuration.totalDurationMs } : {}),
+						...(analysis.sessionDuration?.activeDurationMs !== undefined ? { activeDurationMs: analysis.sessionDuration.activeDurationMs } : {}),
 					});
 				}
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -542,8 +542,10 @@ export interface TodaySessionSummary {
   contextWindowLimit?: number;
   /** Last known context fill in tokens (Copilot CLI, from data.db context_current_tokens). */
   contextReachedTokens?: number;
-  /** Session duration in milliseconds (last interaction − first interaction). Absent when not derivable. */
+  /** Wall-clock session duration in milliseconds (last interaction − first interaction), including idle gaps between turns. Absent when not derivable. Kept for reference/future use; prefer `activeDurationMs` for display. */
   durationMs?: number;
+  /** Net ("active") session duration in milliseconds: sum of merged [requestTimestamp, requestTimestamp+totalElapsed] windows, excluding idle gaps between turns. This is the value shown as "Duration" in the Recent Sessions list. Absent when not derivable. */
+  activeDurationMs?: number;
   /** Workspace/repository name the session belongs to. Absent when attribution is unavailable. */
   workspace?: string;
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3878,7 +3878,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 	): TodaySessionSummary {
 		const modelUsage = sessionData.modelUsage || {};
 		const { inputTok, outputTok, cachedTok } = this._resolveSessionModelTokens(sessionData, modelUsage);
+		// Wall-clock duration (includes idle gaps between turns) — kept for reference/future use.
 		const durationMs = computeSessionDurationMs(sessionData.firstInteraction, sessionData.lastInteraction);
+		// Net/active duration (excludes idle gaps between turns) — this is what's shown as "Duration".
+		const activeDurationMs = analysis.sessionDuration?.activeDurationMs;
 		const workspace = this.resolveSessionWorkspaceName(sessionData, sessionFile);
 		return {
 			title: sessionData.title || null, filePath: sessionFile, interactions,
@@ -3892,6 +3895,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			...(sessionData.maxRequestInputTokens ? { maxRequestInputTokens: sessionData.maxRequestInputTokens } : {}),
 			...(sessionData.contextTier ? { contextTier: sessionData.contextTier } : {}),
 			...(durationMs !== undefined ? { durationMs } : {}),
+			...(activeDurationMs !== undefined ? { activeDurationMs } : {}),
 			...(workspace ? { workspace } : {}),
 		};
 	}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -70,6 +70,7 @@ type TodaySessionSummary = {
 	contextWindowLimit?: number;
 	contextReachedTokens?: number;
 	durationMs?: number;
+	activeDurationMs?: number;
 	workspace?: string;
 };
 
@@ -1035,7 +1036,11 @@ const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
 	{ id: 'editor', label: 'Editor', sortKey: 'editor', align: 'left', render: s => ({ html: escapeHtml(s.editor || 'unknown') }) },
 	{ id: 'workspace', label: 'Workspace', sortKey: 'workspace', align: 'left', cellStyle: 'max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const workspace = escapeHtml(s.workspace || '—'); return { html: workspace, title: workspace }; } },
 	{ id: 'models', label: 'Models', align: 'left', cellStyle: 'font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—'; return { html: models, title: models }; } },
-	{ id: 'durationMs', label: 'Duration', sortKey: 'durationMs', align: 'right', cellStyle: 'white-space:nowrap;', render: s => ({ html: formatDurationShort(s.durationMs) }) },
+	{ id: 'durationMs', label: 'Duration', sortKey: 'durationMs', align: 'right', cellStyle: 'white-space:nowrap;', render: s => {
+		const net = s.activeDurationMs ?? s.durationMs;
+		const wallLabel = s.durationMs !== undefined ? `Wall time: ${formatDurationShort(s.durationMs)}` : undefined;
+		return { html: formatDurationShort(net), ...(wallLabel ? { title: wallLabel } : {}) };
+	} },
 	{
 		id: 'lastActivity', label: 'Last Active', sortKey: 'lastActivity', align: 'right', cellStyle: 'white-space:nowrap;',
 		render: s => ({
@@ -1075,7 +1080,7 @@ const _todaySessionColumnComparators: Partial<Record<SessionSortColumn, (a: Toda
 	title: (a, b) => (a.title || '').localeCompare(b.title || ''),
 	editor: (a, b) => (a.editor || '').localeCompare(b.editor || ''),
 	workspace: (a, b) => (a.workspace || '').localeCompare(b.workspace || ''),
-	durationMs: (a, b) => (a.durationMs ?? -1) - (b.durationMs ?? -1),
+	durationMs: (a, b) => (a.activeDurationMs ?? a.durationMs ?? -1) - (b.activeDurationMs ?? b.durationMs ?? -1),
 	lastActivity: (a, b) => (a.lastActivity || '').localeCompare(b.lastActivity || ''),
 };
 


### PR DESCRIPTION
## Why

The Recent Sessions list's Duration column showed wall-clock time (last interaction minus first interaction), which includes idle gaps between turns (e.g. time the user spent away from the editor). Session analysis already computes a merged "active" duration per session (the union of each request's `[timestamp, timestamp + totalElapsed]` window), which excludes those idle gaps and better reflects actual working time - but it was never surfaced to the session summary or UI.

## What changed

- `src/types.ts`: `TodaySessionSummary` now carries both `durationMs` (wall-clock, doc-clarified) and a new `activeDurationMs` (net/active time).
- `vscode-extension/src/extension.ts`: `collectTodaySessionInfo` now also reads `analysis.sessionDuration.activeDurationMs` and includes it in the summary.
- `vscode-extension/src/webview/usage/main.ts`: the "Duration" column in the Recent Sessions table now renders and sorts by the net time, with a "Wall time: Xm" tooltip so the wall-clock figure is still visible on hover.
- `cli/src/helpers.ts`: populates both fields for parity, since the CLI reuses the same shared analysis functions.

Wall-clock time (`durationMs`) is kept around (just not the default displayed value) in case it's needed elsewhere later.

## Verification

- `tsc --noEmit` clean for both the extension and CLI
- `npm run compile` (lint + build) clean
- All 315 `statsHelpers`/`usageAnalysis` unit tests and the `extension.test.ts` suite pass