### PR TITLE
Fix missing workspace in Recent Sessions for Copilot CLI and Claude Desktop

### DIFF
--- a/src/adapters/copilotCliAdapter.ts
+++ b/src/adapters/copilotCliAdapter.ts
@@ -79,6 +79,23 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 	}
 
 	/**
+	 * Read workspace.yaml next to a discovered events.jsonl file and return its
+	 * cwd value. This supplies workspace attribution for worktree CLI sessions
+	 * without changing the handles() contract.
+	 */
+	async getWorkspacePathForDiscoveredPath(sessionFile: string): Promise<string | undefined> {
+		const yamlPath = path.join(path.dirname(sessionFile), 'workspace.yaml');
+		try {
+			const content = await fs.promises.readFile(yamlPath, 'utf8');
+			const match = content.match(/^cwd:\s*(.+)$/m);
+			const cwd = match?.[1]?.trim();
+			return cwd || undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
 	 * Returns true only for session-store.db virtual paths.
 	 * For events.jsonl files the adapter participates in discovery only; the
 	 * existing fallback JSONL parser in extension.ts continues to own those.
@@ -140,8 +157,7 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 				title: session.summary ?? undefined,
 				firstInteraction: session.created_at,
 				lastInteraction: session.updated_at,
-				// workspacePath is intentionally absent for NULL-repository sessions
-				// so callers can detect the no-workspace case via its absence.
+				workspacePath: session.cwd ?? undefined,
 			};
 		}
 		return { title: undefined, firstInteraction: null, lastInteraction: null };

--- a/src/ecosystemAdapter.ts
+++ b/src/ecosystemAdapter.ts
@@ -37,6 +37,14 @@ export interface IEcosystemAdapter {
 	 */
 	getDisplayNameForDiscoveredPath?(sessionFile: string): string | undefined;
 	/**
+	 * Returns the workspace directory path for a session file that this adapter
+	 * *discovered* but does not *handle* (handles() returns false). Return
+	 * undefined when no workspace is known. Lets adapters like CopilotCli supply
+	 * cwd metadata for events.jsonl files that are parsed by the generic JSONL
+	 * path, instead of forcing handles() to claim them.
+	 */
+	getWorkspacePathForDiscoveredPath?(sessionFile: string): Promise<string | undefined>;
+	/**
 	 * When true, backend sync is skipped for sessions handled by this adapter
 	 * (e.g. Visual Studio binary MessagePack sessions cannot be synced).
 	 */

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -942,6 +942,27 @@ export function resolveWorkspaceFolderFromSessionPath(sessionFilePath: string, w
 	}
 }
 
