### PR TITLE
Bootstrap: read resource group via data source, validate region instead of creating it

### DIFF
--- a/.github/workflows/sharing-server-bootstrap.yml
+++ b/.github/workflows/sharing-server-bootstrap.yml
@@ -1,20 +1,29 @@
 name: Bootstrap Sharing Server Terraform State
 
-# One-off, manually-triggered workflow. Creates the resource group + storage
-# account + blob container that sharing-server-deploy.yml uses as its
-# Terraform remote state backend, and that main.tf's resources derive their
-# Azure region from. Run this once per environment (e.g. after migrating to
-# a new Azure subscription/tenant/region) before pointing TF_STATE_*
-# variables at it — the main deploy workflow's `terraform init` will fail
-# until this backend exists.
+# One-off, manually-triggered workflow. Creates the storage account + blob
+# container that sharing-server-deploy.yml uses as its Terraform remote state
+# backend, inside an EXISTING resource group. Run this once per environment
+# (e.g. after migrating to a new Azure subscription/tenant/region) before
+# pointing TF_STATE_* variables at it — the main deploy workflow's
+# `terraform init` will fail until this backend exists.
+#
+# PREREQUISITE (manual, outside this workflow): the resource group named by
+# `resource_group_name` must already exist in the target region, with this
+# repo's GitHub Actions service principal granted the Contributor role on it.
+# The SP intentionally only has resource-group-scoped permissions, so it
+# cannot create the resource group itself — only someone with broader
+# (subscription-level) access can. To migrate an environment to a new region:
+#   1. az group create -n <rg-name> -l <new-region>
+#   2. az role assignment create --assignee <sp-app-id> --role Contributor \
+#        --scope /subscriptions/<sub-id>/resourceGroups/<rg-name>
+#   3. Re-run this workflow with the new `resource_group_name`/`location`.
+#   4. Update the environment's TF_STATE_* GitHub variables to the new
+#      storage account name output below, then re-run the main deploy.
 #
 # Uses local Terraform state (see sharing-server/infra/bootstrap/main.tf) since
 # it can't depend on the backend it's creating. Re-running this after the
-# resource group/storage account already exist will fail (or need
-# `terraform import` first) — it isn't idempotent across runs, so only run it
-# when you actually need a new backend. To migrate an environment to a new
-# region: delete the existing resource group in Azure first, then re-run this
-# with the new `location`.
+# storage account already exists will try to create a second one — it isn't
+# idempotent across runs, so only run it when you actually need a new backend.
 on:
   workflow_dispatch:
     inputs:
@@ -26,11 +35,11 @@ on:
           - production
         required: true
       resource_group_name:
-        description: 'Azure resource group to create for this environment (must not already exist)'
+        description: 'Existing Azure resource group (created manually beforehand) to create the state storage account in'
         type: string
         required: true
       location:
-        description: 'Azure region to create the resource group in (e.g. francecentral, swedencentral)'
+        description: 'Expected Azure region of the resource group (e.g. francecentral) — validated, not used to create anything'
         type: string
         required: true
 

--- a/sharing-server/infra/bootstrap/main.tf
+++ b/sharing-server/infra/bootstrap/main.tf
@@ -26,15 +26,28 @@ provider "azurerm" {
   resource_provider_registrations = "none"
 }
 
