### PR TITLE
Reconcile modelUsage to actualTokens for event-based sessions

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -20,6 +20,7 @@ import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { parseJetBrainsPartition } from '../../src/jetbrains';
 import type { DetailedStats, ModelUsage, UsageAnalysisStats, WorkspaceCustomizationMatrix, TodaySessionSummary } from '../../src/types';
 import { analyzeSessionUsage, mergeUsageAnalysis, getModelUsageFromSession } from '../../src/usageAnalysis';
+import { reconcileModelUsageToActualTokens } from '../../src/statsHelpers';
 import { withErrorRecovery } from '../../src/utils/errors';
 import * as vscodeStub from './vscode-stub';
 import { loadCache, saveCache, disableCache, getCached, setCached, getCacheStats } from './cliCache';
@@ -353,6 +354,12 @@ export async function processSessionFile(filePath: string, verbose = false): Pro
 					fileModelUsage = { [modelKey]: { inputTokens: jbResult.tokens, outputTokens: 0 } };
 				}
 			}
+
+			// Reconcile the per-model breakdown to the session total so Input+Output never
+			// exceeds Total in CLI reports. Event-based sessions (Copilot CLI without exact
+			// usage, JetBrains, …) derive actualTokens from real output while modelUsage
+			// derives input from accumulated message content; those heuristics can diverge.
+			fileModelUsage = reconcileModelUsageToActualTokens(fileModelUsage, actualTokens || tokens);
 
 			// Count interactions from JSONL
 			const lines = content.trim().split('\n');

--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -111,6 +111,47 @@ export function reconcileModelUsageToTotal(modelUsage: ModelUsage, targetInputTo
 }
 
 /**
+ * Reconciles a per-model usage breakdown so its input+output total matches an
+ * authoritative session total (e.g. `actualTokens` from a debug log, OTel export,
+ * or ecosystem adapter).
+ *
+ * This is needed when the breakdown source and the total source use different
+ * estimation methods — for example, event-based CLI sessions estimate the session
+ * total from real output via an input:output ratio, while the per-model breakdown
+ * estimates input from accumulated message content scaled by a context-growth factor.
+ * In sessions with large user content but small model output, the breakdown input
+ * can exceed the session total, causing the details view to show "Input tokens" >
+ * "Total tokens".
+ *
+ * Output counts are treated as authoritative when they do not already exceed the
+ * total (the output value usually comes from real API counts); otherwise both input
+ * and output are scaled proportionally. Any residual from rounding is swept into the
+ * existing `unknown` bucket by `reconcileModelUsageToTotal`.
+ */
+export function reconcileModelUsageToActualTokens(modelUsage: ModelUsage, actualTokens: number): ModelUsage {
+	if (actualTokens <= 0) { return modelUsage; }
+	const currentInput = Object.values(modelUsage).reduce((s, u) => s + u.inputTokens, 0);
+	const currentOutput = Object.values(modelUsage).reduce((s, u) => s + u.outputTokens, 0);
+	const currentTotal = currentInput + currentOutput;
+	if (currentTotal === 0) {
+		return Object.keys(modelUsage).length === 0
+			? { unknown: { inputTokens: actualTokens, outputTokens: 0 } }
+			: modelUsage;
+	}
+	if (currentTotal === actualTokens) { return modelUsage; }
+
+	if (currentOutput > 0 && currentOutput <= actualTokens) {
+		// Preserve the (presumably real) output counts and scale input to fit.
+		return reconcileModelUsageToTotal(modelUsage, actualTokens - currentOutput, currentOutput);
+	}
+
+	// Proportional scaling of both input and output to the actual total.
+	const inputTarget = Math.round(actualTokens * (currentInput / currentTotal));
+	const outputTarget = actualTokens - inputTarget;
+	return reconcileModelUsageToTotal(modelUsage, inputTarget, outputTarget);
+}
+
+/**
  * Merges `source` language usage into `target` (in-place).
  */
 export function addLanguageUsage(target: LanguageUsage, source: LanguageUsage): void {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -184,7 +184,7 @@ import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceFor
 import { classifySessionTask, buildClassificationInputFromUsageAnalysis, type TaskCategory } from '../../src/taskClassification';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, type SessionAggregateInput } from '../../src/statsHelpers';
+import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, reconcileModelUsageToActualTokens, type SessionAggregateInput } from '../../src/statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -384,7 +384,7 @@ interface WorktreeScanResult {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 60; // Added taskCategory (task classification, issue #1650)
+	private static readonly CACHE_VERSION = 61; // Reconcile modelUsage to actualTokens for event-based sessions without debug logs
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';
@@ -4543,9 +4543,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.extractSessionMetadata(sessionFilePath, preloadedContent, preloadedParsedJson),
 		]);
 
-		const { dailyRollups, totalInteractions } = this.computeDailyRollups(sessionMeta, tokenResult, modelUsage, interactions);
+		// Reconcile the per-model breakdown to the session total. Different sources estimate
+		// these independently (e.g. event-based CLI sessions derive actualTokens from real
+		// output via a ratio, while modelUsage derives input from accumulated message content),
+		// which can make Input+Output exceed Total in the details view.
+		const reconciledModelUsage = reconcileModelUsageToActualTokens(modelUsage, tokenResult.actualTokens ?? tokenResult.tokens);
+
+		const { dailyRollups, totalInteractions } = this.computeDailyRollups(sessionMeta, tokenResult, reconciledModelUsage, interactions);
 		const debugLogTokens = await this.readTokensFromDebugLog(sessionFilePath);
