### PR TITLE
chore: bump versions for release (vscode, cli, jetbrains, visualstudio)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.3.0
+pluginVersion = 0.4.0
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest
+++ b/visualstudio-extension/src/AIEngineeringFluency/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="AIEngineeringFluency.VS.RobBos"
-              Version="1.2.0"
+              Version="1.3.0"
               Language="en-US"
               Publisher="Rob Bos" />
     <DisplayName>AI Engineering Fluency</DisplayName>

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@azure/arm-resources": "^8.0.0",
         "@azure/arm-resources-subscriptions": "^3.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — minor version bumps

Minor version bump for all four marketplace extensions. Desktop app excluded per request.

| Component | Old version | New version | Tag to push after merge |
|---|---|---|---|
| VS Code extension | 0.15.0 | 0.16.0 | `vscode/v0.16.0` |
| CLI | 0.4.0 | 0.5.0 | `cli/v0.5.0` |
| JetBrains plugin | 0.3.0 | 0.4.0 | `jetbrains/v0.4.0` |
| Visual Studio extension | 1.2.0 | 1.3.0 | `vs/v1.3.0` |

### After merging, push these tags (or run the corresponding workflows manually) to trigger publishing:
- `vscode/v0.16.0` → `release.yml`
- `cli/v0.5.0` → `cli-publish.yml`
- `jetbrains/v0.4.0` → `jetbrains-publish.yml`
- `vs/v1.3.0` → `visualstudio-publish.yml`

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>