### PR TITLE
Update maturity social share to generate image and copy caption

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7080,10 +7080,8 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 			searchMcpExtensions: () => this.dispatch('searchMcpExtensions', () => vscode.commands.executeCommand('workbench.extensions.search', '@tag:mcp')),
 			shareToIssue: () => this.dispatch('shareToIssue', () => this.maturityHandleShareToIssue()),
 			resetDismissedTips: () => this.dispatch('resetDismissedTips', async () => { await this.resetDismissedFluencyTips(); await this.refreshMaturityPanel(); }),
-			shareToLinkedIn: () => this.dispatch('shareToLinkedIn', () => this.shareToSocialMedia('linkedin')),
-			shareToBluesky: () => this.dispatch('shareToBluesky', () => this.shareToSocialMedia('bluesky')),
-			shareToMastodon: () => this.dispatch('shareToMastodon', () => this.shareToSocialMedia('mastodon')),
 			downloadChartImage: () => this.dispatch('downloadChartImage', () => this.downloadChartImage()),
+			shareToSocialFailed: async () => { vscode.window.showErrorMessage('Failed to generate share card image.'); },
 		};
 		if (simpleCommands[message.command]) { await simpleCommands[message.command](); return; }
 		await this.handleMaturityConditionalMessage(message);
@@ -7092,11 +7090,18 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 	private async handleMaturityConditionalMessage(message: any): Promise<void> {
 		switch (message.command) {
 			case 'dismissTips': if (message.category) { await this.dispatch('dismissTips', async () => { await this.dismissFluencyTips(message.category); await this.refreshMaturityPanel(); }); } break;
+			case 'installHook': if (message.hookId) { await this.maturityHandleInstallHook(message.hookId); } break;
+			case 'uninstallHook': if (message.hookId) { await this.maturityHandleUninstallHook(message.hookId); } break;
+			default: await this.handleMaturityExportCommand(message); break;
+		}
+	}
+
+	private async handleMaturityExportCommand(message: any): Promise<void> {
+		switch (message.command) {
 			case 'saveChartImage': if (message.data) { await this.dispatch('saveChartImage', () => this.saveChartImageData(message.data)); } break;
 			case 'exportPdf': if (message.data) { await this.dispatch('exportPdf', () => this.exportFluencyScorePdf(message.data)); } break;
 			case 'exportPptx': if (message.data) { await this.dispatch('exportPptx', () => this.exportFluencyScorePptx(message.data)); } break;
-			case 'installHook': if (message.hookId) { await this.maturityHandleInstallHook(message.hookId); } break;
-			case 'uninstallHook': if (message.hookId) { await this.maturityHandleUninstallHook(message.hookId); } break;
+			case 'shareToSocial': if (message.dataUrl && isSharePlatform(message.platform)) { await this.dispatch('shareToSocial', () => this.maturityHandleShareToSocial(message.platform, message.dataUrl)); } break;
 		}
 	}
 
@@ -7171,35 +7176,8 @@ private async resetDismissedFluencyTips(): Promise<void> {
 }
 
 /**
- * Share Copilot Fluency Score to social media platforms
- */
-private async shareToSocialMedia(platform: 'linkedin' | 'bluesky' | 'mastodon'): Promise<void> {
-	const scores = await this.calculateMaturityScores();
-	const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency';
-	const hashtag = '#CopilotFluencyScore';
-	
-	// Build share text with stats
-	const categoryScores = scores.categories.map(c => `${c.icon} ${c.category}: Stage ${c.stage}`).join('\n');
-	
-	const shareText = `🎯 My AI Engineering Fluency Score
-
-Overall: ${scores.overallLabel}
-
-${categoryScores}
-
-Track your Copilot usage and level up your AI-assisted development skills!
-
-Get the extension: ${marketplaceUrl}
-
-${hashtag}`;
-
-	await this.shareTextToSocialPlatform(shareText, platform);
-	this.log(`Shared fluency score to ${platform}`);
-}
-
-/**
  * Copies `shareText` to the clipboard and opens the given social platform's compose/share page
- * in the browser, so the user can paste it in. Shared by the Fluency Score and Share Card views.
+ * in the browser, so the user can paste it in. Used by the diagnostics Share Card view.
  */
 private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' | 'bluesky' | 'mastodon'): Promise<void> {
     const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency';
