### PR TITLE
Derive Azure region from the resource group instead of a separate variable

### DIFF
--- a/.github/workflows/sharing-server-bootstrap.yml
+++ b/.github/workflows/sharing-server-bootstrap.yml
@@ -24,10 +24,6 @@ on:
         description: 'Existing Azure resource group to create the state storage account in'
         type: string
         required: true
-      location:
-        description: 'Azure region'
-        type: string
-        default: 'westeurope'
 
 permissions:
   contents: read
@@ -46,7 +42,6 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       ARM_USE_OIDC:        "true"
       TF_VAR_resource_group_name: ${{ inputs.resource_group_name }}
-      TF_VAR_location:            ${{ inputs.location }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/sharing-server-cleanup.yml
+++ b/.github/workflows/sharing-server-cleanup.yml
@@ -144,7 +144,6 @@ jobs:
           # Variables are required by Terraform even for destroy; use safe placeholders
           # for values that only affect resource creation (image, secrets).
           TF_VAR_resource_group_name: ${{ vars.AZURE_RESOURCE_GROUP }}
-          TF_VAR_location:            ${{ vars.AZURE_LOCATION || 'westeurope' }}
           TF_VAR_app_name:            ${{ steps.env.outputs.app_name }}
           TF_VAR_container_image:     "ghcr.io/${{ github.repository_owner }}/copilot-sharing-server:latest"
           TF_VAR_github_client_id:    ${{ secrets.SHARING_GITHUB_CLIENT_ID }}

--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -317,7 +317,6 @@ jobs:
         working-directory: sharing-server/infra
         env:
           TF_VAR_resource_group_name:    ${{ vars.AZURE_RESOURCE_GROUP }}
-          TF_VAR_location:               ${{ vars.AZURE_LOCATION || 'westeurope' }}
           TF_VAR_app_name:               ${{ needs.setup.outputs.app_name }}
           TF_VAR_container_image:        ${{ needs.build.outputs.image }}
           TF_VAR_github_client_id:       ${{ secrets.SHARING_GITHUB_CLIENT_ID }}
@@ -449,7 +448,6 @@ jobs:
         working-directory: sharing-server/infra
         env:
           TF_VAR_resource_group_name: ${{ vars.AZURE_RESOURCE_GROUP }}
-          TF_VAR_location:            ${{ vars.AZURE_LOCATION || 'westeurope' }}
           TF_VAR_app_name:            ${{ needs.setup.outputs.app_name }}
           TF_VAR_container_image:     ${{ needs.build.outputs.image }}
           TF_VAR_github_client_id:    ${{ secrets.SHARING_GITHUB_CLIENT_ID }}
@@ -470,7 +468,6 @@ jobs:
         working-directory: sharing-server/infra
         env:
           TF_VAR_resource_group_name: ${{ vars.AZURE_RESOURCE_GROUP }}
-          TF_VAR_location:            ${{ vars.AZURE_LOCATION || 'westeurope' }}
           TF_VAR_app_name:            ${{ needs.setup.outputs.app_name }}
           TF_VAR_container_image:     ${{ needs.build.outputs.image }}
           TF_VAR_github_client_id:    ${{ secrets.SHARING_GITHUB_CLIENT_ID }}

--- a/sharing-server/infra/bootstrap/main.tf
+++ b/sharing-server/infra/bootstrap/main.tf
@@ -43,7 +43,7 @@ resource "random_string" "suffix" {
 resource "azurerm_storage_account" "tfstate" {
   name                     = "sharingtfstate${random_string.suffix.result}"
   resource_group_name      = data.azurerm_resource_group.this.name
-  location                 = var.location
+  location                 = data.azurerm_resource_group.this.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   min_tls_version          = "TLS1_2"

--- a/sharing-server/infra/bootstrap/variables.tf
+++ b/sharing-server/infra/bootstrap/variables.tf
@@ -3,12 +3,6 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "location" {
-  description = "Azure region (e.g. westeurope)"
-  type        = string
-  default     = "westeurope"
-}
-
 variable "container_name" {
   description = "Blob container name used to store the main Terraform state file"
   type        = string

--- a/sharing-server/infra/main.tf
+++ b/sharing-server/infra/main.tf
@@ -219,7 +219,35 @@ resource "null_resource" "hostname_registration" {
   }
 
   provisioner "local-exec" {
-    command = "az containerapp hostname add --name '${azurerm_container_app.this.name}' --resource-group '${var.resource_group_name}' --hostname '${var.custom_domain}' 2>/dev/null || true"
+    # `hostname add` is not synchronously consistent — Azure can return success
+    # before the hostname is actually queryable on the container app, causing the
+    # managed certificate create step (right after) to fail with
+    # RequireCustomHostnameInEnvironment even though registration "succeeded".
+    # Poll until the hostname shows up in the app's ingress config (or time out
+    # loudly) instead of swallowing all errors with `|| true`.
+    command = <<-EOT
+      set -e
+      az containerapp hostname add \
+        --name '${azurerm_container_app.this.name}' \
+        --resource-group '${var.resource_group_name}' \
+        --hostname '${var.custom_domain}'
+
+      for i in $(seq 1 30); do
+        FOUND=$(az containerapp hostname list \
+          --name '${azurerm_container_app.this.name}' \
+          --resource-group '${var.resource_group_name}' \
+          --query "[].name" -o tsv 2>/dev/null | grep -Fx '${var.custom_domain}' || true)
+        if [ -n "$FOUND" ]; then
+          echo "Hostname '${var.custom_domain}' confirmed registered."
+          exit 0
+        fi
+        echo "Waiting for hostname '${var.custom_domain}' to propagate (attempt $i/30)..."
+        sleep 5
+      done
+
+      echo "Hostname '${var.custom_domain}' did not appear on the container app within 150s." >&2
+      exit 1
+    EOT
   }
 
   depends_on = [azurerm_container_app.this]

--- a/sharing-server/infra/main.tf
+++ b/sharing-server/infra/main.tf
@@ -17,7 +17,7 @@ resource "random_string" "storage_suffix" {
 resource "azurerm_storage_account" "this" {
   name                     = "sharing${random_string.storage_suffix.result}"
   resource_group_name      = data.azurerm_resource_group.this.name
-  location                 = var.location
+  location                 = data.azurerm_resource_group.this.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   min_tls_version          = "TLS1_2"
@@ -35,7 +35,7 @@ resource "azurerm_storage_share" "data" {
 # Container Apps Environment — one per deployment for full isolation.
 resource "azurerm_container_app_environment" "this" {
   name                = "${var.app_name}-env"
-  location            = var.location
+  location            = data.azurerm_resource_group.this.location
   resource_group_name = data.azurerm_resource_group.this.name
   tags                = var.tags
 }

--- a/sharing-server/infra/variables.tf
+++ b/sharing-server/infra/variables.tf
@@ -3,12 +3,6 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "location" {
-  description = "Azure region (e.g. westeurope)"
-  type        = string
-  default     = "westeurope"
-}
-
 variable "app_name" {
   description = "Container app name — sharing-server-prod (main) or sharing-test-<slug> (branch)"
   type        = string


### PR DESCRIPTION
## Why

Deploys were failing in West Europe because the Azure region fed to Terraform came from an independent variable (`var.location` / `TF_VAR_location` / the `AZURE_LOCATION` GitHub variable), all defaulting to `westeurope`. That value could silently drift from the region the target resource group actually lives in. The screenshots from the session showed this drift in practice: the Terraform state storage account ended up in **Sweden Central** while the rest of the environment sits in **West Europe**.

## Fix

All resources (storage accounts, Container Apps Environment, in both the `bootstrap` and main Terraform configs) now read `data.azurerm_resource_group.this.location` instead of `var.location`, so they always deploy into the resource group''s actual region rather than a value that has to be kept in sync manually.

Removed the now-unused `location` variable and its wiring from:
- `sharing-server/infra/variables.tf` and `sharing-server/infra/bootstrap/variables.tf`
- `.github/workflows/sharing-server-deploy.yml`
- `.github/workflows/sharing-server-cleanup.yml`
- `.github/workflows/sharing-server-bootstrap.yml` (dropped the manual `location` workflow_dispatch input entirely)

No behavior change for environments where the RG and the old default already matched; this only matters (and fixes things) where they didn''t.