### PR TITLE
Fix Input tokens exceeding Total tokens in period stats

### DIFF
--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -158,6 +158,57 @@ export function reconcileModelUsageToActualTokens(modelUsage: ModelUsage, actual
 	return reconcileModelUsageToTotal(modelUsage, inputTarget, outputTarget);
 }
 
+/** Sum of input + output tokens across all models in a usage map. */
+export function sumModelUsageTokens(modelUsage: ModelUsage): number {
+	return Object.values(modelUsage).reduce((s, u) => s + u.inputTokens + u.outputTokens, 0);
+}
+
+/** Scale every token field of a usage map by `fraction` (used for per-day distribution). */
+function scaleModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {
+	const scaled: ModelUsage = {};
+	for (const [model, usage] of Object.entries(modelUsage)) {
+		scaled[model] = {
+			inputTokens: Math.round(usage.inputTokens * fraction),
+			outputTokens: Math.round(usage.outputTokens * fraction),
+			...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * fraction) } : {}),
+			...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(usage.cacheCreationTokens * fraction) } : {}),
+			sessions: 0,
+		};
+	}
+	return scaled;
+}
+
+/**
+ * Distributes a session-level model usage breakdown across the session's daily
+ * rollups, weighted by each day's interaction count, and re-syncs each day's
+ * `actualTokens` to that day's distributed input+output total.
+ *
+ * Re-syncing `actualTokens` is the critical part: period stats derive "Total
+ * tokens" from each rollup's `actualTokens`/`tokens` but "Input/Output tokens"
+ * from the rollup's `modelUsage`. When a debug log upgrades the per-model
+ * breakdown to (much larger) exact API totals, leaving the rollup's token
+ * counts at their old session-file estimate makes Input exceed Total in every
+ * period view. Setting `actualTokens` from the same distributed usage keeps
+ * the two sources consistent by construction.
+ *
+ * Returns undefined when the rollups have no interactions to weight by
+ * (callers should keep their existing rollups in that case).
+ */
+export function distributeModelUsageToDays(
+	dailyRollups: Record<string, DailyRollupEntry>,
+	sessionModelUsage: ModelUsage,
+): Record<string, DailyRollupEntry> | undefined {
+	const totalInteractions = Object.values(dailyRollups).reduce((s, dr) => s + dr.interactions, 0);
+	if (totalInteractions <= 0) { return undefined; }
+	const result: Record<string, DailyRollupEntry> = {};
+	for (const [dayKey, dayRollup] of Object.entries(dailyRollups)) {
+		const fraction = dayRollup.interactions / totalInteractions;
+		const dayModelUsage = scaleModelUsage(sessionModelUsage, fraction);
+		result[dayKey] = { ...dayRollup, modelUsage: dayModelUsage, actualTokens: sumModelUsageTokens(dayModelUsage) };
+	}
+	return result;
+}
+
 /**
  * Merges `source` language usage into `target` (in-place).
  */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -188,7 +188,7 @@ import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceFor
 import { classifySessionTask, buildClassificationInputFromUsageAnalysis, type TaskCategory } from '../../src/taskClassification';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, reconcileModelUsageToActualTokens, type SessionAggregateInput } from '../../src/statsHelpers';
+import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, reconcileModelUsageToActualTokens, distributeModelUsageToDays, type SessionAggregateInput } from '../../src/statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -331,24 +331,6 @@ function _scdlBuildFromBreakdown(modelBreakdown: Record<string, { inputTokens: n
 	return modelUsage;
 }
 
