### PR TITLE
Fix GHE sign-in always redirecting to github.com

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -203,7 +203,7 @@ import {
 	type RepoPrStatsResult,
 } from './githubPrService';
 import { fetchAgentSessionsForRepo } from './agentSessionsService';
-import { getConfiguredGitHubEnterpriseUri } from './githubApiConfig';
+import { getConfiguredGitHubEnterpriseUri, getGitHubAuthProviderId } from './githubApiConfig';
 
 // --- View regression ---
 import {
@@ -1318,9 +1318,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private setupGitHubAuthListener(context: vscode.ExtensionContext): void {
 		context.subscriptions.push(
 			vscode.authentication.onDidChangeSessions(async (e) => {
-				if (e.provider.id !== 'github') { return; }
+				const authProviderId = getGitHubAuthProviderId();
+				if (e.provider.id !== authProviderId) { return; }
 				if (this._githubSignedOutByUser) { return; }
-				const session = await vscode.authentication.getSession('github', ['read:user'], { createIfNone: false });
+				const session = await vscode.authentication.getSession(authProviderId, ['read:user'], { createIfNone: false });
 				if (session) {
 					this.githubSession = session;
 					await this.context.globalState.update('github.authenticated', true);
@@ -1649,7 +1650,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		try {
 			this.log('Attempting GitHub authentication...');
 			const session = await vscode.authentication.getSession(
-				'github',
+				getGitHubAuthProviderId(),
 				['read:user'],
 				{ createIfNone: true }
 			);
@@ -1748,7 +1749,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return;
 		}
 
-		const session = await vscode.authentication.getSession('github', ['read:user'], { createIfNone: false });
+		const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { createIfNone: false });
 		if (!session) {
 			const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
 			this._lastRepoPrStats = result;
@@ -1824,7 +1825,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return;
 		}
 
-		const session = await vscode.authentication.getSession('github', ['read:user'], { createIfNone: false });
+		const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { createIfNone: false });
 		if (!session) {
 			const result: AgentSessionsResult = { repos: [], totalTasks: 0, totalSessions: 0, totalCredits: 0, authenticated: false, since: since.toISOString(), fetchedAt: new Date().toISOString() };
 			this._lastAgentSessionsData = result;
@@ -1899,7 +1900,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 			// Always try silently — never prompt. This picks up sessions from Copilot
 			// or other extensions that already authenticated the user with GitHub.
-			const session = await vscode.authentication.getSession('github', ['read:user'], { createIfNone: false });
+			const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { createIfNone: false });
 			if (session) {
 				this.githubSession = session;
 				this.log(`✅ GitHub session found for ${session.account.label}`);

--- a/vscode-extension/src/githubApiConfig.ts
+++ b/vscode-extension/src/githubApiConfig.ts
@@ -71,6 +71,17 @@ export function getGitHubApiEndpoints(): GitHubApiEndpoints {
 	return deriveGitHubApiEndpoints(getConfiguredGitHubEnterpriseUri());
 }
 
+/**
+ * The `vscode.authentication` provider ID to use for the current configuration. VS Code ships two
+ * built-in GitHub auth providers: `github` (authenticates against github.com) and
+ * `github-enterprise` (authenticates against the host configured via `github-enterprise.uri`).
+ * This mirrors `getGitHubApiEndpoints()` so the auth provider decision is always consistent with
+ * the API host we end up calling.
+ */
+export function getGitHubAuthProviderId(): string {
+	return getGitHubApiEndpoints().hostname === GITHUB_API_HOSTNAME ? 'github' : 'github-enterprise';
+}
+
 /** User-Agent header value sent with all GitHub API requests. */
 export const GITHUB_API_USER_AGENT = 'copilot-token-tracker';
 

--- a/vscode-extension/test/unit/githubApiConfig.test.ts
+++ b/vscode-extension/test/unit/githubApiConfig.test.ts
@@ -1,6 +1,20 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import { deriveGitHubApiEndpoints } from '../../src/githubApiConfig';
+import * as vscode from 'vscode';
+import { deriveGitHubApiEndpoints, getGitHubAuthProviderId } from '../../src/githubApiConfig';
+
+/** Temporarily stub `github-enterprise.uri` for the duration of the callback. */
+function withEnterpriseUri<T>(uri: string | undefined, fn: () => T): T {
+	const original = vscode.workspace.getConfiguration;
+	(vscode.workspace as any).getConfiguration = () => ({
+		get: (key: string) => (key === 'github-enterprise.uri' ? uri : undefined),
+	});
+	try {
+		return fn();
+	} finally {
+		vscode.workspace.getConfiguration = original;
+	}
+}
 
 // ---------------------------------------------------------------------------
 // deriveGitHubApiEndpoints — pure function, no I/O or VS Code dependency
@@ -35,4 +49,32 @@ test('deriveGitHubApiEndpoints: derives api.<tenant> subdomain for GHE.com (data
 test('deriveGitHubApiEndpoints: derives /api/v3 and /api/graphql for on-prem GitHub Enterprise Server', () => {
 	const endpoints = deriveGitHubApiEndpoints('https://github.acme-corp.com');
 	assert.deepEqual(endpoints, { hostname: 'github.acme-corp.com', restPathPrefix: '/api/v3', graphQlPath: '/api/graphql' });
+});
+
+// ---------------------------------------------------------------------------
+// getGitHubAuthProviderId — decides which vscode.authentication provider to use
+// ---------------------------------------------------------------------------
+
+test('getGitHubAuthProviderId: returns "github" when no enterprise URI is configured', () => {
+	withEnterpriseUri(undefined, () => {
+		assert.equal(getGitHubAuthProviderId(), 'github');
+	});
+});
+
+test('getGitHubAuthProviderId: returns "github" for a github.com URI', () => {
+	withEnterpriseUri('https://github.com', () => {
+		assert.equal(getGitHubAuthProviderId(), 'github');
+	});
+});
+
+test('getGitHubAuthProviderId: returns "github-enterprise" for a GHE.com tenant URI', () => {
+	withEnterpriseUri('https://customer.ghe.com', () => {
+		assert.equal(getGitHubAuthProviderId(), 'github-enterprise');
+	});
+});
+
+test('getGitHubAuthProviderId: returns "github-enterprise" for an on-prem GitHub Enterprise Server URI', () => {
+	withEnterpriseUri('https://github.acme-corp.com', () => {
+		assert.equal(getGitHubAuthProviderId(), 'github-enterprise');
+	});
 });


### PR DESCRIPTION
## Problem
When `github-enterprise.uri` is configured (e.g. pointing to `tenant.ghe.com`), clicking "Authenticate with GitHub" in the extension still opened a browser popup to github.com. The API endpoint derivation in `githubApiConfig.ts` correctly handled GHE, but the authentication flow ignored it.

## Root cause
All 5 `vscode.authentication.getSession()` calls and the `onDidChangeSessions` listener in `extension.ts` used the hardcoded provider ID `'github'`, which always authenticates against github.com. VS Code has a separate built-in auth provider `'github-enterprise'` that authenticates against the host configured in `github-enterprise.uri`.

## Fix
- Added `getGitHubAuthProviderId()` in `githubApiConfig.ts`, which reuses the existing `getGitHubApiEndpoints()`/`deriveGitHubApiEndpoints()` logic: returns `'github'` when the derived endpoint is `api.github.com`, otherwise `'github-enterprise'`. This keeps the auth provider decision consistent with the API host used for REST/GraphQL calls.
- Replaced all 5 hardcoded `'github'` provider IDs in `extension.ts` with `getGitHubAuthProviderId()`:
  - `authenticateWithGitHub()`
  - `setupGitHubAuthListener()` (both the `onDidChangeSessions` filter and its inner `getSession` call)
  - `loadRepoPrStats()`
  - `loadAgentSessions()`
  - `restoreGitHubSession()`
- Added unit tests in `githubApiConfig.test.ts` covering `getGitHubAuthProviderId()` for github.com, GHE.com (data residency), and on-prem GitHub Enterprise Server configurations.

## Verification
- `npm run compile` (tsc + eslint + esbuild) passes.
- `npm run compile-tests` passes.
- New and existing unit tests in `test/unit/githubApiConfig.test.ts` pass (10/10).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>