### PR TITLE
Fix scanned paths table overflowing diagnostics report panel

### DIFF
--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -547,6 +547,29 @@ body {
 	background: var(--list-hover-bg);
 }
 
+/* Candidate/scanned paths table: force long paths to wrap within the
+   panel instead of growing the table wider than its container. */
+.candidate-paths-table .session-table {
+	table-layout: fixed;
+}
+
+.candidate-paths-table .session-table th:first-child,
+.candidate-paths-table .session-table td:first-child {
+	width: 60px;
+}
+
+.candidate-paths-table .session-table th:nth-child(2),
+.candidate-paths-table .session-table td:nth-child(2) {
+	width: 140px;
+}
+
+.candidate-paths-table .session-table th:last-child,
+.candidate-paths-table .session-table td:last-child {
+	word-break: break-all;
+	overflow-wrap: anywhere;
+	white-space: normal;
+}
+
 .editor-badge {
 	background: var(--list-active-bg);
 	padding: 2px 6px;


### PR DESCRIPTION
## Why

In the Diagnostics -> Report tab, the "Scanned Paths (all candidate locations)" table lists file paths that can be very long (deep Windows paths, user home directories, etc). Since the table used auto layout with no word-breaking, a long unbroken path would push the whole table wider than the report panel before any wrapping kicked in, so the table visually escaped its container.

## Approach

Scoped a CSS fix to `.candidate-paths-table` in `vscode-extension/src/webview/diagnostics/styles.css`:
- `table-layout: fixed` so the table respects the panel width instead of growing to fit content.
- Fixed widths for the Status and Source columns (60px / 140px), letting the Path column take the remaining space.
- `word-break: break-all` + `overflow-wrap: anywhere` + `white-space: normal` on the Path column so long paths wrap within the column immediately.

This also covers the grouped "Crush" row, since it shares the same last-column selector as the rest of the table.

## Verification

Ran `npm run compile` (tsc + eslint + esbuild) in `vscode-extension/` - all passed.