-function _scdlDistributeToDays(
-	dailyRollups: Record<string, DailyRollupEntry>,
-	supplementModelUsage: ModelUsage
-): Record<string, DailyRollupEntry> | undefined {
-	const totalDayInteractions = Object.values(dailyRollups).reduce((s, dr) => s + dr.interactions, 0);
-	if (totalDayInteractions <= 0) { return undefined; }
-	const result: Record<string, DailyRollupEntry> = {};
-	for (const [dayKey, dayRollup] of Object.entries(dailyRollups)) {
-		const fraction = dayRollup.interactions / totalDayInteractions;
-		const dayModelUsage: ModelUsage = {};
-		for (const [model, usage] of Object.entries(supplementModelUsage)) {
-			dayModelUsage[model] = { inputTokens: Math.round(usage.inputTokens * fraction), outputTokens: Math.round(usage.outputTokens * fraction), sessions: 0, ...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * fraction) } : {}) };
-		}
-		result[dayKey] = { ...dayRollup, modelUsage: dayModelUsage };
-	}
-	return result;
-}
-
 /** One Copilot CLI session where OTel export data was found, for the diagnostics "OTel Delta" tab. */
 interface CopilotCliOtelComparisonSession {
 	file: string;
@@ -394,7 +376,7 @@ interface WorktreeScanResult {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 61; // Reconcile modelUsage to actualTokens for event-based sessions without debug logs
+	private static readonly CACHE_VERSION = 62; // Re-sync dailyRollup actualTokens when debug-log modelUsage is distributed to days; fix ?? skipping reconciliation
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';
@@ -4630,11 +4612,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// these independently (e.g. event-based CLI sessions derive actualTokens from real
 		// output via a ratio, while modelUsage derives input from accumulated message content),
 		// which can make Input+Output exceed Total in the details view.
-		const reconciledModelUsage = reconcileModelUsageToActualTokens(modelUsage, tokenResult.actualTokens ?? tokenResult.tokens);
+		// `||` (not `??`): actualTokens is 0 — never undefined — when no exact usage exists,
+		// so `??` would target 0 and silently skip reconciliation for estimated sessions.
+		const reconciledModelUsage = reconcileModelUsageToActualTokens(modelUsage, tokenResult.actualTokens || tokenResult.tokens);
 
-		const { dailyRollups, totalInteractions } = this.computeDailyRollups(sessionMeta, tokenResult, reconciledModelUsage, interactions);
+		const { dailyRollups } = this.computeDailyRollups(sessionMeta, tokenResult, reconciledModelUsage, interactions);
 		const debugLogTokens = await this.readTokensFromDebugLog(sessionFilePath);
-		const { resolvedActualTokens, finalCacheReadTokens, resolvedModelUsage } = this.resolveAndApplyDebugLog(tokenResult, debugLogTokens, reconciledModelUsage, dailyRollups, totalInteractions);
+		const { resolvedActualTokens, finalCacheReadTokens, resolvedModelUsage } = this.resolveAndApplyDebugLog(tokenResult, debugLogTokens, reconciledModelUsage, dailyRollups);
 
 		await this.applyWindsurfBreakdown(sessionFilePath, resolvedModelUsage, dailyRollups, usageAnalysis);
 
@@ -4781,8 +4765,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// partial (e.g. some requests lack a `model` attribute), so Input+Output
 		// never drifts from Total — see reconcileModelUsageToTotal for why.
 		const supplementModelUsage = reconcileModelUsageToTotal(breakdownUsage, debugLogTokens.inputTokens, debugLogTokens.outputTokens);
+		// Redistribute to days via the shared helper, which also re-syncs each day's
+		// actualTokens to the debug-log-sized usage — see distributeModelUsageToDays.
 		const supplementDailyRollups = cached.dailyRollups
-			? (_scdlDistributeToDays(cached.dailyRollups, supplementModelUsage) ?? cached.dailyRollups)
+			? (distributeModelUsageToDays(cached.dailyRollups, supplementModelUsage) ?? cached.dailyRollups)
 			: cached.dailyRollups;
 		const supplemented: SessionFileCache = {
 			...cached, modelUsage: supplementModelUsage, dailyRollups: supplementDailyRollups,
@@ -4897,8 +4883,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		tokenResult: { tokens: number; actualTokens?: number; cacheReadTokens?: number },
 		debugLogTokens: { inputTokens: number; outputTokens: number; cachedTokens?: number; modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }> } | null | undefined,
 		modelUsage: ModelUsage,
-		dailyRollups: { [utcDayKey: string]: DailyRollupEntry },
-		totalInteractions: number
+		dailyRollups: { [utcDayKey: string]: DailyRollupEntry }
 	): { resolvedActualTokens: number | undefined; finalCacheReadTokens: number | undefined; resolvedModelUsage: ModelUsage } {
 		const resolvedActualTokens = (debugLogTokens && (debugLogTokens.inputTokens + debugLogTokens.outputTokens) > 0)
 			? debugLogTokens.inputTokens + debugLogTokens.outputTokens
@@ -4911,7 +4896,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		this.backfillDailyRollupCacheTokens(dailyRollups, finalCacheReadTokens);
 
-		const resolvedModelUsage = this.applyDebugLogModelBreakdown(modelUsage, debugLogTokens, dailyRollups, totalInteractions);
+		const resolvedModelUsage = this.applyDebugLogModelBreakdown(modelUsage, debugLogTokens, dailyRollups);
 		return { resolvedActualTokens, finalCacheReadTokens, resolvedModelUsage };
 	}
 
@@ -4932,7 +4917,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 	}
 
