### PR TITLE
Hide Cost by Provider panel when only one provider

### DIFF
--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -539,7 +539,9 @@ function buildProviderTotalCard(stats: DetailedStats, allProviders: string[]): H
  */
 function buildProviderPanel(stats: DetailedStats): HTMLElement | null {
 	const allProviders = getAllProviders(stats);
-	if (allProviders.length === 0) { return null; }
+	// With zero or one provider the panel adds no value (nothing to compare or
+	// filter), so hide it entirely.
+	if (allProviders.length <= 1) { return null; }
 
 	const section = el('div', 'section');
 	section.append(iconHeading('h3', 'credit-card', 'Cost by Provider'));


### PR DESCRIPTION
## What

On the details view, the top **Cost by Provider** panel is now hidden when there is only a single provider (or none).

## Why

With just one provider there is nothing to compare or filter, so the panel adds no value and only takes up vertical space.

## Change

`buildProviderPanel` in `vscode-extension/src/webview/details/main.ts` now returns `null` when `allProviders.length <= 1` (previously only `=== 0`).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>