### PR TITLE
Isolate Usage Analysis section render failures from the rest of the dashboard

### DIFF
--- a/vscode-extension/src/webview/shared/formatUtils.ts
+++ b/vscode-extension/src/webview/shared/formatUtils.ts
@@ -113,6 +113,33 @@ export function escapeHtml(text: string): string {
 }
 
 /**
+ * Runs a section-html builder and isolates failures so one broken section can never blank
+ * out an entire page render. If `builder` throws, the error is logged (via `onError`, e.g.
+ * `console.error`) and a small inline error card is returned in its place instead of letting
+ * the exception propagate up through the surrounding template literal (which would otherwise
+ * abort the whole `root.innerHTML` assignment and leave every other section stuck on stale or
+ * blank content).
+ */
+export function safeSectionHtml(
+	label: string,
+	builder: () => string,
+	onError: (message: string) => void = (m) => console.error(m),
+): string {
+	try {
+		return builder();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		onError(`[usage-webview] Section "${label}" failed to render: ${message}`);
+		return `<div class="section" style="border-color: rgba(239, 68, 68, 0.3);">
+			<div class="section-title"><span>⚠️</span><span>${escapeHtml(label)}</span></div>
+			<div style="color: var(--text-secondary); font-size: 12px; padding: 8px 0;">
+				This section couldn't be displayed due to an unexpected error. Other sections are unaffected — try refreshing the dashboard.
+			</div>
+		</div>`;
+	}
+}
+
+/**
  * Formats a byte count as a human-readable file size string.
  */
 export function formatFileSize(bytes: number): string {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -3,7 +3,7 @@ import { el } from '../shared/domUtils';
 import { createPeriodSelector, PERIOD_LABELS, type Period } from '../shared/periodSelector';
 import { navButtonsHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
-import { escapeHtml, formatCompact, formatCost, formatDurationShort, formatFileSize, formatFixed, formatNumber, formatPercent, setFormatLocale } from '../shared/formatUtils';
+import { escapeHtml, formatCompact, formatCost, formatDurationShort, formatFileSize, formatFixed, formatNumber, formatPercent, safeSectionHtml, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis as BaseModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
@@ -3116,13 +3116,13 @@ function buildUsageRootHtml(
 				<button class="tab-button ${activeTab === 'insights' ? 'active' : ''}" data-tab="insights"><span class="codicon codicon-lightbulb"></span> Insights${(stats.insights ?? []).filter(i => i.status === 'new').length > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(stats.insights ?? []).filter(i => i.status === 'new').length}</span>` : ''}</button>
 			</div>
 
-			${buildSessionsTabPanelHtml(stats)}
-			${buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs)}
-			${buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels)}
-			${buildHealthTabPanelHtml(customizationHtml, stats)}
-			${buildReposAndAgentTabPanelsHtml()}
-			${buildWorktreesTabPanelHtml()}
-			${buildInsightsTabPanelHtml(stats.insights ?? [])}
+			${safeSectionHtml('Recent Sessions', () => buildSessionsTabPanelHtml(stats))}
+			${safeSectionHtml('My Activity', () => buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs))}
+			${safeSectionHtml('Tools & Integrations', () => buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels))}
+			${safeSectionHtml('Workspace Health', () => buildHealthTabPanelHtml(customizationHtml, stats))}
+			${safeSectionHtml('Repository PRs & Cloud Agent', () => buildReposAndAgentTabPanelsHtml())}
+			${safeSectionHtml('Worktrees', () => buildWorktreesTabPanelHtml())}
+			${safeSectionHtml('Insights', () => buildInsightsTabPanelHtml(stats.insights ?? []))}
 			<div class="footer">
 				Last updated: ${escapeHtml(new Date(stats.lastUpdated).toLocaleString())} · Updates every 5 minutes
 			</div>
@@ -3574,13 +3574,12 @@ function buildActivityTabPanelHtml(
 	todayTotalRefs: number,
 	last30DaysTotalRefs: number,
 ): string {
-	const modelCostHtml = buildModelCostSectionHtml(stats);
-	const billingComparisonHtml = buildBillingComparisonSectionHtml(stats);
-	return `
-		<div id="tab-panel-activity" class="tab-panel"${activeTab !== 'activity' ? ' style="display:none"' : ''}>
-			${sessionsSummaryHtml}
-			${billingComparisonHtml}
-			<!-- Mode Usage Section -->
+	// Each section is built through safeSectionHtml so a bug in one section (e.g. a data
+	// shape it doesn't expect) renders an inline error card for that section only, instead of
+	// throwing out of this template literal and blanking the entire Activity tab.
+	const modelCostHtml = safeSectionHtml('Model Cost', () => buildModelCostSectionHtml(stats));
+	const billingComparisonHtml = safeSectionHtml('Copilot Billing Coverage', () => buildBillingComparisonSectionHtml(stats));
+	const modeUsageHtml = safeSectionHtml('Interaction Modes', () => `
 			<div class="section">
 				<div class="section-title"><span>🎯</span><span>Interaction Modes</span></div>
 				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), or Agent (autonomous tasks)</div>
@@ -3588,13 +3587,22 @@ function buildActivityTabPanelHtml(
 					${renderModeBarChart(stats.today.modeUsage, '📅 Today')}
 					${renderModeBarChart(stats.last30Days.modeUsage, '📊 Last 30 Days')}
 				</div>
-			</div>
-			${buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs)}
+			</div>`);
+	const contextRefsHtml = safeSectionHtml('Context References', () => buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs));
+	const modelEfficiencyHtml = safeSectionHtml('Model Efficiency', () => buildModelEfficiencySectionHtml(stats));
+	const contextWindowHtml = safeSectionHtml('Context Window', () => buildContextWindowSectionHtml(stats));
+	return `
+		<div id="tab-panel-activity" class="tab-panel"${activeTab !== 'activity' ? ' style="display:none"' : ''}>
+			${sessionsSummaryHtml}
+			${billingComparisonHtml}
+			<!-- Mode Usage Section -->
+			${modeUsageHtml}
+			${contextRefsHtml}
 			${multiModelHtml}
 			${modelCostHtml}
-			${buildModelEfficiencySectionHtml(stats)}
+			${modelEfficiencyHtml}
 			${thinkingEffortHtml}
-			${buildContextWindowSectionHtml(stats)}
+			${contextWindowHtml}
 		</div>`;
 }
 
@@ -4162,12 +4170,32 @@ function buildToolsTabPanelHtml(
 		</div>`;
 }
 
-function renderLayout(stats: UsageAnalysisStats): void {
-	const root = document.getElementById('root');
-	if (!root) {
-		return;
+/**
+ * Assigns the full dashboard HTML to `root`, isolating any failure that escapes the
+ * per-section/per-tab safeSectionHtml wrapping in buildUsageRootHtml. On failure, falls back
+ * to a minimal error state with a reload button instead of leaving the page on stale/blank
+ * content. Returns true on success, false if the fallback error state was shown instead.
+ */
+function assignUsageRootHtml(root: HTMLElement, build: () => string): boolean {
+	try {
+		root.innerHTML = build();
+		return true;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`[usage-webview] renderLayout failed: ${message}`);
+		root.innerHTML = `<div style="padding: 32px; text-align: center; font-size: 14px;">
+			<div style="color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;">⚠️ Something went wrong rendering the dashboard.</div>
+			${createRefreshButton().outerHTML}
+		</div>`;
+		return false;
 	}
+}
 
+/**
+ * Syncs module-level UI state (hygiene matrix, workspace paths, curation analysis cache) from
+ * a fresh stats payload, and resolves the customization matrix to use for this render.
+ */
+function syncRenderLayoutState(stats: UsageAnalysisStats): WorkspaceCustomizationMatrix | null {
 	// customizationMatrix is passed as an extra field on the stats object alongside the typed fields
 	type StatsWithMatrix = UsageAnalysisStats & { customizationMatrix?: WorkspaceCustomizationMatrix | null };
 	const matrix =
@@ -4190,12 +4218,24 @@ function renderLayout(stats: UsageAnalysisStats): void {
 	} else {
 		traceCurationOnce('render-no-curation-update', 'renderLayout.curation.notProvidedInUpdate');
 	}
+	return matrix;
+}
 
-	const customizationHtml = buildCustomizationSectionHtml(matrix);
+function renderLayout(stats: UsageAnalysisStats): void {
+	const root = document.getElementById('root');
+	if (!root) {
+		return;
+	}
+
+	const matrix = syncRenderLayoutState(stats);
+	const customizationHtml = safeSectionHtml('Workspace Customization', () => buildCustomizationSectionHtml(matrix));
+	// buildUsageAllKeysSets and the context-ref totals are cheap, pure aggregations over
+	// already-validated stats — not worth isolating individually. buildUsageRootHtml (and each
+	// tab/section within it) is isolated via safeSectionHtml / assignUsageRootHtml below.
 	const allKeys = buildUsageAllKeysSets(stats);
 	const todayTotalRefs = getTotalContextRefs(stats.today.contextReferences);
 	const last30DaysTotalRefs = getTotalContextRefs(stats.last30Days.contextReferences);
-	const thinkingEffortHtml = buildThinkingEffortSectionHtml(stats);
+	const thinkingEffortHtml = safeSectionHtml('Thinking Effort', () => buildThinkingEffortSectionHtml(stats));
 	const sessionsSummaryHtml = `
 		<!-- Summary Section -->
 		<div class="section">
@@ -4208,7 +4248,7 @@ function renderLayout(stats: UsageAnalysisStats): void {
 			</div>
 		</div>`;
 
-	root.innerHTML = buildUsageRootHtml(
+	const rendered = assignUsageRootHtml(root, () => buildUsageRootHtml(
 		stats,
 		customizationHtml,
 		'',
@@ -4223,7 +4263,8 @@ function renderLayout(stats: UsageAnalysisStats): void {
 		allKeys.allLowCostModels,
 		allKeys.allMediumCostModels,
 		allKeys.allUnknownModels,
-	);
+	));
+	if (!rendered) { return; }
 
 	wireNavigationButtons();
 	wireAboutInfoToggle();

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -13,6 +13,7 @@ import {
 	formatDurationShort,
 	formatFileSize,
 	escapeHtml,
+	safeSectionHtml,
 	markdownToHtml,
 	STAGE_LABELS,
 	STAGE_DESCRIPTIONS
@@ -156,6 +157,57 @@ test('escapeHtml: neutralises a script injection attempt', () => {
 	const result = escapeHtml('<script>alert("xss")</script>');
 	assert.ok(!result.includes('<script'));
 	assert.equal(result, '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+});
+
+// ── safeSectionHtml ───────────────────────────────────────────────────────
+
+test('safeSectionHtml: returns the builder output when it succeeds', () => {
+	const result = safeSectionHtml('My Section', () => '<div>ok</div>');
+	assert.equal(result, '<div>ok</div>');
+});
+
+test('safeSectionHtml: catches a thrown error and renders a fallback card instead', () => {
+	const errors: string[] = [];
+	const result = safeSectionHtml('Model Efficiency', () => {
+		throw new Error('boom');
+	}, (m) => errors.push(m));
+
+	assert.ok(result.includes('Model Efficiency'));
+	assert.ok(result.includes("couldn't be displayed"));
+	assert.equal(errors.length, 1);
+	assert.ok(errors[0].includes('Model Efficiency'));
+	assert.ok(errors[0].includes('boom'));
+});
+
+test('safeSectionHtml: handles non-Error throws (e.g. a thrown string)', () => {
+	const errors: string[] = [];
+	const result = safeSectionHtml('Weird Section', () => {
+		// eslint-disable-next-line @typescript-eslint/no-throw-literal
+		throw 'not an Error instance';
+	}, (m) => errors.push(m));
+
+	assert.ok(result.includes('Weird Section'));
+	assert.ok(errors[0].includes('not an Error instance'));
+});
+
+test('safeSectionHtml: escapes the label in the fallback card to avoid HTML injection', () => {
+	const result = safeSectionHtml('<img src=x onerror=alert(1)>', () => {
+		throw new Error('boom');
+	}, () => { /* noop */ });
+
+	assert.ok(!result.includes('<img src=x'));
+	assert.ok(result.includes('&lt;img'));
+});
+
+test('safeSectionHtml: one failing section does not affect independently built sections', () => {
+	const sectionA = safeSectionHtml('Section A', () => '<div>a-ok</div>', () => { /* noop */ });
+	const sectionB = safeSectionHtml('Section B', () => { throw new Error('section B broke'); }, () => { /* noop */ });
+	const sectionC = safeSectionHtml('Section C', () => '<div>c-ok</div>', () => { /* noop */ });
+
+	const page = `${sectionA}${sectionB}${sectionC}`;
+	assert.ok(page.includes('a-ok'));
+	assert.ok(page.includes('c-ok'));
+	assert.ok(page.includes('Section B'));
 });
 
 // ── markdownToHtml ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

While investigating a report that the Model Efficiency section in Usage Analysis "gets hidden after a while" and only comes back after a full restart, I traced it to how `renderLayout()` builds the Usage Analysis webview: the whole page is one large template-literal chain. If any single section builder (for example `buildModelEfficiencySectionHtml`) throws on an unexpected data shape, the exception propagates out of the whole chain, `root.innerHTML` is never assigned, and the entire dashboard is left on stale or blank content until the extension host is restarted and a clean render succeeds.

## Approach

Added `safeSectionHtml(label, builder)` in `src/webview/shared/formatUtils.ts`. It wraps a section builder call, catches any thrown error, logs it, and returns a small inline "couldn't render" error card in that section's place instead of letting the exception escape the render.

Wired it around:
- Each tab panel in `buildUsageRootHtml` (Sessions, Activity, Tools, Health, Repos/Agent, Worktrees, Insights) so a bug in one tab can't blank sibling tabs.
- Each independent section within the Activity tab (Model Cost, Billing Coverage, Interaction Modes, Context References, Model Efficiency, Thinking Effort, Context Window).
- The customization and thinking-effort HTML built earlier in `renderLayout`.

Also added `assignUsageRootHtml()` as a final safety net around the `root.innerHTML` assignment itself, falling back to a minimal error state with a reload button if something still throws outside the per-section isolation (rather than silently leaving the page as-is).

## Testing

- Added unit tests for `safeSectionHtml` covering: success, thrown `Error`, thrown non-`Error` values, label escaping (to avoid HTML injection via the section label), and independence between sections (one failing section doesn't affect others).
- `npm run compile` (tsc + eslint + esbuild) is clean with no errors or warnings.
- Full `webview-utils.test.ts` suite passes (38/38).

## Notes for reviewers

This is a resiliency fix, not a fix for a specific known data bug in Model Efficiency itself — I didn't find a reproducible root cause for the original data-shape exception, but this change ensures that whatever the cause, one broken section will never again blank out the whole dashboard, and the error will be visible in the console instead of failing silently.