### PR TITLE
Detect numeric-suffixed MCP server collision variants in toolnames check

### DIFF
--- a/.github/scripts/toolnames_utils.py
+++ b/.github/scripts/toolnames_utils.py
@@ -50,6 +50,25 @@ def _normalize_separators(value: str) -> str:
     return value.replace(".", "_").replace("-", "_")
 
 
+def _compile_prefix_pattern(prefix: str) -> re.Pattern[str]:
+    """Build a regex that also matches numeric-suffixed collision variants.
+
+    Some hosts append a digit to a server's registered name when there is a
+    naming collision (e.g. two "context7" MCP servers become "context7" and
+    "context73"). Allow optional trailing digits right before the prefix's
+    final separator so those collision variants still canonicalize to the
+    same key as the un-suffixed prefix.
+    """
+    base, sep = prefix[:-1], prefix[-1]
+    return re.compile(f"^{re.escape(base)}\\d*{re.escape(sep)}")
+
+
+_CANONICAL_PREFIX_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (_compile_prefix_pattern(prefix), replacement)
+    for prefix, replacement in _CANONICAL_PREFIX_RULES
+]
+
+
 def canonicalize_tool_id(tool_id: str) -> str:
     """Return a canonical form of a tool ID for duplicate comparison.
 
@@ -57,9 +76,10 @@ def canonicalize_tool_id(tool_id: str) -> str:
     whether two tool IDs are likely the same tool under different registrations.
     """
     lowered = tool_id.lower()
-    for prefix, replacement in _CANONICAL_PREFIX_RULES:
-        if lowered.startswith(prefix):
-            action = tool_id[len(prefix):]
+    for pattern, replacement in _CANONICAL_PREFIX_PATTERNS:
+        match = pattern.match(lowered)
+        if match:
+            action = tool_id[match.end():]
             return replacement + _normalize_separators(action)
     return _normalize_separators(tool_id)
 


### PR DESCRIPTION
## Context

Investigated #1692 based on a suspicion that some "unknown tool" entries were just reiterations of existing tools with different prefixes.

Findings:
- 7 of the 19 tools reported in #1692 were already correctly caught by the automated "Toolnames Checkup" comment as canonical equivalents of existing entries (e.g. `mcp_io_github_git_get_me` → `github-get_me`).
- However, `mcp_context73_query-docs` / `mcp_context73_resolve-library-id` were flagged as brand-new tools, even though they're the same Context7 MCP server as the existing `mcp_context7_query-docs` / `mcp_context7_resolve-library-id` entries — just with a numeric collision suffix (`context73` instead of `context7`), which some hosts append when multiple MCP servers register similarly-named/truncated identifiers.

## Change

`.github/scripts/toolnames_utils.py`'s canonical-prefix matching only did exact `str.startswith()` checks, so it couldn't recognize these numeric-suffix collision variants. This PR compiles each canonical prefix rule into a regex that allows optional trailing digits right before the prefix's final separator, so `mcp_context73_*`, `mcp_context71_*`, etc. now canonicalize to the same key as `mcp_context7_*`.

## Verification

- Confirmed `canonicalize_tool_id("mcp_context73_query-docs")` now returns the same canonical key as `mcp_context7_query-docs`, and `find_matches_for_new_tool` reports it as a `canonical_equivalent` of the existing Context7 entries.
- Ran `python toolnames_utils.py` against `src/toolNames.json` before and after the change — the strict-duplicate report (friendly-name based, unaffected by this change) is byte-identical, confirming no regressions to existing duplicate detection.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>