### PR TITLE
sharing-server: diagnose org-check failures, admin diagnostics

### DIFF
--- a/sharing-server/infra/main.tf
+++ b/sharing-server/infra/main.tf
@@ -225,12 +225,25 @@ resource "null_resource" "hostname_registration" {
     # RequireCustomHostnameInEnvironment even though registration "succeeded".
     # Poll until the hostname shows up in the app's ingress config (or time out
     # loudly) instead of swallowing all errors with `|| true`.
+    #
+    # `replace_triggered_by` re-runs this on every container app update, on the
+    # assumption that ACA strips custom hostnames on update — but that isn't
+    # always true, so `add` must tolerate the hostname already being present
+    # instead of failing with "'{standardized_hostname}' already exists".
     command = <<-EOT
       set -e
-      az containerapp hostname add \
+      ALREADY_REGISTERED=$(az containerapp hostname list \
         --name '${azurerm_container_app.this.name}' \
         --resource-group '${var.resource_group_name}' \
-        --hostname '${var.custom_domain}'
+        --query "[].name" -o tsv 2>/dev/null | grep -Fx '${var.custom_domain}' || true)
+      if [ -z "$ALREADY_REGISTERED" ]; then
+        az containerapp hostname add \
+          --name '${azurerm_container_app.this.name}' \
+          --resource-group '${var.resource_group_name}' \
+          --hostname '${var.custom_domain}'
+      else
+        echo "Hostname '${var.custom_domain}' is already registered; skipping add."
+      fi
 
       for i in $(seq 1 30); do
         FOUND=$(az containerapp hostname list \

--- a/sharing-server/src/auth.ts
+++ b/sharing-server/src/auth.ts
@@ -176,6 +176,7 @@ export async function validateGitHubToken(token: string): Promise<UserRow | null
 async function checkOrgMembership(userToken: string, username: string, org: string): Promise<boolean> {
 	// Prefer a server-side PAT (already SSO-authorized) so the user's OAuth token
 	// doesn't need read:org or SAML SSO authorization.
+	const usingServerToken = Boolean(process.env.GITHUB_ORG_CHECK_TOKEN);
 	const checkToken = process.env.GITHUB_ORG_CHECK_TOKEN || userToken;
 	try {
 		const res = await fetch(`https://api.github.com/orgs/${org}/members/${username}`, {
@@ -186,9 +187,36 @@ async function checkOrgMembership(userToken: string, username: string, org: stri
 			},
 			signal: AbortSignal.timeout(10_000),
 		});
-		return res.status === 204;
-	} catch {
+		if (res.status === 204) return true;
+		logOrgMembershipFailure(username, org, res.status, usingServerToken);
 		return false;
+	} catch (err) {
+		console.error(`[auth] Org membership check for '${username}' in '${org}' failed with a network/timeout error:`, err);
+		return false;
+	}
+}
+
+/**
+ * Logs the reason an org membership check came back negative, distinguishing
+ * "the user genuinely isn't a member" (404) from "the check itself is broken"
+ * (401/403 — usually an expired/invalid GITHUB_ORG_CHECK_TOKEN, or a user
+ * token missing read:org/SSO authorization when no server PAT is configured).
+ * Without this, both cases produce the exact same "not a member" outcome,
+ * which is impossible to diagnose from the outside.
+ */
+function logOrgMembershipFailure(username: string, org: string, status: number, usingServerToken: boolean): void {
+	if (status === 404) {
+		console.info(`[auth] Org membership check: '${username}' is not a member of '${org}' (404).`);
+	} else if (status === 401 || status === 403) {
+		console.error(
+			`[auth] Org membership check for '${username}' in '${org}' returned ${status} — the ` +
+			`${usingServerToken ? 'GITHUB_ORG_CHECK_TOKEN' : "user's own"} token appears invalid/expired or lacks permission. ` +
+			(usingServerToken
+				? 'Rotate GITHUB_ORG_CHECK_TOKEN.'
+				: "The user's token may need read:org scope or SSO authorization for this org."),
+		);
+	} else {
+		console.warn(`[auth] Org membership check for '${username}' in '${org}' returned unexpected status ${status}.`);
 	}
 }
 

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -238,6 +238,16 @@ function getAdminLoginsFromEnv(): string[] {
 }
 
 /**
+ * Returns true if `login` (case-insensitive) is listed in ADMIN_GITHUB_LOGINS.
+ * Unlike is_admin on the users table, this can be checked before a user row
+ * exists — e.g. to decide whether to show extra diagnostics to an admin who
+ * is being rejected during login (such as an org-membership check failure).
+ */
+export function isConfiguredAdminLogin(login: string): boolean {
+	return getAdminLoginsFromEnv().includes(login.toLowerCase());
+}
+
+/**
  * Sync admin status for all existing users based on ADMIN_GITHUB_LOGINS.
  * When the env var is set and non-empty, it is authoritative: users in the list
  * get is_admin=1, all others get is_admin=0. When unset or empty, no changes are made.

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -8,7 +8,7 @@ import {
 } from '../session.js';
 import {
 	getUserById, getUserByGithubId, getUploadsForUser, upsertUser,
-	getAdminUserSummaries, getAdminDailyTotals,
+	getAdminUserSummaries, getAdminDailyTotals, isConfiguredAdminLogin,
 	type UploadRow, type UserRow, type UserUsageSummary, type AdminDailyRow,
 } from '../db.js';
 import { OAUTH_STATE_MAX_AGE_SECONDS } from '../config.js';
@@ -116,6 +116,7 @@ dashboard.get('/auth/github/callback', async (c) => {
 	if (allowedOrg) {
 		// Prefer a server-side PAT (already SSO-authorized) so the user's OAuth token
 		// doesn't need read:org or SAML SSO authorization.
+		const usingServerToken = Boolean(process.env.GITHUB_ORG_CHECK_TOKEN);
 		const checkToken = process.env.GITHUB_ORG_CHECK_TOKEN || accessToken;
 		try {
 			const memberRes = await fetch(`https://api.github.com/orgs/${allowedOrg}/members/${userData.login}`, {
@@ -127,9 +128,27 @@ dashboard.get('/auth/github/callback', async (c) => {
 				signal: AbortSignal.timeout(10_000),
 			});
 			if (memberRes.status !== 204) {
-				return c.html(errorPage(`Access denied: you are not a member of the "${allowedOrg}" organization.`), 403);
+				// Distinguish "genuinely not a member" (404) from "the check itself is
+				// broken" (401/403 — typically an expired/invalid GITHUB_ORG_CHECK_TOKEN,
+				// or a user token lacking read:org/SSO authorization when no server PAT
+				// is configured). Both cases otherwise look identical to the end user.
+				const brokenCheck = memberRes.status === 401 || memberRes.status === 403;
+				console.error(
+					`[auth/callback] Org membership check for '${userData.login}' in '${allowedOrg}' returned ` +
+					`${memberRes.status} (using ${usingServerToken ? 'GITHUB_ORG_CHECK_TOKEN' : "the user's own token"}).` +
+					(brokenCheck ? ` Likely cause: ${usingServerToken ? 'GITHUB_ORG_CHECK_TOKEN is invalid/expired — rotate it' : "the user's token lacks read:org scope or SSO authorization"}.` : ''),
+				);
+				let adminDetail = '';
+				if (isConfiguredAdminLogin(userData.login)) {
+					adminDetail = brokenCheck
+						? ` (Admin diagnostic: the membership check itself failed with HTTP ${memberRes.status} — ` +
+						  `${usingServerToken ? 'GITHUB_ORG_CHECK_TOKEN is likely invalid or expired. Rotate it.' : "your token likely lacks read:org scope or SSO authorization for this org."})`
+						: ` (Admin diagnostic: the membership check returned HTTP ${memberRes.status} — not a member, per GitHub.)`;
+				}
+				return c.html(errorPage(`Access denied: you are not a member of the "${allowedOrg}" organization.${adminDetail}`), 403);
 			}
-		} catch {
+		} catch (err) {
+			console.error(`[auth/callback] Org membership check for '${userData.login}' in '${allowedOrg}' failed with a network/timeout error:`, err);
 			return c.html(errorPage('Unable to verify organization membership. Please try again.'), 502);
 		}
 	}


### PR DESCRIPTION
## Why

After migrating to a new Azure subscription, a login attempt on prod failed with "Access denied: you are not a member of the xebia organization" even though the user is genuinely a member. The root cause turned out to be a likely-expired `GITHUB_ORG_CHECK_TOKEN` PAT (created ~90 days ago), but the server had no way to tell that apart from a real non-membership response - both cases returned the exact same generic error, both to the user and in the logs.

## What changed

- **`auth.ts`** (`checkOrgMembership`, used by the bearer-token API auth path) and **`dashboard.ts`** (the inline org check in the `/auth/github/callback` OAuth web login flow) now log the actual GitHub API response status instead of collapsing every non-204 response to `false`:
  - `404` -> genuinely not a member (info log)
  - `401`/`403` -> the check itself is broken, most likely an expired/invalid `GITHUB_ORG_CHECK_TOKEN`, or (when no server PAT is configured) a user token missing `read:org`/SSO authorization (error log with actionable hint)
  - anything else -> unexpected status (warning log)
  - network/timeout errors are logged distinctly too
- **`db.ts`**: added `isConfiguredAdminLogin(login)`, a thin wrapper around the existing `ADMIN_GITHUB_LOGINS` allowlist that can be checked before any DB user row exists (needed since this runs during login, before `is_admin` is otherwise available).
- **`dashboard.ts`**: when the org-membership check rejects a user who is listed in `ADMIN_GITHUB_LOGINS`, the "access denied" error page now appends an admin-only diagnostic line revealing the actual HTTP status and likely cause (e.g. "GITHUB_ORG_CHECK_TOKEN is likely invalid or expired. Rotate it."). Non-admin users still see only the original generic message.

No behavior change for the happy path or for regular users - this is purely additive diagnostics for whoever is configured as an admin via `ADMIN_GITHUB_LOGINS` (already set to `rajbos` in prod).

## Testing

- `npx tsc --noEmit` - clean
- `npm run build` - succeeds
- `npm test` - all 28 sharing-server tests pass, including the org-membership-gating suite