### PR TITLE
Fix custom domain cert reconcile: stale resource address broke hostname re-registration

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -387,8 +387,9 @@ jobs:
               # and triggers another 60-minute wait).
               echo "Cert '$EXPECTED_CERT_NAME' found in Azure but not in TF state. Importing..."
               if terraform import 'azurerm_container_app_environment_managed_certificate.this[0]' "$AZURE_CERT_ID"; then
-                # Drop stale custom-domain state so cert_binding re-runs to re-bind.
-                terraform state rm 'azurerm_container_app_custom_domain.this[0]' 2>/dev/null || true
+                # Drop stale cert-binding state so it re-runs to re-bind (hostname
+                # registration is untouched here since we didn't delete the hostname).
+                terraform state rm 'null_resource.cert_binding[0]' 2>/dev/null || true
                 echo "Import done. Terraform will rebind the cert without recreating it."
               else
                 # Import failed; delete the Azure cert so apply doesn't hit "already exists".
@@ -401,7 +402,11 @@ jobs:
                   --name "$ENV_NAME" \
                   --resource-group "$TF_VAR_resource_group_name" \
                   --certificate "$EXPECTED_CERT_NAME" --yes 2>/dev/null || true
-                terraform state rm 'azurerm_container_app_custom_domain.this[0]' 2>/dev/null || true
+                # Hostname was deleted above, so hostname_registration must also be
+                # dropped from state or Terraform will (wrongly) believe it's still
+                # registered and skip re-adding it before the cert create call.
+                terraform state rm 'null_resource.hostname_registration[0]' 2>/dev/null || true
+                terraform state rm 'null_resource.cert_binding[0]' 2>/dev/null || true
                 terraform state rm 'azurerm_container_app_environment_managed_certificate.this[0]' 2>/dev/null || true
                 echo "Cleanup done. Terraform will create cert and domain binding from scratch."
               fi
@@ -428,8 +433,12 @@ jobs:
                   --certificate "$AZURE_CERT_NAME" --yes 2>/dev/null || true
               fi
 
-              # Remove stale TF state entries so Terraform creates fresh resources
-              terraform state rm 'azurerm_container_app_custom_domain.this[0]' 2>/dev/null || true
+              # Remove stale TF state entries so Terraform creates fresh resources.
+              # Hostname was deleted above, so hostname_registration must also be
+              # dropped from state or Terraform will (wrongly) believe it's still
+              # registered and skip re-adding it before the cert create call.
+              terraform state rm 'null_resource.hostname_registration[0]' 2>/dev/null || true
+              terraform state rm 'null_resource.cert_binding[0]' 2>/dev/null || true
               terraform state rm 'azurerm_container_app_environment_managed_certificate.this[0]' 2>/dev/null || true
               echo "Cleanup done. Terraform will create cert and domain binding from scratch."
             fi


### PR DESCRIPTION
## Why

The sharing-server deploy workflow's custom-domain Terraform apply was failing with:

```
RequireCustomHostnameInEnvironment: Creating managed certificate requires hostname
'<domain>' added as a custom hostname to a container app or route in environment
```

## Root cause

The "Reconcile custom domain Terraform state" step in `sharing-server-deploy.yml` still referenced `azurerm_container_app_custom_domain.this[0]`, a resource address that no longer exists in `main.tf` (it was replaced by `null_resource.cert_binding` in an earlier refactor, per the comment at `main.tf:249`). That `terraform state rm` call was a silent no-op.

Worse, none of the cleanup branches removed `null_resource.hostname_registration` from state after deleting the hostname in Azure via `az containerapp hostname delete`. Terraform then believed the hostname was still registered on the container app (since its trigger, the app ID, hadn't changed) and skipped re-running `az containerapp hostname add`. The subsequent managed-certificate create call failed because the hostname had been deleted but never re-added.

## Fix

- Replaced the stale `azurerm_container_app_custom_domain.this[0]` references with the correct `null_resource.cert_binding[0]` address in all three cleanup branches.
- Added `terraform state rm 'null_resource.hostname_registration[0]'` to the two branches that delete the Azure hostname, so Terraform re-adds it before attempting to create the certificate.

No infrastructure resources changed (`main.tf` untouched) - this only fixes the GitHub Actions reconcile script's bookkeeping so it stays in sync with the actual Terraform resource graph.