### PR TITLE
Add Share Card tab to Diagnostics panel

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8384,12 +8384,19 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
         if (typeof message.key === 'string' && typeof message.value === 'number') { await this.dispatch('setDebugCounter:diagnostics', () => this.diagHandleSetDebugCounter(message.key, message.value)); } break;
       case "setDebugFlag":
         if (typeof message.key === 'string' && typeof message.value === 'boolean') { await this.dispatch('setDebugFlag:diagnostics', () => this.diagHandleSetDebugFlag(message.key, message.value)); } break;
+      case "copyText":
+        if (typeof message.text === 'string') { await this.dispatch('copyText:diagnostics', () => this.diagHandleCopyText(message.text)); } break;
     }
   }
 
   private async diagHandleCopyReport(): Promise<void> {
     await vscode.env.clipboard.writeText(this.lastDiagnosticReport);
     vscode.window.showInformationMessage("Diagnostic report copied to clipboard");
+  }
+
+  private async diagHandleCopyText(text: string): Promise<void> {
+    await vscode.env.clipboard.writeText(text);
+    vscode.window.showInformationMessage("Summary copied to clipboard");
   }
 
   private async diagHandleOpenIssue(): Promise<void> {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -674,6 +674,63 @@ function flagRow(key: string, label: string, value: boolean): string {
     </tr>`;
 }
 
+/** Builds the plain-text version of the share summary, used by the "Copy Summary Text" button. */
+function buildShareSummaryText(
+  editors: string[],
+  editorStats: Record<string, { count: number; interactions: number }>,
+  totalSessions: number,
+  totalInteractions: number,
+  totalTokens: number,
+): string {
+  const editorList = editors
+    .map((editor) => `${getEditorIcon(editor)} ${editor} (${editorStats[editor].count})`)
+    .join(", ");
+  return `My AI Coding Toolbox — ${editors.length} editor${editors.length === 1 ? "" : "s"} detected: ${editorList}. ` +
+    `${totalSessions} sessions, ${totalInteractions} interactions, ${formatTokenCount(totalTokens)} tokens in the last 14 days. #AIEngineeringFluency`;
+}
+
+/** Renders a screenshot-friendly "Share Card" tab summarizing the detected editors — meant to be
+ * shared in social media posts, mirroring the visual style of the startup loading screen. */
+function renderShareCardTab(detailedFiles: SessionFileDetails[]): string {
+  if (detailedFiles.length === 0) {
+    return `<div id="tab-share" class="tab-content">
+      <div class="info-box">
+        <div class="info-box-title">📸 Share Card</div>
+        <div>No session activity found yet. Once you have some AI coding sessions, a shareable summary card will appear here.</div>
+      </div>
+    </div>`;
+  }
+  const editorStats = getEditorStats(detailedFiles);
+  const editors = Object.keys(editorStats).sort((a, b) => editorStats[b].count - editorStats[a].count);
+  const totalSessions = detailedFiles.length;
+  const totalInteractions = detailedFiles.reduce((sum, sf) => sum + Number(sf.interactions || 0), 0);
+  const totalTokens = detailedFiles.reduce((sum, sf) => sum + Number(sf.tokens || 0), 0);
+  const pills = editors
+    .map((editor) => `<div class="share-pill"><span>${getEditorIcon(editor)}</span><span>${escapeHtml(editor)}</span><span class="share-pill-count">${editorStats[editor].count}</span></div>`)
+    .join("");
+  return `<div id="tab-share" class="tab-content">
+    <div class="info-box">
+      <div class="info-box-title">📸 Share Card</div>
+      <div>A snapshot of your AI coding toolbox — screenshot this card to share your editor mix on social media.</div>
+    </div>
+    <div class="share-card">
+      <div class="share-badge">🤖 AI Engineering Fluency</div>
+      <div class="share-title">My AI Coding Toolbox</div>
+      <div class="share-subtitle">Last 14 days · ${editors.length} editor${editors.length === 1 ? "" : "s"} detected</div>
+      <div class="share-pills">${pills}</div>
+      <div class="share-stats">
+        <div class="share-stat"><div class="share-stat-value">${totalSessions}</div><div class="share-stat-label">Sessions</div></div>
+        <div class="share-stat"><div class="share-stat-value">${totalInteractions}</div><div class="share-stat-label">Interactions</div></div>
+        <div class="share-stat"><div class="share-stat-value" title="${totalTokens.toLocaleString()} tokens">${formatTokenCount(totalTokens)}</div><div class="share-stat-label">Tokens</div></div>
+        <div class="share-stat"><div class="share-stat-value">${editors.length}</div><div class="share-stat-label">Editors</div></div>
+      </div>
+    </div>
+    <div class="button-group" style="margin-top: 12px;">
+      <button class="button secondary" id="btn-copy-share-summary"><span>📋</span><span>Copy Summary Text</span></button>
+    </div>
+  </div>`;
+}
+
 function renderDebugTab(counters: GlobalStateCounters | undefined): string {
   const c = counters ?? { openCount: 0, unknownMcpOpenCount: 0, fluencyBannerDismissed: false, unknownMcpDismissedVersion: '' };
   return `
@@ -1891,6 +1948,16 @@ function setupButtonHandlers(): void {
     vscode.postMessage({ command: "copyReport" });
   });
 
+  document.getElementById("btn-copy-share-summary")?.addEventListener("click", () => {
+    const editorStats = getEditorStats(storedDetailedFiles);
+    const editors = Object.keys(editorStats).sort((a, b) => editorStats[b].count - editorStats[a].count);
+    const totalSessions = storedDetailedFiles.length;
+    const totalInteractions = storedDetailedFiles.reduce((sum, sf) => sum + Number(sf.interactions || 0), 0);
+    const totalTokens = storedDetailedFiles.reduce((sum, sf) => sum + Number(sf.tokens || 0), 0);
+    const text = buildShareSummaryText(editors, editorStats, totalSessions, totalInteractions, totalTokens);
+    vscode.postMessage({ command: "copyText", text });
+  });
+
   document.getElementById("btn-issue")?.addEventListener("click", () => {
     vscode.postMessage({ command: "openIssue" });
   });
@@ -2858,6 +2925,7 @@ ${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
 <button class="tab" data-tab="sessions">📁 Session Files (${detailedFiles.length})</button>
 <button class="tab" data-tab="cache">💾 Cache</button>
 <button class="tab" data-tab="path-analyzer">🔬 Path Analyzer</button>
+<button class="tab" data-tab="share">📸 Share Card</button>
 </div>
 
 <div class="tabs leaf-tabs" data-group="research" style="display: none;">
@@ -2876,13 +2944,10 @@ ${data.isDebugMode ? '<button class="tab" data-tab="debug">🐛 Debug</button>' 
 ${buildDiagReportTabHtml(escapedReport)}
 
 <div id="tab-sessions" class="tab-content">
-<div class="info-box">
-<div class="info-box-title">📁 Session File Analysis</div>
-<div>
+<div class="info-box"><div class="info-box-title">📁 Session File Analysis</div><div>
 This tab shows session files with activity in the last 14 days from all detected editors. </br>
 Click on an editor panel to filter, click column headers to sort, and click a file name to open it.
-</div>
-</div>
+</div></div>
 <div id="session-table-container">${renderSessionTable(detailedFiles, detailedFiles.length === 0)}</div>
 </div>
 
@@ -2899,6 +2964,7 @@ ${data.isDebugMode ? renderDebugTab(data.globalStateCounters) : ''}
 <div id="tab-path-analyzer" class="tab-content">
 ${renderFolderAnalyzerTab()}
 </div>
+${renderShareCardTab(detailedFiles)}
 <div id="tab-model-usage" class="tab-content">
 ${renderModelUsageTab(detailedFiles, isLoading)}
 </div>

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -290,6 +290,90 @@ body {
 	margin-top: 6px;
 }
 
+/* Share Card tab — a screenshot-friendly summary of detected editors */
+.share-card {
+	background: linear-gradient(135deg, var(--bg-tertiary), var(--bg-secondary));
+	border: 1px solid var(--border-color);
+	border-radius: 16px;
+	padding: 24px 28px;
+	max-width: 640px;
+	box-shadow: 0 8px 32px var(--shadow-color);
+}
+
+.share-badge {
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--link-color);
+	margin-bottom: 6px;
+}
+
+.share-title {
+	font-size: 22px;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin-bottom: 4px;
+}
+
+.share-subtitle {
+	font-size: 12px;
+	color: var(--text-muted);
+	margin-bottom: 18px;
+}
+
+.share-pills {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 18px;
+}
+
+.share-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-color);
+	border-radius: 20px;
+	font-size: 13px;
+	color: var(--text-primary);
+}
+
+.share-pill-count {
+	font-weight: 700;
+	color: var(--link-color);
+}
+
+.share-stats {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+	gap: 10px;
+}
+
+.share-stat {
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	padding: 10px;
+	text-align: center;
+}
+
+.share-stat-value {
+	font-size: 18px;
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.share-stat-label {
+	font-size: 10px;
+	color: var(--text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	margin-top: 2px;
+}
+
 .otel-delta-positive {
 	color: var(--success-fg);
 }


### PR DESCRIPTION
## Why

The startup loading screen shows a nice snapshot of detected editors (icons, names, pill-style badges), but that view disappears once loading finishes. There was no way to get that same "detected editors on this machine" summary later, e.g. to screenshot for a social media post about your AI coding toolbox.

## What changed

Adds a new **"Share Card"** tab to the existing Diagnostic Report webview (`vscode-extension/src/webview/diagnostics/`):

- Renders a screenshot-friendly card mirroring the loading screen's visual style: badge, title, editor pills (icon + name + session count), and stat tiles for total sessions, interactions, tokens, and editor count.
- Reuses the existing `EDITOR_ICON_MAP` / `getEditorIcon` and `getEditorStats` helpers already used elsewhere in the Diagnostics panel, so no new editor-detection logic was added.
- Adds a "Copy Summary Text" button that copies a plain-text version of the card (e.g. `My AI Coding Toolbox - 3 editors detected: ...`) to the clipboard, via a new generic `copyText` webview message handled in `extension.ts`.

## Notes for reviewers

- Purely additive: no existing tabs, data flows, or message handlers were changed.
- The card is a static snapshot (no live progress animation like the loading screen) since it's meant to be viewed after the fact, not during startup.
- Verified with `npm run compile` (build + lint clean) and the full `npm run test:node` suite (all passing).