### PR TITLE
Add setting to hide automatic tool calls in Tool Usage view

### DIFF
--- a/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
@@ -2637,7 +2637,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     card.append(
       el("div", "provider-card-label", `${getProviderIcon(provider)} ${provider}`),
       el("div", "provider-card-value", formatCost(stats.month.billingGroupCosts?.[provider] || 0)),
-      el("div", "provider-card-sub", `Today ${formatCost(stats.today.billingGroupCosts?.[provider] || 0)} \xB7 30d ${formatCost(stats.last30Days.billingGroupCosts?.[provider] || 0)}`)
+      el("div", "provider-card-sub", "Cost this month")
     );
     const toggle = () => {
       if (excludedProviders.has(provider)) {
@@ -2664,7 +2664,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     card.append(
       el("div", "provider-card-label", "\u2211 Total (selected)"),
       el("div", "provider-card-value", formatCost(sumBillingGroupCosts(stats.month.billingGroupCosts, included))),
-      el("div", "provider-card-sub", `Today ${formatCost(sumBillingGroupCosts(stats.today.billingGroupCosts, included))} \xB7 30d ${formatCost(sumBillingGroupCosts(stats.last30Days.billingGroupCosts, included))}`)
+      el("div", "provider-card-sub", "Cost this month")
     );
     return card;
   }

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -2946,10 +2946,11 @@ ${_renderMultiModelMixedCostSessions(switching)}
         </div>
     `;
   }
-  function renderToolsTable(byTool, limit = 10, nameResolver = lookupToolName) {
-    const sortedTools = Object.entries(byTool).sort(([, a3], [, b3]) => b3 - a3).slice(0, limit);
+  function renderToolsTable(byTool, limit = 10, nameResolver = lookupToolName, applyAutoFilter = false) {
+    const entries = applyAutoFilter && hideAutomaticToolCalls ? Object.entries(byTool).filter(([tool]) => !AUTOMATIC_TOOL_SET_WV.has(tool.toLowerCase())) : Object.entries(byTool);
+    const sortedTools = entries.sort(([, a3], [, b3]) => b3 - a3).slice(0, limit);
     if (sortedTools.length === 0) {
-      return '<div style="color: var(--text-muted);">No tools used yet</div>';
+      return applyAutoFilter && hideAutomaticToolCalls ? '<div style="color: var(--text-muted);">No purposeful tools used yet (automatic tool calls are hidden)</div>' : '<div style="color: var(--text-muted);">No tools used yet</div>';
     }
     const rows = sortedTools.map(([tool, count], idx) => {
       const friendly = escapeHtml(nameResolver(tool));
@@ -3015,6 +3016,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
   var sessionSortDirection = "desc";
   var cachedTodaySessions = [];
   var use24HourTime = true;
+  var hideAutomaticToolCalls = true;
   var sessionsLookback = "today";
   var latestTodaySessions = [];
   var recentSessionsCache = {};
@@ -5857,27 +5859,27 @@ ${_renderMultiModelMixedCostSessions(switching)}
 			<!-- Tool Calls Section -->
 			<div class="section">
 				<div class="section-title"><span>\u{1F527}</span><span>Tool Usage</span></div>
-				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions</div>
+				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions${hideAutomaticToolCalls ? ' (automatic tool calls hidden \u2014 disable "Hide Automatic Tool Calls" in settings to show them)' : ""}</div>
 				<div class="three-column">
 					<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
 					<div class="list">
 						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.today.toolCalls.total)}</div>
-						${renderToolsTable(unionFill(stats.today.toolCalls.byTool, allToolKeys), 10)}
+						${renderToolsTable(unionFill(stats.today.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
 					<div class="list">
 						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.last30Days.toolCalls.total)}</div>
-							${renderToolsTable(unionFill(stats.last30Days.toolCalls.byTool, allToolKeys), 10)}
+							${renderToolsTable(unionFill(stats.last30Days.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 						</div>
 					</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
 					<div class="list">
 						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.month.toolCalls.total)}</div>
-							${renderToolsTable(unionFill(stats.month.toolCalls.byTool, allToolKeys), 10)}
+							${renderToolsTable(unionFill(stats.month.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 						</div>
 					</div>
 				</div>
@@ -6091,6 +6093,9 @@ ${_renderMultiModelMixedCostSessions(switching)}
     }
     if (typeof message.data?.use24HourTime === "boolean") {
       use24HourTime = message.data.use24HourTime;
+    }
+    if (typeof message.data?.hideAutomaticToolCalls === "boolean") {
+      hideAutomaticToolCalls = message.data.hideAutomaticToolCalls;
     }
     const sanitized = sanitizeStats(message.data);
     if (sanitized) {
@@ -6702,6 +6707,7 @@ For each issue, please provide specific steps or code changes to fix it.`;
     }
     setFormatLocale(initialData.locale);
     use24HourTime = initialData.use24HourTime !== false;