-	private applyDebugLogModelBreakdown(modelUsage: ModelUsage, debugLogTokens: { inputTokens: number; outputTokens: number; modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }> } | null | undefined, dailyRollups: { [utcDayKey: string]: DailyRollupEntry }, totalInteractions: number): ModelUsage {
+	private applyDebugLogModelBreakdown(modelUsage: ModelUsage, debugLogTokens: { inputTokens: number; outputTokens: number; modelBreakdown: Record<string, { inputTokens: number; outputTokens: number; cachedTokens: number }> } | null | undefined, dailyRollups: { [utcDayKey: string]: DailyRollupEntry }): ModelUsage {
 		if (!debugLogTokens || debugLogTokens.inputTokens + debugLogTokens.outputTokens === 0) { return modelUsage; }
 		const breakdownUsage: ModelUsage = {};
 		for (const [model, bd] of Object.entries(debugLogTokens.modelBreakdown)) {
@@ -4946,9 +4931,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 			debugLogTokens.inputTokens,
 			debugLogTokens.outputTokens,
 		);
-		for (const [dayKey, dayRollup] of Object.entries(dailyRollups)) {
-			const fraction = totalInteractions > 0 ? dayRollup.interactions / totalInteractions : 1;
-			dailyRollups[dayKey].modelUsage = this.scaledModelUsage(resolvedModelUsage, fraction);
+		// Redistribute to days AND re-sync each day's actualTokens — the rollups were
+		// built from the (smaller) session-file estimate, and period stats derive
+		// "Total tokens" from rollup actualTokens but "Input/Output" from rollup
+		// modelUsage. Leaving the old day totals in place makes Input exceed Total.
+		const redistributed = distributeModelUsageToDays(dailyRollups, resolvedModelUsage);
+		if (redistributed) {
+			for (const [dayKey, dayRollup] of Object.entries(redistributed)) {
+				dailyRollups[dayKey] = dayRollup;
+			}
 		}
 		return resolvedModelUsage;
 	}

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -10,6 +10,8 @@ computeSessionTotalTokens,
 computeSessionDurationMs,
 reconcileModelUsageToTotal,
 reconcileModelUsageToActualTokens,
+distributeModelUsageToDays,
+sumModelUsageTokens,
 type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../../src/statsHelpers';
@@ -1083,4 +1085,92 @@ const day = result.dailyStatsMap.get('2025-03-15')!;
 assert.equal(day.modelUsage['gpt-4o']?.sessions, 1);
 assert.equal(day.editorModelUsage!['VS Code']['gpt-4o']?.sessions, 1);
 assert.equal(day.editorUsage['VS Code']?.sessions, 1);
+});
+
+// ── distributeModelUsageToDays ───────────────────────────────────────────────
+
+test('distributeModelUsageToDays: distributes usage by interaction weight and re-syncs day actualTokens', () => {
+	const rollups = {
+		'2025-03-14': { tokens: 500, actualTokens: 0, thinkingTokens: 0, interactions: 3, modelUsage: {} },
+		'2025-03-15': { tokens: 500, actualTokens: 0, thinkingTokens: 0, interactions: 1, modelUsage: {} },
+	};
+	const sessionUsage: ModelUsage = { 'gpt-4o': { inputTokens: 8000, outputTokens: 2000, cachedReadTokens: 4000, sessions: 0 } };
+	const result = distributeModelUsageToDays(rollups, sessionUsage)!;
+	assert.ok(result, 'returns distributed rollups');
+	assert.equal(result['2025-03-14'].modelUsage['gpt-4o'].inputTokens, 6000, '3/4 of input');
+	assert.equal(result['2025-03-15'].modelUsage['gpt-4o'].inputTokens, 2000, '1/4 of input');
+	assert.equal(result['2025-03-14'].modelUsage['gpt-4o'].cachedReadTokens, 3000, 'cache reads distributed too');
+	// The invariant this helper exists for: each day's actualTokens equals that
+	// day's distributed input+output, so period Total >= period Input.
+	assert.equal(result['2025-03-14'].actualTokens, 7500);
+	assert.equal(result['2025-03-15'].actualTokens, 2500);
+});
+
+test('distributeModelUsageToDays: returns undefined when rollups have no interactions', () => {
+	const rollups = {
+		'2025-03-15': { tokens: 100, actualTokens: 0, thinkingTokens: 0, interactions: 0, modelUsage: {} },
+	};
+	assert.equal(distributeModelUsageToDays(rollups, { 'gpt-4o': { inputTokens: 10, outputTokens: 5, sessions: 0 } }), undefined);
+});
+
+test('sumModelUsageTokens: sums input+output across models, ignoring cache fields', () => {
+	assert.equal(sumModelUsageTokens({
+		'a': { inputTokens: 100, outputTokens: 20, cachedReadTokens: 90, sessions: 0 },
+		'b': { inputTokens: 50, outputTokens: 5, sessions: 0 },
+	}), 175);
+});
+
+// ── Regression: Input tokens must never exceed Total tokens per period ───────
+// Shaped on real data from a machine where the details view showed
+// "Input tokens" > "Total tokens" on every period: a VS Code Chat session
+// whose file-based estimate was ~1.04M tokens but whose Copilot Chat debug
+// log recorded ~18.5M exact API tokens. The debug-log path replaced the
+// per-day modelUsage with the (much larger) debug totals but left the day
+// rollup's tokens/actualTokens at the old estimate, so aggregated Input
+// (from modelUsage) exceeded aggregated Total (from rollup tokens).
+test('aggregatePeriodStats: debug-log-sized modelUsage cannot exceed period total after distributeModelUsageToDays (regression)', () => {
+	const ranges = makeRanges('2025-03-15');
+	// Day rollups as originally built from the session-file estimate.
+	const rollups = {
+		'2025-03-14': { tokens: 542265, actualTokens: 0, thinkingTokens: 0, interactions: 2, modelUsage: {} },
+		'2025-03-15': { tokens: 500000, actualTokens: 0, thinkingTokens: 0, interactions: 2, modelUsage: {} },
+	};
+	// Debug-log exact totals (real session 354a5617: in=18,387,960 out=135,055).
+	const debugUsage: ModelUsage = { 'gpt-4.1': { inputTokens: 18387960, outputTokens: 135055, cachedReadTokens: 17691909, sessions: 0 } };
+	const distributed = distributeModelUsageToDays(rollups, debugUsage)!;
+	const input: SessionAggregateInput = {
+		editorType: 'VS Code',
+		mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+		sessionData: makeSession({ dailyRollups: distributed }),
+	};
+	const result = aggregatePeriodStats([input], ranges);
+	for (const [name, period] of [['last30Days', result.last30DaysStats], ['month', result.monthStats]] as const) {
+		const inputTokens = Object.values(period.modelUsage).reduce((s, u) => s + u.inputTokens, 0);
+		const outputTokens = Object.values(period.modelUsage).reduce((s, u) => s + u.outputTokens, 0);
+		assert.ok(inputTokens + outputTokens <= period.tokens + period.thinkingTokens,
+			`${name}: Input+Output (${inputTokens + outputTokens}) must not exceed Total (${period.tokens + period.thinkingTokens})`);
+		assert.ok(inputTokens > 18000000, `${name}: input reflects debug-log totals`);
+	}
+});
+
+// Documents the pre-fix behaviour: distributing debug-log modelUsage WITHOUT
+// re-syncing day actualTokens reproduces the "Input > Total" bug in aggregation.
+test('aggregatePeriodStats: stale rollup tokens with debug-log modelUsage reproduces Input > Total (bug shape)', () => {
+	const ranges = makeRanges('2025-03-15');
+	const buggyRollups = {
+		'2025-03-15': {
+			tokens: 1042265, actualTokens: 0, thinkingTokens: 0, interactions: 4,
+			// Debug-log-sized usage pasted onto a day whose token counts were never updated.
+			modelUsage: { 'gpt-4.1': { inputTokens: 18387960, outputTokens: 135055, sessions: 0 } },
+		},
+	};
+	const input: SessionAggregateInput = {
+		editorType: 'VS Code',
+		mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+		sessionData: makeSession({ dailyRollups: buggyRollups }),
+	};
+	const result = aggregatePeriodStats([input], ranges);
+	const inputTokens = Object.values(result.last30DaysStats.modelUsage).reduce((s, u) => s + u.inputTokens, 0);
+	assert.ok(inputTokens > result.last30DaysStats.tokens,
+		'unsynced rollups make Input exceed Total — this is why distributeModelUsageToDays must re-sync actualTokens');
 });


