### PR TITLE
Left-align tooltip stats table columns

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2694,7 +2694,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const pad = (cell: string) => `${cell}&nbsp;&nbsp;&nbsp;&nbsp;`;
 		const grams = (n: number) => `${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} grams`;
 		const liters = (n: number) => `${n.toLocaleString(undefined, { minimumFractionDigits: 3, maximumFractionDigits: 3 })} liters`;
-		tooltip.appendMarkdown(`|  | 📅 Today | 📊 ${secondaryLabel} |\n|---|---|---|\n`);
+		tooltip.appendMarkdown(`|  | 📅 Today | 📊 ${secondaryLabel} |\n|:---|:---|:---|\n`);
 		tooltip.appendMarkdown(`| Tokens : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${secondaryStats.tokens.toLocaleString()} |\n`);
 		tooltip.appendMarkdown(`| GitHub Copilot cost : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
 		tooltip.appendMarkdown(`| All providers cost : | ${pad(`$ ${this.sumBillingGroupCosts(detailedStats.today.billingGroupCosts).toFixed(2)}`)} | $ ${this.sumBillingGroupCosts(secondaryStats.billingGroupCosts).toFixed(2)} |\n`);


### PR DESCRIPTION
## Why

In the status bar tooltip's main stats table (Today vs. Current Month/Last 30 Days), the "📅 Today" column header/icon was visually misaligned with the numeric values in the column below it.

## What changed

The table's separator row used bare dashes (`|---|---|---|`), which VS Code's markdown renderer centers by default. Added explicit left-align markers (`|:---|:---|:---|`) so headers and values in every column render left-aligned and stay in sync.

## Verification

Ran `npm run compile` (tsc + eslint + esbuild) in `vscode-extension/` — clean.