+    hideAutomaticToolCalls = initialData.hideAutomaticToolCalls !== false;
     const savedColumns = initialData.sessionColumnSettings?.enabledColumns;
     if (Array.isArray(savedColumns)) {
       const valid = savedColumns.filter((c4) => ALL_SESSION_COLUMN_IDS.includes(c4));

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -169,6 +169,11 @@
           "default": true,
           "description": "Show times in 24-hour format (e.g. 14:30). When disabled, 12-hour AM/PM format is used (e.g. 2:30 PM)."
         },
+        "aiEngineeringFluency.display.hideAutomaticToolCalls": {
+          "type": "boolean",
+          "default": true,
+          "description": "In the Tool Usage view, hide tools marked \"auto\" (tools Copilot calls automatically, e.g. file reads and searches) so purposeful/intentional tool calls stand out. Disable to show automatic tool calls again."
+        },
         "aiEngineeringFluency.display.statusBar.showTokens": {
           "type": "string",
           "enum": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3204,6 +3204,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('display.use24HourTime', true);
 	}
 
+	private getHideAutomaticToolCallsSetting(): boolean {
+		return vscode.workspace.getConfiguration('aiEngineeringFluency').get<boolean>('display.hideAutomaticToolCalls', true);
+	}
+
 	private getStatusBarShowTokensSetting(): StatusBarDisplaySetting {
 		return vscode.workspace.getConfiguration('aiEngineeringFluency.display.statusBar').get<StatusBarDisplaySetting>('showTokens', 'both');
 	}
@@ -3320,6 +3324,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 		if (this.chartPanel && (this.lastFullDailyStats || this.lastDailyStats)) {
 			this.chartPanel.webview.html = this.getChartHtml(this.chartPanel.webview, this.lastFullDailyStats ?? this.lastDailyStats!);
+		}
+		if (this.analysisPanel && this.lastUsageAnalysisStats) {
+			void this.analysisPanel.webview.postMessage({ command: 'updateStats', data: this._buildAnalysisUpdateData(this.lastUsageAnalysisStats) });
 		}
 	}
 
@@ -6444,6 +6451,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			curationAnalysis: analysisStats.curationAnalysis ?? null,
 			copilotApiBalance: this._buildCopilotApiBalance(),
 			monthBillingGroupCosts: this.lastDetailedStats?.month.billingGroupCosts ?? null,
+			hideAutomaticToolCalls: this.getHideAutomaticToolCallsSetting(),
 		};
 	}
 
@@ -10170,6 +10178,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       suppressedUnknownTools,
       todaySessions: stats.todaySessions || [],
       use24HourTime: this.getUse24HourTimeSetting(),