### PR DESCRIPTION
## Problem
On all periods in the Details view, **Input tokens exceeded Total tokens** (e.g. Last 30 Days: Input 2.2B > Total 2.1B).

## Root cause (verified with real data on a local machine)
For sessions with Copilot Chat debug logs, `applyDebugLogModelBreakdown` and `_scdlDistributeToDays` rescaled each day rollup's `modelUsage` to the debug log's exact API totals but **never updated the rollup's `tokens`/`actualTokens`**. Period aggregation takes Total from rollup tokens (stale session-file estimate) and Input/Output from `modelUsage` (debug-log sized) → Input > Total.

Measured locally: 48 sessions with debug logs — rollup tokens summed to 10.0M while modelUsage input+output summed to 125.1M (>12×).

Secondary bug: `tokenResult.actualTokens ?? tokenResult.tokens` — `actualTokens` is `0` (never `undefined`) when unknown, so the fallback never fired and modelUsage reconciliation was silently skipped for estimated sessions. The CLI already correctly used `||`.

## Fix
- New shared helper `distributeModelUsageToDays()` in `src/statsHelpers.ts`: distributes session modelUsage across day rollups by interaction weight **and re-syncs each day's `actualTokens`** to the distributed input+output, keeping Total ≥ Input+Output by construction.
- Both debug-log supplement paths in `extension.ts` now use it (replaces `_scdlDistributeToDays`).
- `??` → `||` for the actualTokens reconciliation fallback (matches CLI).
- `CACHE_VERSION` 61 → 62 so cached rollups get rebuilt.

## Tests
- Unit tests for `distributeModelUsageToDays` / `sumModelUsageTokens`.
- Regression test shaped on real session data (file estimate ~1.04M tokens vs debug log ~18.5M) asserting Input+Output ≤ Total per period after the fix.
- A "bug shape" test documenting that unsynced rollups reproduce Input > Total.

All 90 statsHelpers tests plus the full `npm run test:node` suite pass; `npm run compile` (tsc + eslint + esbuild) is clean.