### PR TITLE
Distinguish Copilot desktop app sessions from terminal CLI sessions

### DIFF
--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -61,7 +61,7 @@ export interface DailyEntry {
 const COPILOT_EDITOR_NAMES = new Set([
 	'VS Code', 'VS Code Insiders', 'VS Code Exploration',
 	'VS Code Server', 'VS Code Server (Insiders)', 'VSCodium',
-	'Visual Studio', 'JetBrains', 'Copilot CLI', 'MS Scout (Copilot CLI)',
+	'Visual Studio', 'JetBrains', 'Copilot CLI', 'Copilot CLI (App)', 'MS Scout (Copilot CLI)',
 ]);
 
 const MODEL_PROVIDER_PREFIXES: Array<[string, string]> = [

--- a/src/adapters/copilotCliAdapter.ts
+++ b/src/adapters/copilotCliAdapter.ts
@@ -24,7 +24,7 @@ import type {
 	CandidatePath,
 	UsageAnalysisAdapterContext,
 } from '../ecosystemAdapter';
-import { CopilotCliStoreAccess, isMicrosoftScoutCwd } from '../copilotCliStore';
+import { CopilotCliStoreAccess, isMicrosoftScoutCwd, isCopilotAppClientName } from '../copilotCliStore';
 import { getCopilotCliExactUsage } from '../copilotCliOtel';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
@@ -44,22 +44,30 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 	private readonly store = new CopilotCliStoreAccess();
 	/** UUIDs of sessions discovered to have been created by Microsoft Scout. */
 	private readonly _scoutSessionIds = new Set<string>();
+	/**
+	 * UUIDs of sessions whose workspace.yaml records `client_name: github/autopilot`,
+	 * meaning they were started via the Copilot desktop app (which wraps the CLI)
+	 * rather than the plain terminal CLI (`client_name: github/cli`, or absent on
+	 * older sessions predating this field).
+	 */
+	private readonly _appSessionIds = new Set<string>();
 
 	/**
 	 * Returns the per-session display name.
 	 * Sessions whose cwd is under Documents\Microsoft Scout are shown as
 	 * "MS Scout (Copilot CLI)" to distinguish them from regular CLI sessions.
+	 * Sessions started via the Copilot desktop app are shown as "Copilot CLI (App)".
 	 */
 	getDisplayName(sessionFile: string): string {
 		// DB virtual path: session-store.db#<uuid>
 		const sessionId = this.store.getSessionId(sessionFile);
-		if (sessionId && this._scoutSessionIds.has(sessionId)) {
-			return 'MS Scout (Copilot CLI)';
-		}
 		// events.jsonl path: ~/.copilot/session-state/<uuid>/events.jsonl
 		const eventsUuid = path.basename(path.dirname(sessionFile));
-		if (eventsUuid && this._scoutSessionIds.has(eventsUuid)) {
+		if ((sessionId && this._scoutSessionIds.has(sessionId)) || (eventsUuid && this._scoutSessionIds.has(eventsUuid))) {
 			return 'MS Scout (Copilot CLI)';
+		}
+		if ((sessionId && this._appSessionIds.has(sessionId)) || (eventsUuid && this._appSessionIds.has(eventsUuid))) {
+			return 'Copilot CLI (App)';
 		}
 		return 'Copilot CLI';
 	}
@@ -67,13 +75,16 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 	/**
 	 * Called for files that were *discovered* by this adapter but not *handled*
 	 * (i.e. events.jsonl files, which are parsed by the JSONL fallback parser).
-	 * Returns 'MS Scout (Copilot CLI)' when the session UUID was marked as Scout
-	 * during discover(), undefined otherwise.
+	 * Returns 'MS Scout (Copilot CLI)' or 'Copilot CLI (App)' when the session UUID
+	 * was marked as such during discover(), undefined otherwise.
 	 */
 	getDisplayNameForDiscoveredPath(sessionFile: string): string | undefined {
 		const eventsUuid = path.basename(path.dirname(sessionFile));
 		if (eventsUuid && this._scoutSessionIds.has(eventsUuid)) {
 			return 'MS Scout (Copilot CLI)';
+		}
+		if (eventsUuid && this._appSessionIds.has(eventsUuid)) {
+			return 'Copilot CLI (App)';
 		}
 		return undefined;
 	}
@@ -194,16 +205,21 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 
 	/**
 	 * Reads workspace.yaml from a UUID session directory and adds the UUID to
-	 * _scoutSessionIds if the cwd indicates a Microsoft Scout session.
+	 * _scoutSessionIds if the cwd indicates a Microsoft Scout session, and/or to
+	 * _appSessionIds if client_name indicates the Copilot desktop app.
 	 * Silently ignores missing or unreadable files.
 	 */
 	private async _tryMarkScoutFromWorkspaceYaml(uuidDir: string, uuid: string): Promise<void> {
 		const yamlPath = path.join(uuidDir, 'workspace.yaml');
 		try {
 			const content = await fs.promises.readFile(yamlPath, 'utf8');
-			const match = content.match(/^cwd:\s*(.+)$/m);
-			if (match && isMicrosoftScoutCwd(match[1].trim())) {
+			const cwdMatch = content.match(/^cwd:\s*(.+)$/m);
+			if (cwdMatch && isMicrosoftScoutCwd(cwdMatch[1].trim())) {
 				this._scoutSessionIds.add(uuid);
+			}
+			const clientMatch = content.match(/^client_name:\s*(.+)$/m);
+			if (clientMatch && isCopilotAppClientName(clientMatch[1].trim())) {
+				this._appSessionIds.add(uuid);
 			}
 		} catch { /* workspace.yaml may not exist */ }
 	}
@@ -286,10 +302,15 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 			const dbOnlySessions = await this.store.discoverNewSessionsWithCwd(knownUuids);
 			if (dbOnlySessions.length > 0) {
 				log(`📄 Found ${dbOnlySessions.length} chat-only session(s) in Copilot CLI session-store.db`);
-				for (const { id, cwd } of dbOnlySessions) {
+				await Promise.all(dbOnlySessions.map(async ({ id, cwd }) => {
 					if (isMicrosoftScoutCwd(cwd)) {
 						this._scoutSessionIds.add(id);
 					}
+					// Chat-only sessions still get a session-state/<uuid>/ dir with workspace.yaml
+					// (just no events.jsonl), so client_name (app vs. terminal CLI) is still detectable.
+					await this._tryMarkScoutFromWorkspaceYaml(path.join(root, id), id);
+				}));
+				for (const { id } of dbOnlySessions) {
 					sessionFiles.push(this.store.virtualPath(id));
 				}
 			}

--- a/src/copilotCliStore.ts
+++ b/src/copilotCliStore.ts
@@ -47,6 +47,15 @@ export function isMicrosoftScoutCwd(cwd: string | null | undefined): boolean {
 	return cwd.replace(/\\/g, '/').toLowerCase().includes('/microsoft scout');
 }
 
+/**
+ * Returns true when a session's workspace.yaml `client_name` value indicates it was
+ * started via the Copilot desktop app (which wraps the CLI process), as opposed to the
+ * plain terminal CLI (`github/cli`) or an older session predating this field.
+ */
+export function isCopilotAppClientName(clientName: string | null | undefined): boolean {
+	return clientName === 'github/autopilot';
+}
+
 export interface CliStoreTurn {
 	session_id: string;
 	turn_index: number;

--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -16,7 +16,7 @@ import { toLocalDayKey } from './utils/dayKeys';
 export const COPILOT_EDITOR_NAMES = new Set([
 	'VS Code', 'VS Code Insiders', 'VS Code Exploration',
 	'VS Code Server', 'VS Code Server (Insiders)', 'VSCodium',
-	'Visual Studio', 'JetBrains', 'Copilot CLI', 'MS Scout (Copilot CLI)',
+	'Visual Studio', 'JetBrains', 'Copilot CLI', 'Copilot CLI (App)', 'MS Scout (Copilot CLI)',
 ]);
 
 /**

--- a/vscode-extension/src/editorIcons.ts
+++ b/vscode-extension/src/editorIcons.ts
@@ -16,6 +16,7 @@ export const EDITOR_ICON_MAP: Record<string, string> = {
 	'Codex CLI': '🌀',
 	'Continue': '▶️',
 	'Copilot CLI': '🤖',
+	'Copilot CLI (App)': '🤖',
 	'Crush': '🦾',
 	'Cursor': '🖱️',
 	'Devin': '🧠',

--- a/vscode-extension/test/unit/copilotCliAdapter.test.ts
+++ b/vscode-extension/test/unit/copilotCliAdapter.test.ts
@@ -71,6 +71,35 @@ test('CopilotCliAdapter.getDisplayName: returns MS Scout label for tracked Scout
     }
 });
 
+test('CopilotCliAdapter.getDisplayName: returns Copilot CLI (App) label for tracked app sessions via DB virtual path', () => {
+    const appSessionId = '44444444-4444-4444-4444-444444444444';
+    const appVirtualPath = path.join(os.homedir(), '.copilot', `session-store.db#${appSessionId}`);
+    const appSessionIds = (adapter as unknown as { _appSessionIds: Set<string> })._appSessionIds;
+
+    appSessionIds.add(appSessionId);
+    try {
+        assert.equal(adapter.getDisplayName(appVirtualPath), 'Copilot CLI (App)');
+        assert.equal(adapter.getDisplayName(path.join(os.homedir(), '.copilot', 'session-store.db#other-session')), 'Copilot CLI');
+    } finally {
+        appSessionIds.delete(appSessionId);
+    }
+});
+
+test('CopilotCliAdapter.getDisplayNameForDiscoveredPath: returns Copilot CLI (App) label for tracked app UUID, undefined otherwise', () => {
+    const appUuid = '55555555-5555-5555-5555-555555555555';
+    const eventsPath = path.join(os.homedir(), '.copilot', 'session-state', appUuid, 'events.jsonl');
+    const otherPath = path.join(os.homedir(), '.copilot', 'session-state', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'events.jsonl');
+    const appSessionIds = (adapter as unknown as { _appSessionIds: Set<string> })._appSessionIds;
+
+    appSessionIds.add(appUuid);
+    try {
+        assert.equal(adapter.getDisplayNameForDiscoveredPath!(eventsPath), 'Copilot CLI (App)');
+        assert.equal(adapter.getDisplayNameForDiscoveredPath!(otherPath), undefined);
+    } finally {
+        appSessionIds.delete(appUuid);
+    }
+});
+
 test('CopilotCliAdapter: implements IDiscoverableEcosystem', () => {
     assert.ok(isDiscoverable(adapter));
 });
@@ -228,6 +257,55 @@ test('CopilotCliAdapter.discover: marks sessions with Scout workspace.yaml cwd a
         'Scout session should be labelled MS Scout (Copilot CLI)');
     assert.equal(fresh.getDisplayName(regularEventsPath), 'Copilot CLI',
         'Regular CLI session should be labelled Copilot CLI');
+});
+
+test('CopilotCliAdapter.discover: marks sessions with client_name: github/autopilot workspace.yaml as App', async (t) => {
+    const tmpHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cli-home-app-'));
+    const stateDir = path.join(tmpHome, '.copilot', 'session-state');
+    await fs.promises.mkdir(stateDir, { recursive: true });
+
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    t.after(async () => {
+        if (originalHome === undefined) { delete process.env.HOME; } else { process.env.HOME = originalHome; }
+        if (originalUserProfile === undefined) { delete process.env.USERPROFILE; } else { process.env.USERPROFILE = originalUserProfile; }
+        await fs.promises.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    if (os.homedir() !== tmpHome) {
+        t.skip(`os.homedir() doesn't honour env override on this platform (got ${os.homedir()})`);
+        return;
+    }
+
+    // App session: has events.jsonl + workspace.yaml with client_name: github/autopilot
+    const appUuid = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    const appDir = path.join(stateDir, appUuid);
+    await fs.promises.mkdir(appDir, { recursive: true });
+    await fs.promises.writeFile(path.join(appDir, 'events.jsonl'), '{"type":"start"}\n');
+    await fs.promises.writeFile(path.join(appDir, 'workspace.yaml'),
+        'cwd: C:\\Users\\me\\code\\my-project\nclient_name: github/autopilot\n');
+
+    // Regular terminal CLI session: client_name: github/cli
+    const cliUuid = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+    const cliDir = path.join(stateDir, cliUuid);
+    await fs.promises.mkdir(cliDir, { recursive: true });
+    await fs.promises.writeFile(path.join(cliDir, 'events.jsonl'), '{"type":"start"}\n');
+    await fs.promises.writeFile(path.join(cliDir, 'workspace.yaml'),
+        'cwd: C:\\Users\\me\\code\\my-project\nclient_name: github/cli\n');
+
+    const fresh = new CopilotCliAdapter();
+    await fresh.discover(() => { /* noop */ });
+
+    const appEventsPath = path.join(appDir, 'events.jsonl');
+    const cliEventsPath = path.join(cliDir, 'events.jsonl');
+
+    assert.equal(fresh.getDisplayName(appEventsPath), 'Copilot CLI (App)',
+        'App-wrapped session should be labelled Copilot CLI (App)');
+    assert.equal(fresh.getDisplayName(cliEventsPath), 'Copilot CLI',
+        'Terminal CLI session should be labelled Copilot CLI');
 });
 
 test('CopilotCliAdapter.discover: returns empty result when session-state dir does not exist', async (t) => {


### PR DESCRIPTION
## Summary

Detects and surfaces whether a Copilot CLI session was started via the **desktop app** (which wraps the CLI process) versus the plain **terminal CLI**, using the `client_name` field (`github/autopilot` vs `github/cli`) recorded in each session's `workspace.yaml`.

This follows the exact same mechanism already used to label "MS Scout (Copilot CLI)" sessions, so it automatically flows through to every view that consumes the adapter's per-session display name: session list, log viewer, charts, usage analysis, and diagnostics tiles.

## Changes

- `src/copilotCliStore.ts` — add `isCopilotAppClientName()` helper
- `src/adapters/copilotCliAdapter.ts` — track app-session UUIDs during `discover()` (both `events.jsonl`-backed and DB-only chat-only sessions) and return `'Copilot CLI (App)'` from `getDisplayName()` / `getDisplayNameForDiscoveredPath()` (falls back to `'Copilot CLI'` when `client_name` is `github/cli` or absent on older sessions)
- `vscode-extension/src/editorIcons.ts` — icon map entry for `'Copilot CLI (App)'`
- `src/statsHelpers.ts` / `cli/src/analysis.ts` — add `'Copilot CLI (App)'` to the Copilot-billed editor set so cost attribution/billing group stays correct
- New unit tests covering the new display name and `discover()` marking logic

## Verification

- `npm run compile` (vscode-extension) — clean
- Unit tests: `copilotCliAdapter.test.ts` (17/17), `chartDataBuilder`/`statsHelpers`/`workspaceHelpers` (372/372)
- `cli` project builds successfully
- `.github/skills/validate-editor-names/validate-editor-names.js` — all checks pass, confirms icon map coverage
- Verified against real local session data: 107 of 108 sessions from today were correctly attributed to the app, 1 to the CLI