### PR TITLE
Group npm dependabot updates (minor/patch) for scripts, skills, cli, desktop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -133,18 +133,46 @@ updates:
     directory: /.github/scripts
     schedule:
       interval: daily
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: /.github/skills/azure-storage-loader
     schedule:
       interval: daily
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: /cli
     schedule:
       interval: daily
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: /desktop
     schedule:
       interval: daily
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
The recently added npm dependabot entries (`/.github/scripts`, `/.github/skills/azure-storage-loader`, `/cli`, `/desktop`) didn't have PR grouping configured, unlike the other ecosystem entries in this file. This caused a flood of individual PRs for minor/patch updates (e.g. from the new `/desktop` entry).

This PR adds the same `minor-and-patch-updates` grouping (matching the pattern already used for the vscode-extension/sharing-server, github-actions, gradle, and nuget entries) to all four npm directories, so minor/patch bumps are grouped into a single PR per ecosystem.