@@ -7259,6 +7237,60 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
         break;
       }
     }
+  }
+
+  /**
+   * Saves the generated share-card image to a temp file, copies the caption to the clipboard,
+   * and opens the chosen social platform so the user can paste and attach the image.
+   */
+  private async maturityHandleShareToSocial(platform: 'linkedin' | 'bluesky' | 'mastodon', dataUrl: string): Promise<void> {
+    const base64Match = dataUrl.match(/^data:image\/png;base64,(.+)$/);
+    if (!base64Match) {
+      void vscode.window.showErrorMessage('Failed to process share card image.');
+      return;
+    }
+
+    let platformUrl: string;
+    const marketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=RobBos.ai-engineering-fluency';
+    switch (platform) {
+      case 'linkedin':
+        platformUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(marketplaceUrl)}`;
+        break;
+      case 'bluesky':
+        platformUrl = 'https://bsky.app/intent/compose';
+        break;
+      case 'mastodon': {
+        const instance = await vscode.window.showInputBox({
+          prompt: 'Enter your Mastodon instance (e.g., mastodon.social)',
+          placeHolder: 'mastodon.social',
+          value: 'mastodon.social',
+        });
+        if (!instance) { return; }
+        platformUrl = `https://${instance}/share`;
+        break;
+      }
+      default:
+        platformUrl = marketplaceUrl;
+    }
+
+    const fileName = `ai-engineering-fluency-share-${Date.now()}.png`;
+    const filePath = path.join(os.tmpdir(), fileName);
+    const uri = vscode.Uri.file(filePath);
+    const buffer = Buffer.from(base64Match[1], 'base64');
+    await vscode.workspace.fs.writeFile(uri, buffer);
+
+    const shareText = 'I am tracking my AI usage through this great tracker: AI Engineering Fluency! Track your usage as well #AIEngineeringFluency';
+    await vscode.env.clipboard.writeText(shareText);
+    await vscode.env.openExternal(vscode.Uri.parse(platformUrl));
+
+    const selection = await vscode.window.showInformationMessage(
+      'Share card image saved and caption copied to clipboard.',
+      'Open Image',
+    );
+    if (selection === 'Open Image') {
+      void vscode.env.openExternal(uri);
+    }
+    this.log(`Shared fluency score card to ${platform}`);
   }
 
   /**

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -527,6 +527,42 @@ async function handleScreenshotExport(command: 'exportPdf' | 'exportPptx'): Prom
   vscode.postMessage({ command, data: images });
 }
 
+async function handleShareToSocial(platform: 'linkedin' | 'bluesky' | 'mastodon'): Promise<void> {
+  const data = initialData;
+  if (!data) { return; }
+
+  const html2canvasModule = await import('html2canvas');
+  const html2canvas = (html2canvasModule.default ?? html2canvasModule) as unknown as (element: HTMLElement, options?: Record<string, unknown>) => Promise<HTMLCanvasElement>;
+
+  const card = document.createElement('div');
+  card.style.cssText = 'position:absolute;left:-9999px;top:0;width:1200px;height:630px;background:#1b1b1e;border-radius:16px;display:flex;flex-direction:column;justify-content:center;align-items:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;';
+
+  const stageColors = ['#93c5fd', '#a78bfa', '#3b82f6', '#22d3ee'];
+  const stageColor = stageColors[data.overallStage - 1] || '#58a6ff';
+
+  card.innerHTML = `
+    <div style="text-align:center;color:#fff;padding:48px;">
+      <div style="font-size:28px;margin-bottom:12px;">🎯 AI Engineering Fluency Score</div>
+      <div style="font-size:14px;color:#b8b8c8;margin-bottom:32px;text-transform:uppercase;letter-spacing:2px;">Overall AI Engineering Fluency</div>
+      <div style="font-size:56px;font-weight:800;color:${stageColor};margin-bottom:12px;">${escapeHtml(data.overallLabel)}</div>
+      <div style="font-size:20px;color:#b8b8c8;margin-bottom:40px;">${escapeHtml(STAGE_DESCRIPTIONS[data.overallStage] || '')}</div>
+      <div style="font-size:22px;font-weight:700;color:#58a6ff;margin-bottom:8px;">#AIEngineeringFluency</div>
+      <div style="font-size:14px;color:#7a7a8a;">Track your AI usage with AI Engineering Fluency</div>
+    </div>
+  `;
+
+  document.body.appendChild(card);
+  try {
+    const canvas = await html2canvas(card, { backgroundColor: '#1b1b1e', scale: 2, useCORS: true, width: 1200, height: 630 });
+    const dataUrl = canvas.toDataURL('image/png');
+    vscode.postMessage({ command: 'shareToSocial', platform, dataUrl });
+  } catch {
+    vscode.postMessage({ command: 'shareToSocialFailed', platform });
+  } finally {
+    document.body.removeChild(card);
+  }
+}
+
 function wireMaturityNavButtons(): void {
   document.getElementById('btn-refresh')?.addEventListener('click', () => { vscode.postMessage({ command: 'refresh' }); });
   document.getElementById('btn-level-viewer-inline')?.addEventListener('click', () => { vscode.postMessage({ command: 'showFluencyLevelViewer' }); });
@@ -558,9 +594,9 @@ function wireMaturityActionButtons(): void {
     });
   });
   document.getElementById('btn-reset-tips')?.addEventListener('click', () => { vscode.postMessage({ command: 'resetDismissedTips' }); });
-  document.getElementById('btn-share-linkedin')?.addEventListener('click', () => { vscode.postMessage({ command: 'shareToLinkedIn' }); });
-  document.getElementById('btn-share-bluesky')?.addEventListener('click', () => { vscode.postMessage({ command: 'shareToBluesky' }); });
-  document.getElementById('btn-share-mastodon')?.addEventListener('click', () => { vscode.postMessage({ command: 'shareToMastodon' }); });
+  document.getElementById('btn-share-linkedin')?.addEventListener('click', () => { void handleShareToSocial('linkedin'); });
+  document.getElementById('btn-share-bluesky')?.addEventListener('click', () => { void handleShareToSocial('bluesky'); });
+  document.getElementById('btn-share-mastodon')?.addEventListener('click', () => { void handleShareToSocial('mastodon'); });
 }
 
 function wireExportHandlers(): void {


### PR DESCRIPTION
The Fluency Score social share buttons previously copied only plain text to the clipboard. This changes them to produce a branded share-card image and a matching caption, making the posts more visual and consistent.

What changed:
- Clicking Share on LinkedIn/Bluesky/Mastodon now renders a 1200x630 share-card image via `html2canvas` inside the maturity webview.
- The extension saves the image to a temp PNG file, copies the caption text to the clipboard, opens the chosen social platform, and shows a notification with an "Open Image" button so the user can attach the image.
- Caption copied to the clipboard:
  > I am tracking my AI usage through this great tracker: AI Engineering Fluency! Track your usage as well #AIEngineeringFluency
- Removed the old text-only `shareToSocialMedia` flow for the maturity view; `shareTextToSocialPlatform` is still used by the diagnostics Share Card tab and was left unchanged.

Notes:
- The image is written to `os.tmpdir()` with a timestamped filename.
- Mastodon still prompts for the instance before opening the compose page.
- Build (`npm run compile`) reports 0 problems and all unit tests pass.