### PR TITLE
Support GHE.com as hosting

### DIFF
--- a/.github/workflows/vscode-nightly-prerelease.yml
+++ b/.github/workflows/vscode-nightly-prerelease.yml
@@ -64,12 +64,20 @@ jobs:
         STABLE_VERSION=$(node -p "require('./vscode-extension/package.json').version")
         MAJOR=$(echo "$STABLE_VERSION" | cut -d. -f1)
         MINOR=$(echo "$STABLE_VERSION" | cut -d. -f2)
-        # Patch = YYYYMMDD — unique per day, always higher than any normal patch number
         PATCH_DATE=$(date +%Y%m%d)
-        PRE_RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH_DATE}"
+
+        # Patch = YYYYMMDD + a 2-digit build counter (01, 02, ...) — unique per day, and unique
+        # per run within a day so a manual re-run (e.g. after merging a fix) doesn't collide with
+        # a version already published today. Always keeping the same digit width (date + 2 digits)
+        # keeps versions strictly increasing both within a day and across days, which the
+        # Marketplace requires.
+        EXISTING_COUNT=$(git tag --list "vscode/nightly/v${MAJOR}.${MINOR}.${PATCH_DATE}*" | wc -l)
+        BUILD_NUM=$((EXISTING_COUNT + 1))
+        BUILD_SUFFIX=$(printf "%02d" "$BUILD_NUM")
+        PRE_RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH_DATE}${BUILD_SUFFIX}"
         echo "version=$PRE_RELEASE_VERSION" >> "$GITHUB_OUTPUT"
         echo "stable_version=$STABLE_VERSION" >> "$GITHUB_OUTPUT"