+      hideAutomaticToolCalls: this.getHideAutomaticToolCallsSetting(),
       insights: this.buildCurrentInsights(stats),
       curationAnalysis: stats.curationAnalysis ?? null,
       sessionColumnSettings,

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -105,6 +105,8 @@ type UsageAnalysisStats = {
 	suppressedUnknownTools?: string[];
 	todaySessions?: TodaySessionSummary[];
 	use24HourTime?: boolean;
+	/** When true (default), rows tagged "auto" are hidden from the Tool Usage tables so only intentional tool calls are shown. */
+	hideAutomaticToolCalls?: boolean;
 	insights?: EvaluatedInsight[];
 	curationAnalysis?: ToolCurationAnalysis | null;
 	/** Persisted "Recent Sessions" column visibility (optional column ids). Absent/invalid entries mean "show all". */
@@ -957,13 +959,18 @@ function renderMissedPotential(stats: UsageAnalysisStats): string {
     `;
 }
 
-function renderToolsTable(byTool: { [key: string]: number }, limit = 10, nameResolver: (id: string) => string = lookupToolName): string {
-	const sortedTools = Object.entries(byTool)
+function renderToolsTable(byTool: { [key: string]: number }, limit = 10, nameResolver: (id: string) => string = lookupToolName, applyAutoFilter = false): string {
+	const entries = applyAutoFilter && hideAutomaticToolCalls
+		? Object.entries(byTool).filter(([tool]) => !AUTOMATIC_TOOL_SET_WV.has(tool.toLowerCase()))
+		: Object.entries(byTool);
+	const sortedTools = entries
 		.sort(([, a], [, b]) => b - a)
 		.slice(0, limit);
 
 	if (sortedTools.length === 0) {
-		return '<div style="color: var(--text-muted);">No tools used yet</div>';
+		return applyAutoFilter && hideAutomaticToolCalls
+			? '<div style="color: var(--text-muted);">No purposeful tools used yet (automatic tool calls are hidden)</div>'
+			: '<div style="color: var(--text-muted);">No tools used yet</div>';
 	}
 
 	    const rows = sortedTools.map(([tool, count], idx) => {
@@ -1048,6 +1055,8 @@ let sessionSortColumn: SessionSortColumn = 'interactions';
 let sessionSortDirection: 'asc' | 'desc' = 'desc';
 let cachedTodaySessions: TodaySessionSummary[] = [];
 let use24HourTime = true;
+/** When true (default), the Tool Usage tables hide rows tagged "auto" so purposeful tool calls stand out. */
+let hideAutomaticToolCalls = true;
 // Lookback selector state: "today" renders the summaries bundled with updateStats;
 // longer windows are lazily requested from the extension host and cached here.
 let sessionsLookback: SessionsLookback = 'today';
@@ -4121,27 +4130,27 @@ function buildToolsTabPanelHtml(
 			<!-- Tool Calls Section -->
 			<div class="section">
 				<div class="section-title"><span>🔧</span><span>Tool Usage</span></div>
-				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions</div>
+				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions${hideAutomaticToolCalls ? ' (automatic tool calls hidden — disable "Hide Automatic Tool Calls" in settings to show them)' : ''}</div>
 				<div class="three-column">
 					<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📅 Today</h4>
 					<div class="list">
 						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.today.toolCalls.total)}</div>
-						${renderToolsTable(unionFill(stats.today.toolCalls.byTool, allToolKeys), 10)}
+						${renderToolsTable(unionFill(stats.today.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📆 Last 30 Days</h4>
 					<div class="list">
 						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.last30Days.toolCalls.total)}</div>
-							${renderToolsTable(unionFill(stats.last30Days.toolCalls.byTool, allToolKeys), 10)}
+							${renderToolsTable(unionFill(stats.last30Days.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 						</div>
 					</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">📅 Previous Month</h4>
 					<div class="list">
 						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.month.toolCalls.total)}</div>
-							${renderToolsTable(unionFill(stats.month.toolCalls.byTool, allToolKeys), 10)}
+							${renderToolsTable(unionFill(stats.month.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 						</div>
 					</div>
 				</div>
@@ -4368,6 +4377,9 @@ function handleUpdateStats(message: any): void {
 	}
 	if (typeof message.data?.use24HourTime === 'boolean') {
 		use24HourTime = message.data.use24HourTime;
+	}
+	if (typeof message.data?.hideAutomaticToolCalls === 'boolean') {
+		hideAutomaticToolCalls = message.data.hideAutomaticToolCalls;
 	}
 	const sanitized = sanitizeStats(message.data);
 	if (sanitized) {
@@ -4993,6 +5005,7 @@ async function bootstrap(): Promise<void> {
 	}
 	setFormatLocale(initialData.locale);
 	use24HourTime = initialData.use24HourTime !== false;
+	hideAutomaticToolCalls = initialData.hideAutomaticToolCalls !== false;
 	const savedColumns = initialData.sessionColumnSettings?.enabledColumns;
 	if (Array.isArray(savedColumns)) {
 		const valid = savedColumns.filter((c): c is SessionColumnId => (ALL_SESSION_COLUMN_IDS as string[]).includes(c));


### PR DESCRIPTION
## Summary
Adds a new setting, `aiEngineeringFluency.display.hideAutomaticToolCalls` (default: **enabled**), which hides "auto" tagged rows from the Tool Usage tables (Today / Last 30 Days / Previous Month) so purposeful/intentional tool calls are what you see by default. Disabling the setting shows automatic tool calls again, same as before.

Note: updating which tools are classified as `auto` in `src/automaticTools.json` is being handled separately.

## Changes
- `vscode-extension/package.json`: new `aiEngineeringFluency.display.hideAutomaticToolCalls` boolean setting (default `true`).
- `vscode-extension/src/extension.ts`: reads the setting, includes it in the initial usage-webview payload and live update payload, and refreshes the usage panel when the setting changes.
- `vscode-extension/src/webview/usage/main.ts`: `renderToolsTable` now optionally filters out tools in the automatic-tool set before sorting/limiting; applied to the 3 main Tool Usage tables (not the MCP tables, which never contain automatic tools). Section subtitle notes when auto calls are hidden.
- Refreshed the Visual Studio host's committed webview bundles (`details.js`, `usage.js`) via the `sync-host-views` skill so the new behavior — and an unrelated pre-existing stale `details.js` bundle — are current. JetBrains and the desktop app copy webview bundles from `dist/` at their own build time, so no committed files needed updating there.

## Validation
- `npm run compile` (tsc + eslint + esbuild) — passed
- `npm run test:node` — all existing unit tests passed
- `./build.ps1 -Project visualstudio` — built cleanly, no `error CS`