### PR TITLE
Add period selector and social sharing to Share Card

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -280,6 +280,11 @@ export function tooltipSecondaryPeriod(
 
 // ── extension.ts module-level helpers ────────────────────────────────────────
 
+/** Type guard for the social platforms supported by `shareTextToSocialPlatform`. */
+function isSharePlatform(value: unknown): value is 'linkedin' | 'bluesky' | 'mastodon' {
+	return value === 'linkedin' || value === 'bluesky' || value === 'mastodon';
+}
+
 /**
  * Groups per-editor model usage into billing groups (e.g. "GitHub Copilot", "Anthropic").
  * Extracted as a module-level function to keep `computeBillingGroupCosts` complexity low.
@@ -7189,6 +7194,16 @@ Get the extension: ${marketplaceUrl}
 
 ${hashtag}`;
 
+	await this.shareTextToSocialPlatform(shareText, platform);
+	this.log(`Shared fluency score to ${platform}`);
+}
+
+/**
+ * Copies `shareText` to the clipboard and opens the given social platform's compose/share page
+ * in the browser, so the user can paste it in. Shared by the Fluency Score and Share Card views.
+ */
+private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' | 'bluesky' | 'mastodon'): Promise<void> {
+    const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency';
     switch (platform) {
       case "linkedin": {
         // LinkedIn share URL - opens in browser for user to add their own commentary
@@ -7245,8 +7260,6 @@ ${hashtag}`;
         break;
       }
     }
-
-    this.log(`Shared fluency score to ${platform}`);
   }
 
   /**
@@ -8415,6 +8428,11 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
         if (typeof message.key === 'string' && typeof message.value === 'boolean') { await this.dispatch('setDebugFlag:diagnostics', () => this.diagHandleSetDebugFlag(message.key, message.value)); } break;
       case "copyText":
         if (typeof message.text === 'string') { await this.dispatch('copyText:diagnostics', () => this.diagHandleCopyText(message.text)); } break;
+      case "shareCardToSocial":
+        if (typeof message.text === 'string' && isSharePlatform(message.platform)) {
+          await this.dispatch('shareCardToSocial:diagnostics', () => this.diagHandleShareCardToSocial(message.text, message.platform));
+        }
+        break;
     }
   }
 
@@ -8426,6 +8444,11 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
   private async diagHandleCopyText(text: string): Promise<void> {
     await vscode.env.clipboard.writeText(text);
     vscode.window.showInformationMessage("Summary copied to clipboard");
+  }
+
+  private async diagHandleShareCardToSocial(text: string, platform: 'linkedin' | 'bluesky' | 'mastodon'): Promise<void> {
+    await this.shareTextToSocialPlatform(text, platform);
+    this.log(`Shared Share Card to ${platform}`);
   }
 
   private async diagHandleOpenIssue(): Promise<void> {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -2,7 +2,7 @@
 import { navButtonsHtml } from "../shared/buttonConfig";
 import { wireExtensionPointButtons } from "../shared/extensionPoints";
 import { escapeHtml, formatFileSize, getTimeSince, getEditorIcon } from "../shared/formatUtils";
-import { createPeriodSelector, type Period } from "../shared/periodSelector";
+import { createPeriodSelector, PERIOD_LABELS, type Period } from "../shared/periodSelector";
 import { createViewStateManager } from "../shared/viewState";
 // CSS imported as text via esbuild
 import themeStyles from "../shared/theme.css";
@@ -179,6 +179,7 @@ type DiagnosticsViewState = {
   activeTab?: string;
   activeSubtab?: string;
   otelDeltaPeriod?: OtelDeltaPeriod;
+  shareCardPeriod?: Period;
 };
 
 type FolderFileResult = {
@@ -203,10 +204,15 @@ const diagState = createViewStateManager<DiagnosticsViewState>(vscode, {
   activeTab: undefined,
   activeSubtab: undefined,
   otelDeltaPeriod: "all",
+  shareCardPeriod: "last14",
 });
 
 let currentOtelComparison: CopilotCliOtelComparison | null | undefined;
 let currentOtelDeltaPeriod: OtelDeltaPeriod = diagState.restore().otelDeltaPeriod ?? "all";
+
+// Periods offered by the Share Card's period selector, in display order.
+const SHARE_CARD_PERIOD_ORDER: Period[] = ["last7", "last14", "last30", "last90", "allTime"];
+let currentShareCardPeriod: Period = diagState.restore().shareCardPeriod ?? "last14";
 
 // Sorting and filtering state
 let currentSortColumn: "lastInteraction" | "size" | "tokens" | "interactions" | "contextRefs" = "lastInteraction";
@@ -674,6 +680,28 @@ function flagRow(key: string, label: string, value: boolean): string {
     </tr>`;
 }
 
+/** Rolling lookback (in days) for each period the Share Card period selector offers. Periods absent from
+ * this map (e.g. "allTime") are treated as "no filtering". */
+const SHARE_CARD_PERIOD_DAYS: Partial<Record<Period, number>> = { last7: 7, last14: 14, last30: 30, last90: 90 };
+
+/** Returns the sessions from `detailedFiles` whose last interaction falls within `period` (allTime = no filtering). */
+function filterFilesByShareCardPeriod(detailedFiles: SessionFileDetails[], period: Period, now: Date = new Date()): SessionFileDetails[] {
+  const days = SHARE_CARD_PERIOD_DAYS[period];
+  if (days === undefined) { return detailedFiles; } // allTime (or any unmapped period): no filtering
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - days);
+  return detailedFiles.filter((sf) => {
+    if (!sf.lastInteraction) { return false; }
+    const activity = new Date(sf.lastInteraction);
+    return !Number.isNaN(activity.getTime()) && activity >= cutoff && activity <= now;
+  });
+}
+
+/** Lowercase, human-readable phrase describing a Share Card period, for use mid-sentence. */
+function shareCardPeriodPhrase(period: Period): string {
+  return period === "allTime" ? "of all time" : `in the ${PERIOD_LABELS[period].toLowerCase()}`;
+}
+
 /** Builds the plain-text version of the share summary, used by the "Copy Summary Text" button. */
 function buildShareSummaryText(
   editors: string[],
@@ -681,12 +709,13 @@ function buildShareSummaryText(
   totalSessions: number,
   totalInteractions: number,
   totalTokens: number,
+  period: Period,
 ): string {
   const editorList = editors
     .map((editor) => `${getEditorIcon(editor)} ${editor} (${editorStats[editor].count})`)
     .join(", ");
   return `My AI Coding Toolbox — ${editors.length} editor${editors.length === 1 ? "" : "s"} detected: ${editorList}. ` +
-    `${totalSessions} sessions, ${totalInteractions} interactions, ${formatTokenCount(totalTokens)} tokens in the last 14 days. #AIEngineeringFluency`;
+    `${totalSessions} sessions, ${totalInteractions} interactions, ${formatTokenCount(totalTokens)} tokens ${shareCardPeriodPhrase(period)}. #AIEngineeringFluency`;
 }
 
 /** Renders a screenshot-friendly "Share Card" tab summarizing the detected editors — meant to be
@@ -709,23 +738,32 @@ function renderShareCardTab(detailedFiles: SessionFileDetails[], isLoadingSessio
       </div>
     </div>`;
   }
-  const editorStats = getEditorStats(detailedFiles);
+  const period = currentShareCardPeriod;
+  const filteredFiles = filterFilesByShareCardPeriod(detailedFiles, period);
+  const editorStats = getEditorStats(filteredFiles);
   const editors = Object.keys(editorStats).sort((a, b) => editorStats[b].count - editorStats[a].count);
-  const totalSessions = detailedFiles.length;
-  const totalInteractions = detailedFiles.reduce((sum, sf) => sum + Number(sf.interactions || 0), 0);
-  const totalTokens = detailedFiles.reduce((sum, sf) => sum + Number(sf.tokens || 0), 0);
+  const totalSessions = filteredFiles.length;
+  const totalInteractions = filteredFiles.reduce((sum, sf) => sum + Number(sf.interactions || 0), 0);
+  const totalTokens = filteredFiles.reduce((sum, sf) => sum + Number(sf.tokens || 0), 0);
   const pills = editors
     .map((editor) => `<div class="share-pill"><span>${getEditorIcon(editor)}</span><span>${escapeHtml(editor)}</span><span class="share-pill-count">${editorStats[editor].count}</span></div>`)
     .join("");
+  const emptyPeriodNotice = totalSessions === 0
+    ? `<div style="margin-top: 8px; font-size: 12px; color: var(--text-muted);">No session activity in this period. Try a wider range.</div>`
+    : "";
   return `<div id="tab-share" class="tab-content">
     <div class="info-box">
       <div class="info-box-title">📸 Share Card</div>
       <div>A snapshot of your AI coding toolbox — screenshot this card to share your editor mix on social media.</div>
     </div>
+    <div class="share-card-controls" style="margin-bottom: 12px; display: flex; align-items: center; gap: 8px;">
+      <span style="font-size: 12px; color: var(--text-muted);">Period:</span>
+      <span id="share-card-period-selector"></span>
+    </div>
     <div class="share-card">
       <div class="share-badge">🤖 AI Engineering Fluency</div>
       <div class="share-title">My AI Coding Toolbox</div>
-      <div class="share-subtitle">Last 14 days · ${editors.length} editor${editors.length === 1 ? "" : "s"} detected</div>
+      <div class="share-subtitle">${escapeHtml(PERIOD_LABELS[period])} · ${editors.length} editor${editors.length === 1 ? "" : "s"} detected</div>
       <div class="share-pills">${pills}</div>
       <div class="share-stats">
         <div class="share-stat"><div class="share-stat-value">${totalSessions}</div><div class="share-stat-label">Sessions</div></div>
@@ -734,8 +772,14 @@ function renderShareCardTab(detailedFiles: SessionFileDetails[], isLoadingSessio
         <div class="share-stat"><div class="share-stat-value">${editors.length}</div><div class="share-stat-label">Editors</div></div>
       </div>
     </div>
+    ${emptyPeriodNotice}
     <div class="button-group" style="margin-top: 12px;">
       <button class="button secondary" id="btn-copy-share-summary"><span>📋</span><span>Copy Summary Text</span></button>
+    </div>
+    <div class="share-buttons" style="margin-top: 12px;">
+      <button id="btn-share-card-linkedin" class="share-btn share-btn-linkedin"><span class="share-btn-icon">💼</span><span>Share on LinkedIn</span></button>
+      <button id="btn-share-card-bluesky" class="share-btn share-btn-bluesky"><span class="share-btn-icon">🦋</span><span>Share on Bluesky</span></button>
+      <button id="btn-share-card-mastodon" class="share-btn share-btn-mastodon"><span class="share-btn-icon">🐘</span><span>Share on Mastodon</span></button>
     </div>
   </div>`;
 }
@@ -1952,18 +1996,55 @@ function wireNavButtons(): void {
   wireExtensionPointButtons(vscode);
 }
 
-/** Wires the "Copy Summary Text" button on the Share Card tab. Re-run after
- * `reRenderShareCard()` replaces the tab's markup, since the button element is recreated. */
-function setupShareSummaryButtonHandler(): void {
-  document.getElementById("btn-copy-share-summary")?.addEventListener("click", () => {
-    const editorStats = getEditorStats(storedDetailedFiles);
-    const editors = Object.keys(editorStats).sort((a, b) => editorStats[b].count - editorStats[a].count);
-    const totalSessions = storedDetailedFiles.length;
-    const totalInteractions = storedDetailedFiles.reduce((sum, sf) => sum + Number(sf.interactions || 0), 0);
-    const totalTokens = storedDetailedFiles.reduce((sum, sf) => sum + Number(sf.tokens || 0), 0);
-    const text = buildShareSummaryText(editors, editorStats, totalSessions, totalInteractions, totalTokens);
-    vscode.postMessage({ command: "copyText", text });
+/** Renders the Share Card's period dropdown into its placeholder span, reusing the shared period-selector
+ * component for visual/state consistency with the other period selectors in this webview (e.g. Model Usage). */
+function renderShareCardPeriodSelector(): void {
+  const wrapper = document.getElementById("share-card-period-selector");
+  if (!wrapper) { return; }
+  wrapper.replaceChildren();
+  const { select } = createPeriodSelector({
+    id: "share-card-period-select",
+    selected: currentShareCardPeriod,
+    periods: SHARE_CARD_PERIOD_ORDER,
+    label: "",
+    onChange: (value) => {
+      currentShareCardPeriod = value as Period;
+      diagState.patch({ shareCardPeriod: currentShareCardPeriod });
+      reRenderShareCard();
+    },
   });
+  wrapper.append(select);
+}
+
+/** Builds the current Share Card's plain-text summary from live filtered session data, for both
+ * the "Copy Summary Text" button and the social share buttons. */
+function buildCurrentShareSummaryText(): string {
+  const filteredFiles = filterFilesByShareCardPeriod(storedDetailedFiles, currentShareCardPeriod);
+  const editorStats = getEditorStats(filteredFiles);
+  const editors = Object.keys(editorStats).sort((a, b) => editorStats[b].count - editorStats[a].count);
+  const totalSessions = filteredFiles.length;
+  const totalInteractions = filteredFiles.reduce((sum, sf) => sum + Number(sf.interactions || 0), 0);
+  const totalTokens = filteredFiles.reduce((sum, sf) => sum + Number(sf.tokens || 0), 0);
+  return buildShareSummaryText(editors, editorStats, totalSessions, totalInteractions, totalTokens, currentShareCardPeriod);
+}
+
+/** Wires the "Copy Summary Text" button, social share buttons, and period selector on the Share
+ * Card tab. Re-run after `reRenderShareCard()` replaces the tab's markup, since these elements are recreated. */
+function setupShareSummaryButtonHandler(): void {
+  renderShareCardPeriodSelector();
+  document.getElementById("btn-copy-share-summary")?.addEventListener("click", () => {
+    vscode.postMessage({ command: "copyText", text: buildCurrentShareSummaryText() });
+  });
+  const socialPlatforms: Array<{ id: string; platform: "linkedin" | "bluesky" | "mastodon" }> = [
+    { id: "btn-share-card-linkedin", platform: "linkedin" },
+    { id: "btn-share-card-bluesky", platform: "bluesky" },
+    { id: "btn-share-card-mastodon", platform: "mastodon" },
+  ];
+  for (const { id, platform } of socialPlatforms) {
+    document.getElementById(id)?.addEventListener("click", () => {
+      vscode.postMessage({ command: "shareCardToSocial", platform, text: buildCurrentShareSummaryText() });
+    });
+  }
 }
 
 /** Re-renders the Share Card tab once session files have finished loading, since it is

--- a/vscode-extension/src/webview/diagnostics/styles.css
+++ b/vscode-extension/src/webview/diagnostics/styles.css
@@ -374,6 +374,81 @@ body {
 	margin-top: 2px;
 }
 
+/* Share Card social share buttons — mirrors the Fluency Score share-section styling */
+.share-buttons {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	gap: 10px;
+}
+
+.share-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 10px 14px;
+	border-radius: 6px;
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	border: 1px solid;
+	background: var(--button-secondary-bg);
+}
+
+.share-btn-icon {
+	font-size: 16px;
+	flex-shrink: 0;
+}
+
+.share-btn:active {
+	transform: translateY(0);
+}
+
+.share-btn-linkedin {
+	color: #0a66c2;
+	border-color: rgba(10, 102, 194, 0.5);
+}
+
+.share-btn-linkedin:hover {
+	background: rgba(10, 102, 194, 0.12);
+	border-color: #0a66c2;
+	transform: translateY(-2px);
+	box-shadow: 0 4px 12px rgba(10, 102, 194, 0.25);
+}
+
+.share-btn-bluesky {
+	color: #1285fe;
+	border-color: rgba(18, 133, 254, 0.5);
+}
+
+.share-btn-bluesky:hover {
+	background: rgba(18, 133, 254, 0.12);
+	border-color: #1285fe;
+	transform: translateY(-2px);
+	box-shadow: 0 4px 12px rgba(18, 133, 254, 0.25);
+}
+
+.share-btn-mastodon {
+	color: #6364ff;
+	border-color: rgba(99, 100, 255, 0.5);
+}
+
+.share-btn-mastodon:hover {
+	background: rgba(99, 100, 255, 0.12);
+	border-color: #6364ff;
+	transform: translateY(-2px);
+	box-shadow: 0 4px 12px rgba(99, 100, 255, 0.25);
+}
+
+/* Light theme overrides for share button text colors */
+body[data-vscode-theme-kind="vscode-light"] .share-btn-linkedin,
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .share-btn-linkedin { color: #0a66c2; }
+body[data-vscode-theme-kind="vscode-light"] .share-btn-bluesky,
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .share-btn-bluesky { color: #0369a1; }
+body[data-vscode-theme-kind="vscode-light"] .share-btn-mastodon,
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .share-btn-mastodon { color: #4f46e5; }
+
 .otel-delta-positive {
 	color: var(--success-fg);
 }

--- a/vscode-extension/src/webview/shared/periodSelector.ts
+++ b/vscode-extension/src/webview/shared/periodSelector.ts
@@ -1,13 +1,15 @@
 import { el } from './domUtils';
 
 /** Time-window periods supported by the shared period selector. */
-export type Period = 'today' | 'last7' | 'last30' | 'currentMonth' | 'lastMonth' | 'thisWeek' | 'allTime';
+export type Period = 'today' | 'last7' | 'last14' | 'last30' | 'last90' | 'currentMonth' | 'lastMonth' | 'thisWeek' | 'allTime';
 
 /** Human-readable labels for each period, matching the Chart time-window dropdown. */
 export const PERIOD_LABELS: Record<Period, string> = {
 	today: 'Today',
 	last7: 'Last 7 days',
+	last14: 'Last 14 days',
 	last30: 'Last 30 days',
+	last90: 'Last 90 days',
 	currentMonth: 'Current month',
 	lastMonth: 'Previous month',
 	thisWeek: 'This week',


### PR DESCRIPTION
## Why
The Share Card tab in the diagnostics webview always summarized a hardcoded "Last 14 days" window with no way to pick a different range, and had no social sharing options even though the Fluency Score view already has a well-established share pattern (LinkedIn/Bluesky/Mastodon).

## Approach

**Period selector**
- Extended the shared `Period` type (`vscode-extension/src/webview/shared/periodSelector.ts`) with `last14` and `last90` so it now covers `Last 7/14/30/90 days` and `All time`, alongside the existing periods used elsewhere.
- Added a period dropdown to `renderShareCardTab` in `vscode-extension/src/webview/diagnostics/main.ts`, placed in a controls row **outside** the `.share-card` div so the screenshottable card itself stays free of interactive controls.
- Reused the existing `createPeriodSelector` component and the same render-into-placeholder-span pattern already used by the Model Usage time selector, for visual/state consistency.
- Selecting a period re-filters `storedDetailedFiles` by `lastInteraction` (via a new `filterFilesByShareCardPeriod` helper) before computing sessions/interactions/tokens/editor pills, and updates the card's "Last N days" subtitle and the "Copy Summary Text" output to match.
- The selected period persists across reloads via the existing `diagState` view-state manager (mirrors how `otelDeltaPeriod` is persisted).

**Social sharing**
- Added LinkedIn/Bluesky/Mastodon share buttons to the Share Card tab, also placed outside `.share-card`, next to "Copy Summary Text".
- Reused the exact button markup/CSS classes (`share-buttons`, `share-btn`, `share-btn-linkedin/-bluesky/-mastodon`) from the Fluency Score view's `buildShareSectionHtml`, ported into `diagnostics/styles.css`.
- On the host side, extracted the platform-dispatch logic (copy text to clipboard + open the platform's compose page, or prompt for a Mastodon instance) out of the Fluency Score's `shareToSocialMedia` into a shared `shareTextToSocialPlatform` helper, so both views use one implementation. Added a new `shareCardToSocial` webview message and `diagHandleShareCardToSocial` handler.
- The share buttons reuse the exact same `buildShareSummaryText` output as "Copy Summary Text" (which already ends with `#AIEngineeringFluency`), so the hashtag is included consistently across the copy button and all three social share flows.

## Verification
- `npm run compile` (tsc --noEmit && eslint && esbuild) passes with no errors or warnings.
- `npm run test:node` — full unit test suite passes (no regressions).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>