### PR TITLE
Fix worktree repository attribution showing worktree name

### DIFF
--- a/src/adapters/copilotCliAdapter.ts
+++ b/src/adapters/copilotCliAdapter.ts
@@ -160,7 +160,7 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		return exact?.modelUsage ?? {};
 	}
 
-	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
+	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string; repository?: string }> {
 		if (this.store.isCliStoreSession(sessionFile)) {
 			const session = await this.store.readSession(sessionFile);
 			if (!session) { return { title: undefined, firstInteraction: null, lastInteraction: null }; }
@@ -169,6 +169,7 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 				firstInteraction: session.created_at,
 				lastInteraction: session.updated_at,
 				workspacePath: session.cwd ?? undefined,
+				repository: session.repository ?? undefined,
 			};
 		}
 		return { title: undefined, firstInteraction: null, lastInteraction: null };

--- a/src/ecosystemAdapter.ts
+++ b/src/ecosystemAdapter.ts
@@ -76,12 +76,15 @@ export interface IEcosystemAdapter {
 	/**
 	 * Extract session metadata.
 	 * workspacePath is the raw cwd / workspace directory path if known by this ecosystem.
+	 * repository is the authoritative repository identifier (e.g. "owner/repo") when the
+	 * ecosystem records it directly, preferred over deriving a name from workspacePath.
 	 */
 	getMeta(sessionFile: string): Promise<{
 		title: string | undefined;
 		firstInteraction: string | null;
 		lastInteraction: string | null;
 		workspacePath?: string;
+		repository?: string;
 	}>;
 
 	/**

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -67,6 +67,34 @@ export function normalizeToRepoRoot(p: string): string {
 }
 
 /**
+ * Derive a repository display name from a session's workspace/cwd path.
+ *
+ * Two agent-worktree layouts exist and place the repo folder on opposite sides of
+ * the "copilot-worktrees" marker:
+ *   - Copilot CLI app store:  "<home>/.copilot/copilot-worktrees/<repo>/<worktree>[/...]" -> "<repo>"
+ *     (the repo folder comes *after* the marker)
+ *   - User-repo / Claude:     "<repo>/copilot-worktrees/<name>[/...]"                     -> "<repo>"
+ *     "<repo>/.claude/worktrees/<name>[/...]"                                             -> "<repo>"
+ *     (the repo folder comes *before* the marker; handled by normalizeToRepoRoot)
+ *
+ * Using a plain path.basename() on an app-store worktree path yields the worktree
+ * name (e.g. "rajbos-supreme-carnival") instead of the repository — this helper
+ * returns the repository folder name instead. Falls back to the last path segment.
+ */
+export function getRepoNameFromWorkspacePath(p: string): string {
+	const segments = splitNormalizedPath(p);
+	const lower = segments.map(s => s.toLowerCase());
+	const wtIdx = lower.lastIndexOf('copilot-worktrees');
+	// App-store layout: repo folder is the segment right after the marker, which is
+	// itself nested directly under the ".copilot" store directory.
+	if (wtIdx > 0 && lower[wtIdx - 1] === '.copilot' && wtIdx + 1 < segments.length) {
+		return segments[wtIdx + 1];
+	}
+	const rootSegments = splitNormalizedPath(normalizeToRepoRoot(p));
+	return rootSegments.length > 0 ? rootSegments[rootSegments.length - 1] : path.basename(p);
+}
+
+/**
  * Strip the synthetic leading slash from Windows drive-letter URI paths.
  * Example: "/C:/repo/file.ts" -> "C:/repo/file.ts".
  */

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -28,7 +28,8 @@ export {
 	normalizePathForComparison,
 	normalizePathForDedup,
 	normalizePathSeparators,
-	normalizeToRepoRoot
+	normalizeToRepoRoot,
+	getRepoNameFromWorkspacePath
 } from './utils/pathUtils';
 
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -177,6 +177,7 @@ import {
   normalizePath as _normalizePath,
   normalizePathForDedup as _normalizePathForDedup,
   normalizeToRepoRoot as _normalizeToRepoRoot,
+  getRepoNameFromWorkspacePath as _getRepoNameFromWorkspacePath,
 } from '../../src/workspaceHelpers';
 
 // --- Chart building ---
@@ -5248,7 +5249,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 		details.interactions = interactionCount;
 		details.editorRoot = eco.getEditorRoot(sessionFile);
 		details.editorName = getEcosystemDisplayName(eco, sessionFile);
-		if (meta.workspacePath) { details.repository = path.basename(meta.workspacePath); details.workspacePath = meta.workspacePath; }
+		if (meta.workspacePath) {
+			// Prefer the ecosystem's authoritative repository (e.g. Copilot CLI's DB "owner/repo"
+			// column). Only fall back to deriving a name from the path when it's absent, and use a
+			// worktree-aware derivation so app-store worktree paths resolve to the repo folder
+			// instead of the transient worktree name.
+			details.repository = meta.repository || _getRepoNameFromWorkspacePath(meta.workspacePath);
+			details.workspacePath = meta.workspacePath;
+		}
 		await this.updateCacheWithSessionDetails(sessionFile, stat, details, tokenResult, modelUsage);
 		return details;
 	}

