### PR TITLE
Fix lowercase "windsurf" label in Share Card and editor filter

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -503,7 +503,7 @@ function getEditorStats(files: SessionFileDetails[]): {
 } {
   const stats: { [key: string]: { count: number; interactions: number } } = {};
   for (const sf of files) {
-    const editor = sf.editorSource || "Unknown";
+    const editor = sf.editorName || sf.editorSource || "Unknown";
     if (!stats[editor]) {
       stats[editor] = { count: 0, interactions: 0 };
     }
@@ -533,7 +533,7 @@ function getUnattributedTokens(sf: SessionFileDetails): number {
 }
 
 function applySessionFilters(detailedFiles: SessionFileDetails[]): FilteredSessionResult {
-  let filteredFiles = currentEditorFilter ? detailedFiles.filter((sf) => sf.editorSource === currentEditorFilter) : detailedFiles;
+  let filteredFiles = currentEditorFilter ? detailedFiles.filter((sf) => (sf.editorName || sf.editorSource) === currentEditorFilter) : detailedFiles;
   if (currentContextRefFilter) {
     filteredFiles = filteredFiles.filter((sf) => { const value = sf.contextReferences[currentContextRefFilter!]; return typeof value === "number" && value > 0; });
   }


### PR DESCRIPTION
## Why

The diagnostics webview's Share Card (and the editor filter panel) showed "windsurf" in lowercase while every other editor was properly capitalized (e.g. "Claude Code", "OpenCode").

## Root cause

Session files carry two related fields: a machine-readable `editorSource` key and a human-readable `editorName`. The Windsurf/Devin adapter (`src/windsurf.ts`) sets `editorSource: 'windsurf'` (lowercase) alongside `editorName: 'Windsurf'` (capitalized) - a two-field split unique to that adapter. Every other adapter happens to already store a capitalized value in `editorSource`, so `getEditorStats()` grouping by `editorSource` only surfaced the bug for Windsurf.

## Fix

`getEditorStats()` in `vscode-extension/src/webview/diagnostics/main.ts` now prefers `editorName`, falling back to `editorSource`, matching the pattern already used elsewhere in the same file (the main sessions table). Updated the matching filter click-through comparison in `applySessionFilters()` so clicking the "Windsurf" panel still filters correctly.

## Verification

- `npm run compile` (tsc + eslint + esbuild) passes cleanly.
- No existing unit tests cover this webview file's rendering functions.