### PR TITLE
Harmonize period selectors across VS Code extension webviews

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3835,15 +3835,29 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	/**
-	 * Build session summaries for a lookback window (last 7/30 days) and send them
-	 * to the analysis panel. Used by the "Recent Sessions" tab lookback selector;
-	 * the default "Today" view keeps using the summaries bundled with updateStats.
+	 * Build session summaries for a lookback window and send them to the analysis panel.
+	 * Used by the "Recent Sessions" tab lookback selector; the default "Today" view
+	 * keeps using the summaries bundled with updateStats.
 	 */
-	private async loadRecentSessions(days: number): Promise<void> {
+	private async loadRecentSessions(period: ChartTimeWindow): Promise<void> {
 		if (!this.analysisPanel) { return; }
-		const lookbackDays = days === 30 ? 30 : 7;
 		const now = new Date();
-		const windowStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - lookbackDays);
+		let windowStart: Date;
+		switch (period) {
+			case 'last7':
+				windowStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+				break;
+			case 'last30':
+				windowStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+				break;
+			case 'currentMonth':
+				windowStart = new Date(now.getFullYear(), now.getMonth(), 1);
+				break;
+			case 'today':
+			case 'allTime':
+			default:
+				return;
+		}
 		const windowStartKey = toLocalDayKey(windowStart);
 		const sessions: TodaySessionSummary[] = [];
 		try {
@@ -3858,7 +3872,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.error('Error loading recent sessions:', error);
 		}
 		sessions.sort((a, b) => b.interactions - a.interactions);
-		this.analysisPanel.webview.postMessage({ command: 'recentSessionsLoaded', days: lookbackDays, sessions });
+		this.analysisPanel.webview.postMessage({ command: 'recentSessionsLoaded', period, sessions });
 	}
 
 	private computeLastActivityKey(sessionData: SessionFileCache, mtime: number): string {
@@ -6291,7 +6305,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			},
 			loadRepoPrStats: () => this.dispatch('loadRepoPrStats', () => this.loadRepoPrStats()),
 			loadAgentSessions: () => this.dispatch('loadAgentSessions', () => this.loadAgentSessions()),
-			loadRecentSessions: (message) => this.dispatch('loadRecentSessions', () => this.loadRecentSessions(Number(message.days))),
+			loadRecentSessions: (message) => this.dispatch('loadRecentSessions', () => this.loadRecentSessions(message.period as ChartTimeWindow)),
 			openSessionFile: (message) => this._handleOpenSessionFile(message),
 			insightAction: (message) => this.dispatch(`insightAction:${message.id ?? ''}`, () => this.handleInsightAction(message)),
 			traceUsageCuration: (message) => this._logTraceCuration(message),

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -447,7 +447,7 @@ function buildTimeWindowControl(data: InitialChartData): HTMLElement {
 		disabled: periodsReady ? [] : ['allTime'],
 		disabledTitle: 'Full history is still loading',
 		label: 'Time window:',
-		onChange: (value) => { void switchTimeWindow(value, data); },
+		onChange: (value) => { void switchTimeWindow(value as ChartTimeWindow, data); },
 	});
 	wrapper.classList.add('chart-time-window');
 	group.append(wrapper);

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -3,6 +3,7 @@ import { el, createButton, iconHeading } from '../shared/domUtils';
 import { getNavButtons } from '../shared/buttonConfig';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
+import { createPeriodSelector, PERIOD_LABELS, type Period } from '../shared/periodSelector';
 import { getCurrentPeriodFraction, computeProjectionExtra } from './projectionUtils';
 import { createViewStateManager } from '../shared/viewState';
 // CSS imported as text via esbuild
