### PR TITLE
Clarify month cost label in Cost by Provider cards

### DIFF
--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -503,7 +503,7 @@ function buildProviderCard(stats: DetailedStats, provider: string): HTMLElement 
 	card.append(
 		el('div', 'provider-card-label', `${getProviderIcon(provider)} ${provider}`),
 		el('div', 'provider-card-value', formatCost(stats.month.billingGroupCosts?.[provider] || 0)),
-		el('div', 'provider-card-sub', `Today ${formatCost(stats.today.billingGroupCosts?.[provider] || 0)} · 30d ${formatCost(stats.last30Days.billingGroupCosts?.[provider] || 0)}`)
+		el('div', 'provider-card-sub', 'Cost this month')
 	);
 
 	const toggle = (): void => {
@@ -526,7 +526,7 @@ function buildProviderTotalCard(stats: DetailedStats, allProviders: string[]): H
 	card.append(
 		el('div', 'provider-card-label', '∑ Total (selected)'),
 		el('div', 'provider-card-value', formatCost(sumBillingGroupCosts(stats.month.billingGroupCosts, included))),
-		el('div', 'provider-card-sub', `Today ${formatCost(sumBillingGroupCosts(stats.today.billingGroupCosts, included))} · 30d ${formatCost(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, included))}`)
+		el('div', 'provider-card-sub', 'Cost this month')
 	);
 	return card;
 }


### PR DESCRIPTION
## Summary
The "Cost by Provider" cards on the details page show a big cost value with no indication it's the current month's spend, while the sub-caption below it labels "Today" and "30d" clearly. This was confusing.

## Change
Replaced the `Today X · 30d Y` sub-caption on each provider card and the "Total (selected)" card with a plain **"Cost this month"** label, matching the big value shown. Today/30-day figures remain visible in the metrics table below (and via clicking a period column to filter), so nothing is lost — just de-duplicated and clarified.

## Files changed
- `vscode-extension/src/webview/details/main.ts`