--- a/vscode-extension/test/unit/utils-pathUtils.test.ts
+++ b/vscode-extension/test/unit/utils-pathUtils.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 
 import {
 	fileUriToPath,
+	getRepoNameFromWorkspacePath,
 	hasWindowsDriveSegment,
 	normalizePath,
 	normalizePathForDedup,
@@ -171,3 +172,47 @@ test('normalizeToRepoRoot: ignores an unrelated "worktrees" folder without the .
 		'/home/me/repos/proj/worktrees/foo'
 	);
 });
+
+// getRepoNameFromWorkspacePath tests
+test('getRepoNameFromWorkspacePath: app-store worktree resolves to the repo folder, not the worktree name', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('C:\\Users\\me\\.copilot\\copilot-worktrees\\ai-engineering-fluency\\rajbos-supreme-carnival'),
+		'ai-engineering-fluency'
+	);
+});
+
+test('getRepoNameFromWorkspacePath: app-store worktree with an owner sub-segment', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('C:\\Users\\me\\.copilot\\copilot-worktrees\\authority-contribution-scraper\\rajbos\\huskiest-oleta'),
+		'authority-contribution-scraper'
+	);
+});
+
+test('getRepoNameFromWorkspacePath: app-store worktree with a posix path', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('/home/me/.copilot/copilot-worktrees/github-copilot-token-usage/rajbos-covetable-youlanda'),
+		'github-copilot-token-usage'
+	);
+});
+
+test('getRepoNameFromWorkspacePath: user-repo copilot-worktrees layout resolves to the repo before the marker', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('C:\\Users\\me\\repos\\proj\\copilot-worktrees\\session-123'),
+		'proj'
+	);
+});
+
+test('getRepoNameFromWorkspacePath: claude worktree layout resolves to the repo before the marker', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('/home/me/repos/proj/.claude/worktrees/feature-x'),
+		'proj'
+	);
+});
+
+test('getRepoNameFromWorkspacePath: plain repo path returns its basename', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('C:\\Users\\me\\repos\\my-repo'),
+		'my-repo'
+	);
+});
+


### PR DESCRIPTION
## Problem

In the Charts "By Repository" split, some worktree-backed sessions were labelled with their transient **worktree folder name** (e.g. `quizzical-visvesvaraya-9e47b5`, `rajbos-supreme-carnival`) instead of the actual **repository**.

## Root cause

`processEcosystemSessionDetails` in `extension.ts` derived the repository as `path.basename(meta.workspacePath)`. For any worktree-backed ecosystem session (Copilot CLI, Claude Code, OpenCode, Devin, …) the workspace cwd points at a worktree subfolder, so `basename` returns the worktree name, not the repo.

The Copilot CLI's `session-store.db` already stores the authoritative `repository` (`owner/repo`) column, but it was being ignored.

## Fix

- `IEcosystemAdapter.getMeta` gains an optional `repository?` field; `CopilotCliAdapter` now returns the DB's `repository` value.
- Attribution now prefers `meta.repository` and only falls back to a path-derived name when it's absent.
- New worktree-aware helper `getRepoNameFromWorkspacePath` (in `src/utils/pathUtils.ts`) resolves the repo folder for **both** layouts:
  - app-store: `~/.copilot/copilot-worktrees/<repo>/<worktree>` → `<repo>`
  - user-repo / Claude: `<repo>/copilot-worktrees|.claude/worktrees/<name>` → `<repo>`
  - plain repo paths are unchanged (no regression)

This generalizes the fix across every ecosystem adapter that returns a worktree cwd.

## Tests

- Added 6 unit tests for `getRepoNameFromWorkspacePath` covering both worktree layouts, an owner sub-segment, and plain repo paths.
- Full `npm run test:node` suite passes; `npm run compile` (tsc + eslint + esbuild) clean.

The CLI builds no repository datasets, so it was unaffected.