+/**
+ * Best-effort workspace display name for a session summary. Prefers an explicit
+ * workspace folder path cached on the session, then the repository name, then
+ * workspaceStorage folder resolution. Returns undefined when attribution is
+ * unavailable.
+ */
+export function resolveSessionWorkspaceName(
+	sessionData: { workspaceFolderPath?: string; repository?: string },
+	sessionFilePath: string,
+	workspaceIdToFolderCache?: Map<string, string | undefined>
+): string | undefined {
+	if (sessionData.workspaceFolderPath) { return path.basename(sessionData.workspaceFolderPath); }
+	if (sessionData.repository) { return sessionData.repository; }
+	if (!workspaceIdToFolderCache) { return undefined; }
+	try {
+		const workspaceFolder = resolveWorkspaceFolderFromSessionPath(sessionFilePath, workspaceIdToFolderCache);
+		if (workspaceFolder) { return path.basename(workspaceFolder); }
+	} catch { /* attribution is optional */ }
+	return undefined;
+}
+
 // ── Editor-detection private predicates ──────────────────────────────────────
 
 /** Returns true for Gemini CLI session paths (`.gemini/tmp/.../chats/session-*.jsonl`). */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -170,6 +170,7 @@ import {
   detectEditorSource as _detectEditorSource,
   parseGitRemoteUrl as _parseGitRemoteUrl,
   extractRepositoryFromContentReferences as _extractRepositoryFromContentReferences,
+  resolveSessionWorkspaceName as _resolveSessionWorkspaceName,
   isMcpTool as _isMcpTool,
   normalizeMcpToolName as _normalizeMcpToolName,
   extractMcpServerName as _extractMcpServerName,
@@ -3911,18 +3912,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	/**
-	 * Best-effort workspace name for a session summary. Uses the repository name
-	 * already cached on the session data, falling back to the workspaceStorage
-	 * folder resolution (cached per workspace id). Returns undefined when
+	 * Best-effort workspace name for a session summary. Prefers the workspace
+	 * folder path already cached on the session data, then the repository name,
+	 * then workspaceStorage folder resolution. Returns undefined when
 	 * attribution is unavailable.
 	 */
 	private resolveSessionWorkspaceName(sessionData: SessionFileCache, sessionFile: string): string | undefined {
-		if (sessionData.repository) { return sessionData.repository; }
-		try {
-			const workspaceFolder = _resolveWorkspaceFolderFromSessionPath(sessionFile, this._workspaceIdToFolderCache);
-			if (workspaceFolder) { return path.basename(workspaceFolder); }
-		} catch { /* attribution is optional */ }
-		return undefined;
+		return _resolveSessionWorkspaceName(sessionData, sessionFile, this._workspaceIdToFolderCache);
 	}
 
 	private _mergeCodeWorkspaceCustomizationFiles(norm: string): CustomizationFileEntry[] {
@@ -4398,8 +4394,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		lastInteraction: string | null;
 		dailyInteractions: { [localDayKey: string]: number };
 		dailyFractions?: Record<string, number>;
+		workspacePath?: string;
 	}> {
 		let title: string | undefined;
+		let workspacePath: string | undefined;
 		const timestamps: number[] = [];
 		const requestTimestamps: number[] = [];
 
@@ -4411,6 +4409,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 				return { ...meta, dailyInteractions: {}, ...(dailyFractions ? { dailyFractions } : {}) };
 			}
 
+			// Some adapters discover files they do not handle (e.g. Copilot CLI events.jsonl).
+			// Ask them for workspace attribution before falling back to generic parsing.
+			workspacePath = await this.findWorkspacePathForDiscoveredPath(sessionFile);
+
 			// Handle Windsurf virtual sessions
 			if (this.windsurf.isWindsurfSessionFile(sessionFile)) {
 				return this.extractWindsurfSessionMetadata(sessionFile);
@@ -4418,7 +4420,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 			const fileContent = preloadedContent ?? await fs.promises.readFile(sessionFile, 'utf8');
 			if (_isUuidPointerFile(fileContent)) {
-				return { title, firstInteraction: null, lastInteraction: null, dailyInteractions: {} };
+				return { title, firstInteraction: null, lastInteraction: null, dailyInteractions: {}, workspacePath };
 			}
 
 			const isJsonlContent = sessionFile.endsWith('.jsonl') || _isJsonlContent(fileContent);
@@ -4445,7 +4447,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 			dailyInteractions[dayKey] = (dailyInteractions[dayKey] || 0) + 1;
 		}
 
-		return { title, firstInteraction, lastInteraction, dailyInteractions };
+		return { title, firstInteraction, lastInteraction, dailyInteractions, workspacePath };
+	}
+
+	/**
+	 * Ask any discoverable ecosystem adapter that does *not* handle this file whether
+	 * it can still supply a workspace directory path for it. Used for files like
+	 * Copilot CLI events.jsonl that are discovered by an adapter but parsed generically.
+	 */
+	private async findWorkspacePathForDiscoveredPath(sessionFile: string): Promise<string | undefined> {
+		for (const eco of this.ecosystems) {
+			if (eco.handles(sessionFile)) { continue; }
+			if (typeof eco.getWorkspacePathForDiscoveredPath !== 'function') { continue; }
+			try {
+				const cwd = await eco.getWorkspacePathForDiscoveredPath(sessionFile);
+				if (cwd) { return cwd; }
+			} catch { /* adapter failed; try next */ }
+		}
+		return undefined;
 	}
 
 	private extractMetadataFromJsonl(lines: string[]): { title: string | undefined; timestamps: number[]; requestTimestamps: number[] } {
@@ -4665,7 +4684,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		mtime: number,
 		fileSize: number,
 		usageAnalysis: SessionUsageAnalysis,
-		sessionMeta: { title?: string; firstInteraction: string | null; lastInteraction: string | null },
+		sessionMeta: { title?: string; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string },
 		resolvedActualTokens: number | undefined,
 		finalCacheReadTokens: number | undefined,
 		debugLogTokens: { inputTokens: number; outputTokens: number; modelTurns?: number; copilotNanoAiu?: number } | null | undefined,
@@ -4682,6 +4701,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tokens: tokenResult.tokens, interactions, modelUsage: resolvedModelUsage, mtime, size: fileSize,
 			usageAnalysis, title: sessionMeta.title, firstInteraction: sessionMeta.firstInteraction,
 			lastInteraction: sessionMeta.lastInteraction, actualTokens: resolvedActualTokens, taskCategory,
+			// Persist workspace attribution from the adapter so the Recent Sessions list can
+			// show it without requiring a separate getSessionFileDetails() parse pass.
+			...(sessionMeta.workspacePath ? { workspaceFolderPath: sessionMeta.workspacePath } : {}),
 			// Repository is discovered separately by getSessionFileDetails() (via content-reference
 			// git-root lookup) and is not recomputed here. Without preserving it, every cache-miss
 			// rebuild of this entry (e.g. an actively-edited session whose file keeps changing)

--- a/vscode-extension/test/unit/copilotCliAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotCliAdapter.test.ts
@@ -133,6 +133,103 @@ test('CopilotCliAdapter: safe-default methods return zero values', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// getMeta workspace attribution for DB-only sessions
+// ---------------------------------------------------------------------------
+
+test('CopilotCliAdapter.getMeta: returns workspacePath from DB session cwd', async () => {
+    const sessionId = 'db-session-1111-1111-1111-111111111111';
+    const virtualPath = path.join(os.homedir(), '.copilot', `session-store.db#${sessionId}`);
+    const cwd = 'C:\\Users\\me\\code\\my-project';
+
+    const mockStore = {
+        isCliStoreSession: (p: string) => p === virtualPath,
+        readSession: async (_p: string) => ({
+            id: sessionId,
+            cwd,
+            repository: null,
+            branch: null,
+            summary: 'Summary from DB',
+            created_at: '2026-07-20T10:00:00.000Z',
+            updated_at: '2026-07-20T10:05:00.000Z',
+        }),
+    };
+
+    const fresh = new CopilotCliAdapter();
+    (fresh as unknown as { store: typeof mockStore }).store = mockStore;
+
+    const meta = await fresh.getMeta(virtualPath);
+    assert.equal(meta.title, 'Summary from DB');
+    assert.equal(meta.workspacePath, cwd);
+});
+
+test('CopilotCliAdapter.getMeta: omits workspacePath when DB cwd is null', async () => {
+    const sessionId = 'db-session-2222-2222-2222-222222222222';
+    const virtualPath = path.join(os.homedir(), '.copilot', `session-store.db#${sessionId}`);
+
+    const mockStore = {
+        isCliStoreSession: (p: string) => p === virtualPath,
+        readSession: async (_p: string) => ({
+            id: sessionId,
+            cwd: null,
+            repository: null,
+            branch: null,
+            summary: 'Chat-only session',
+            created_at: '2026-07-20T10:00:00.000Z',
+            updated_at: '2026-07-20T10:05:00.000Z',
+        }),
+    };
+
+    const fresh = new CopilotCliAdapter();
+    (fresh as unknown as { store: typeof mockStore }).store = mockStore;
+
+    const meta = await fresh.getMeta(virtualPath);
+    assert.equal(meta.title, 'Chat-only session');
+    assert.equal(meta.workspacePath, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// getWorkspacePathForDiscoveredPath — workspace.yaml next to events.jsonl
+// ---------------------------------------------------------------------------
+
+test('CopilotCliAdapter.getWorkspacePathForDiscoveredPath: reads cwd from workspace.yaml', async (t) => {
+    const tmpHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cli-ws-'));
+    const stateDir = path.join(tmpHome, '.copilot', 'session-state');
+    const uuid = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    const uuidDir = path.join(stateDir, uuid);
+    await fs.promises.mkdir(uuidDir, { recursive: true });
+    const eventsPath = path.join(uuidDir, 'events.jsonl');
+    const cwd = 'C:\\Users\\me\\code\\my-project';
+    await fs.promises.writeFile(path.join(uuidDir, 'workspace.yaml'), `cwd: ${cwd}\n`);
+    await fs.promises.writeFile(eventsPath, '{"type":"start"}\n');
+
+    t.after(async () => {
+        await fs.promises.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    const fresh = new CopilotCliAdapter();
+    const workspacePath = await fresh.getWorkspacePathForDiscoveredPath!(eventsPath);
+    assert.equal(workspacePath, cwd);
+});
+
+test('CopilotCliAdapter.getWorkspacePathForDiscoveredPath: returns undefined when workspace.yaml is missing', async (t) => {
+    const tmpHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cli-ws-missing-'));
+    const stateDir = path.join(tmpHome, '.copilot', 'session-state');
+    const uuid = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+    const uuidDir = path.join(stateDir, uuid);
+    await fs.promises.mkdir(uuidDir, { recursive: true });
+    const eventsPath = path.join(uuidDir, 'events.jsonl');
+    await fs.promises.writeFile(eventsPath, '{"type":"start"}\n');
+
+    t.after(async () => {
+        await fs.promises.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    const fresh = new CopilotCliAdapter();
+    const workspacePath = await fresh.getWorkspacePathForDiscoveredPath!(eventsPath);
+    assert.equal(workspacePath, undefined);
+});
+
+// ---------------------------------------------------------------------------
 // discover() against a synthetic ~/.copilot/session-state/ layout
 // ---------------------------------------------------------------------------
 

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -1791,9 +1791,10 @@ test('parseCodeWorkspaceFolders: returns empty array when folders key is missing
 // ── resolveSessionWorkspaceName ──────────────────────────────────────────
 
 test('resolveSessionWorkspaceName: prefers workspaceFolderPath over repository', () => {
+    const workspaceFolderPath = nodePath.join('C:', 'Users', 'me', 'code', 'my-project');
     const name = resolveSessionWorkspaceName(
-        { workspaceFolderPath: 'C:\\Users\\me\\code\\my-project', repository: 'owner/repo' },
-        'C:\\Users\\me\\.copilot\\session-store.db#session-id'
+        { workspaceFolderPath, repository: 'owner/repo' },
+        nodePath.join('C:', 'Users', 'me', '.copilot', 'session-store.db#session-id')
     );
     assert.equal(name, 'my-project');
 });

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -15,6 +15,7 @@ import {
     normalizePathForDedup,
     fileUriToPath,
     parseWorkspaceStorageJsonFile,
+    resolveSessionWorkspaceName,
 } from '../../../src/workspaceHelpers';
 
 // ---------------------------------------------------------------------------
@@ -1785,4 +1786,51 @@ test('parseCodeWorkspaceFolders: returns empty array when folders key is missing
     } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+});
+
+// ── resolveSessionWorkspaceName ──────────────────────────────────────────
+
+test('resolveSessionWorkspaceName: prefers workspaceFolderPath over repository', () => {
+    const name = resolveSessionWorkspaceName(
+        { workspaceFolderPath: 'C:\\Users\\me\\code\\my-project', repository: 'owner/repo' },
+        'C:\\Users\\me\\.copilot\\session-store.db#session-id'
+    );
+    assert.equal(name, 'my-project');
+});
+
+test('resolveSessionWorkspaceName: falls back to repository when workspaceFolderPath is absent', () => {
+    const name = resolveSessionWorkspaceName(
+        { repository: 'owner/repo' },
+        'some-session.jsonl'
+    );
+    assert.equal(name, 'owner/repo');
+});
+
+test('resolveSessionWorkspaceName: falls back to workspaceStorage resolution', () => {
+    const tmpDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'wh-rsws-'));
+    try {
+        const workspaceFolder = nodePath.join(tmpDir, 'my-vscode-project');
+        fs.mkdirSync(workspaceFolder, { recursive: true });
+        const workspaceStorage = nodePath.join(tmpDir, 'workspaceStorage', 'wsid123');
+        fs.mkdirSync(workspaceStorage, { recursive: true });
+        fs.writeFileSync(
+            nodePath.join(workspaceStorage, 'workspace.json'),
+            JSON.stringify({ folder: workspaceFolder }),
+            'utf8'
+        );
+        const sessionFile = nodePath.join(workspaceStorage, 'chatSessions', 'session.json');
+        const cache = new Map<string, string | undefined>();
+        const name = resolveSessionWorkspaceName({}, sessionFile, cache);
+        assert.equal(name, 'my-vscode-project');
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test('resolveSessionWorkspaceName: returns undefined when no attribution is available', () => {
+    const name = resolveSessionWorkspaceName(
+        {},
+        '/home/user/.claude/projects/hash/session.jsonl'
+    );
+    assert.equal(name, undefined);
 });


### PR DESCRIPTION
Recent sessions from Copilot CLI and Claude Desktop were showing `—` in the Workspace column, while VS Code sessions showed the workspace correctly.

The cache built by `getSessionFileDataCached()` never stored the `workspacePath` that ecosystem adapters already knew, and `resolveSessionWorkspaceName()` only looked at `repository` and `workspaceStorage` resolution. This left adapter-discovered sessions with no workspace attribution in the Recent Sessions list.

Changes:
- `CopilotCliAdapter.getMeta()` now returns `workspacePath` from the DB `cwd` column for DB-only sessions.
- Added optional `IEcosystemAdapter.getWorkspacePathForDiscoveredPath()` so adapters can supply workspace metadata for files they discover but do not handle.
- `CopilotCliAdapter` implements the new method by reading `cwd` from `workspace.yaml` next to discovered `events.jsonl` files.
- `extension.ts` asks adapters for discovered-path workspace attribution during metadata extraction and persists it as `workspaceFolderPath` in the session cache.
- `resolveSessionWorkspaceName()` now prefers `workspaceFolderPath`, falling back to repository and workspaceStorage resolution.
- Extracted `resolveSessionWorkspaceName()` to `workspaceHelpers.ts` and added unit tests for the adapter and workspace resolution.

Tested with the full VS Code extension unit suite and the CLI build.