-# Terraform manages the resource group itself so the target Azure region is
-# set in exactly one place: this bootstrap config. The main sharing-server
-# config (../main.tf) reads the region back via a data source on this same
-# resource group, so migrating regions is just: delete this resource group
-# (and everything in it) in Azure, change `location` below, re-run this
-# bootstrap, then re-run the main deploy — no other config needs to change.
-resource "azurerm_resource_group" "this" {
-  name     = var.resource_group_name
-  location = var.location
+# The GitHub Actions service principal only has Contributor scoped to this
+# resource group (RBAC can only be granted once the RG exists), so it can
+# never create the resource group itself — that requires subscription-level
+# permission this SP intentionally does not have. The resource group must be
+# created manually (by someone with broader access) in the target region,
+# with the SP's Contributor role assignment (re-)created on it, BEFORE this
+# bootstrap runs. See the sharing-server-bootstrap.yml workflow comments for
+# the exact steps.
+#
+# This is a data source (not a managed resource) for that reason. `var.location`
+# is only used to validate the RG actually is where you think it is — a
+# postcondition fails loudly on mismatch instead of silently bootstrapping the
+# wrong region.
+data "azurerm_resource_group" "this" {
+  name = var.resource_group_name
+
+  lifecycle {
+    postcondition {
+      condition     = self.location == var.location
+      error_message = "Resource group '${var.resource_group_name}' is in '${self.location}', not the expected '${var.location}'. Create/move the resource group to the expected region first (see sharing-server-bootstrap.yml)."
+    }
+  }
 }
 
 # Storage account names must be globally unique, 3-24 chars, lowercase alphanumeric only.
@@ -49,8 +62,8 @@ resource "random_string" "suffix" {
 
 resource "azurerm_storage_account" "tfstate" {
   name                     = "sharingtfstate${random_string.suffix.result}"
-  resource_group_name      = azurerm_resource_group.this.name
-  location                 = azurerm_resource_group.this.location
+  resource_group_name      = data.azurerm_resource_group.this.name
+  location                 = data.azurerm_resource_group.this.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   min_tls_version          = "TLS1_2"

--- a/sharing-server/infra/bootstrap/outputs.tf
+++ b/sharing-server/infra/bootstrap/outputs.tf
@@ -1,9 +1,9 @@
 output "resource_group_name" {
-  value = azurerm_resource_group.this.name
+  value = data.azurerm_resource_group.this.name
 }
 
 output "location" {
-  value = azurerm_resource_group.this.location
+  value = data.azurerm_resource_group.this.location
 }
 
 output "storage_account_name" {

--- a/sharing-server/infra/bootstrap/variables.tf
+++ b/sharing-server/infra/bootstrap/variables.tf
@@ -1,10 +1,10 @@
 variable "resource_group_name" {
-  description = "Azure resource group to create (or reuse, if it already exists and is imported first) for this environment's resources"
+  description = "Existing Azure resource group for this environment's resources. Must be created manually (outside Terraform) with the GitHub Actions service principal's Contributor role assigned on it — this SP intentionally has no subscription-level permission to create resource groups itself."
   type        = string
 }
 
 variable "location" {
-  description = "Azure region to create the resource group in (e.g. francecentral). All resources deployed by the main sharing-server config derive their region from this resource group's location, so this is the single place a region migration starts from."
+  description = "Expected Azure region of the resource group (e.g. francecentral). Only used to validate the resource group is actually where you think it is — bootstrap fails loudly on mismatch rather than silently deploying to the wrong region. All resources deployed by the main sharing-server config derive their actual region from the resource group itself, so a region migration means: manually create/move the resource group to the new region and RBAC-assign the SP there first, then update this value to match."
   type        = string
 }
 


### PR DESCRIPTION
## Why

PR #1685 made bootstrap Terraform create the resource group itself so region migrations had a single source of truth. In practice this can't work: the GitHub Actions service principal only has Contributor scoped to its resource group, granted after the RG exists via RBAC — it has no subscription-level permission to create resource groups. Confirmed against the real prod migration attempt (Sweden Central -> France Central): the SP could not list/create the resource group.

## What changed

sharing-server/infra/bootstrap/main.tf reverts to reading the resource group via a data source (as before #1685), but adds a \lifecycle { postcondition {...} }\ on it that fails loudly if the resource group isn't in the expected \ar.location\ — so a region mismatch is caught immediately instead of silently bootstrapping (or migrating) into the wrong place.

The resource group and the SP's RBAC role assignment on it must now be created manually (outside Terraform, by someone with broader subscription-level access) before running the bootstrap workflow. This is documented directly in \.github/workflows/sharing-server-bootstrap.yml\ with the exact \z group create\ / \z role assignment create\ commands to run first.

- \sharing-server/infra/bootstrap/main.tf\: resource group back to a data source, with a region-match postcondition.
- \sharing-server/infra/bootstrap/variables.tf\: updated descriptions to reflect the manual-creation prerequisite.
- \sharing-server/infra/bootstrap/outputs.tf\: outputs now read from the data source again.
- \.github/workflows/sharing-server-bootstrap.yml\: documents the manual prerequisite steps (create RG + assign Contributor role) before running this workflow.

## Note

main.tf (the primary deploy config) is unaffected by either change — it always derives its region from whatever the resource group actually is, via its own data source.