### PR TITLE
Have bootstrap Terraform create the resource group in the target region

### DIFF
--- a/.github/workflows/sharing-server-bootstrap.yml
+++ b/.github/workflows/sharing-server-bootstrap.yml
@@ -1,15 +1,20 @@
 name: Bootstrap Sharing Server Terraform State
 
-# One-off, manually-triggered workflow. Creates the storage account + blob
-# container that sharing-server-deploy.yml uses as its Terraform remote state
-# backend. Run this once per environment (e.g. after migrating to a new Azure
-# subscription/tenant) before pointing TF_STATE_* variables at it — the main
-# deploy workflow's `terraform init` will fail until this backend exists.
+# One-off, manually-triggered workflow. Creates the resource group + storage
+# account + blob container that sharing-server-deploy.yml uses as its
+# Terraform remote state backend, and that main.tf's resources derive their
+# Azure region from. Run this once per environment (e.g. after migrating to
+# a new Azure subscription/tenant/region) before pointing TF_STATE_*
+# variables at it — the main deploy workflow's `terraform init` will fail
+# until this backend exists.
 #
 # Uses local Terraform state (see sharing-server/infra/bootstrap/main.tf) since
 # it can't depend on the backend it's creating. Re-running this after the
-# storage account already exists will try to create a second one — it isn't
-# idempotent across runs, so only run it when you actually need a new backend.
+# resource group/storage account already exist will fail (or need
+# `terraform import` first) — it isn't idempotent across runs, so only run it
+# when you actually need a new backend. To migrate an environment to a new
+# region: delete the existing resource group in Azure first, then re-run this
+# with the new `location`.
 on:
   workflow_dispatch:
     inputs:
@@ -21,7 +26,11 @@ on:
           - production
         required: true
       resource_group_name:
-        description: 'Existing Azure resource group to create the state storage account in'
+        description: 'Azure resource group to create for this environment (must not already exist)'
+        type: string
+        required: true
+      location:
+        description: 'Azure region to create the resource group in (e.g. francecentral, swedencentral)'
         type: string
         required: true
 
@@ -42,6 +51,7 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       ARM_USE_OIDC:        "true"
       TF_VAR_resource_group_name: ${{ inputs.resource_group_name }}
+      TF_VAR_location:            ${{ inputs.location }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -73,6 +83,7 @@ jobs:
             echo "| \`TF_STATE_RESOURCE_GROUP\` | \`$(terraform output -raw resource_group_name)\` |"
             echo "| \`TF_STATE_STORAGE_ACCOUNT\` | \`$(terraform output -raw storage_account_name)\` |"
             echo "| \`TF_STATE_CONTAINER\` | \`$(terraform output -raw container_name)\` |"
+            echo "| _(resource group region)_ | \`$(terraform output -raw location)\` |"
             echo ""
             echo "Set these as environment-scoped variables on the \`${{ inputs.environment }}\` GitHub Environment, then re-run the deploy workflow."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/sharing-server/infra/bootstrap/main.tf
+++ b/sharing-server/infra/bootstrap/main.tf
@@ -26,8 +26,15 @@ provider "azurerm" {
   resource_provider_registrations = "none"
 }
 
-data "azurerm_resource_group" "this" {
-  name = var.resource_group_name
+# Terraform manages the resource group itself so the target Azure region is
+# set in exactly one place: this bootstrap config. The main sharing-server
+# config (../main.tf) reads the region back via a data source on this same
+# resource group, so migrating regions is just: delete this resource group
+# (and everything in it) in Azure, change `location` below, re-run this
+# bootstrap, then re-run the main deploy — no other config needs to change.
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.location
 }
 
 # Storage account names must be globally unique, 3-24 chars, lowercase alphanumeric only.
@@ -42,8 +49,8 @@ resource "random_string" "suffix" {
 
 resource "azurerm_storage_account" "tfstate" {
   name                     = "sharingtfstate${random_string.suffix.result}"
-  resource_group_name      = data.azurerm_resource_group.this.name
-  location                 = data.azurerm_resource_group.this.location
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   min_tls_version          = "TLS1_2"

--- a/sharing-server/infra/bootstrap/outputs.tf
+++ b/sharing-server/infra/bootstrap/outputs.tf
@@ -1,5 +1,9 @@
 output "resource_group_name" {
-  value = var.resource_group_name
+  value = azurerm_resource_group.this.name
+}
+
+output "location" {
+  value = azurerm_resource_group.this.location
 }
 
 output "storage_account_name" {

--- a/sharing-server/infra/bootstrap/variables.tf
+++ b/sharing-server/infra/bootstrap/variables.tf
@@ -1,5 +1,10 @@
 variable "resource_group_name" {
-  description = "Existing Azure resource group to create the Terraform state storage account in"
+  description = "Azure resource group to create (or reuse, if it already exists and is imported first) for this environment's resources"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region to create the resource group in (e.g. francecentral). All resources deployed by the main sharing-server config derive their region from this resource group's location, so this is the single place a region migration starts from."
   type        = string
 }
 


### PR DESCRIPTION
## Why

Sweden Central is currently out of Container Apps environment capacity (\ManagedEnvironmentCapacityHeavyUsageError\), blocking the sharing-server-test/prod region migration. Since PR #1677 made main.tf derive its Azure region from the resource group's own location (instead of a hardcoded variable), the only way to control that region was to control the resource group's location - but the bootstrap config only ever read an *existing* resource group via a data source, so the region was implicitly whatever it happened to be created in outside of Terraform.

## What changed

sharing-server/infra/bootstrap/main.tf now creates the resource group itself (azurerm_resource_group.this) with an explicit location variable, instead of assuming it pre-exists. main.tf is unchanged - it keeps deriving region from this same resource group via a data source, so this is the single place a region migration starts from.

- sharing-server/infra/bootstrap/main.tf: resource group is now a managed resource; storage account references updated accordingly.
- sharing-server/infra/bootstrap/variables.tf: added location variable.
- sharing-server/infra/bootstrap/outputs.tf: added location output (also renamed resource_group_name output to read from the resource, not the input var).
- .github/workflows/sharing-server-bootstrap.yml: re-added a location workflow_dispatch input, wired to TF_VAR_location, and updated docs/summary output to reflect that this workflow now creates the resource group (not just the state storage account).

## How to migrate a region (e.g. prod: Sweden Central -> France Central)

1. Delete the existing resource group in Azure (throws away everything in it).
2. Re-run sharing-server-bootstrap.yml for that environment with the new resource_group_name and location: francecentral.
3. Re-run the main deploy workflow - main.tf will create all resources fresh in the new region, since it reads the region from the resource group bootstrap just created.

## Note

This intentionally does not touch main.tf/its variables.tf - no override variable was reintroduced there, keeping the 'single source of truth for region' property from #1677 intact, just moving that source of truth to where it can actually be controlled.