### PR TITLE
Fix Team Server last-sync timestamp gap and slow Backend Storage panel load

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -1636,6 +1636,7 @@ return true;
 			this.deps.logger.log,
 			this.deps.logger.warn,
 		);
+		await this.tryUpdateSharingServerLastSyncAt();
 	}
 
 	/**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9425,6 +9425,31 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
   }
 
   /**
+   * Computes Backend Storage + GitHub Auth status and posts it to the webview immediately.
+   * These are cheap relative to the stats/usage-analysis/report pipeline, so sending them early
+   * lets the Settings > Backend Storage tab populate right away instead of showing a "not
+   * available" placeholder for the several seconds the rest of diagnostics load takes.
+   * Returns the computed values so the caller can reuse them in the final diagnosticDataLoaded message.
+   */
+  private async sendBackendStorageInfoEarly(
+    panel: vscode.WebviewPanel,
+  ): Promise<{ backendStorageInfo: any; githubAuthStatus: { authenticated: boolean; username?: string } }> {
+    const backendStorageInfo = await this.getBackendStorageInfo();
+    this.log(
+      `Backend storage info retrieved: azure.enabled=${backendStorageInfo.azure?.enabled}, azure.configured=${backendStorageInfo.azure?.isConfigured}, teamServer.enabled=${backendStorageInfo.teamServer?.enabled}, teamServer.configured=${backendStorageInfo.teamServer?.isConfigured}`,
+    );
+    const githubAuthStatus = this.getGitHubAuthStatus();
+    if (this.isPanelOpen(panel)) {
+      panel.webview.postMessage({
+        command: "backendStorageInfoLoaded",
+        backendStorageInfo,
+        githubAuth: githubAuthStatus,
+      });
+    }
+    return { backendStorageInfo, githubAuthStatus };
+  }
+
+  /**
    * Load all diagnostic data in the background and update the webview progressively.
    */
   private async loadDiagnosticDataInBackground(
@@ -9436,6 +9461,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       if (this._sessionRestorePromise) {
         await this._sessionRestorePromise;
       }
+
+      const { backendStorageInfo, githubAuthStatus } = await this.sendBackendStorageInfoEarly(panel);
 
       if (!this.lastDetailedStats) {
         this.log(
@@ -9458,12 +9485,6 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       const sessionFileData = await this.getSessionFilePreviewData(sessionFiles);
       const sessionFolders = this.buildSessionFolderData(sessionFiles);
       const candidatePaths = this.sessionDiscovery.getDiagnosticCandidatePaths();
-      const backendStorageInfo = await this.getBackendStorageInfo();
-      this.log(
-        `Backend storage info retrieved: azure.enabled=${backendStorageInfo.azure?.enabled}, azure.configured=${backendStorageInfo.azure?.isConfigured}, teamServer.enabled=${backendStorageInfo.teamServer?.enabled}, teamServer.configured=${backendStorageInfo.teamServer?.isConfigured}`,
-      );
-
-      const githubAuthStatus = this.getGitHubAuthStatus();
       const otelComparison = await this.tryComputeCopilotCliOtelComparison(sessionFiles);
 
       if (!this.isPanelOpen(panel)) {

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -933,13 +933,7 @@ function renderBackendStoragePanel(
     return `
       <div class="info-box">
         <div class="info-box-title">☁️ Backend Storage</div>
-        <div>Backend storage information is not available. This may be a temporary issue.</div>
-        <div class="button-group" style="margin-top: 12px;">
-          <button class="button" id="btn-configure-backend">
-            <span>🔧</span>
-            <span>Configure Backend</span>
-          </button>
-        </div>
+        <div>⏳ Loading backend storage status...</div>
       </div>
     `;
   }
@@ -2492,6 +2486,8 @@ function setupMessageHandlers(): void {
     const message = event.data as DiagMessage;
     if (message.command === "diagnosticDataLoaded") {
       handleDiagnosticDataLoaded(message);
+    } else if (message.command === "backendStorageInfoLoaded") {
+      handleBackendStorageSection(message);
     } else if (message.command === "githubAuthUpdated") {
       handleGithubAuthUpdated(message);
     } else if (message.command === "diagnosticDataError") {

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -1224,6 +1224,36 @@ test('syncToBackendStore tracks Azure and Team Server "last sync" independently 
 	fs.rmSync(lockDir, { recursive: true, force: true });
 });
 
+test('uploadFluencyScoreToSharingServer updates the Team Server lastSync marker on success', async () => {
+	const globalState = new Map<string, unknown>();
+	const mockContext = {
+		globalState: {
+			get: (key: string) => globalState.get(key),
+			update: async (key: string, value: unknown) => { globalState.set(key, value); },
+		},
+	} as unknown as vscode.ExtensionContext;
+	const sharingServerSvc = { uploadRollups: async () => {}, uploadFluencyScore: async () => {} };
+	const svc = new SyncService(
+		makeDeps({
+			context: mockContext,
+			getGithubToken: () => 'fake-token',
+		}),
+		{} as any,
+		{} as any,
+		undefined,
+		BackendUtility,
+		sharingServerSvc as any,
+	);
+	await svc.uploadFluencyScoreToSharingServer({
+		sharingServerEnabled: true,
+		sharingServerEndpointUrl: 'https://test-sharing-server/',
+	} as any, { overallStage: 'exploring' });
+	assert.ok(
+		globalState.get('backend.sharingServerLastSyncAt'),
+		'A successful fluency-score upload is a real Team Server sync and must update its own lastSync marker'
+	);
+});
+
 // ── Sync lock management ─────────────────────────────────────────────────
 
 test('acquireSyncLock succeeds when no context is provided', async () => {


### PR DESCRIPTION
## Problem

Two follow-on issues surfaced after #1727 (which decoupled Azure/Team Server sync):

1. **Team Server "Last Sync" still showed "Never"** even right after a successful sync. The output log showed `Sharing server fluency-score upload: ok`, but that message comes from a *different* upload path - `uploadFluencyScoreToSharingServer()`, triggered from `computeAndUploadFluencyScore()` (runs on startup/analysis) - which never updated `backend.sharingServerLastSyncAt`. Only the periodic rollup sync (`doSyncToBackendStore`) updated that timestamp, and on a fresh session it may not have run yet.
2. **Settings > Backend Storage tab briefly showed an alarming placeholder** ("Backend storage information is not available. This may be a temporary issue.") for a couple of seconds after opening the Diagnostics panel, because backend/GitHub-auth status was bundled into the same `postMessage` as the much slower stats/usage-analysis/report pipeline.

## Approach

- `uploadFluencyScoreToSharingServer()` now also calls `tryUpdateSharingServerLastSyncAt()` on success, so any successful Team Server sync (rollups or fluency score) updates the same shared timestamp.
- Extracted a `sendBackendStorageInfoEarly()` helper in `extension.ts` that computes Backend Storage + GitHub Auth status (cheap: settings + a file listing) and posts it to the webview immediately via a new `backendStorageInfoLoaded` message, decoupled from the heavier report/stats pipeline that follows.
- Reworded the webview's empty-state placeholder from an error-sounding message to a neutral "Loading backend storage status..." message, since it's now only shown for the brief instant before the early message arrives.
- Added a regression test asserting `uploadFluencyScoreToSharingServer` updates `backend.sharingServerLastSyncAt` on success.

## Testing

- `npm run compile`: clean (0 errors, 0 warnings).
- `npm run test:node`: full suite passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>