-		const { resolvedActualTokens, finalCacheReadTokens, resolvedModelUsage } = this.resolveAndApplyDebugLog(tokenResult, debugLogTokens, modelUsage, dailyRollups, totalInteractions);
+		const { resolvedActualTokens, finalCacheReadTokens, resolvedModelUsage } = this.resolveAndApplyDebugLog(tokenResult, debugLogTokens, reconciledModelUsage, dailyRollups, totalInteractions);
 
 		await this.applyWindsurfBreakdown(sessionFilePath, resolvedModelUsage, dailyRollups, usageAnalysis);
 

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -9,6 +9,7 @@ aggregatePeriodStats,
 computeSessionTotalTokens,
 computeSessionDurationMs,
 reconcileModelUsageToTotal,
+reconcileModelUsageToActualTokens,
 type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../../src/statsHelpers';
@@ -227,6 +228,58 @@ const totalInput = Object.values(result).reduce((s, u) => s + u.inputTokens, 0);
 const totalOutput = Object.values(result).reduce((s, u) => s + u.outputTokens, 0);
 assert.strictEqual(totalInput, 1000);
 assert.strictEqual(totalOutput, 333);
+});
+
+// ── reconcileModelUsageToActualTokens ─────────────────────────────────────────
+
+test('reconcileModelUsageToActualTokens: no-op when the breakdown already sums to the actual total', () => {
+const modelUsage: ModelUsage = { 'gpt-4': { inputTokens: 70, outputTokens: 30 } };
+const result = reconcileModelUsageToActualTokens(modelUsage, 100);
+assert.deepEqual(result, { 'gpt-4': { inputTokens: 70, outputTokens: 30 } });
+});
+
+test('reconcileModelUsageToActualTokens: scales input down while preserving real output counts', () => {
+// Event-based CLI sessions can estimate total input from accumulated message content
+// while the session total is derived from real output via an input:output ratio. When
+// user content is large and model output is small, the breakdown input can exceed total.
+const modelUsage: ModelUsage = { 'gpt-4o': { inputTokens: 1000, outputTokens: 100 } };
+const result = reconcileModelUsageToActualTokens(modelUsage, 300);
+// Output stays authoritative (100), input shrinks to fit the 300 total.
+assert.deepEqual(result['gpt-4o'], { inputTokens: 200, outputTokens: 100 });
+const total = Object.values(result).reduce((s, u) => s + u.inputTokens + u.outputTokens, 0);
+assert.strictEqual(total, 300);
+});
+
+test('reconcileModelUsageToActualTokens: proportional fallback when output already exceeds the actual total', () => {
+const modelUsage: ModelUsage = { 'o1': { inputTokens: 50, outputTokens: 200 } };
+const result = reconcileModelUsageToActualTokens(modelUsage, 100);
+const total = Object.values(result).reduce((s, u) => s + u.inputTokens + u.outputTokens, 0);
+assert.strictEqual(total, 100);
+assert.ok(result['o1'].outputTokens <= 100);
+assert.ok(result['o1'].inputTokens <= 100);
+});
+
+test('reconcileModelUsageToActualTokens: distributes across multiple models preserving output shares', () => {
+const modelUsage: ModelUsage = {
+'gpt-4': { inputTokens: 500, outputTokens: 80 },
+'claude-3-5-sonnet': { inputTokens: 300, outputTokens: 20 },
+};
+const result = reconcileModelUsageToActualTokens(modelUsage, 250);
+assert.deepEqual(result['gpt-4'], { inputTokens: 94, outputTokens: 80 });
+assert.deepEqual(result['claude-3-5-sonnet'], { inputTokens: 56, outputTokens: 20 });
+const total = Object.values(result).reduce((s, u) => s + u.inputTokens + u.outputTokens, 0);
+assert.strictEqual(total, 250);
+});
+
+test('reconcileModelUsageToActualTokens: no-op when actualTokens is zero or negative', () => {
+const modelUsage: ModelUsage = { 'gpt-4': { inputTokens: 100, outputTokens: 50 } };
+assert.deepEqual(reconcileModelUsageToActualTokens(modelUsage, 0), modelUsage);
+assert.deepEqual(reconcileModelUsageToActualTokens(modelUsage, -1), modelUsage);
+});
+
+test('reconcileModelUsageToActualTokens: creates unknown bucket for empty modelUsage', () => {
+const result = reconcileModelUsageToActualTokens({}, 100);
+assert.deepEqual(result, { unknown: { inputTokens: 100, outputTokens: 0 } });
 });
 
 // ── addEditorUsage ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Users reported that the Details view still shows "Input tokens" greater than "Total tokens" for historical periods, even after the debug-log reconciliation shipped last week.

The remaining divergence comes from event-based JSONL sessions (Copilot CLI without exact `session-store.db` data, JetBrains, etc.). For those sessions, the session total (`actualTokens`) is estimated from real output using an input:output ratio, while the per-model breakdown (`modelUsage`) estimates input from accumulated message content scaled by a context-growth factor. When user content is large but model output is small, the breakdown input can exceed the session total.

This PR adds `reconcileModelUsageToActualTokens()` in `src/statsHelpers.ts`, which preserves the (presumably real) output counts and scales input to fit the session total, with proportional fallback when output already exceeds the total. It applies the helper in both the VS Code extension and the CLI so the invariant `Input + Output <= Total` holds everywhere. `CACHE_VERSION` is bumped to invalidate stale cached entries.

Key points for review:
- Output is treated as authoritative because it is usually derived from real API response counts.
- The helper reuses the existing `reconcileModelUsageToTotal()` residual handling, sweeping rounding errors into the `unknown` bucket.
- A proportional fallback scales both input and output when the output alone already exceeds the total.