@@ -52,7 +53,7 @@ type ChartPeriodData = {
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
-type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth' | 'allTime';
+type ChartTimeWindow = Period;
 
 type InitialChartData = {
 	labels: string[];
@@ -141,14 +142,6 @@ const chartState = createViewStateManager<ChartWebviewState>(vscode, {
 function saveWebviewState(): void {
 	chartState.save({ period: currentPeriod, timeWindow: currentTimeWindow, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode });
 }
-
-const TIME_WINDOW_LABELS: Record<ChartTimeWindow, string> = {
-	today: 'Today',
-	last7: 'Last 7 days',
-	last30: 'Last 30 days',
-	currentMonth: 'Current month',
-	allTime: 'All time',
-};
 
 function getWindowStartDate(timeWindow: ChartTimeWindow, now: Date): string {
 	const y = now.getFullYear();
@@ -445,22 +438,19 @@ function buildPeriodToggles(periodsReady: boolean): HTMLElement {
 	return periodToggles;
 }
 
-function buildTimeWindowControl(periodsReady: boolean): HTMLElement {
+function buildTimeWindowControl(data: InitialChartData): HTMLElement {
+	const periodsReady = data.periodsReady !== false;
 	const group = el('div', 'control-group');
-	group.append(el('span', 'control-label', 'Time window:'));
-	const windowSelect = document.createElement('select');
-	windowSelect.id = 'time-window-select';
-	windowSelect.className = 'time-window-select';
-	const windows: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
-	windows.forEach(w => {
-		const option = document.createElement('option');
-		option.value = w;
-		option.textContent = TIME_WINDOW_LABELS[w];
-		if (w === currentTimeWindow) { option.selected = true; }
-		if (w === 'allTime' && !periodsReady) { option.disabled = true; }
-		windowSelect.append(option);
+	const { wrapper } = createPeriodSelector({
+		id: 'time-window-select',
+		selected: currentTimeWindow,
+		disabled: periodsReady ? [] : ['allTime'],
+		disabledTitle: 'Full history is still loading',
+		label: 'Time window:',
+		onChange: (value) => { void switchTimeWindow(value, data); },
 	});
-	group.append(windowSelect);
+	wrapper.classList.add('chart-time-window');
+	group.append(wrapper);
 	if (!periodsReady) {
 		const loadingNote = el('span', 'loading-note', 'Loading history…');
 		loadingNote.title = 'Full history is still loading. "All time" and weekly/monthly aggregation are not available yet.';
@@ -513,10 +503,9 @@ function buildRollingControl(): HTMLElement {
 
 function buildChartControls(data: InitialChartData): HTMLElement {
 	const controls = el('div', 'chart-controls');
-	const periodsReady = data.periodsReady !== false;
 
 	const scopeRow = el('div', 'chart-controls-row scope-row');
-	scopeRow.append(buildTimeWindowControl(periodsReady), el('div', 'control-group-separator'), buildPeriodToggles(periodsReady), el('div', 'control-group-separator'), buildRollingControl());
+	scopeRow.append(buildTimeWindowControl(data), el('div', 'control-group-separator'), buildPeriodToggles(data.periodsReady !== false), el('div', 'control-group-separator'), buildRollingControl());
 
 	const metricRow = el('div', 'chart-controls-row metric-row');
 	metricRow.append(buildMetricControl(data));
@@ -661,10 +650,6 @@ function wireInteractions(data: InitialChartData): void {
 		const btn = document.getElementById(id);
 		btn?.addEventListener('click', () => { void switchPeriod(period, data); });
 	});
-
-	// Time window selector
-	const timeWindowSelect = document.getElementById('time-window-select') as HTMLSelectElement | null;
-	timeWindowSelect?.addEventListener('change', () => { void switchTimeWindow(timeWindowSelect.value as ChartTimeWindow, data); });
 
 	// Chart metric toggle buttons
 	const metricButtons: Array<{ id: string; metric: typeof currentMetric }> = [
@@ -930,8 +915,8 @@ function getChartColors(): ChartColors {
 
 function buildBaseOptions(c: ChartColors, periodsReady: boolean) {
 	const title = !periodsReady && currentTimeWindow === 'allTime'
-		? `${TIME_WINDOW_LABELS[currentTimeWindow]} (loading history…)`
-		: TIME_WINDOW_LABELS[currentTimeWindow];
+		? `${PERIOD_LABELS[currentTimeWindow]} (loading history…)`
+		: PERIOD_LABELS[currentTimeWindow];
 	return {
 		responsive: true, maintainAspectRatio: false,
 		interaction: { mode: 'index' as const, intersect: false },

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -2,6 +2,7 @@
 import { navButtonsHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
 import { escapeHtml, formatFileSize, getTimeSince, getEditorIcon } from "../shared/formatUtils";
+import { createPeriodSelector, type Period } from "../shared/periodSelector";
 import { createViewStateManager } from "../shared/viewState";
 // CSS imported as text via esbuild
 import themeStyles from "../shared/theme.css";
@@ -225,6 +226,7 @@ let storedDetailedFiles: SessionFileDetails[] = [];
 let isLoading = true;
 let currentBackendInfo: BackendStorageInfo | undefined;
 let currentGithubAuth: GitHubAuthStatus | undefined;
+let currentModelUsageTimeRange = "all";
 
 function removeSessionFilesSection(reportText: string): string {
   return reportText.replace(SESSION_FILES_SECTION_REGEX, "");
@@ -992,20 +994,30 @@ function renderFolderAnalysisResults(
     </div>`;
 }
 
+const MODEL_USAGE_PERIOD_ORDER: Period[] = ["allTime", "lastMonth", "currentMonth", "thisWeek", "today"];
+const MODEL_USAGE_PERIOD_TO_TIME_RANGE: Record<string, string> = {
+  today: "today",
+  thisWeek: "week",
+  currentMonth: "month",
+  lastMonth: "lastMonth",
+  allTime: "all",
+  yesterday: "yesterday",
+};
+const MODEL_USAGE_TIME_RANGE_TO_PERIOD: Record<string, string> = {
+  today: "today",
+  week: "thisWeek",
+  month: "currentMonth",
+  lastMonth: "lastMonth",
+  all: "allTime",
+  yesterday: "yesterday",
+};
+
 function renderModelUsageTab(detailedFiles: SessionFileDetails[], isLoadingSessions: boolean = false): string {
   const editorStats = getEditorStats(detailedFiles);
   const editorOptions = Object.keys(editorStats).sort()
     .map((editor) => `<option value="${escapeHtml(editor)}">${escapeHtml(getEditorIcon(editor))} ${escapeHtml(editor)} (${editorStats[editor].count})</option>`)
     .join("");
   const statusText = isLoadingSessions ? "⏳ Loading sessions…" : "";
-  const timeRangeOptions = [
-    { value: "all", label: "🕐 All Time" },
-    { value: "lastMonth", label: "📅 Last Month" },
-    { value: "month", label: "📆 Current Month" },
-    { value: "week", label: "🗓️ This Week" },
-    { value: "today", label: "☀️ Today" },
-    { value: "yesterday", label: "🌙 Yesterday" },
-  ].map((o) => `<option value="${o.value}">${o.label}</option>`).join("");
   return `
     <div class="info-box">
       <div class="info-box-title">🧮 Model Usage Breakdown</div>
@@ -1023,14 +1035,34 @@ function renderModelUsageTab(detailedFiles: SessionFileDetails[], isLoadingSessi
           <option value="all">🌐 All Editors</option>
           ${editorOptions}
         </select>
-        <select id="model-usage-time-select" class="tool-type-select" ${isLoadingSessions ? "disabled" : ""}>
-          ${timeRangeOptions}
-        </select>
+        <span id="model-usage-time-selector"></span>
         <span id="model-usage-status" style="font-size: 12px; color: var(--text-muted);">${escapeHtml(statusText)}</span>
       </div>
     </div>
     <div id="model-usage-results"></div>
   `;
+}
+
+function renderModelUsageTimeSelector(disabled: boolean = false): void {
+  const wrapper = document.getElementById("model-usage-time-selector");
+  if (!wrapper) { return; }
+  wrapper.replaceChildren();
+  const selectedPeriod = MODEL_USAGE_TIME_RANGE_TO_PERIOD[currentModelUsageTimeRange] ?? "allTime";
+  const { select } = createPeriodSelector({
+    id: "model-usage-time-select",
+    selected: selectedPeriod,
+    periods: MODEL_USAGE_PERIOD_ORDER,
+    extraOptions: [{ value: "yesterday", label: "Yesterday" }],
+    label: "",
+    onChange: (value) => {
+      const timeRange = MODEL_USAGE_PERIOD_TO_TIME_RANGE[value];
+      if (!timeRange) { return; }
+      currentModelUsageTimeRange = timeRange;
+      triggerModelUsageAnalysis();
+    },
+  });
+  select.disabled = disabled;
+  wrapper.append(select);
 }
 
 function buildModelUsageTableRow(row: ModelUsageRow, showCache1h: boolean): string {
@@ -1692,10 +1724,9 @@ function setupFolderAnalyzerHandlers(): void {
 
 function triggerModelUsageAnalysis(): void {
   const select = document.getElementById("model-usage-editor-select") as HTMLSelectElement | null;
-  const timeSelect = document.getElementById("model-usage-time-select") as HTMLSelectElement | null;
   if (!select || select.disabled) { return; }
   const editor = select.value || "all";
-  const timeRange = timeSelect?.value || "all";
+  const timeRange = currentModelUsageTimeRange || "all";
 
   const resultsDiv = document.getElementById("model-usage-results");
   if (resultsDiv) {
@@ -1713,14 +1744,15 @@ function setupModelUsageHandlers(): void {
   document.getElementById("model-usage-editor-select")?.addEventListener("change", () => {
     triggerModelUsageAnalysis();
   });
-  document.getElementById("model-usage-time-select")?.addEventListener("change", () => {
-    triggerModelUsageAnalysis();
-  });
 }
 
 function handleModelUsageResult(message: DiagMessage): void {
   const resultsDiv = document.getElementById("model-usage-results");
   if (!resultsDiv) { return; }
+  if (typeof message.timeRange === "string" && message.timeRange) {
+    currentModelUsageTimeRange = message.timeRange;
+    renderModelUsageTimeSelector(false);
+  }
   if (message.stillLoading) {
     resultsDiv.innerHTML = `
       <div class="info-box" style="margin-top: 12px;">
@@ -2183,8 +2215,7 @@ function handleSessionFilesLoaded(message: DiagMessage): void {
     modelUsageSelect.innerHTML = `<option value="all">🌐 All Editors</option>${editorOptions}`;
     modelUsageSelect.disabled = false;
   }
-  const modelUsageTimeSelect = document.getElementById("model-usage-time-select") as HTMLSelectElement | null;
-  if (modelUsageTimeSelect) { modelUsageTimeSelect.disabled = false; }
+  renderModelUsageTimeSelector(false);
   const modelUsageStatus = document.getElementById("model-usage-status");
   if (modelUsageStatus) { modelUsageStatus.textContent = ""; }
 
@@ -2924,6 +2955,7 @@ function renderLayout(data: DiagnosticsData): void {
   setupGitHubAuthHandlers();
   setupFolderAnalyzerHandlers();
   setupModelUsageHandlers();
+  renderModelUsageTimeSelector(isLoading);
   setupButtonHandlers();
   setupDisplaySettingHandlers();
   setupToolAnalysisSortHandlers();

--- a/vscode-extension/src/webview/shared/periodSelector.ts
+++ b/vscode-extension/src/webview/shared/periodSelector.ts
@@ -1,0 +1,98 @@
+import { el } from './domUtils';
+
+/** Canonical time-window periods used across the extension's webviews. */
+export type Period = 'today' | 'last7' | 'last30' | 'currentMonth' | 'allTime';
+
+/** Human-readable labels for each period, matching the Chart time-window dropdown. */
+export const PERIOD_LABELS: Record<Period, string> = {
+	today: 'Today',
+	last7: 'Last 7 days',
+	last30: 'Last 30 days',
+	currentMonth: 'Current month',
+	allTime: 'All time',
+};
+
+/** Ordered list of all canonical periods. */
+export const ALL_PERIODS: Period[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
+
+export type PeriodSelectorOptions = {
+	/** Value currently selected. */
+	selected: Period;
+	/** Periods that should be visible but unselectable. */
+	disabled?: Period[] | Set<Period>;
+	/** Optional tooltip shown on disabled options. */
+	disabledTitle?: string;
+	/** Label shown before the dropdown. Pass an empty string to omit the label. */
+	label?: string;
+	/** `id` for the underlying `<select>`. */
+	id?: string;
+	/** Called whenever the user selects a new period. */
+	onChange: (value: Period) => void;
+};
+
+export type PeriodSelectorResult = {
+	/** Wrapper containing the optional label and the `<select>`. */
+	wrapper: HTMLDivElement;
+	/** The dropdown element. */
+	select: HTMLSelectElement;
+};
+
+/**
+ * Creates a reusable period dropdown styled consistently across webviews.
+ *
+ * The dropdown always shows the canonical periods from the Chart time-window
+ * selector. Consumers can disable individual periods (e.g. "All time" when
+ * historical data is still loading).
+ */
+export function createPeriodSelector(options: PeriodSelectorOptions): PeriodSelectorResult {
+	const wrapper = el('div', 'period-selector');
+	wrapper.style.display = 'inline-flex';
+	wrapper.style.alignItems = 'center';
+	wrapper.style.gap = '4px';
+
+	const labelText = options.label ?? 'Time window:';
+	if (labelText) {
+		const label = el('span', 'period-selector-label', labelText);
+		label.style.fontSize = '11px';
+		label.style.color = 'var(--vscode-descriptionForeground, var(--text-secondary, #9ca3af))';
+		wrapper.append(label);
+	}
+
+	const select = document.createElement('select');
+	select.className = 'period-selector-select';
+	if (options.id) {
+		select.id = options.id;
+	}
+	select.style.background = 'var(--vscode-dropdown-background, var(--button-secondary-bg, #2d2d2d))';
+	select.style.color = 'var(--vscode-dropdown-foreground, var(--text-primary, #cccccc))';
+	select.style.border = '1px solid var(--border-subtle, #555555)';
+	select.style.borderRadius = '4px';
+	select.style.padding = '4px 8px';
+	select.style.fontSize = '13px';
+	select.style.cursor = 'pointer';
+	select.style.minHeight = '24px';
+
+	const disabledSet = new Set<Period>(options.disabled ?? []);
+	for (const period of ALL_PERIODS) {
+		const option = document.createElement('option');
+		option.value = period;
+		option.textContent = PERIOD_LABELS[period];
+		if (period === options.selected) {
+			option.selected = true;
+		}
+		if (disabledSet.has(period)) {
+			option.disabled = true;
+			if (options.disabledTitle) {
+				option.title = options.disabledTitle;
+			}
+		}
+		select.append(option);
+	}
+
+	select.addEventListener('change', () => {
+		options.onChange(select.value as Period);
+	});
+
+	wrapper.append(select);
+	return { wrapper, select };
+}

--- a/vscode-extension/src/webview/shared/periodSelector.ts
+++ b/vscode-extension/src/webview/shared/periodSelector.ts
@@ -1,7 +1,7 @@
 import { el } from './domUtils';
 
-/** Canonical time-window periods used across the extension's webviews. */
-export type Period = 'today' | 'last7' | 'last30' | 'currentMonth' | 'allTime';
+/** Time-window periods supported by the shared period selector. */
+export type Period = 'today' | 'last7' | 'last30' | 'currentMonth' | 'lastMonth' | 'thisWeek' | 'allTime';
 
 /** Human-readable labels for each period, matching the Chart time-window dropdown. */
 export const PERIOD_LABELS: Record<Period, string> = {
@@ -9,25 +9,43 @@ export const PERIOD_LABELS: Record<Period, string> = {
 	last7: 'Last 7 days',
 	last30: 'Last 30 days',
 	currentMonth: 'Current month',
+	lastMonth: 'Previous month',
+	thisWeek: 'This week',
 	allTime: 'All time',
 };
 
-/** Ordered list of all canonical periods. */
-export const ALL_PERIODS: Period[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
+/** Ordered list of the canonical periods used by default. */
+export const CANONICAL_PERIODS: Period[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
+
+/** Ordered list of every known period, including extras such as Previous month / This week. */
+export const ALL_PERIODS: Period[] = ['today', 'last7', 'last30', 'currentMonth', 'lastMonth', 'thisWeek', 'allTime'];
+
+export type PeriodSelectorExtraOption = {
+	value: string;
+	label: string;
+	/** When true the option is visible but cannot be selected. */
+	disabled?: boolean;
+	/** Optional tooltip for this option. */
+	title?: string;
+};
 
 export type PeriodSelectorOptions = {
 	/** Value currently selected. */
-	selected: Period;
-	/** Periods that should be visible but unselectable. */
+	selected: string;
+	/** Which known periods to show and in which order. Defaults to the canonical 5. */
+	periods?: Period[];
+	/** Extra ad-hoc options appended after the known periods (e.g. "Yesterday"). */
+	extraOptions?: PeriodSelectorExtraOption[];
+	/** Known periods that should be visible but unselectable. */
 	disabled?: Period[] | Set<Period>;
-	/** Optional tooltip shown on disabled options. */
+	/** Optional tooltip shown on disabled known periods. */
 	disabledTitle?: string;
 	/** Label shown before the dropdown. Pass an empty string to omit the label. */
 	label?: string;
 	/** `id` for the underlying `<select>`. */
 	id?: string;
-	/** Called whenever the user selects a new period. */
-	onChange: (value: Period) => void;
+	/** Called whenever the user selects a new value. */
+	onChange: (value: string) => void;
 };
 
 export type PeriodSelectorResult = {
@@ -37,12 +55,18 @@ export type PeriodSelectorResult = {
 	select: HTMLSelectElement;
 };
 
+function setOptionSelected(option: HTMLOptionElement, value: string, selected: string): void {
+	if (value === selected) {
+		option.selected = true;
+	}
+}
+
 /**
  * Creates a reusable period dropdown styled consistently across webviews.
  *
- * The dropdown always shows the canonical periods from the Chart time-window
- * selector. Consumers can disable individual periods (e.g. "All time" when
- * historical data is still loading).
+ * By default the dropdown shows the canonical Chart time-window periods.
+ * Consumers can supply a custom period list, disable periods (e.g. "All time"
+ * when historical data is still loading), and append extra options.
  */
 export function createPeriodSelector(options: PeriodSelectorOptions): PeriodSelectorResult {
 	const wrapper = el('div', 'period-selector');
@@ -73,13 +97,12 @@ export function createPeriodSelector(options: PeriodSelectorOptions): PeriodSele
 	select.style.minHeight = '24px';
 
 	const disabledSet = new Set<Period>(options.disabled ?? []);
-	for (const period of ALL_PERIODS) {
+	const periods = options.periods ?? CANONICAL_PERIODS;
+	for (const period of periods) {
 		const option = document.createElement('option');
 		option.value = period;
 		option.textContent = PERIOD_LABELS[period];
-		if (period === options.selected) {
-			option.selected = true;
-		}
+		setOptionSelected(option, period, options.selected);
 		if (disabledSet.has(period)) {
 			option.disabled = true;
 			if (options.disabledTitle) {
@@ -89,8 +112,22 @@ export function createPeriodSelector(options: PeriodSelectorOptions): PeriodSele
 		select.append(option);
 	}
 
+	for (const extra of options.extraOptions ?? []) {
+		const option = document.createElement('option');
+		option.value = extra.value;
+		option.textContent = extra.label;
+		if (extra.title) {
+			option.title = extra.title;
+		}
+		setOptionSelected(option, extra.value, options.selected);
+		if (extra.disabled) {
+			option.disabled = true;
+		}
+		select.append(option);
+	}
+
 	select.addEventListener('change', () => {
-		options.onChange(select.value as Period);
+		options.onChange(select.value);
 	});
 
 	wrapper.append(select);

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1242,7 +1242,7 @@ function renderSessionsLookbackSelector(): void {
 		disabledTitle: 'All-time sessions are not loaded yet',
 		label: '',
 		onChange: (value) => {
-			sessionsLookback = value;
+			sessionsLookback = value as Period;
 			refreshSessionsPanelBody();
 		},
 	});
@@ -4067,9 +4067,9 @@ function renderModelEfficiencyPeriodSelector(): void {
 		disabledTitle: 'Not available for model efficiency',
 		label: '',
 		onChange: (value) => {
-			const dataKey = EFFICIENCY_PERIOD_TO_DATA_KEY[value];
+			const dataKey = EFFICIENCY_PERIOD_TO_DATA_KEY[value as Period];
 			if (!dataKey) { return; }
-			efficiencySelectedPeriod = value;
+			efficiencySelectedPeriod = value as Period;
 			efficiencyPeriod = dataKey;
 			rerenderModelEfficiencyTable();
 		},

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1,5 +1,6 @@
 // Usage Analysis webview
 import { el } from '../shared/domUtils';
+import { createPeriodSelector, PERIOD_LABELS, type Period } from '../shared/periodSelector';
 import { navButtonsHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
 import { escapeHtml, formatCompact, formatCost, formatDurationShort, formatFileSize, formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
@@ -1008,7 +1009,7 @@ function renderToolsTable(byTool: { [key: string]: number }, limit = 10, nameRes
 
 // --- Recent Sessions table with sortable, toggleable columns ---
 type SessionSortColumn = 'title' | 'interactions' | 'toolCalls' | 'inputTokens' | 'outputTokens' | 'thinkingTokens' | 'cachedTokens' | 'totalTokens' | 'estimatedCost' | 'editor' | 'workspace' | 'durationMs' | 'lastActivity';
-type SessionsLookback = 'today' | '7' | '30';
+type SessionsLookback = Period;
 
 /** Optional (toggleable) session table columns. Title is always shown and is not part of this set. */
 type SessionColumnId = 'interactions' | 'toolCalls' | 'inputTokens' | 'outputTokens' | 'thinkingTokens' | 'cachedTokens' | 'totalTokens' | 'estimatedCost' | 'editor' | 'workspace' | 'models' | 'durationMs' | 'lastActivity';
@@ -1063,7 +1064,7 @@ let use24HourTime = true;
 // longer windows are lazily requested from the extension host and cached here.
 let sessionsLookback: SessionsLookback = 'today';
 let latestTodaySessions: TodaySessionSummary[] = [];
-const recentSessionsCache: { [days: string]: TodaySessionSummary[] } = {};
+const recentSessionsCache: { [period: string]: TodaySessionSummary[] } = {};
 /** Which optional columns are currently visible. Title (and the row number) are always shown. */
 let enabledSessionColumns: Set<SessionColumnId> = new Set(ALL_SESSION_COLUMN_IDS);
 
@@ -1195,7 +1196,7 @@ function setupSessionsTableSort(): void {
 		const container = document.getElementById('sessions-table-container');
 		if (container) { container.innerHTML = buildSessionsTableHtml(cachedTodaySessions); }
 	});
-	setupSessionsLookbackSelector();
+	renderSessionsLookbackSelector();
 	setupSessionColumnsMenu();
 }
 
@@ -1230,15 +1231,22 @@ function setupSessionColumnsMenu(): void {
 	}
 }
 
-function setupSessionsLookbackSelector(): void {
-	const select = document.getElementById('sessions-lookback') as HTMLSelectElement | null;
-	if (!select) { return; }
-	select.value = sessionsLookback;
-	select.addEventListener('change', () => {
-		const value = select.value;
-		sessionsLookback = (value === '7' || value === '30') ? value : 'today';
-		refreshSessionsPanelBody();
+function renderSessionsLookbackSelector(): void {
+	const wrapper = document.getElementById('sessions-lookback-wrapper');
+	if (!wrapper) { return; }
+	wrapper.replaceChildren();
+	const { wrapper: selectorWrapper } = createPeriodSelector({
+		id: 'sessions-lookback',
+		selected: sessionsLookback,
+		disabled: ['allTime'],
+		disabledTitle: 'All-time sessions are not loaded yet',
+		label: '',
+		onChange: (value) => {
+			sessionsLookback = value;
+			refreshSessionsPanelBody();
+		},
 	});
+	wrapper.append(selectorWrapper);
 	// A full re-render may have restored a non-today lookback whose data was
 	// rendered from cache already; if the cache is empty, request it now.
 	if (sessionsLookback !== 'today' && !recentSessionsCache[sessionsLookback]) {
@@ -1259,18 +1267,18 @@ function refreshSessionsPanelBody(): void {
 		body.innerHTML = renderTodaySessionsTable(cached);
 		return;
 	}
-	body.innerHTML = `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for the last ${sessionsLookback} days…</div>`;
-	vscode.postMessage({ command: 'loadRecentSessions', days: Number(sessionsLookback) });
+	body.innerHTML = `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${PERIOD_LABELS[sessionsLookback]}…</div>`;
+	vscode.postMessage({ command: 'loadRecentSessions', period: sessionsLookback });
 }
 
 function handleRecentSessionsLoaded(message: any): void {
-	const days = Number(message.days);
-	if (days !== 7 && days !== 30) { return; }
+	const period = message.period as Period;
+	if (!period) { return; }
 	const sessions = Array.isArray(message.sessions)
 		? message.sessions.filter((s: any) => s && typeof s === 'object' && typeof s.interactions === 'number') as TodaySessionSummary[]
 		: [];
-	recentSessionsCache[String(days)] = sessions;
-	if (sessionsLookback === String(days)) {
+	recentSessionsCache[period] = sessions;
+	if (sessionsLookback === period) {
 		refreshSessionsPanelBody();
 	}
 }
@@ -3427,17 +3435,13 @@ function buildSessionsTabPanelHtml(stats: UsageAnalysisStats): string {
 	const cachedForLookback = sessionsLookback === 'today' ? latestTodaySessions : recentSessionsCache[sessionsLookback];
 	const bodyHtml = cachedForLookback
 		? renderTodaySessionsTable(cachedForLookback)
-		: `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for the last ${sessionsLookback} days…</div>`;
+		: `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${PERIOD_LABELS[sessionsLookback]}…</div>`;
 	return `
 		<div id="tab-panel-sessions" class="tab-panel"${activeTab !== 'sessions' ? ' style="display:none"' : ''}>
 			<div class="section">
 				<div class="section-title" style="display:flex; align-items:center; gap:8px;">
 					<span>📋</span><span>Recent Sessions</span>
-					<select id="sessions-lookback" style="margin-left:auto; font-size:12px; padding:2px 6px; background:var(--vscode-dropdown-background, var(--bg-secondary)); color:var(--vscode-dropdown-foreground, var(--text-primary)); border:1px solid var(--border-subtle); border-radius:4px;">
-						<option value="today"${sessionsLookback === 'today' ? ' selected' : ''}>Today</option>
-						<option value="7"${sessionsLookback === '7' ? ' selected' : ''}>Last 7 days</option>
-						<option value="30"${sessionsLookback === '30' ? ' selected' : ''}>Last 30 days</option>
-					</select>
+					<span id="sessions-lookback-wrapper" style="margin-left:auto;"></span>
 					${buildSessionColumnsMenuHtml()}
 				</div>
 				<div class="section-subtitle">Individual session breakdown for the selected period — sorted by number of interactions (most active first).</div>
@@ -3915,17 +3919,17 @@ function buildUnknownMcpToolsBannerHtml(stats: UsageAnalysisStats): string {
 
 // --- Model Efficiency section (issue #1649) ---
 
-type EfficiencyPeriodKey = 'today' | 'last30Days' | 'month' | 'lastMonth';
+type EfficiencyPeriodKey = 'today' | 'last30Days' | 'month';
 type EfficiencyRow = { model: string; counters: ModelEfficiencyCounters; rates: ReturnType<typeof deriveModelEfficiencyRates> };
 type EfficiencySortColumn = 'model' | 'calls' | 'editTurns' | 'oneShotRate' | 'retryRate' | 'selfCorrectionRate' | 'costPerCall' | 'costPerEdit' | 'outputTokensPerCall' | 'cacheHitRate';
 
-const EFFICIENCY_PERIOD_LABELS: { key: EfficiencyPeriodKey; label: string }[] = [
-	{ key: 'today', label: '📅 Today' },
-	{ key: 'last30Days', label: '📆 Last 30 Days' },
-	{ key: 'month', label: '📅 This Month' },
-	{ key: 'lastMonth', label: '📅 Previous Month' },
-];
+const EFFICIENCY_PERIOD_TO_DATA_KEY: Partial<Record<Period, EfficiencyPeriodKey>> = {
+	today: 'today',
+	last30: 'last30Days',
+	currentMonth: 'month',
+};
 
+let efficiencySelectedPeriod: Period = 'last30';
 let efficiencyPeriod: EfficiencyPeriodKey = 'last30Days';
 let efficiencySortColumn: EfficiencySortColumn = 'calls';
 let efficiencySortDirection: 'asc' | 'desc' = 'desc';
@@ -4032,28 +4036,17 @@ function buildModelEfficiencyTableHtml(): string {
 		${hiddenNote}`;
 }
 
-function buildEfficiencyPeriodButtonsHtml(): string {
-	return EFFICIENCY_PERIOD_LABELS.map(p => {
-		const active = p.key === efficiencyPeriod;
-		const style = active
-			? 'background:var(--vscode-button-background, #0e639c); color:var(--vscode-button-foreground, #fff); border:1px solid transparent;'
-			: 'background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border-subtle);';
-		return `<button type="button" class="eff-period-btn" data-eff-period="${p.key}" style="font-size:12px; padding:2px 10px; border-radius:4px; cursor:pointer; ${style}">${p.label}</button>`;
-	}).join('');
-}
-
 function buildModelEfficiencySectionHtml(stats: UsageAnalysisStats): string {
 	cachedModelEfficiency = {
 		today: stats.today.modelEfficiency,
 		last30Days: stats.last30Days.modelEfficiency,
 		month: stats.month.modelEfficiency,
-		lastMonth: stats.lastMonth.modelEfficiency,
 	};
 	return `
 		<div class="section" id="section-model-efficiency">
 			<div class="section-title"><span>🎯</span><span>Model Efficiency</span></div>
 			<div class="section-subtitle">Compare models on quality and efficiency, not just cost — one-shot edit rate, retries, self-corrections, per-turn cost, and cache hit rate. Retry/self-correction detection needs structured tool-call data, so some editors show token metrics only.</div>
-			<div id="model-efficiency-controls" style="display:flex; gap:6px; flex-wrap:wrap; margin:8px 0;">${buildEfficiencyPeriodButtonsHtml()}</div>
+			<div id="model-efficiency-controls" style="display:flex; gap:6px; flex-wrap:wrap; margin:8px 0;"><span id="model-efficiency-period-selector"></span></div>
 			<div style="margin:2px 0 8px 0;">
 				<label style="display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--text-secondary); cursor:pointer;" title="Shows only models above the 25th-percentile turn count (Q1). Uncheck to see all models.">
 					<input type="checkbox" id="eff-filter-low-usage"${efficiencyFilterLowUsage ? ' checked' : ''} style="cursor:pointer;">
@@ -4064,18 +4057,29 @@ function buildModelEfficiencySectionHtml(stats: UsageAnalysisStats): string {
 		</div>`;
 }
 
+function renderModelEfficiencyPeriodSelector(): void {
+	const wrapper = document.getElementById('model-efficiency-period-selector');
+	if (!wrapper) { return; }
+	wrapper.replaceChildren();
+	const { wrapper: selectorWrapper } = createPeriodSelector({
+		selected: efficiencySelectedPeriod,
+		disabled: ['last7', 'allTime'],
+		disabledTitle: 'Not available for model efficiency',
+		label: '',
+		onChange: (value) => {
+			const dataKey = EFFICIENCY_PERIOD_TO_DATA_KEY[value];
+			if (!dataKey) { return; }
+			efficiencySelectedPeriod = value;
+			efficiencyPeriod = dataKey;
+			rerenderModelEfficiencyTable();
+		},
+	});
+	wrapper.append(selectorWrapper);
+}
+
 function rerenderModelEfficiencyTable(): void {
 	const table = document.getElementById('model-efficiency-table');
 	if (table) { table.innerHTML = buildModelEfficiencyTableHtml(); }
-}
-
-function handleEfficiencyPeriodClick(periodBtn: HTMLElement): void {
-	const key = periodBtn.getAttribute('data-eff-period') as EfficiencyPeriodKey | null;
-	if (!key) { return; }
-	efficiencyPeriod = key;
-	const controls = document.getElementById('model-efficiency-controls');
-	if (controls) { controls.innerHTML = buildEfficiencyPeriodButtonsHtml(); }
-	rerenderModelEfficiencyTable();
 }
 
 function handleEfficiencySortClick(th: HTMLElement): void {
@@ -4090,14 +4094,12 @@ function handleEfficiencySortClick(th: HTMLElement): void {
 	rerenderModelEfficiencyTable();
 }
 
-/** Wires period buttons, sortable headers, and the low-usage filter for the Model Efficiency section (delegated, survives table re-renders). */
+/** Wires sortable headers and the low-usage filter for the Model Efficiency section (delegated, survives table re-renders). */
 function setupModelEfficiencySection(): void {
 	const section = document.getElementById('section-model-efficiency');
 	if (!section) { return; }
 	section.addEventListener('click', (e) => {
 		const target = e.target as HTMLElement;
-		const periodBtn = target.closest<HTMLElement>('button.eff-period-btn');
-		if (periodBtn) { handleEfficiencyPeriodClick(periodBtn); return; }
 		const th = target.closest<HTMLElement>('th[data-eff-sort]');
 		if (th) { handleEfficiencySortClick(th); }
 	});
@@ -4236,6 +4238,8 @@ function renderLayout(stats: UsageAnalysisStats): void {
 	renderRepositoryHygienePanels();
 	setupTabs();
 	setupModelEfficiencySection();
+	renderModelEfficiencyPeriodSelector();
+	renderSessionsLookbackSelector();
 	setupWorktreesHandlers();
 	wireCopyButtons();
 	// Initialize currentInsights from the stats and wire card buttons
@@ -4375,8 +4379,9 @@ function handleUpdateStats(message: any): void {
 	if (sanitized) {
 		_ulLoadingActive = false;
 		// New stats invalidate any lazily-loaded lookback data; it is re-requested on demand.
-		delete recentSessionsCache['7'];
-		delete recentSessionsCache['30'];
+		for (const key of Object.keys(recentSessionsCache)) {
+			delete recentSessionsCache[key];
+		}
 		renderLayout(sanitized);
 		setupSessionsTableSort();
 		renderRepositoryHygienePanels();


### PR DESCRIPTION
We had four different time-window controls scattered across the webviews (Chart, Usage Model Efficiency, Usage Recent Sessions, Diagnostics Model Usage), each with its own labels, ordering, and disabled-state logic. This made it easy for the UX to drift and for backend code to receive inconsistent period values.

This change introduces a single reusable `PeriodSelector` component in `vscode-extension/src/webview/shared/periodSelector.ts` and replaces all of the existing inline buttons and `<select>` elements with it. The Chart's existing periods are used as the canonical set, with support for optional disabled items (e.g. "All Time" where lazy loading is not yet implemented) and ad-hoc extra options for views that need them.

Key points for review:
- Model Efficiency maps the canonical periods onto its existing data keys; periods that have no backend data are rendered disabled rather than hidden.
- Recent Sessions now supports `currentMonth` in addition to `last7`/`last30`; the cache key and `loadRecentSessions` message contract were updated accordingly.
- Diagnostics Model Usage keeps its existing backend time-range values (`all`, `week`, `month`, `lastMonth`, `today`, `yesterday`) but now renders them through the shared component, so the UI stays consistent without touching `getModelUsageTimeRangeBounds`.
- The component is plain DOM (no framework), so it returns the wrapper and underlying `<select>` for callers that need to attach listeners or styles.