### PR TITLE
Fix Share Card tab showing no data after session files load

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -1943,11 +1943,9 @@ function wireNavButtons(): void {
   wireExtensionPointButtons(vscode);
 }
 
-function setupButtonHandlers(): void {
-  document.getElementById("btn-copy")?.addEventListener("click", () => {
-    vscode.postMessage({ command: "copyReport" });
-  });
-
+/** Wires the "Copy Summary Text" button on the Share Card tab. Re-run after
+ * `reRenderShareCard()` replaces the tab's markup, since the button element is recreated. */
+function setupShareSummaryButtonHandler(): void {
   document.getElementById("btn-copy-share-summary")?.addEventListener("click", () => {
     const editorStats = getEditorStats(storedDetailedFiles);
     const editors = Object.keys(editorStats).sort((a, b) => editorStats[b].count - editorStats[a].count);
@@ -1957,6 +1955,20 @@ function setupButtonHandlers(): void {
     const text = buildShareSummaryText(editors, editorStats, totalSessions, totalInteractions, totalTokens);
     vscode.postMessage({ command: "copyText", text });
   });
+}
+
+/** Re-renders the Share Card tab once session files have finished loading, since it is
+ * initially rendered with an empty file list before the async load completes. */
+function reRenderShareCard(): void {
+  replaceTabContent("share", renderShareCardTab(storedDetailedFiles), setupShareSummaryButtonHandler);
+}
+
+function setupButtonHandlers(): void {
+  document.getElementById("btn-copy")?.addEventListener("click", () => {
+    vscode.postMessage({ command: "copyReport" });
+  });
+
+  setupShareSummaryButtonHandler();
 
   document.getElementById("btn-issue")?.addEventListener("click", () => {
     vscode.postMessage({ command: "openIssue" });
@@ -2289,6 +2301,7 @@ function handleSessionFilesLoaded(message: DiagMessage): void {
   triggerModelUsageAnalysis();
 
   reRenderTable();
+  reRenderShareCard();
 }
 
 function handleCacheCleared(): void {


### PR DESCRIPTION
## Why

The diagnostics view's Share Card tab always showed "No session activity found yet", even after session files finished loading in the background.

## Root cause

The Share Card tab is rendered once during the initial diagnostics page render, at which point session files haven't loaded yet (they load asynchronously). When the `sessionFilesLoaded` message arrives, `handleSessionFilesLoaded()` only re-rendered the Session Files table (`reRenderTable()`) - it never refreshed the Share Card tab, so it stayed stuck on its empty-state markup.

## Fix

- Added `reRenderShareCard()`, following the existing `replaceTabContent()` pattern already used for the Tool Analysis and OTel Delta tabs, and call it alongside `reRenderTable()` in `handleSessionFilesLoaded()`.
- Extracted the "Copy Summary Text" button wiring into `setupShareSummaryButtonHandler()` so it can be re-attached after the tab's markup is replaced (the button element is recreated on re-render).

## Verification

- `npm run compile` (tsc + eslint + esbuild) passes with no errors.
- `npx tsc --noEmit` passes.