### PR TITLE
Fix diagnostics table overflow for session folders and scanned paths

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -328,9 +328,12 @@ function buildCandidatePathsElement(
   description.style.cssText = "color: #999; font-size: 12px; margin: 4px 0 8px 0;";
   description.textContent = "These are all the paths the extension checks for session files. Paths marked with ✅ exist on this system.";
   container.appendChild(description);
+  const tableContainer = document.createElement("div");
+  tableContainer.className = "table-container";
+  container.appendChild(tableContainer);
   const table = document.createElement("table");
   table.className = "session-table";
-  container.appendChild(table);
+  tableContainer.appendChild(table);
   const thead = document.createElement("thead");
   const headerRow = document.createElement("tr");
   for (const text of ["Status", "Source", "Path"]) {
@@ -1327,9 +1330,13 @@ function buildSessionFoldersElement(folders: SessionFolder[]): HTMLElement {
   heading.textContent = "Main Session Folders (by editor root):";
   container.appendChild(heading);
 
+  const tableContainer = document.createElement("div");
+  tableContainer.className = "table-container";
+  container.appendChild(tableContainer);
+
   const table = document.createElement("table");
   table.className = "session-table";
-  container.appendChild(table);
+  tableContainer.appendChild(table);
 
   const thead = document.createElement("thead");
   table.appendChild(thead);

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -570,6 +570,47 @@ body {
 	white-space: normal;
 }
 
+.candidate-paths-table .session-table td:nth-child(2) .editor-badge {
+	white-space: normal;
+	word-break: break-word;
+}
+
+/* Main Session Folders table: same treatment as the candidate paths table
+   so long folder paths wrap instead of forcing the table (and page) wider
+   than the panel. */
+.session-folders-table .session-table {
+	table-layout: fixed;
+}
+
+.session-folders-table .session-table th:first-child,
+.session-folders-table .session-table td:first-child {
+	word-break: break-all;
+	overflow-wrap: anywhere;
+	white-space: normal;
+}
+
+.session-folders-table .session-table th:nth-child(2),
+.session-folders-table .session-table td:nth-child(2) {
+	width: 150px;
+}
+
+.session-folders-table .session-table td:nth-child(2) .editor-badge {
+	white-space: normal;
+	word-break: break-word;
+}
+
+.session-folders-table .session-table th:nth-child(3),
+.session-folders-table .session-table td:nth-child(3) {
+	width: 110px;
+}
+
+.session-folders-table .session-table th:last-child,
+.session-folders-table .session-table td:last-child {
+	width: 150px;
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
 .editor-badge {
 	background: var(--list-active-bg);
 	padding: 2px 6px;


### PR DESCRIPTION
## Problem
On the Diagnostics report, the **Main Session Folders** table and the **Scanned Paths** table could render wider than their containing panel, forcing a page-level horizontal scrollbar, with visible background/overlap glitches around the sticky header.

## Root cause
Both tables were appended directly into the tab (not wrapped in the scroll-bounded `.table-container` used by other tables elsewhere), and their first columns had no wrap/width constraints:
- Long, unbroken folder paths in the Folder column had no `word-break`, so a single long path forced the whole table wider.
- Editor badges (`white-space: nowrap`) in narrow fixed-width columns could visually spill past their cell.

## Fix
- Wrap both tables in `.table-container` so they scroll internally (matching other tables), keeping sticky headers correctly bounded within their own scroll area instead of the whole page.
- Apply `table-layout: fixed` with sized columns for the folders table, matching the existing `.candidate-paths-table` treatment, and let the Folder/Path columns wrap long text.
- Allow editor badges in narrow columns to wrap instead of overflowing into neighboring cells.

## Testing
- `npm run compile` (tsc + eslint + esbuild) ✅
- `npm run test:node` — all existing unit tests pass ✅