-        echo "Pre-release version: $PRE_RELEASE_VERSION (based on stable $STABLE_VERSION)"
+        echo "Pre-release version: $PRE_RELEASE_VERSION (based on stable $STABLE_VERSION, build #$BUILD_NUM today)"
 
     - name: Bump version in package.json (no commit — build only)
       if: steps.check_changes.outputs.has_changes == 'true'

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the VS Code extension will be documented in this file.
 ### Features
 - Model Efficiency section in Usage Analysis: per-model one-shot edit rate, retry rate, self-correction rate, cost per turn, cost per edit, output tokens per turn, and cache hit rate, with sortable columns and period switcher (#1649)
 - Insight card that flags models with high edit-retry rates and compares them against your best-performing model (#1649)
+- GitHub API requests (PR stats, cloud-agent sessions, Copilot plan info) now honor VS Code's `github-enterprise.uri` setting, so they target a GHE.com or GitHub Enterprise Server host instead of always hitting github.com — matching where the user actually signed in
 
 ### Bug Fixes
 - Claude Code: attribute multi-day session tokens to the day each turn actually occurred instead of collapsing everything onto the session's start day, and discover subagent/workflow transcripts under `<sessionId>/subagents/**` that were previously silently excluded (#1608)

--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -1,5 +1,5 @@
 import * as https from 'https';
-import { GITHUB_API_HOSTNAME, buildGitHubApiHeaders } from './githubApiConfig';
+import { getGitHubApiEndpoints, buildGitHubApiHeaders } from './githubApiConfig';
 
 export type AgentSessionSource = 'cloud-agent' | 'cli-remote' | 'unknown';
 
@@ -89,10 +89,11 @@ export function fetchAgentTasksPage(
 		if (archived) { queryParams += '&archived=true'; }
 		if (since) { queryParams += `&since=${encodeURIComponent(since)}`; }
 
+		const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: `/agents/repos/${owner}/${repo}/tasks?${queryParams}`,
+				hostname,
+				path: `${restPathPrefix}/agents/repos/${owner}/${repo}/tasks?${queryParams}`,
 				headers: buildGitHubApiHeaders(token),
 			},
 			(res) => {
@@ -130,10 +131,11 @@ export function fetchAgentTaskDetail(
 	token: string,
 ): Promise<TaskDetailResult> {
 	return new Promise((resolve) => {
+		const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: `/agents/repos/${owner}/${repo}/tasks/${encodeURIComponent(taskId)}`,
+				hostname,
+				path: `${restPathPrefix}/agents/repos/${owner}/${repo}/tasks/${encodeURIComponent(taskId)}`,
 				headers: buildGitHubApiHeaders(token),
 			},
 			(res) => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -203,6 +203,7 @@ import {
 	type RepoPrStatsResult,
 } from './githubPrService';
 import { fetchAgentSessionsForRepo } from './agentSessionsService';
+import { getConfiguredGitHubEnterpriseUri } from './githubApiConfig';
 
 // --- View regression ---
 import {
@@ -1763,7 +1764,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 
 		const workspacePaths = this._buildWorkspacePaths();
-		const repos = discoverGitHubRepos(workspacePaths);
+		const repos = discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
 		this.analysisPanel.webview.postMessage({ command: 'repoPrStatsProgress', total: repos.length, done: 0 });
 
 		const results: RepoPrInfo[] = [];
@@ -1838,7 +1839,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 
 		const workspacePaths = this._buildWorkspacePaths();
-		const repos = discoverGitHubRepos(workspacePaths);
+		const repos = discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
 		this.analysisPanel.webview.postMessage({ command: 'agentSessionsProgress', total: repos.length, done: 0 });
 
 		const repoResults = [];

--- a/vscode-extension/src/githubApiConfig.ts
+++ b/vscode-extension/src/githubApiConfig.ts
@@ -3,8 +3,73 @@
  * Used by agentSessionsService.ts and githubPrService.ts.
  */
 
-/** GitHub REST API hostname. */
+import * as vscode from 'vscode';
+
+/** GitHub REST API hostname for github.com (the default, used when no enterprise URI is configured). */
 export const GITHUB_API_HOSTNAME = 'api.github.com';
+
+/** Where to reach a configured GitHub host: hostname for REST calls, REST path prefix, and GraphQL path. */
+export interface GitHubApiEndpoints {
+	/** REST API hostname, e.g. `api.github.com` or `api.tenant.ghe.com`. */
+	hostname: string;
+	/** Path prefix prepended to REST paths — empty for github.com/GHE.com, `/api/v3` for on-prem GitHub Enterprise Server. */
+	restPathPrefix: string;
+	/** GraphQL endpoint path — `/graphql` for github.com/GHE.com, `/api/graphql` for on-prem GitHub Enterprise Server. */
+	graphQlPath: string;
+}
+
+const GITHUB_DOT_COM_ENDPOINTS: GitHubApiEndpoints = {
+	hostname: GITHUB_API_HOSTNAME,
+	restPathPrefix: '',
+	graphQlPath: '/graphql',
+};
+
+/**
+ * Derive the GitHub API endpoints for an optional GitHub Enterprise base URI, mirroring the same
+ * derivation VS Code's own built-in GitHub Authentication provider (and the `github-enterprise.uri`
+ * setting) uses to decide which host to authenticate against:
+ *
+ * - unset / empty / unparseable / a github.com URI → github.com defaults.
+ * - GitHub Enterprise Cloud with data residency (authority ends in `.ghe.com`, e.g. `octocat.ghe.com`)
+ *   → REST API on an `api.` subdomain (`https://api.octocat.ghe.com`), same paths as github.com.
+ * - GitHub Enterprise Server (on-prem, any other host) → REST under `/api/v3`, GraphQL under `/api/graphql`.
+ *
+ * Pure function (no VS Code dependency) so it can be unit tested directly.
+ */
+export function deriveGitHubApiEndpoints(enterpriseUri: string | undefined): GitHubApiEndpoints {
+	if (!enterpriseUri) { return GITHUB_DOT_COM_ENDPOINTS; }
+
+	let url: URL;
+	try {
+		url = new URL(enterpriseUri);
+	} catch {
+		return GITHUB_DOT_COM_ENDPOINTS;
+	}
+
+	const authority = url.host;
+	if (!authority || authority === 'github.com' || authority === 'www.github.com' || authority === 'api.github.com') {
+		return GITHUB_DOT_COM_ENDPOINTS;
+	}
+
+	const isGheCloud = /\.ghe\.com$/i.test(authority);
+	return isGheCloud
+		? { hostname: `api.${authority}`, restPathPrefix: '', graphQlPath: '/graphql' }
+		: { hostname: authority, restPathPrefix: '/api/v3', graphQlPath: '/api/graphql' };
+}
+
+/**
+ * Read the user's configured GitHub Enterprise URI, if any (the same `github-enterprise.uri` setting
+ * VS Code's built-in GitHub Authentication provider uses). Set this to authenticate against and query
+ * a GHE.com or GitHub Enterprise Server instance instead of github.com.
+ */
+export function getConfiguredGitHubEnterpriseUri(): string | undefined {
+	return vscode.workspace.getConfiguration().get<string>('github-enterprise.uri') || undefined;
+}
+
+/** The GitHub API endpoints to use for the current configuration (github.com, GHE.com, or GHES). */
+export function getGitHubApiEndpoints(): GitHubApiEndpoints {
+	return deriveGitHubApiEndpoints(getConfiguredGitHubEnterpriseUri());
+}
 
 /** User-Agent header value sent with all GitHub API requests. */
 export const GITHUB_API_USER_AGENT = 'copilot-token-tracker';

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -1,6 +1,6 @@
 import * as https from 'https';
 import * as childProcess from 'child_process';
-import { GITHUB_API_HOSTNAME, GITHUB_API_USER_AGENT, GITHUB_API_ACCEPT_V3, GITHUB_API_VERSION } from './githubApiConfig';
+import { getGitHubApiEndpoints, GITHUB_API_USER_AGENT, GITHUB_API_ACCEPT_V3, GITHUB_API_VERSION } from './githubApiConfig';
 
 export type RepoPrDetail = {
 	number: number;
@@ -76,11 +76,12 @@ export type CopilotPlanResult = { planInfo?: CopilotPlanInfo; statusCode?: numbe
 
 /** Internal low-level fetcher for the copilot_internal/user endpoint. */
 function fetchCopilotPlanInfoPage(token: string): Promise<CopilotPlanResult> {
+	const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: '/copilot_internal/user',
+				hostname,
+				path: `${restPathPrefix}/copilot_internal/user`,
 				headers: {
 					Authorization: `Bearer ${token}`,
 					'User-Agent': GITHUB_API_USER_AGENT,
@@ -159,11 +160,12 @@ export type CopilotTokenEndpointResult = { info?: CopilotTokenEndpointInfo; stat
 
 /** Internal low-level fetcher for the copilot_internal/v2/token endpoint. */
 function fetchCopilotTokenEndpointInfoPage(token: string): Promise<CopilotTokenEndpointResult> {
+	const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: '/copilot_internal/v2/token',
+				hostname,
+				path: `${restPathPrefix}/copilot_internal/v2/token`,
 				headers: {
 					Authorization: `Bearer ${token}`,
 					'User-Agent': GITHUB_API_USER_AGENT,
@@ -235,11 +237,12 @@ function fetchUserEnterprisesPage(token: string): Promise<UserEnterprisesResult>
 	const query = JSON.stringify({
 		query: '{ viewer { enterprises(first: 10, membershipType: ALL) { nodes { slug name } } } }',
 	});
+	const { hostname, graphQlPath } = getGitHubApiEndpoints();
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: '/graphql',
+				hostname,
+				path: graphQlPath,
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${token}`,
@@ -311,11 +314,12 @@ export function fetchEnterprisePremiumBudgets(
 
 function fetchEnterprisePremiumBudgetsPage(enterpriseSlug: string, username: string, token: string): Promise<EnterpriseBudgetResult> {
 	const params = new URLSearchParams({ user: username, budgetTarget: 'premium_req' });
+	const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: `/enterprises/${encodeURIComponent(enterpriseSlug)}/settings/billing/budgets?${params}`,
+				hostname,
+				path: `${restPathPrefix}/enterprises/${encodeURIComponent(enterpriseSlug)}/settings/billing/budgets?${params}`,
 				headers: {
 					Authorization: `Bearer ${token}`,
 					'User-Agent': GITHUB_API_USER_AGENT,
@@ -370,11 +374,12 @@ export function fetchRepoPrsPage(
 	token: string,
 	page: number,
 ): Promise<{ prs: any[]; statusCode?: number; error?: string }> {
+	const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 	return new Promise((resolve) => {
 		const req = https.request(
 			{
-				hostname: GITHUB_API_HOSTNAME,
-				path: `/repos/${owner}/${repo}/pulls?state=all&per_page=100&sort=created&direction=desc&page=${page}`,
+				hostname,
+				path: `${restPathPrefix}/repos/${owner}/${repo}/pulls?state=all&per_page=100&sort=created&direction=desc&page=${page}`,
 				headers: {
 					Authorization: `Bearer ${token}`,
 					'User-Agent': GITHUB_API_USER_AGENT,
@@ -435,13 +440,28 @@ export async function fetchRepoPrs(
 	return { prs: allPrs };
 }
 
+/** Escape a string for safe embedding inside a regular expression. */
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Discover GitHub repos from workspace paths using git remote.
  * Deduplicates by owner/repo so each GitHub repo is only fetched once.
+ *
+ * Always matches github.com remotes; when `enterpriseUri` is configured (the
+ * `github-enterprise.uri` setting), remotes on that host (e.g. a `tenant.ghe.com`
+ * or on-prem GitHub Enterprise Server) are recognized too.
  */
-export function discoverGitHubRepos(workspacePaths: string[]): { owner: string; repo: string }[] {
+export function discoverGitHubRepos(workspacePaths: string[], enterpriseUri?: string): { owner: string; repo: string }[] {
 	const seen = new Set<string>();
 	const repos: { owner: string; repo: string }[] = [];
+	let enterpriseHost: string | undefined;
+	if (enterpriseUri) {
+		try { enterpriseHost = new URL(enterpriseUri).host; } catch { /* ignore invalid URI — fall back to github.com only */ }
+	}
+	const hostAlternation = enterpriseHost ? `github\\.com|${escapeRegExp(enterpriseHost)}` : 'github\\.com';
+	const remotePattern = new RegExp(`(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
 	for (const workspacePath of workspacePaths) {
 		try {
 			const remote = childProcess.execSync('git remote get-url origin', {
@@ -450,8 +470,7 @@ export function discoverGitHubRepos(workspacePaths: string[]): { owner: string; 
 				timeout: 3000,
 				stdio: ['pipe', 'pipe', 'pipe'],
 			}).trim();
-			// Only process github.com remotes
-			const match = remote.match(/github\.com[:/]([^/]+)\/([^/\s]+?)(?:\.git)?$/i);
+			const match = remote.match(remotePattern);
 			if (!match) { continue; }
 			const key = `${match[1]}/${match[2]}`.toLowerCase();
 			if (seen.has(key)) { continue; }

--- a/vscode-extension/test/unit/githubApiConfig.test.ts
+++ b/vscode-extension/test/unit/githubApiConfig.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import { deriveGitHubApiEndpoints } from '../../src/githubApiConfig';
+
+// ---------------------------------------------------------------------------
+// deriveGitHubApiEndpoints — pure function, no I/O or VS Code dependency
+// ---------------------------------------------------------------------------
+
+test('deriveGitHubApiEndpoints: returns github.com defaults when no enterprise URI is configured', () => {
+	const endpoints = deriveGitHubApiEndpoints(undefined);
+	assert.deepEqual(endpoints, { hostname: 'api.github.com', restPathPrefix: '', graphQlPath: '/graphql' });
+});
+
+test('deriveGitHubApiEndpoints: returns github.com defaults for an empty string', () => {
+	const endpoints = deriveGitHubApiEndpoints('');
+	assert.deepEqual(endpoints, { hostname: 'api.github.com', restPathPrefix: '', graphQlPath: '/graphql' });
+});
+
+test('deriveGitHubApiEndpoints: returns github.com defaults for an unparseable URI', () => {
+	const endpoints = deriveGitHubApiEndpoints('not a url');
+	assert.deepEqual(endpoints, { hostname: 'api.github.com', restPathPrefix: '', graphQlPath: '/graphql' });
+});
+
+test('deriveGitHubApiEndpoints: returns github.com defaults for a github.com URI', () => {
+	assert.deepEqual(deriveGitHubApiEndpoints('https://github.com'), { hostname: 'api.github.com', restPathPrefix: '', graphQlPath: '/graphql' });
+	assert.deepEqual(deriveGitHubApiEndpoints('https://www.github.com'), { hostname: 'api.github.com', restPathPrefix: '', graphQlPath: '/graphql' });
+	assert.deepEqual(deriveGitHubApiEndpoints('https://api.github.com'), { hostname: 'api.github.com', restPathPrefix: '', graphQlPath: '/graphql' });
+});
+
+test('deriveGitHubApiEndpoints: derives api.<tenant> subdomain for GHE.com (data residency)', () => {
+	const endpoints = deriveGitHubApiEndpoints('https://customer.ghe.com');
+	assert.deepEqual(endpoints, { hostname: 'api.customer.ghe.com', restPathPrefix: '', graphQlPath: '/graphql' });
+});
+
+test('deriveGitHubApiEndpoints: derives /api/v3 and /api/graphql for on-prem GitHub Enterprise Server', () => {
+	const endpoints = deriveGitHubApiEndpoints('https://github.acme-corp.com');
+	assert.deepEqual(endpoints, { hostname: 'github.acme-corp.com', restPathPrefix: '/api/v3', graphQlPath: '/api/graphql' });
+});

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, fetchCopilotTokenEndpointInfo, fetchUserEnterprises, fetchEnterprisePremiumBudgets, type CopilotPlanInfo, type CopilotTokenEndpointInfo, type EnterpriseInfo, type EnterpriseBudgetEntry } from '../../src/githubPrService';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as childProcess from 'node:child_process';
+import { detectAiType, fetchRepoPrs, fetchCopilotPlanInfo, fetchCopilotTokenEndpointInfo, fetchUserEnterprises, fetchEnterprisePremiumBudgets, discoverGitHubRepos, type CopilotPlanInfo, type CopilotTokenEndpointInfo, type EnterpriseInfo, type EnterpriseBudgetEntry } from '../../src/githubPrService';
 
 // ---------------------------------------------------------------------------
 // detectAiType — pure function, no I/O
@@ -322,4 +326,66 @@ test('fetchEnterprisePremiumBudgets: returns empty array when no budgets configu
 	const { budgets, error } = await fetchEnterprisePremiumBudgets('acme-corp', 'rajbos', 'token', mockFetcher);
 	assert.equal(error, undefined);
 	assert.deepEqual(budgets, []);
+});
+
+// ---------------------------------------------------------------------------
+// discoverGitHubRepos — reads real git remotes from temp repos
+// ---------------------------------------------------------------------------
+
+/** Create a temp dir with a git repo whose `origin` remote is `remoteUrl`. */
+function makeGitRepoWithRemote(remoteUrl: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-gh-repos-'));
+	childProcess.execSync('git init -q', { cwd: dir });
+	childProcess.execSync(`git remote add origin ${remoteUrl}`, { cwd: dir });
+	return dir;
+}
+
+test('discoverGitHubRepos: matches a github.com remote', () => {
+	const dir = makeGitRepoWithRemote('https://github.com/rajbos/ai-engineering-fluency.git');
+	try {
+		const repos = discoverGitHubRepos([dir]);
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('discoverGitHubRepos: ignores a non-github.com remote when no enterprise URI is configured', () => {
+	const dir = makeGitRepoWithRemote('https://customer.ghe.com/rajbos/private-repo.git');
+	try {
+		const repos = discoverGitHubRepos([dir]);
+		assert.deepEqual(repos, []);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('discoverGitHubRepos: matches a GHE.com remote when the enterprise URI is configured', () => {
+	const dir = makeGitRepoWithRemote('https://customer.ghe.com/rajbos/private-repo.git');
+	try {
+		const repos = discoverGitHubRepos([dir], 'https://customer.ghe.com');
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'private-repo' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('discoverGitHubRepos: still matches github.com remotes when an enterprise URI is also configured', () => {
+	const dir = makeGitRepoWithRemote('https://github.com/rajbos/ai-engineering-fluency.git');
+	try {
+		const repos = discoverGitHubRepos([dir], 'https://customer.ghe.com');
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('discoverGitHubRepos: matches an on-prem GitHub Enterprise Server remote via SSH form', () => {
+	const dir = makeGitRepoWithRemote('git@github.acme-corp.com:rajbos/internal-tool.git');
+	try {
+		const repos = discoverGitHubRepos([dir], 'https://github.acme-corp.com');
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'internal-tool' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
- **Route GitHub API calls through configured GHE.com/GHES host**
- **Nightly workflow: avoid version collisions on same-day re-runs**
