### PR TITLE
Show total cost across all providers in details page with filter

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,12 @@ export interface PeriodStats {
    * rates for all others.
    */
   billingGroupCosts?: Record<string, number>;
+  /**
+   * Per-editor model usage breakdown for this period — mirrors `DailyTokenStats.editorModelUsage`.
+   * Lets consumers (e.g. the Details webview) determine which billing group(s) an editor or
+   * model belongs to, so the "Usage by Editor"/"Model Usage" lists can be filtered by provider.
+   */
+  editorModelUsage?: { [editor: string]: ModelUsage };
 }
 
 export interface DetailedStats {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3101,6 +3101,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				waterUsage: todayWater, estimatedCost: this.calculateEstimatedCost(todayStats.modelUsage),
 				estimatedCostCopilot: todayCopilotCost,
 				billingGroupCosts: this.computeBillingGroupCosts(todayStats.editorModelUsage, todayCopilotCost),
+				editorModelUsage: todayStats.editorModelUsage,
 				...(todayStats.cachedTokens > 0 ? { cachedTokens: todayStats.cachedTokens } : {})
 			},
 			month: {
@@ -3114,6 +3115,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				waterUsage: monthWater, estimatedCost: this.calculateEstimatedCost(monthStats.modelUsage),
 				estimatedCostCopilot: monthCopilotCost,
 				billingGroupCosts: this.computeBillingGroupCosts(monthStats.editorModelUsage, monthCopilotCost),
+				editorModelUsage: monthStats.editorModelUsage,
 				...(monthStats.cachedTokens > 0 ? { cachedTokens: monthStats.cachedTokens } : {})
 			},
 			lastMonth: {
@@ -3127,6 +3129,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				waterUsage: lastMonthWater, estimatedCost: this.calculateEstimatedCost(lastMonthStats.modelUsage),
 				estimatedCostCopilot: lastMonthCopilotCost,
 				billingGroupCosts: this.computeBillingGroupCosts(lastMonthStats.editorModelUsage, lastMonthCopilotCost),
+				editorModelUsage: lastMonthStats.editorModelUsage,
 				...(lastMonthStats.cachedTokens > 0 ? { cachedTokens: lastMonthStats.cachedTokens } : {})
 			},
 			last30Days: {
@@ -3140,6 +3143,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				waterUsage: last30DaysWater, estimatedCost: this.calculateEstimatedCost(last30DaysStats.modelUsage),
 				estimatedCostCopilot: last30DaysCopilotCost,
 				billingGroupCosts: this.computeBillingGroupCosts(last30DaysStats.editorModelUsage, last30DaysCopilotCost),
+				editorModelUsage: last30DaysStats.editorModelUsage,
 				...(last30DaysStats.cachedTokens > 0 ? { cachedTokens: last30DaysStats.cachedTokens } : {})
 			},
 			lastUpdated: now

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3245,15 +3245,19 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private buildCostParts(show: StatusBarDisplaySetting, stats: DetailedStats): string[] {
 		const fmt = (v: number) => `$${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+		const totalCost = (period: PeriodStats) => {
+			const billingTotal = this.sumBillingGroupCosts(period.billingGroupCosts);
+			return billingTotal > 0 || period.billingGroupCosts ? billingTotal : (period.estimatedCostCopilot ?? 0);
+		};
 		const parts: string[] = [];
 		if (show === 'today' || show === 'both' || show === 'todayAndCurrentMonth') {
-			parts.push(fmt(stats.today.estimatedCostCopilot ?? 0));
+			parts.push(fmt(totalCost(stats.today)));
 		}
 		if (show === 'last30days' || show === 'both') {
-			parts.push(fmt(stats.last30Days.estimatedCostCopilot ?? 0));
+			parts.push(fmt(totalCost(stats.last30Days)));
 		}
 		if (show === 'currentMonth' || show === 'todayAndCurrentMonth') {
-			parts.push(fmt(stats.month.estimatedCostCopilot ?? 0));
+			parts.push(fmt(totalCost(stats.month)));
 		}
 		return parts;
 	}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8126,6 +8126,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     const sortSettings = this.context.globalState.get('details.sortSettings', {
       editor: { key: 'name', dir: 'asc' },
       model: { key: 'name', dir: 'asc' },
+      excludedProviders: [],
     });
     const dataWithBackend = {
       ...stats,

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -10,6 +10,7 @@ import styles from './styles.css';
 import { getWindowData } from '../../../../src/webview/shared/dataLoader';
 import { registerMessageHandler } from '../shared/messageHandler';
 import type { ModelUsage } from '../shared/types';
+import { getBillingGroup } from '../../../../src/chartDataBuilder';
 
 type EditorUsage = Record<string, { tokens: number; sessions: number }>;
 type TableSortKey = 'name' | 'today' | 'last30Days' | 'month' | 'lastMonth' | 'projected';
@@ -37,6 +38,8 @@ cachedTokens?: number;
  * GitHub Copilot's UBB billing.
  */
 billingGroupCosts?: Record<string, number>;
+/** Per-editor model usage breakdown, used to determine which billing group(s) an editor/model belongs to for provider filtering. */
+editorModelUsage?: { [editor: string]: ModelUsage };
 };
 
 type DetailedStats = {
@@ -300,15 +303,13 @@ const isEmptyState = (stats.today.tokens ?? 0) === 0 && (stats.last30Days.tokens
 if (isEmptyState) {
 sections.append(buildEmptyStateSection());
 } else {
-sections.append(buildSummaryCards(stats));
+const providerPanel = buildProviderPanel(stats);
+if (providerPanel) {
+sections.append(providerPanel);
+}
 }
 
 sections.append(buildMetricsSection(stats, projections));
-
-const providerCostSection = buildCostByProviderSection(stats);
-if (providerCostSection) {
-sections.append(providerCostSection);
-}
 
 const editorSection = buildEditorUsageSection(stats);
 if (editorSection) {
@@ -378,32 +379,6 @@ function buildPlanBadge(stats: DetailedStats): HTMLElement | null {
 	return badge;
 }
 
-/** Creates a single summary card (label above value), matching the chart webview pattern. */
-function buildCard(id: string, label: string, value: string): HTMLElement {
-	const card = el('div', 'card');
-	card.id = id;
-	card.append(el('div', 'card-label', label), el('div', 'card-value', value));
-	return card;
-}
-
-/** Builds the row of hero summary cards shown above the metrics table. */
-function buildSummaryCards(stats: DetailedStats): HTMLElement {
-	const cards = el('div', 'cards');
-	cards.id = 'summary-cards';
-	const allProviders = getAllProviders(stats);
-	const costCard = buildCard('card-month-cost', '💰 Est. Cost This Month', formatCost(totalCostForPeriod(stats.month, allProviders)));
-	costCard.title = allProviders.length > 0
-		? `Sum of estimated costs across ${includedProviders(allProviders).length} of ${allProviders.length} selected provider(s). Use the "⚙ Providers" filter in the Cost by Provider section to change which providers are included.`
-		: 'Based on GitHub Copilot AI Credit rates (UBB) — no per-provider breakdown is available yet.';
-	cards.append(
-		buildCard('card-today-tokens', '📅 Tokens Today', totalTokenCell(stats.today)),
-		buildCard('card-30d-tokens', '📈 Tokens Last 30 Days', totalTokenCell(stats.last30Days)),
-		costCard,
-		buildCard('card-today-sessions', '📂 Sessions Today', formatNumber(stats.today.sessions)),
-	);
-	return cards;
-}
-
 type MetricGroup = { heading: string; rows: MetricRow[] };
 
 function buildMetricsGroups(stats: DetailedStats, projections: Projections): MetricGroup[] {
@@ -440,6 +415,17 @@ function buildGroupHeaderRow(label: string): HTMLTableRowElement {
 	const td = document.createElement('td');
 	td.colSpan = 6;
 	td.textContent = label;
+	tr.append(td);
+	return tr;
+}
+
+/** Builds a single-row, full-width placeholder for tables emptied out by the provider filter. */
+function buildNoDataRow(colSpan: number, message: string): HTMLTableRowElement {
+	const tr = document.createElement('tr');
+	tr.className = 'no-data-row';
+	const td = document.createElement('td');
+	td.colSpan = colSpan;
+	td.textContent = message;
 	tr.append(td);
 	return tr;
 }
@@ -483,130 +469,83 @@ return section;
 // Cost by Provider section
 // ---------------------------------------------------------------------------
 
-type ProviderCostItem = { provider: string; today: number; last30Days: number; month: number; lastMonth: number; projected: number };
+/** Emoji shown next to each billing-group/provider name in the provider panel. */
+const PROVIDER_ICONS: Record<string, string> = {
+	'GitHub Copilot': '🐙',
+	'Anthropic': '🅰️',
+	'Google': '🔷',
+	'OpenAI': '🟢',
+	'Mistral AI': '🌬️',
+	'xAI': '✖️',
+	'Microsoft': '🪟',
+	'Alibaba': '🐉',
+	'Other': '❔',
+};
 
-function buildProviderCostItem(stats: DetailedStats, provider: string): ProviderCostItem {
-	const today = stats.today.billingGroupCosts?.[provider] || 0;
-	const last30Days = stats.last30Days.billingGroupCosts?.[provider] || 0;
-	const month = stats.month.billingGroupCosts?.[provider] || 0;
-	const lastMonth = stats.lastMonth.billingGroupCosts?.[provider] || 0;
-	return { provider, today, last30Days, month, lastMonth, projected: calculateProjection(last30Days) };
+function getProviderIcon(provider: string): string {
+	return PROVIDER_ICONS[provider] ?? '💵';
 }
 
-/** Builds a single provider row, greyed out (but still visible) when filtered out via the checkbox menu. */
-function buildProviderCostRow(item: ProviderCostItem, isExcluded: boolean): HTMLTableRowElement {
-	const tr = document.createElement('tr');
-	if (isExcluded) { tr.style.opacity = '0.45'; }
-	const labelTd = document.createElement('td');
-	const labelWrapper = document.createElement('span');
-	labelWrapper.className = 'metric-label';
-	labelWrapper.textContent = `💵 ${item.provider}`;
-	labelTd.append(labelWrapper);
-	tr.append(labelTd,
-		buildValueCell(formatCost(item.today)),
-		buildValueCell(formatCost(item.last30Days)),
-		buildValueCell(formatCost(item.month)),
-		buildValueCell(formatCost(item.lastMonth)),
-		buildValueCell(formatCost(item.projected)));
-	return tr;
-}
+/** Builds a single clickable provider card; clicking toggles it in/out of `excludedProviders`. */
+function buildProviderCard(stats: DetailedStats, provider: string): HTMLElement {
+	const isExcluded = excludedProviders.has(provider);
+	const card = el('div', `provider-card${isExcluded ? ' provider-card-excluded' : ''}`);
+	card.tabIndex = 0;
+	card.setAttribute('role', 'button');
+	card.setAttribute('aria-pressed', String(!isExcluded));
+	card.title = isExcluded
+		? `${provider} is hidden — click to show it again and include it in the totals below.`
+		: `Click to hide ${provider} — filters it out of the totals and the Editor/Model usage lists below.`;
 
-/** Builds the bold "Total (selected providers)" footer row summing only the checked providers. */
-function buildProviderCostTotalRow(stats: DetailedStats, allProviders: string[]): HTMLTableRowElement {
-	const providers = includedProviders(allProviders);
-	const tr = document.createElement('tr');
-	tr.style.fontWeight = '700';
-	tr.style.borderTop = '2px solid var(--border-color)';
-	const labelTd = document.createElement('td');
-	const labelWrapper = document.createElement('span');
-	labelWrapper.className = 'metric-label';
-	labelWrapper.textContent = `∑ Total (${providers.length}/${allProviders.length} selected)`;
-	labelTd.append(labelWrapper);
-	tr.append(labelTd,
-		buildValueCell(formatCost(sumBillingGroupCosts(stats.today.billingGroupCosts, providers))),
-		buildValueCell(formatCost(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, providers))),
-		buildValueCell(formatCost(sumBillingGroupCosts(stats.month.billingGroupCosts, providers))),
-		buildValueCell(formatCost(sumBillingGroupCosts(stats.lastMonth.billingGroupCosts, providers))),
-		buildValueCell(formatCost(calculateProjection(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, providers)))));
-	return tr;
-}
+	card.append(
+		el('div', 'provider-card-label', `${getProviderIcon(provider)} ${provider}`),
+		el('div', 'provider-card-value', formatCost(stats.month.billingGroupCosts?.[provider] || 0)),
+		el('div', 'provider-card-sub', `Today ${formatCost(stats.today.billingGroupCosts?.[provider] || 0)} · 30d ${formatCost(stats.last30Days.billingGroupCosts?.[provider] || 0)}`)
+	);
 
-/** Builds the "⚙ Providers" filter toggle button + its checkbox dropdown menu. */
-function buildProviderFilterControl(allProviders: string[]): HTMLElement {
-	const wrap = el('div', 'provider-filter-wrap');
-	const toggle = document.createElement('button');
-	toggle.type = 'button';
-	toggle.className = 'provider-filter-toggle';
-	toggle.textContent = '⚙ Providers';
-	const menu = el('div', 'provider-filter-menu');
-	menu.style.display = 'none';
-
-	allProviders.forEach(provider => {
-		const label = el('label', 'provider-filter-item');
-		const checkbox = document.createElement('input');
-		checkbox.type = 'checkbox';
-		checkbox.checked = !excludedProviders.has(provider);
-		checkbox.addEventListener('change', () => {
-			if (checkbox.checked) { excludedProviders.delete(provider); } else { excludedProviders.add(provider); }
-			saveSortSettings();
-			rerenderFromLastStats();
-		});
-		const span = document.createElement('span');
-		span.textContent = provider;
-		label.append(checkbox, span);
-		menu.append(label);
+	const toggle = (): void => {
+		if (excludedProviders.has(provider)) { excludedProviders.delete(provider); } else { excludedProviders.add(provider); }
+		saveSortSettings();
+		rerenderFromLastStats();
+	};
+	card.addEventListener('click', toggle);
+	card.addEventListener('keydown', (e) => {
+		if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
 	});
+	return card;
+}
 
-	toggle.addEventListener('click', (e) => {
-		e.stopPropagation();
-		menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
-	});
-	menu.addEventListener('click', (e) => e.stopPropagation());
-	document.addEventListener('click', () => { menu.style.display = 'none'; });
-
-	wrap.append(toggle, menu);
-	return wrap;
+/** Builds the non-interactive "Total (selected)" card summarizing the currently included providers. */
+function buildProviderTotalCard(stats: DetailedStats, allProviders: string[]): HTMLElement {
+	const included = includedProviders(allProviders);
+	const card = el('div', 'provider-card provider-card-total');
+	card.title = `Sum of ${included.length} of ${allProviders.length} selected provider(s).`;
+	card.append(
+		el('div', 'provider-card-label', '∑ Total (selected)'),
+		el('div', 'provider-card-value', formatCost(sumBillingGroupCosts(stats.month.billingGroupCosts, included))),
+		el('div', 'provider-card-sub', `Today ${formatCost(sumBillingGroupCosts(stats.today.billingGroupCosts, included))} · 30d ${formatCost(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, included))}`)
+	);
+	return card;
 }
 
 /**
- * Builds the "Cost by Provider" table showing estimated cost per billing group
- * (GitHub Copilot, Anthropic, Google, OpenAI, …) for every period, plus a
- * checkbox filter so specific providers can be excluded from the totals shown
- * in the summary card and the "Estimated cost (selected providers)" metric row.
+ * Builds the "Cost by Provider" panel shown at the top of the page (replacing the old
+ * fixed hero cards). Each provider is a clickable card — clicking toggles it in/out of
+ * `excludedProviders`, which also filters the "Usage by Editor" and "Model Usage" lists
+ * further down the page to just the selected provider(s).
  */
-function buildCostByProviderSection(stats: DetailedStats): HTMLElement | null {
+function buildProviderPanel(stats: DetailedStats): HTMLElement | null {
 	const allProviders = getAllProviders(stats);
 	if (allProviders.length === 0) { return null; }
 
 	const section = el('div', 'section');
-	const headerRow = el('div', 'section-header-row');
-	headerRow.append(iconHeading('h3', 'credit-card', 'Cost by Provider'), buildProviderFilterControl(allProviders));
-	section.append(headerRow);
+	section.append(iconHeading('h3', 'credit-card', 'Cost by Provider'));
+	section.append(el('div', 'provider-panel-hint', 'Click a provider to hide/show it — this also filters the Editor & Model usage lists below.'));
 
-	const table = document.createElement('table');
-	table.className = 'stats-table';
-	const thead = document.createElement('thead');
-	const headRow = document.createElement('tr');
-	const HEADERS = [{ icon: '💵', text: 'Provider' }, { icon: '📅', text: 'Today' }, { icon: '📈', text: 'Last 30 Days' }, { icon: '🗓️', text: 'Current Month' }, { icon: '📆', text: 'Previous Month' }, { icon: '🌍', text: 'Projected Year' }];
-	HEADERS.forEach((h, idx) => {
-		const th = document.createElement('th');
-		th.className = idx === 0 ? '' : 'align-right';
-		const w = el('div', 'period-header');
-		w.textContent = `${h.icon} ${h.text}`;
-		th.append(w);
-		headRow.append(th);
-	});
-	thead.append(headRow);
-	table.append(thead);
-
-	const tbody = document.createElement('tbody');
-	allProviders.forEach(provider => {
-		const item = buildProviderCostItem(stats, provider);
-		tbody.append(buildProviderCostRow(item, excludedProviders.has(provider)));
-	});
-	tbody.append(buildProviderCostTotalRow(stats, allProviders));
-	table.append(tbody);
-	section.append(table);
+	const grid = el('div', 'provider-cards');
+	grid.append(buildProviderTotalCard(stats, allProviders));
+	allProviders.forEach(provider => grid.append(buildProviderCard(stats, provider)));
+	section.append(grid);
 	return section;
 }
 
@@ -631,10 +570,12 @@ excludedProviders: Array.from(excludedProviders)
 // Cost-by-provider helpers
 // ---------------------------------------------------------------------------
 
+const ALL_PERIODS = ['today', 'last30Days', 'month', 'lastMonth'] as const;
+
 /** Returns every billing-group (provider) name seen across all four periods, "GitHub Copilot" first. */
 function getAllProviders(stats: DetailedStats): string[] {
 const set = new Set<string>();
-(['today', 'last30Days', 'month', 'lastMonth'] as const).forEach(period => {
+ALL_PERIODS.forEach(period => {
 Object.keys(stats[period].billingGroupCosts ?? {}).forEach(p => set.add(p));
 });
 return Array.from(set).sort((a, b) => {
@@ -665,6 +606,40 @@ if (allProviders.length === 0) {
 return period.estimatedCostCopilot ?? period.estimatedCost ?? 0;
 }
 return sumBillingGroupCosts(period.billingGroupCosts, includedProviders(allProviders));
+}
+
+/** Billing group(s) an editor's usage falls into, derived from its per-model breakdown across all periods. */
+function editorBillingGroups(stats: DetailedStats, editor: string): Set<string> {
+	const groups = new Set<string>();
+	ALL_PERIODS.forEach(period => {
+		const modelUsage = stats[period].editorModelUsage?.[editor];
+		if (modelUsage) { Object.keys(modelUsage).forEach(model => groups.add(getBillingGroup(editor, model))); }
+	});
+	return groups;
+}
+
+/** Billing group(s) a model belongs to, derived from every editor that used it across all periods. */
+function modelBillingGroups(stats: DetailedStats, model: string): Set<string> {
+	const groups = new Set<string>();
+	ALL_PERIODS.forEach(period => {
+		const editorModelUsage = stats[period].editorModelUsage;
+		if (!editorModelUsage) { return; }
+		Object.keys(editorModelUsage).forEach(editor => {
+			if (editorModelUsage[editor][model]) { groups.add(getBillingGroup(editor, model)); }
+		});
+	});
+	return groups;
+}
+
+/**
+ * Whether an item (editor or model) should remain visible given the current provider filter.
+ * With nothing excluded, everything is visible. When we have no billing-group data for the
+ * item (e.g. older cached stats), it is never hidden — we only filter what we can attribute.
+ */
+function isVisibleForProviderFilter(groups: Set<string>): boolean {
+	if (excludedProviders.size === 0) { return true; }
+	if (groups.size === 0) { return true; }
+	return Array.from(groups).some(g => !excludedProviders.has(g));
 }
 
 type EditorItem = {
@@ -702,14 +677,14 @@ function buildEditorRow(item: EditorItem, totals: { today: number; last30Days: n
 	return tr;
 }
 
-function buildEditorTbody(stats: DetailedStats, allEditors: string[]): HTMLTableSectionElement {
+function buildEditorTbody(stats: DetailedStats, editors: string[]): HTMLTableSectionElement {
 const totals = {
-	today: Object.values(stats.today.editorUsage).reduce((s, e) => s + e.tokens, 0),
-	last30Days: Object.values(stats.last30Days.editorUsage).reduce((s, e) => s + e.tokens, 0),
-	month: Object.values(stats.month.editorUsage).reduce((s, e) => s + e.tokens, 0),
-	lastMonth: Object.values(stats.lastMonth.editorUsage).reduce((s, e) => s + e.tokens, 0),
+	today: editors.reduce((s, e) => s + (stats.today.editorUsage[e]?.tokens || 0), 0),
+	last30Days: editors.reduce((s, e) => s + (stats.last30Days.editorUsage[e]?.tokens || 0), 0),
+	month: editors.reduce((s, e) => s + (stats.month.editorUsage[e]?.tokens || 0), 0),
+	lastMonth: editors.reduce((s, e) => s + (stats.lastMonth.editorUsage[e]?.tokens || 0), 0),
 };
-const items: EditorItem[] = allEditors.map(editor => {
+const items: EditorItem[] = editors.map(editor => {
 	const todayUsage = stats.today.editorUsage[editor] || { tokens: 0, sessions: 0 };
 	const last30DaysUsage = stats.last30Days.editorUsage[editor] || { tokens: 0, sessions: 0 };
 	const monthUsage = stats.month.editorUsage[editor] || { tokens: 0, sessions: 0 };
@@ -730,6 +705,10 @@ items.sort((a, b) => {
 	return editorSortDir === 'asc' ? cmp : -cmp;
 });
 const tbody = document.createElement('tbody');
+if (items.length === 0) {
+	tbody.append(buildNoDataRow(6, 'No editor usage matches the selected provider filter.'));
+	return tbody;
+}
 items.forEach(item => tbody.append(buildEditorRow(item, totals)));
 return tbody;
 }
@@ -745,6 +724,8 @@ const allEditors = new Set([
 if (allEditors.size === 0) {
 return null;
 }
+
+const visibleEditors = Array.from(allEditors).filter(editor => isVisibleForProviderFilter(editorBillingGroups(stats, editor)));
 
 const section = el('div', 'section');
 const heading = iconHeading('h3', 'device-desktop', 'Usage by Editor');
@@ -773,7 +754,7 @@ editorSortDir = editorSortDir === 'asc' ? 'desc' : 'asc';
 editorSortKey = key;
 editorSortDir = key === 'name' ? 'asc' : 'desc';
 }
-const newTbody = buildEditorTbody(stats, Array.from(allEditors));
+const newTbody = buildEditorTbody(stats, visibleEditors);
 const oldTbody = table.querySelector('tbody');
 if (oldTbody) { table.replaceChild(newTbody, oldTbody); } else { table.append(newTbody); }
 saveSortSettings();
@@ -781,7 +762,7 @@ saveSortSettings();
 );
 
 table.append(thead);
-table.append(buildEditorTbody(stats, Array.from(allEditors)));
+table.append(buildEditorTbody(stats, visibleEditors));
 section.append(table);
 return section;
 }
@@ -925,14 +906,7 @@ if (allModels.size === 0) {
 return null;
 }
 
-// Determine top N models by last30Days usage; the rest go into the "Other" group
-const sortedByLast30Days = Array.from(allModels).sort((a, b) => {
-const aUsage = stats.last30Days.modelUsage[a] || { inputTokens: 0, outputTokens: 0 };
-const bUsage = stats.last30Days.modelUsage[b] || { inputTokens: 0, outputTokens: 0 };
-return (bUsage.inputTokens + bUsage.outputTokens) - (aUsage.inputTokens + aUsage.outputTokens);
-});
-const topModels = sortedByLast30Days.slice(0, TOP_N_MODELS);
-const otherModels = sortedByLast30Days.slice(TOP_N_MODELS);
+const visibleModels = new Set(Array.from(allModels).filter(model => isVisibleForProviderFilter(modelBillingGroups(stats, model))));
 
 const section = el('div', 'section');
 const heading = iconHeading('h3', 'symbol-numeric', 'Model Usage (Tokens)');
@@ -940,6 +914,23 @@ section.append(heading);
 
 const table = document.createElement('table');
 table.className = 'stats-table';
+
+if (visibleModels.size === 0) {
+const tbody = document.createElement('tbody');
+tbody.append(buildNoDataRow(6, 'No model usage matches the selected provider filter.'));
+table.append(tbody);
+section.append(table);
+return section;
+}
+
+// Determine top N models by last30Days usage; the rest go into the "Other" group
+const sortedByLast30Days = Array.from(visibleModels).sort((a, b) => {
+const aUsage = stats.last30Days.modelUsage[a] || { inputTokens: 0, outputTokens: 0 };
+const bUsage = stats.last30Days.modelUsage[b] || { inputTokens: 0, outputTokens: 0 };
+return (bUsage.inputTokens + bUsage.outputTokens) - (aUsage.inputTokens + aUsage.outputTokens);
+});
+const topModels = sortedByLast30Days.slice(0, TOP_N_MODELS);
+const otherModels = sortedByLast30Days.slice(TOP_N_MODELS);
 
 const modelColHeaders: ColHeader[] = [
 { icon: '🧠', text: 'Model', key: 'name' },

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -31,6 +31,12 @@ waterUsage: number;
 estimatedCost: number;
 estimatedCostCopilot?: number;
 cachedTokens?: number;
+/**
+ * Estimated cost per billing group (e.g. "GitHub Copilot", "Anthropic", "Google")
+ * for this period in USD. Used to show/filter cost across all providers, not just
+ * GitHub Copilot's UBB billing.
+ */
+billingGroupCosts?: Record<string, number>;
 };
 
 type DetailedStats = {
@@ -51,6 +57,8 @@ sortSettings?: {
 editor?: { key?: string; dir?: string };
 model?: { key?: string; dir?: string };
 modelOtherExpanded?: boolean;
+/** Billing-group (provider) names that the user has unchecked in the cost provider filter. */
+excludedProviders?: string[];
 };
 };
 
@@ -67,6 +75,7 @@ type WebviewMessage =
 editor: { key: TableSortKey; dir: SortDir };
 model: { key: TableSortKey; dir: SortDir };
 modelOtherExpanded: boolean;
+excludedProviders: string[];
 }};
 
 /** Aggregated projection values calculated from last-30-days data. */
@@ -107,6 +116,10 @@ let editorSortDir: SortDir = (_initSort?.editor?.dir as SortDir) ?? 'asc';
 let modelSortKey: TableSortKey = (_initSort?.model?.key as TableSortKey) ?? 'name';
 let modelSortDir: SortDir = (_initSort?.model?.dir as SortDir) ?? 'asc';
 let modelOtherExpanded: boolean = (_initSort?.modelOtherExpanded) ?? false;
+/** Billing-group (provider) names deselected in the "Cost by Provider" filter. Empty = all providers included. */
+let excludedProviders: Set<string> = new Set(_initSort?.excludedProviders ?? []);
+/** Last rendered stats, kept so provider-filter toggles can trigger a full re-render. */
+let lastStats: DetailedStats | null = null;
 
 function calculateProjection(last30DaysValue: number): number {
 // Project annual value based on last 30 days average
@@ -218,14 +231,16 @@ return { thead, updateHeaders };
 
 function render(stats: DetailedStats): void {
 setCompactNumbers(stats.compactNumbers !== false);
+lastStats = stats;
 const root = document.getElementById('root');
 if (!root) { return; }
 
+const allProviders = getAllProviders(stats);
 const projectedTokens = Math.round(calculateProjection(stats.last30Days.tokens + stats.last30Days.thinkingTokens));
 const projectedSessions = Math.round(calculateProjection(stats.last30Days.sessions));
 const projectedCo2 = calculateProjection(stats.last30Days.co2);
 const projectedWater = calculateProjection(stats.last30Days.waterUsage);
-const projectedCost = calculateProjection(stats.last30Days.estimatedCost);
+const projectedCost = calculateProjection(totalCostForPeriod(stats.last30Days, allProviders));
 const projectedCostCopilot = calculateProjection(stats.last30Days.estimatedCostCopilot ?? 0);
 const projectedTrees = calculateProjection(stats.last30Days.treesEquivalent);
 
@@ -240,6 +255,11 @@ projectedTrees
 });
 
 wireButtons();
+}
+
+/** Re-renders using the last stats payload — used after the provider filter changes. */
+function rerenderFromLastStats(): void {
+if (lastStats) { render(lastStats); }
 }
 
 function renderShell(
@@ -284,6 +304,11 @@ sections.append(buildSummaryCards(stats));
 }
 
 sections.append(buildMetricsSection(stats, projections));
+
+const providerCostSection = buildCostByProviderSection(stats);
+if (providerCostSection) {
+sections.append(providerCostSection);
+}
 
 const editorSection = buildEditorUsageSection(stats);
 if (editorSection) {
@@ -365,10 +390,15 @@ function buildCard(id: string, label: string, value: string): HTMLElement {
 function buildSummaryCards(stats: DetailedStats): HTMLElement {
 	const cards = el('div', 'cards');
 	cards.id = 'summary-cards';
+	const allProviders = getAllProviders(stats);
+	const costCard = buildCard('card-month-cost', '💰 Est. Cost This Month', formatCost(totalCostForPeriod(stats.month, allProviders)));
+	costCard.title = allProviders.length > 0
+		? `Sum of estimated costs across ${includedProviders(allProviders).length} of ${allProviders.length} selected provider(s). Use the "⚙ Providers" filter in the Cost by Provider section to change which providers are included.`
+		: 'Based on GitHub Copilot AI Credit rates (UBB) — no per-provider breakdown is available yet.';
 	cards.append(
 		buildCard('card-today-tokens', '📅 Tokens Today', totalTokenCell(stats.today)),
 		buildCard('card-30d-tokens', '📈 Tokens Last 30 Days', totalTokenCell(stats.last30Days)),
-		buildCard('card-month-cost', '💰 Est. Cost This Month (UBB)', formatCost(stats.month.estimatedCostCopilot ?? 0)),
+		costCard,
 		buildCard('card-today-sessions', '📂 Sessions Today', formatNumber(stats.today.sessions)),
 	);
 	return cards;
@@ -377,6 +407,7 @@ function buildSummaryCards(stats: DetailedStats): HTMLElement {
 type MetricGroup = { heading: string; rows: MetricRow[] };
 
 function buildMetricsGroups(stats: DetailedStats, projections: Projections): MetricGroup[] {
+	const allProviders = getAllProviders(stats);
 	const tokenRows: MetricRow[] = [
 		{ label: 'Total tokens', labelTooltip: 'All LLM API tokens counted across every call in this period — matches the status bar. When debug logs are available this is the definitive total; otherwise it falls back to per-model attribution or the text-based estimate.', icon: '🟣', color: '#c37bff', today: totalTokenCell(stats.today), last30Days: totalTokenCell(stats.last30Days), month: totalTokenCell(stats.month), lastMonth: totalTokenCell(stats.lastMonth), projected: formatCompact(projections.projectedTokens) },
 		{ label: 'Input tokens', labelTooltip: 'Total prompt tokens sent to the model, including any cache-read tokens (shown separately below).', icon: '⬆️', color: '#c37bff', today: inputTokenCell(stats.today), last30Days: inputTokenCell(stats.last30Days), month: inputTokenCell(stats.month), lastMonth: inputTokenCell(stats.lastMonth), projected: '—' },
@@ -387,7 +418,8 @@ function buildMetricsGroups(stats: DetailedStats, projections: Projections): Met
 		{ label: 'Thinking tokens', icon: '🧠', color: '#a78bfa', today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), month: formatCompact(stats.month.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: '—' },
 	];
 	const costRows: MetricRow[] = [
-		{ label: 'Estimated cost (UBB)', labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. UBB = Usage Based Billing.', icon: '🟢', color: '#7ce38b', today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), month: formatCost(stats.month.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) },
+		{ label: 'Estimated cost (selected providers)', labelTooltip: 'Sum of estimated cost across the providers selected in the Cost by Provider filter below — GitHub Copilot uses UBB AI Credit rates, other providers use their own API pricing.', icon: '💵', color: '#7ce38b', today: formatCost(totalCostForPeriod(stats.today, allProviders)), last30Days: formatCost(totalCostForPeriod(stats.last30Days, allProviders)), month: formatCost(totalCostForPeriod(stats.month, allProviders)), lastMonth: formatCost(totalCostForPeriod(stats.lastMonth, allProviders)), projected: formatCost(projections.projectedCost) },
+		{ label: 'Estimated cost (GitHub Copilot UBB)', labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. UBB = Usage Based Billing.', icon: '🟢', color: '#7ce38b', today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), month: formatCost(stats.month.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) },
 	];
 	const activityRows: MetricRow[] = [
 		{ label: 'Sessions', icon: '📂', color: '#66aaff', today: formatNumber(stats.today.sessions), last30Days: formatNumber(stats.last30Days.sessions), month: formatNumber(stats.month.sessions), lastMonth: formatNumber(stats.lastMonth.sessions), projected: formatNumber(projections.projectedSessions) },
@@ -447,6 +479,137 @@ section.append(table);
 return section;
 }
 
+// ---------------------------------------------------------------------------
+// Cost by Provider section
+// ---------------------------------------------------------------------------
+
+type ProviderCostItem = { provider: string; today: number; last30Days: number; month: number; lastMonth: number; projected: number };
+
+function buildProviderCostItem(stats: DetailedStats, provider: string): ProviderCostItem {
+	const today = stats.today.billingGroupCosts?.[provider] || 0;
+	const last30Days = stats.last30Days.billingGroupCosts?.[provider] || 0;
+	const month = stats.month.billingGroupCosts?.[provider] || 0;
+	const lastMonth = stats.lastMonth.billingGroupCosts?.[provider] || 0;
+	return { provider, today, last30Days, month, lastMonth, projected: calculateProjection(last30Days) };
+}
+
+/** Builds a single provider row, greyed out (but still visible) when filtered out via the checkbox menu. */
+function buildProviderCostRow(item: ProviderCostItem, isExcluded: boolean): HTMLTableRowElement {
+	const tr = document.createElement('tr');
+	if (isExcluded) { tr.style.opacity = '0.45'; }
+	const labelTd = document.createElement('td');
+	const labelWrapper = document.createElement('span');
+	labelWrapper.className = 'metric-label';
+	labelWrapper.textContent = `💵 ${item.provider}`;
+	labelTd.append(labelWrapper);
+	tr.append(labelTd,
+		buildValueCell(formatCost(item.today)),
+		buildValueCell(formatCost(item.last30Days)),
+		buildValueCell(formatCost(item.month)),
+		buildValueCell(formatCost(item.lastMonth)),
+		buildValueCell(formatCost(item.projected)));
+	return tr;
+}
+
+/** Builds the bold "Total (selected providers)" footer row summing only the checked providers. */
+function buildProviderCostTotalRow(stats: DetailedStats, allProviders: string[]): HTMLTableRowElement {
+	const providers = includedProviders(allProviders);
+	const tr = document.createElement('tr');
+	tr.style.fontWeight = '700';
+	tr.style.borderTop = '2px solid var(--border-color)';
+	const labelTd = document.createElement('td');
+	const labelWrapper = document.createElement('span');
+	labelWrapper.className = 'metric-label';
+	labelWrapper.textContent = `∑ Total (${providers.length}/${allProviders.length} selected)`;
+	labelTd.append(labelWrapper);
+	tr.append(labelTd,
+		buildValueCell(formatCost(sumBillingGroupCosts(stats.today.billingGroupCosts, providers))),
+		buildValueCell(formatCost(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, providers))),
+		buildValueCell(formatCost(sumBillingGroupCosts(stats.month.billingGroupCosts, providers))),
+		buildValueCell(formatCost(sumBillingGroupCosts(stats.lastMonth.billingGroupCosts, providers))),
+		buildValueCell(formatCost(calculateProjection(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, providers)))));
+	return tr;
+}
+
+/** Builds the "⚙ Providers" filter toggle button + its checkbox dropdown menu. */
+function buildProviderFilterControl(allProviders: string[]): HTMLElement {
+	const wrap = el('div', 'provider-filter-wrap');
+	const toggle = document.createElement('button');
+	toggle.type = 'button';
+	toggle.className = 'provider-filter-toggle';
+	toggle.textContent = '⚙ Providers';
+	const menu = el('div', 'provider-filter-menu');
+	menu.style.display = 'none';
+
+	allProviders.forEach(provider => {
+		const label = el('label', 'provider-filter-item');
+		const checkbox = document.createElement('input');
+		checkbox.type = 'checkbox';
+		checkbox.checked = !excludedProviders.has(provider);
+		checkbox.addEventListener('change', () => {
+			if (checkbox.checked) { excludedProviders.delete(provider); } else { excludedProviders.add(provider); }
+			saveSortSettings();
+			rerenderFromLastStats();
+		});
+		const span = document.createElement('span');
+		span.textContent = provider;
+		label.append(checkbox, span);
+		menu.append(label);
+	});
+
+	toggle.addEventListener('click', (e) => {
+		e.stopPropagation();
+		menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+	});
+	menu.addEventListener('click', (e) => e.stopPropagation());
+	document.addEventListener('click', () => { menu.style.display = 'none'; });
+
+	wrap.append(toggle, menu);
+	return wrap;
+}
+
+/**
+ * Builds the "Cost by Provider" table showing estimated cost per billing group
+ * (GitHub Copilot, Anthropic, Google, OpenAI, …) for every period, plus a
+ * checkbox filter so specific providers can be excluded from the totals shown
+ * in the summary card and the "Estimated cost (selected providers)" metric row.
+ */
+function buildCostByProviderSection(stats: DetailedStats): HTMLElement | null {
+	const allProviders = getAllProviders(stats);
+	if (allProviders.length === 0) { return null; }
+
+	const section = el('div', 'section');
+	const headerRow = el('div', 'section-header-row');
+	headerRow.append(iconHeading('h3', 'credit-card', 'Cost by Provider'), buildProviderFilterControl(allProviders));
+	section.append(headerRow);
+
+	const table = document.createElement('table');
+	table.className = 'stats-table';
+	const thead = document.createElement('thead');
+	const headRow = document.createElement('tr');
+	const HEADERS = [{ icon: '💵', text: 'Provider' }, { icon: '📅', text: 'Today' }, { icon: '📈', text: 'Last 30 Days' }, { icon: '🗓️', text: 'Current Month' }, { icon: '📆', text: 'Previous Month' }, { icon: '🌍', text: 'Projected Year' }];
+	HEADERS.forEach((h, idx) => {
+		const th = document.createElement('th');
+		th.className = idx === 0 ? '' : 'align-right';
+		const w = el('div', 'period-header');
+		w.textContent = `${h.icon} ${h.text}`;
+		th.append(w);
+		headRow.append(th);
+	});
+	thead.append(headRow);
+	table.append(thead);
+
+	const tbody = document.createElement('tbody');
+	allProviders.forEach(provider => {
+		const item = buildProviderCostItem(stats, provider);
+		tbody.append(buildProviderCostRow(item, excludedProviders.has(provider)));
+	});
+	tbody.append(buildProviderCostTotalRow(stats, allProviders));
+	table.append(tbody);
+	section.append(table);
+	return section;
+}
+
 function getSortIndicator(colKey: TableSortKey, activeKey: TableSortKey, dir: SortDir): string {
 if (colKey !== activeKey) { return ' ↕'; }
 return dir === 'asc' ? ' ↑' : ' ↓';
@@ -458,9 +621,50 @@ command: 'saveSortSettings',
 settings: {
 editor: { key: editorSortKey, dir: editorSortDir },
 model: { key: modelSortKey, dir: modelSortDir },
-modelOtherExpanded
+modelOtherExpanded,
+excludedProviders: Array.from(excludedProviders)
 }
 });
+}
+
+// ---------------------------------------------------------------------------
+// Cost-by-provider helpers
+// ---------------------------------------------------------------------------
+
+/** Returns every billing-group (provider) name seen across all four periods, "GitHub Copilot" first. */
+function getAllProviders(stats: DetailedStats): string[] {
+const set = new Set<string>();
+(['today', 'last30Days', 'month', 'lastMonth'] as const).forEach(period => {
+Object.keys(stats[period].billingGroupCosts ?? {}).forEach(p => set.add(p));
+});
+return Array.from(set).sort((a, b) => {
+if (a === 'GitHub Copilot') { return -1; }
+if (b === 'GitHub Copilot') { return 1; }
+return a.localeCompare(b);
+});
+}
+
+/** Providers currently selected (not filtered out) from the given full provider list. */
+function includedProviders(allProviders: string[]): string[] {
+return allProviders.filter(p => !excludedProviders.has(p));
+}
+
+/** Sums the billing-group costs for the given providers only. */
+function sumBillingGroupCosts(billingGroupCosts: Record<string, number> | undefined, providers: string[]): number {
+if (!billingGroupCosts) { return 0; }
+return providers.reduce((s, p) => s + (billingGroupCosts[p] || 0), 0);
+}
+
+/**
+ * Total estimated cost for a period across the currently selected providers.
+ * Falls back to the legacy Copilot-only estimate when no billing-group breakdown
+ * is available (e.g. stale cached data from an older extension version).
+ */
+function totalCostForPeriod(period: PeriodStats, allProviders: string[]): number {
+if (allProviders.length === 0) {
+return period.estimatedCostCopilot ?? period.estimatedCost ?? 0;
+}
+return sumBillingGroupCosts(period.billingGroupCosts, includedProviders(allProviders));
 }
 
 type EditorItem = {
@@ -848,6 +1052,7 @@ notes.className = 'notes';
 
 const items = [
 'Cost (UBB) uses GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what you are billed under Usage Based Billing.',
+'"Estimated cost (selected providers)" and the summary cost card sum estimated spend across all providers (GitHub Copilot, Anthropic, Google, OpenAI, …); use the "⚙ Providers" filter in the Cost by Provider section to include/exclude specific providers.',
 'Estimated CO₂ is based on ~0.2 g CO₂e per 1,000 tokens.',
 'Estimated water usage is based on ~0.3 L per 1,000 tokens.',
 'Tree equivalent represents the fraction of a single mature tree\'s annual CO₂ absorption (~21 kg/year).'

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -105,6 +105,65 @@ body {
 	letter-spacing: 0.2px;
 }
 
+.section-header-row {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 10px;
+}
+
+.section-header-row h3 {
+	margin: 0 0 10px;
+}
+
+.provider-filter-wrap {
+	position: relative;
+	flex-shrink: 0;
+}
+
+.provider-filter-toggle {
+	font-size: 12px;
+	padding: 4px 10px;
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	border: 1px solid var(--border-subtle);
+	border-radius: 4px;
+	cursor: pointer;
+}
+
+.provider-filter-toggle:hover {
+	background: var(--list-hover-bg);
+}
+
+.provider-filter-menu {
+	position: absolute;
+	right: 0;
+	top: 100%;
+	margin-top: 4px;
+	z-index: 20;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	box-shadow: 0 4px 10px var(--shadow-color);
+	padding: 4px 0;
+	min-width: 180px;
+}
+
+.provider-filter-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 10px;
+	font-size: 12px;
+	white-space: nowrap;
+	cursor: pointer;
+	color: var(--text-primary);
+}
+
+.provider-filter-item:hover {
+	background: var(--list-hover-bg);
+}
+
 .stats-table {
 	width: 100%;
 	border-collapse: collapse;

--- a/vscode-extension/src/webview/details/styles.css
+++ b/vscode-extension/src/webview/details/styles.css
@@ -51,35 +51,72 @@ body {
 	cursor: help;
 }
 
-.cards {
+.provider-panel-hint {
+	color: var(--text-secondary);
+	font-size: 11px;
+	margin: -4px 0 10px;
+}
+
+.provider-cards {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 	gap: 10px;
 	text-align: center;
 }
 
-.card {
+.provider-card {
 	background: var(--bg-secondary);
 	border: 1px solid var(--border-color);
 	border-radius: 10px;
 	padding: 12px;
 	box-shadow: 0 4px 10px var(--shadow-color);
 	text-align: center;
+	cursor: pointer;
+	transition: background-color 0.1s ease, opacity 0.1s ease;
 }
 
-.card-label {
+.provider-card:hover {
+	background: var(--list-hover-bg);
+}
+
+.provider-card-excluded {
+	opacity: 0.45;
+}
+
+.provider-card-total {
+	cursor: default;
+	border-style: dashed;
+}
+
+.provider-card-total:hover {
+	background: var(--bg-secondary);
+}
+
+.provider-card-label {
 	color: var(--text-secondary);
 	font-size: 11px;
 	margin-bottom: 6px;
 }
 
-.card-value {
+.provider-card-value {
 	color: var(--text-primary);
 	font-size: 18px;
 	font-weight: 700;
 }
 
+.provider-card-sub {
+	color: var(--text-secondary);
+	font-size: 10px;
+	margin-top: 4px;
+}
 
+.no-data-row td {
+	text-align: center;
+	color: var(--text-secondary);
+	font-size: 12px;
+	padding: 14px;
+	font-style: italic;
+}
 
 .sections {
 	display: flex;
@@ -103,65 +140,6 @@ body {
 	gap: 6px;
 	color: var(--text-primary);
 	letter-spacing: 0.2px;
-}
-
-.section-header-row {
-	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	gap: 10px;
-}
-
-.section-header-row h3 {
-	margin: 0 0 10px;
-}
-
-.provider-filter-wrap {
-	position: relative;
-	flex-shrink: 0;
-}
-
-.provider-filter-toggle {
-	font-size: 12px;
-	padding: 4px 10px;
-	background: var(--bg-tertiary);
-	color: var(--text-primary);
-	border: 1px solid var(--border-subtle);
-	border-radius: 4px;
-	cursor: pointer;
-}
-
-.provider-filter-toggle:hover {
-	background: var(--list-hover-bg);
-}
-
-.provider-filter-menu {
-	position: absolute;
-	right: 0;
-	top: 100%;
-	margin-top: 4px;
-	z-index: 20;
-	background: var(--bg-secondary);
-	border: 1px solid var(--border-color);
-	border-radius: 6px;
-	box-shadow: 0 4px 10px var(--shadow-color);
-	padding: 4px 0;
-	min-width: 180px;
-}
-
-.provider-filter-item {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 4px 10px;
-	font-size: 12px;
-	white-space: nowrap;
-	cursor: pointer;
-	color: var(--text-primary);
-}
-
-.provider-filter-item:hover {
-	background: var(--list-hover-bg);
 }
 
 .stats-table {


### PR DESCRIPTION
## Summary

The Details webview only showed the GitHub Copilot UBB cost estimate, even though the backend already computes per-billing-group costs (`billingGroupCosts`: GitHub Copilot, Anthropic, Google, OpenAI, Mistral AI, xAI, Microsoft, Alibaba, Other) via `computeBillingGroupCosts` — that data just wasn't surfaced in the UI.

This PR:
- Adds a new **"Cost by Provider"** section/table to the details page showing estimated cost per billing group for Today / Last 30 Days / Current Month / Previous Month / Projected Year, with a total row.
- Adds a **"⚙ Providers" filter menu** (checkboxes) to include/exclude specific providers from the totals. Selection is persisted via `details.sortSettings.excludedProviders` (same mechanism used for sort settings), defaulting to all providers included.
- Updates the **"💰 Est. Cost This Month"** summary card and the **"Estimated cost"** row in Key Metrics to sum across the currently selected providers (all, by default) instead of only Copilot's UBB estimate.
- Keeps the original Copilot-only UBB cost row (`Estimated cost (GitHub Copilot UBB)`) alongside the new all-providers total for reference/back-compat.
- Falls back to the old Copilot-only behavior when `billingGroupCosts` isn't present (e.g. stale cached webview state).

## Verification
- `npm run compile` (tsc + eslint + esbuild) — passes.
- `npm run test:node` — full suite passes (61 test files).

No dedicated unit tests exist for the details webview's DOM-building logic (consistent with the rest of that file), so this was verified via compile/lint and the full backend test suite, which covers `computeBillingGroupCosts`/`getBillingGroup` indirectly through `statsHelpers`/`chartDataBuilder` tests.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>