### PR TITLE
Use subagent/delegation signals in fluency scoring and hints

### DIFF
--- a/src/hermes.ts
+++ b/src/hermes.ts
@@ -42,6 +42,7 @@ import * as os from 'os';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import { toLocalDayKey } from './utils/dayKeys';
+import { STAGE_THRESHOLDS } from './maturityScoring';
 
 type SqlJsStatic = initSqlJs.SqlJsStatic;
 type SqlDatabase = initSqlJs.Database;
@@ -303,6 +304,49 @@ export class HermesDataAccess {
 		} catch {
 			return [];
 		}
+	}
+
+	/**
+	 * Returns child-session counts (rows with `source = 'subagent'`) keyed by `parent_session_id`,
+	 * restricted to the given candidate session ids. Shared helper behind `getMultiAgentParentCount()`
+	 * and the daily multi-agent usage trend (`extension.ts`'s `_computeAgenticDailyTrend`).
+	 */
+	async getChildCounts(candidateSessionIds: string[]): Promise<Map<string, number>> {
+		const counts = new Map<string, number>();
+		if (candidateSessionIds.length === 0) { return counts; }
+		const db = await this.getDb(this.getDbPath());
+		if (!db) { return counts; }
+		try {
+			const result = db.exec(
+				`SELECT parent_session_id, COUNT(*) as child_count FROM sessions
+				 WHERE parent_session_id IS NOT NULL
+				 GROUP BY parent_session_id`,
+			);
+			const rows = this.rowsToObjects(result);
+			const candidateSet = new Set(candidateSessionIds);
+			for (const row of rows) {
+				const parentId = row['parent_session_id'] as string | null;
+				const childCount = (row['child_count'] as number) ?? 0;
+				if (parentId && candidateSet.has(parentId)) { counts.set(parentId, childCount); }
+			}
+		} catch { /* optional enrichment — suppress */ }
+		return counts;
+	}
+
+	/**
+	 * Counts how many of the given (candidate) session ids are "multi-agent parents" —
+	 * i.e. have `minChildren` or more sessions with `source = 'subagent'` pointing at them
+	 * via `parent_session_id`. Mirrors `CopilotAppDataAccess.getSessionHierarchy()`'s
+	 * multi-agent detection, but for Hermes's global state.db. Used to feed
+	 * `UsageAnalysisPeriod.multiAgentParentSessions` alongside Copilot CLI data.
+	 */
+	async getMultiAgentParentCount(candidateSessionIds: string[], minChildren: number = STAGE_THRESHOLDS.agentic.multiAgentMinChildren): Promise<number> {
+		const childCounts = await this.getChildCounts(candidateSessionIds);
+		let count = 0;
+		for (const childCount of childCounts.values()) {
+			if (childCount >= minChildren) { count++; }
+		}
+		return count;
 	}
 
 	/** Read session metadata for a virtual session path. */

--- a/src/maturityScoring.ts
+++ b/src/maturityScoring.ts
@@ -7,9 +7,11 @@ import type {
 	UsageAnalysisStats,
 	WorkspaceCustomizationMatrix,
 	UsageAnalysisPeriod,
+	AgenticTrendPoint,
 } from './types';
 import automaticToolIds from './automaticTools.json';
 import fluencyLevelDataRaw from './fluencyLevelData.json';
+import { countDelegationToolCalls } from './taskClassification';
 
 /** Set of tool IDs that Copilot uses autonomously (reading files, searching, etc.).
  *  These are excluded from fluency scoring since the user doesn't configure them. */
@@ -91,6 +93,10 @@ export const STAGE_THRESHOLDS = {
 		stage4MinMultiAgentParents: 3,
 		/** Minimum number of child workspaces per session to count as multi-agent orchestration. */
 		multiAgentMinChildren: 2,
+		/** Minimum sessions classified as `Delegation` (sub-agent/Task-tool usage) to reach at least Stage 3. */
+		stage3MinDelegationSessions: 2,
+		/** Minimum sessions classified as `Delegation` to reach at least Stage 4. */
+		stage4MinDelegationSessions: 5,
 	},
 	toolUsage: {
 		/** Minimum number of distinct advanced built-in tools used to promote to Stage 3. */
@@ -428,6 +434,26 @@ function _agApplyMultiAgentBooster(
 	return stage;
 }
 
+/**
+ * Booster for sessions classified as `Delegation` (tool calls matching subagent/delegate
+ * patterns — see `taskClassification.ts`). Complements `_agApplyMultiAgentBooster`: it works
+ * for adapters without data.db/JSONL parent-child hierarchy data (e.g. Hermes, Claude Code),
+ * since it only needs the tool names already captured in `toolCalls`/`taskCategory`.
+ */
+function _agApplyDelegationBooster(
+	delegationSessions: number,
+	T: typeof STAGE_THRESHOLDS.agentic,
+	stage: Stage,
+	evidence: string[],
+): Stage {
+	if (delegationSessions < T.stage3MinDelegationSessions) { return stage; }
+	const label = delegationSessions === 1 ? '1 session' : `${fmt(delegationSessions)} sessions`;
+	evidence.push(`${label} delegated work to sub-agents (Task/delegate tool calls)`);
+	stage = promoteStage(stage, 3);
+	if (delegationSessions >= T.stage4MinDelegationSessions) { stage = promoteStage(stage, 4); }
+	return stage;
+}
+
 function _agBuildTips(stage: Stage): string[] {
 	const tips: string[] = [];
 	if (stage < 2) { tips.push('Try [agent mode](https://code.visualstudio.com/docs/copilot/agents/overview) — it can run terminal commands, edit files, and explore your codebase autonomously — [▶ Agent Mode video](https://tech.hub.ms/github-copilot/videos/agent-mode)'); }
@@ -486,8 +512,23 @@ function _agApplyStageQualifications(stage: Stage, p: UsageAnalysisPeriod, T: ty
 	if (_agQualifiesMultiFileStage4(p.editScope, T)) { result = promoteStage(result, 4); }
 	
 	result = _agApplyMultiAgentBooster(p.multiAgentParentSessions ?? 0, T, result, evidence);
+	result = _agApplyDelegationBooster(p.delegationSessions ?? 0, T, result, evidence);
 	
 	return result;
+}
+
+/**
+ * Add evidence for sub-agent/delegate tool-call volume (adapter-agnostic, derived from
+ * `toolCalls.byTool` — see `countDelegationToolCalls()`). This is a volume signal shown
+ * alongside the `delegationSessions` stage booster; it doesn't affect the stage itself
+ * since a single delegating session can rack up many tool calls.
+ */
+function _agAddDelegationToolCallEvidence(evidence: string[], p: UsageAnalysisPeriod): void {
+	const delegationCalls = countDelegationToolCalls(p.toolCalls.byTool);
+	if (delegationCalls === 0) { return; }
+	const sessions = p.delegationSessions ?? 0;
+	const avgSuffix = sessions > 0 ? ` (avg ${(delegationCalls / sessions).toFixed(1)} per delegating session)` : '';
+	evidence.push(`${fmt(delegationCalls)} sub-agent/delegate tool calls executed${avgSuffix}`);
 }
 
 function _scoreAgentic(p: UsageAnalysisPeriod): CategoryScore {
@@ -498,6 +539,7 @@ function _scoreAgentic(p: UsageAnalysisPeriod): CategoryScore {
 	stage = _agAddBasicEvidence(evidence, p, stage);
 	stage = _agAddEditScopeEvidence(evidence, p, stage, T);
 	stage = _agApplyStageQualifications(stage, p, T, evidence);
+	_agAddDelegationToolCallEvidence(evidence, p);
 
 	return { stage, evidence, tips: _agBuildTips(stage) };
 }
@@ -1189,6 +1231,7 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 	categories: { category: string; icon: string; stage: number; evidence: string[]; tips: string[] }[];
 	period: UsageAnalysisPeriod;
 	lastUpdated: string;
+	agenticTrend?: AgenticTrendPoint[];
 }> {
 	const stats = await calculateUsageAnalysisStatsFn(useCache);
 	const p = stats.last30Days;
@@ -1214,6 +1257,7 @@ export async function calculateMaturityScores(lastCustomizationMatrix: Workspace
 			{ category: 'Workflow Integration', icon: '🔄', stage: wi.stage, evidence: wi.evidence, tips: wi.tips }
 		],
 		period: p,
-		lastUpdated: stats.lastUpdated.toISOString()
+		lastUpdated: stats.lastUpdated.toISOString(),
+		agenticTrend: stats.agenticDailyTrend
 	};
 }

--- a/src/taskClassification.ts
+++ b/src/taskClassification.ts
@@ -54,7 +54,21 @@ const EDIT_TOOL_PATTERN = /edit|write|create_?file|replace_?string|str_replace|a
 const READ_TOOL_PATTERN = /read_?file|grep_?search|file_?search|search|glob|list_dir|websearch|fetch/i;
 const TERMINAL_TOOL_PATTERN = /terminal|bash|shell|run_?command/i;
 const PLANNING_TOOL_PATTERN = /todo|task[-_]?create|enterplanmode|\bplan\b/i;
-const DELEGATION_TOOL_PATTERN = /subagent|sub[-_]?agent|agent[-_]?spawn|delegate/i;
+/** Exported so other modules (e.g. `maturityScoring.ts`) can detect delegation/sub-agent tool
+ *  calls without duplicating the pattern. Matches tool names used by Copilot CLI's Task tool,
+ *  Claude Code's Task tool, and similar sub-agent/delegate tools across other adapters. */
+export const DELEGATION_TOOL_PATTERN = /subagent|sub[-_]?agent|agent[-_]?spawn|delegate/i;
+
+/** Sums tool-call counts for tools matching `DELEGATION_TOOL_PATTERN` (e.g. `toolCalls.byTool`
+ *  from a `UsageAnalysisPeriod`). Used as an adapter-agnostic signal for sub-agent delegation
+ *  volume, independent of the per-session `Delegation` task-category classification above. */
+export function countDelegationToolCalls(byTool: Record<string, number>): number {
+	let total = 0;
+	for (const [tool, count] of Object.entries(byTool)) {
+		if (DELEGATION_TOOL_PATTERN.test(tool)) { total += count; }
+	}
+	return total;
+}
 const TEST_TOOL_PATTERN = /run_?tests?|pytest|vitest|jest/i;
 
 const GIT_KEYWORD_PATTERN = /\bgit\s+(push|commit|merge|pull|rebase|checkout|clone)\b/i;
@@ -169,4 +183,4 @@ export function buildClassificationInputFromChatTurns(turns: ChatTurn[]): TaskCl
 	return { toolNames, terminalCommands, userText: userTextParts.join(' ') };
 }
 
-export default { classifySessionTask, buildClassificationInputFromUsageAnalysis, buildClassificationInputFromChatTurns };
+export default { classifySessionTask, buildClassificationInputFromUsageAnalysis, buildClassificationInputFromChatTurns, countDelegationToolCalls };

--- a/src/types.ts
+++ b/src/types.ts
@@ -589,6 +589,22 @@ missedPotential?: MissedPotentialWorkspace[];
 todaySessions?: TodaySessionSummary[];
 /** Optional tool curation analysis (VS Code only; absent in CLI/VS/JetBrains). */
 curationAnalysis?: ToolCurationAnalysis | null;
+/**
+ * Daily-bucketed multi-agent/delegation usage over the trailing ~30 days, for the
+ * "Multi-Agent Usage" sparkline on the Fluency dashboard. Absent when no sessions
+ * with multi-agent signals were found in the window.
+ */
+agenticDailyTrend?: AgenticTrendPoint[];
+}
+
+/** One day's worth of multi-agent/delegation signal, used to render a trend sparkline. */
+export interface AgenticTrendPoint {
+  /** UTC date key, e.g. "2024-06-01". */
+  date: string;
+  /** Sessions that day with 2+ direct children (data.db/Hermes hierarchy). */
+  multiAgentParentSessions: number;
+  /** Sessions that day classified as `Delegation` by `classifySessionTask()`. */
+  delegationSessions: number;
 }
 
 /** Matrix types used for Usage Analysis customization matrix */
@@ -635,6 +651,14 @@ export interface UsageAnalysisPeriod {
    * absent (undefined) when data.db is not available.
    */
   multiAgentParentSessions?: number;
+  /**
+   * Number of sessions in this period classified as `Delegation` by `classifySessionTask()`
+   * (tool calls matching subagent/delegate patterns — Copilot CLI/Claude Code Task tool,
+   * Hermes subagent source, etc.). A second, adapter-agnostic signal for sub-agent usage,
+   * complementary to `multiAgentParentSessions` (which requires data.db/JSONL hierarchy data).
+   * Populated during session caching; absent (undefined) when no such sessions exist.
+   */
+  delegationSessions?: number;
   /**
    * Context-window usage aggregated across the period's sessions.
    * Absent when no session in the period carried context-size data.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -51,6 +51,7 @@ import type {
   WorkspaceCustomizationRow,
   WorkspaceCustomizationMatrix,
   UsageAnalysisPeriod,
+  AgenticTrendPoint,
   SessionFileDetails,
   PromptTokenDetail,
   ActualUsage,
@@ -98,6 +99,7 @@ import { getEcosystemDisplayName } from '../../src/ecosystemAdapter';
 import { buildAdapterRegistry, createDataAccessInstances } from '../../src/adapters';
 import { CopilotAppDataAccess, type SessionContextWindow } from './copilotAppData';
 import { PiDataAccess } from '../../src/pi';
+import { HermesDataAccess } from '../../src/hermes';
 import { getVSCodeUserPaths } from '../../src/adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from '../../src/jetbrains';
@@ -151,6 +153,7 @@ import {
   getFluencyLevelData as _getFluencyLevelData,
   calculateFluencyScoreForTeamMember as _calculateFluencyScoreForTeamMember,
   calculateMaturityScores as _calculateMaturityScores,
+  STAGE_THRESHOLDS,
 } from '../../src/maturityScoring';
 
 // --- Workspace helpers ---
@@ -423,6 +426,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private mistralVibe!: MistralVibeDataAccess;
 	private geminiCli!: GeminiCliDataAccess;
 	public windsurf!: WindsurfDataAccess;
+	private hermes!: HermesDataAccess;
 	private ecosystems!: IEcosystemAdapter[];
 	private cacheManager!: CacheManager;
 	private hookManager!: HookManager;
@@ -1245,6 +1249,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.mistralVibe = dataAccess.mistralVibe;
 		this.geminiCli = dataAccess.geminiCli;
 		this.windsurf = new WindsurfDataAccess(extensionUri, (m) => this.log(m));
+		this.hermes = dataAccess.hermes;
 		this.ecosystems = buildAdapterRegistry({
 			...dataAccess,
 			estimateTokens: (t, m) => this.estimateTokensFromText(t, m),
@@ -3509,6 +3514,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const unresolvedWorkspaceInteractionCounts = new Map<string, number>();
 		this._workspaceIdToFolderCache.clear();
 		this._customizationFilesCache.clear();
+		let agenticDailyTrend: AgenticTrendPoint[] | undefined;
 		try {
 			const { results: usageResults, totalFiles } = await this.loadUsageSessionFiles(preloaded, cutoffMs);
 			const periods = { todayStats, last30DaysStats, monthStats, lastMonthStats, todayUtcKey, last30DaysUtcStartKey, monthUtcStartKey, lastMonthUtcStartKey, lastMonthUtcEndKey };
@@ -3517,6 +3523,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.deduplicateWorkspacePaths(workspaceSessionCounts, workspaceInteractionCounts);
 			this.buildUsageCustomizationMatrix(workspaceSessionCounts, workspaceInteractionCounts, unresolvedWorkspaceIds, unresolvedWorkspaceInteractionCounts);
 			await this.enrichMultiAgentParentCount(usageResults, last30DaysStats, last30DaysUtcStartKey);
+			agenticDailyTrend = await this._computeAgenticDailyTrend(usageResults, last30DaysUtcStartKey);
 			await this.enrichContextWindowFromAppData(usageResults, periods, todaySessionsList);
 		} catch (error) {
 			this.error('Error calculating usage analysis stats:', error);
@@ -3533,6 +3540,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			missedPotential: this._lastMissedPotential || [],
 			todaySessions: todaySessionsList.sort((a, b) => b.interactions - a.interactions),
 			curationAnalysis: this.computeCurationAnalysis(last30DaysStats),
+			agenticDailyTrend,
 		};
 		this.lastUsageAnalysisStats = stats;
 		return stats;
@@ -3715,34 +3723,128 @@ class CopilotTokenTracker implements vscode.Disposable {
 		};
 	}
 
+	/** Splits usage results (within the last-30-days window) into Copilot CLI uuids and Hermes session ids, along with each id's day key (for daily trend bucketing). */
+	private _collectMultiAgentCandidateIds(
+		usageResults: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
+		last30DaysUtcStartKey: string,
+	): { cliUuids: string[]; hermesIds: string[]; dayByCliUuid: Map<string, string>; dayByHermesId: Map<string, string> } {
+		const cliUuids: string[] = [];
+		const hermesIds: string[] = [];
+		const dayByCliUuid = new Map<string, string>();
+		const dayByHermesId = new Map<string, string>();
+		for (const r of usageResults) {
+			if (!r) { continue; }
+			const lastActivityKey = this.computeLastActivityKey(r.sessionData, r.mtime);
+			if (lastActivityKey < last30DaysUtcStartKey) { continue; }
+			const uuid = this.extractCopilotCliUuid(r.sessionFile);
+			if (uuid) { cliUuids.push(uuid); dayByCliUuid.set(uuid, lastActivityKey); continue; }
+			if (this.hermes.isHermesSessionFile(r.sessionFile)) {
+				const id = this.hermes.getSessionId(r.sessionFile);
+				if (id) { hermesIds.push(id); dayByHermesId.set(id, lastActivityKey); }
+			}
+		}
+		return { cliUuids, hermesIds, dayByCliUuid, dayByHermesId };
+	}
+
+	/** Counts Copilot CLI sessions (from data.db hierarchy) with 2+ direct child workspaces. */
+	private async _countCliMultiAgentParents(cliUuids: string[]): Promise<number> {
+		if (cliUuids.length === 0) { return 0; }
+		try {
+			const hierarchy = await this.copilotAppData.getSessionHierarchy(cliUuids);
+			let count = 0;
+			for (const uuid of cliUuids) {
+				const node = hierarchy.get(uuid);
+				if (node && node.totalChildCount >= STAGE_THRESHOLDS.agentic.multiAgentMinChildren) { count++; }
+			}
+			return count;
+		} catch {
+			return 0; /* optional enrichment — suppress */
+		}
+	}
+
 	/**
-	 * Query data.db for multi-agent parent count and set it on the period.
-	 * A session counts as a "multi-agent parent" when it has 2+ direct child workspaces.
-	 * Errors are swallowed — this is optional enrichment only.
+	 * Query data.db (Copilot CLI) and Hermes's state.db for multi-agent parent counts and
+	 * set the combined total on the period. A session counts as a "multi-agent parent" when
+	 * it has 2+ direct children (child workspaces for Copilot CLI; `source='subagent'` rows
+	 * pointing back via `parent_session_id` for Hermes). Errors are swallowed — optional enrichment only.
 	 */
 	private async enrichMultiAgentParentCount(
 		usageResults: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
 		last30DaysStats: UsageAnalysisPeriod,
 		last30DaysUtcStartKey: string,
 	): Promise<void> {
-		const uuids: string[] = [];
-		for (const r of usageResults) {
-			if (!r) { continue; }
-			const lastActivityKey = this.computeLastActivityKey(r.sessionData, r.mtime);
-			if (lastActivityKey < last30DaysUtcStartKey) { continue; }
-			const uuid = this.extractCopilotCliUuid(r.sessionFile);
-			if (uuid) { uuids.push(uuid); }
+		const { cliUuids, hermesIds } = this._collectMultiAgentCandidateIds(usageResults, last30DaysUtcStartKey);
+		let count = await this._countCliMultiAgentParents(cliUuids);
+		if (hermesIds.length > 0) {
+			try {
+				count += await this.hermes.getMultiAgentParentCount(hermesIds);
+			} catch { /* optional enrichment — suppress */ }
 		}
-		if (uuids.length === 0) { return; }
-		try {
-			const hierarchy = await this.copilotAppData.getSessionHierarchy(uuids);
-			let count = 0;
-			for (const uuid of uuids) {
+		if (count > 0) { last30DaysStats.multiAgentParentSessions = count; }
+	}
+
+	/** Buckets multi-agent-parent counts (CLI + Hermes) per day into `byDay`. Shared by `_computeAgenticDailyTrend`. */
+	private async _bucketMultiAgentParentsByDay(
+		cliUuids: string[],
+		hermesIds: string[],
+		dayByCliUuid: Map<string, string>,
+		dayByHermesId: Map<string, string>,
+		byDay: Map<string, { multiAgentParentSessions: number; delegationSessions: number }>,
+	): Promise<void> {
+		const getEntry = (day: string) => {
+			let entry = byDay.get(day);
+			if (!entry) { entry = { multiAgentParentSessions: 0, delegationSessions: 0 }; byDay.set(day, entry); }
+			return entry;
+		};
+		const threshold = STAGE_THRESHOLDS.agentic.multiAgentMinChildren;
+		if (cliUuids.length > 0) {
+			const hierarchy = await this.copilotAppData.getSessionHierarchy(cliUuids);
+			for (const uuid of cliUuids) {
 				const node = hierarchy.get(uuid);
-				if (node && node.totalChildCount >= 2) { count++; }
+				const day = dayByCliUuid.get(uuid);
+				if (node && node.totalChildCount >= threshold && day) { getEntry(day).multiAgentParentSessions++; }
 			}
-			if (count > 0) { last30DaysStats.multiAgentParentSessions = count; }
-		} catch { /* optional enrichment — suppress */ }
+		}
+		if (hermesIds.length > 0) {
+			const childCounts = await this.hermes.getChildCounts(hermesIds);
+			for (const id of hermesIds) {
+				const childCount = childCounts.get(id) ?? 0;
+				const day = dayByHermesId.get(id);
+				if (childCount >= threshold && day) { getEntry(day).multiAgentParentSessions++; }
+			}
+		}
+	}
+
+	/**
+	 * Builds the daily "Multi-Agent Usage" trend (last ~30 days) shown as a sparkline on the
+	 * Fluency dashboard's Agentic category card. Each day combines two independent signals:
+	 * multi-agent-parent sessions (data.db/Hermes hierarchy, 2+ children) and delegation
+	 * sessions (adapter-agnostic tool-name classification). Errors are swallowed — optional
+	 * enrichment only, absent from the payload when it fails or there is no signal.
+	 */
+	private async _computeAgenticDailyTrend(
+		usageResults: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
+		last30DaysUtcStartKey: string,
+	): Promise<AgenticTrendPoint[] | undefined> {
+		try {
+			const { cliUuids, hermesIds, dayByCliUuid, dayByHermesId } = this._collectMultiAgentCandidateIds(usageResults, last30DaysUtcStartKey);
+			const byDay = new Map<string, { multiAgentParentSessions: number; delegationSessions: number }>();
+			await this._bucketMultiAgentParentsByDay(cliUuids, hermesIds, dayByCliUuid, dayByHermesId, byDay);
+			for (const r of usageResults) {
+				if (!r || r.sessionData.taskCategory !== 'Delegation') { continue; }
+				const day = this.computeLastActivityKey(r.sessionData, r.mtime);
+				if (day < last30DaysUtcStartKey) { continue; }
+				const entry = byDay.get(day) ?? { multiAgentParentSessions: 0, delegationSessions: 0 };
+				entry.delegationSessions++;
+				byDay.set(day, entry);
+			}
+			if (byDay.size === 0) { return undefined; }
+			return Array.from(byDay.entries())
+				.map(([date, v]) => ({ date, ...v }))
+				.sort((a, b) => a.date.localeCompare(b.date));
+		} catch {
+			return undefined; /* optional enrichment — suppress */
+		}
 	}
 
 	/** The usage periods whose date range contains the given UTC activity key. */
@@ -4022,6 +4124,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 	}
 
+	/** Increments `period.delegationSessions` when the session was classified as `Delegation` (see `taskClassification.ts`). */
+	private _incrementDelegationSessions(period: UsageAnalysisPeriod, sessionData: SessionFileCache): void {
+		if (sessionData.taskCategory !== 'Delegation') { return; }
+		period.delegationSessions = (period.delegationSessions ?? 0) + 1;
+	}
+
 	private aggregateSessionFileIntoStats(
 		r: { sessionFile: string; sessionData: SessionFileCache; mtime: number },
 		periods: { todayStats: UsageAnalysisPeriod; last30DaysStats: UsageAnalysisPeriod; monthStats: UsageAnalysisPeriod; lastMonthStats: UsageAnalysisPeriod; todayUtcKey: string; last30DaysUtcStartKey: string; monthUtcStartKey: string; lastMonthUtcStartKey: string; lastMonthUtcEndKey: string },
@@ -4042,6 +4150,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.mergeUsageAnalysis(periods.last30DaysStats, analysis);
 			this._mergeContextWindowStats(periods.last30DaysStats, sessionData);
 			_mergeModelEfficiencyTokens(periods.last30DaysStats, sessionData.modelUsage, this.modelPricing);
+			this._incrementDelegationSessions(periods.last30DaysStats, sessionData);
 			this.trackWorkspaceForSession(sessionFile, interactions,
 				wsMaps.workspaceSessionCounts, wsMaps.workspaceInteractionCounts,
 				wsMaps.unresolvedWorkspaceIds, wsMaps.unresolvedWorkspaceInteractionCounts);
@@ -4051,18 +4160,21 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.mergeUsageAnalysis(periods.monthStats, analysis);
 			this._mergeContextWindowStats(periods.monthStats, sessionData);
 			_mergeModelEfficiencyTokens(periods.monthStats, sessionData.modelUsage, this.modelPricing);
+			this._incrementDelegationSessions(periods.monthStats, sessionData);
 		}
 		if (inLastMonth) {
 			periods.lastMonthStats.sessions++;
 			this.mergeUsageAnalysis(periods.lastMonthStats, analysis);
 			this._mergeContextWindowStats(periods.lastMonthStats, sessionData);
 			_mergeModelEfficiencyTokens(periods.lastMonthStats, sessionData.modelUsage, this.modelPricing);
+			this._incrementDelegationSessions(periods.lastMonthStats, sessionData);
 		}
 		if (lastActivityUtcKey === periods.todayUtcKey) {
 			periods.todayStats.sessions++;
 			this.mergeUsageAnalysis(periods.todayStats, analysis);
 			this._mergeContextWindowStats(periods.todayStats, sessionData);
 			_mergeModelEfficiencyTokens(periods.todayStats, sessionData.modelUsage, this.modelPricing);
+			this._incrementDelegationSessions(periods.todayStats, sessionData);
 			todaySessionsList.push(this.collectTodaySessionInfo(sessionData, sessionFile, analysis, interactions, mtime));
 		}
 	}
@@ -7050,6 +7162,7 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 		categories: { category: string; icon: string; stage: number; evidence: string[]; tips: string[] }[];
 		period: UsageAnalysisPeriod;
 		lastUpdated: string;
+		agenticTrend?: AgenticTrendPoint[];
 	}> {
 		return _calculateMaturityScores(this._lastCustomizationMatrix, (useCache) => this.calculateUsageAnalysisStats(useCache, preloaded), useCache, this._copilotPlanResolved?.isMCPEnabled);
 	}
@@ -7563,6 +7676,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       }[];
       period: UsageAnalysisPeriod;
       lastUpdated: string;
+      agenticTrend?: AgenticTrendPoint[];
       dismissedTips?: string[];
       isDebugMode?: boolean;
       installedHooks?: string[];

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -979,6 +979,22 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		allowToast: true,
 	},
 
+	// ── Sub-agent delegation (tool-call based, no hierarchy data required) ────
+	{
+		id: 'subagent-delegation',
+		category: 'agentic',
+		severity: 'celebration',
+		title: '🧩 You\'re delegating work to sub-agents!',
+		buildBody: (ctx) => {
+			const n = ctx.last30Days.delegationSessions!;
+			return `You've delegated work to sub-agents/Task tools in ${n} sessions over the last 30 days. ` +
+				`Breaking work into focused delegated tasks is a strong AI-engineering habit — it keeps each agent's context tight and lets you parallelize independent pieces of work.`;
+		},
+		appliesTo: (ctx) => (ctx.last30Days.delegationSessions ?? 0) >= 5 && (ctx.last30Days.multiAgentParentSessions ?? 0) < 3,
+		weight: 32,
+		allowToast: true,
+	},
+
 	// ── Edit scope ───────────────────────────────────────────────────────────
 	{
 		id: 'single-file-edits-only',

--- a/vscode-extension/src/webview/maturity/main.ts
+++ b/vscode-extension/src/webview/maturity/main.ts
@@ -32,12 +32,19 @@ type CategoryScore = {
 	tips: string[];      // suggestions to reach next stage
 };
 
+type AgenticTrendPoint = {
+	date: string;
+	multiAgentParentSessions: number;
+	delegationSessions: number;
+};
+
 type MaturityData = {
 	overallStage: number;
 	overallLabel: string;
 	categories: CategoryScore[];
 	period: UsageAnalysisPeriod;
 	lastUpdated: string;
+	agenticTrend?: AgenticTrendPoint[];
 	dismissedTips?: string[];
 	isDebugMode?: boolean;
 	fluencyLevels?: CategoryLevelData[];
@@ -153,6 +160,47 @@ function stageColor(stage: number): string {
 		case 4: return '#22d3ee';
 		default: return '#666';
 	}
+}
+
+// ── Multi-Agent Usage sparkline ────────────────────────────────────────
+
+/** Renders a small inline SVG sparkline of daily multi-agent-parent + delegation sessions, for the Agentic category card. */
+function renderAgenticSparkline(trend: AgenticTrendPoint[] | undefined): string {
+	if (!trend || trend.length === 0) { return ''; }
+	const totalSessions = trend.reduce((sum, p) => sum + p.multiAgentParentSessions + p.delegationSessions, 0);
+	if (totalSessions === 0) { return ''; }
+
+	const width = 260, height = 46, padding = 4;
+	const maxVal = Math.max(1, ...trend.map(p => p.multiAgentParentSessions + p.delegationSessions));
+	const n = trend.length;
+	const stepX = n > 1 ? (width - padding * 2) / (n - 1) : 0;
+	const toY = (v: number) => height - padding - (v / maxVal) * (height - padding * 2);
+
+	const linePoints = (values: number[]) =>
+		values.map((v, i) => `${(padding + i * stepX).toFixed(1)},${toY(v).toFixed(1)}`).join(' ');
+
+	const totalPoints = linePoints(trend.map(p => p.multiAgentParentSessions + p.delegationSessions));
+	const parentPoints = linePoints(trend.map(p => p.multiAgentParentSessions));
+
+	const first = escapeHtml(trend[0].date);
+	const last = escapeHtml(trend[n - 1].date);
+
+	return `
+    <div class="agentic-sparkline" style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #2a2a30;">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px;">
+        <span style="font-size: 11px; font-weight: 600; color: #999;">📈 Multi-Agent Usage (last ${n} days)</span>
+      </div>
+      <svg viewBox="0 0 ${width} ${height}" width="100%" height="${height}" xmlns="http://www.w3.org/2000/svg">
+        <polyline points="${totalPoints}" fill="none" stroke="#22d3ee" stroke-width="2" />
+        <polyline points="${parentPoints}" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="3,2" />
+      </svg>
+      <div style="display: flex; justify-content: space-between; font-size: 9px; color: #666;">
+        <span>${first}</span>
+        <span style="color:#22d3ee;">— total</span>
+        <span style="color:#a78bfa;">┄ multi-agent parents</span>
+        <span>${last}</span>
+      </div>
+    </div>`;
 }
 
 
@@ -335,6 +383,7 @@ function buildCategoryCard(
   ` : '';
 
   const hookButton = buildHookReminderButton(cat.category, cat.tips.length, data.installedHooks ?? []);
+  const sparklineHtml = cat.category === 'Agentic' ? renderAgenticSparkline(data.agenticTrend) : '';
 
   return `
     <div class="category-card">
@@ -347,6 +396,7 @@ function buildCategoryCard(
         <div class="category-progress-fill" style="width: ${progressPct}%; background: ${color};"></div>
       </div>
       <ul class="evidence-list">${evidenceHtml || '<li class="evidence-item"><span class="evidence-icon">-</span><span>No significant activity detected</span></li>'}</ul>
+      ${sparklineHtml}
       ${!tipsAreDismissed && cat.tips.length > 0 ? `
         <div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #2a2a30;">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px;">

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -475,3 +475,52 @@ test('model-edit-retries: action opens the usage analysis view', () => {
 	const insight = results.find(i => i.id === RETRIES_ID);
 	assert.equal(insight!.actionCommand, 'aiEngineeringFluency.showUsageAnalysis');
 });
+
+// ---------------------------------------------------------------------------
+// multi-agent-orchestration / subagent-delegation insight tests
+// ---------------------------------------------------------------------------
+
+const MULTI_AGENT_ID = 'multi-agent-orchestration';
+const SUBAGENT_DELEGATION_ID = 'subagent-delegation';
+
+test('multi-agent-orchestration: fires when multiAgentParentSessions >= 3', () => {
+	const ctx = makeCtx();
+	(ctx.last30Days as UsageAnalysisPeriod & { multiAgentParentSessions?: number }).multiAgentParentSessions = 3;
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === MULTI_AGENT_ID);
+	assert.ok(insight, 'should fire at 3 multi-agent parent sessions');
+	assert.ok(insight!.body.includes('3'));
+});
+
+test('multi-agent-orchestration: does NOT fire below threshold', () => {
+	const ctx = makeCtx();
+	(ctx.last30Days as UsageAnalysisPeriod & { multiAgentParentSessions?: number }).multiAgentParentSessions = 2;
+	const results = evaluateInsights(ctx, {}, 7, null);
+	assert.equal(results.find(i => i.id === MULTI_AGENT_ID), undefined);
+});
+
+test('subagent-delegation: fires when delegationSessions >= 5 and no multi-agent hierarchy signal', () => {
+	const ctx = makeCtx();
+	(ctx.last30Days as UsageAnalysisPeriod & { delegationSessions?: number }).delegationSessions = 5;
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === SUBAGENT_DELEGATION_ID);
+	assert.ok(insight, 'should fire at 5 delegation sessions');
+	assert.ok(insight!.body.includes('5'));
+});
+
+test('subagent-delegation: does NOT fire below threshold', () => {
+	const ctx = makeCtx();
+	(ctx.last30Days as UsageAnalysisPeriod & { delegationSessions?: number }).delegationSessions = 4;
+	const results = evaluateInsights(ctx, {}, 7, null);
+	assert.equal(results.find(i => i.id === SUBAGENT_DELEGATION_ID), undefined);
+});
+
+test('subagent-delegation: does NOT fire when multi-agent-orchestration already covers the signal', () => {
+	const ctx = makeCtx();
+	const period = ctx.last30Days as UsageAnalysisPeriod & { delegationSessions?: number; multiAgentParentSessions?: number };
+	period.delegationSessions = 5;
+	period.multiAgentParentSessions = 3;
+	const results = evaluateInsights(ctx, {}, 7, null);
+	assert.equal(results.find(i => i.id === SUBAGENT_DELEGATION_ID), undefined, 'should defer to the richer multi-agent-orchestration insight');
+	assert.ok(results.find(i => i.id === MULTI_AGENT_ID), 'multi-agent-orchestration should still fire');
+});

--- a/vscode-extension/test/unit/maturityScoring.test.ts
+++ b/vscode-extension/test/unit/maturityScoring.test.ts
@@ -542,6 +542,40 @@ test('calculateMaturityScores: AG multiAgentParentSessions=3 → Stage 4', async
     assert.equal(ag.stage, 4);
 });
 
+test('calculateMaturityScores: AG delegationSessions=2 → Stage 3', async () => {
+    const stats = emptyStats();
+    stats.last30Days.delegationSessions = 2;
+    const result = await calculateMaturityScores(undefined, async () => stats);
+    const ag = result.categories.find(c => c.category === 'Agentic')!;
+    assert.ok(ag.stage >= 3, `expected AG >= 3 with 2 delegation sessions, got ${ag.stage}`);
+    assert.ok(ag.evidence.some(e => e.includes('delegated work to sub-agents')), 'evidence should mention sub-agent delegation');
+});
+
+test('calculateMaturityScores: AG delegationSessions=5 → Stage 4', async () => {
+    const stats = emptyStats();
+    stats.last30Days.delegationSessions = 5;
+    const result = await calculateMaturityScores(undefined, async () => stats);
+    const ag = result.categories.find(c => c.category === 'Agentic')!;
+    assert.equal(ag.stage, 4);
+});
+
+test('calculateMaturityScores: AG delegationSessions=1 → no booster (below threshold)', async () => {
+    const stats = emptyStats();
+    stats.last30Days.delegationSessions = 1;
+    const result = await calculateMaturityScores(undefined, async () => stats);
+    const ag = result.categories.find(c => c.category === 'Agentic')!;
+    assert.ok(!ag.evidence.some(e => e.includes('delegated work to sub-agents')));
+});
+
+test('calculateMaturityScores: AG delegation tool-call volume adds evidence with avg per session', async () => {
+    const stats = emptyStats();
+    stats.last30Days.delegationSessions = 2;
+    stats.last30Days.toolCalls.byTool = { subagent: 4, delegate_task: 2, edit_file: 10 };
+    const result = await calculateMaturityScores(undefined, async () => stats);
+    const ag = result.categories.find(c => c.category === 'Agentic')!;
+    assert.ok(ag.evidence.some(e => e.includes('sub-agent/delegate tool calls executed') && e.includes('avg 3.0 per delegating session')));
+});
+
 test('calculateMaturityScores: AG editsAgent sessions provide evidence', async () => {
     const stats = emptyStats();
     stats.last30Days.agentTypes.editsAgent = 5;

--- a/vscode-extension/test/unit/taskClassification.test.ts
+++ b/vscode-extension/test/unit/taskClassification.test.ts
@@ -5,6 +5,7 @@ import taskClassificationDefault, {
 	classifySessionTask,
 	buildClassificationInputFromUsageAnalysis,
 	buildClassificationInputFromChatTurns,
+	countDelegationToolCalls,
 } from '../../../src/taskClassification';
 import type { ChatTurn, ContextReferenceUsage, SessionUsageAnalysis } from '../../../src/types';
 
@@ -133,4 +134,24 @@ test('default export bundles all three functions', () => {
 	assert.equal(taskClassificationDefault.classifySessionTask, classifySessionTask);
 	assert.equal(taskClassificationDefault.buildClassificationInputFromUsageAnalysis, buildClassificationInputFromUsageAnalysis);
 	assert.equal(taskClassificationDefault.buildClassificationInputFromChatTurns, buildClassificationInputFromChatTurns);
+});
+
+// ── countDelegationToolCalls ───────────────────────────────────────────────
+
+test('countDelegationToolCalls: sums counts for subagent/delegate-matching tool names', () => {
+	const total = countDelegationToolCalls({ subagent: 3, delegate_task: 2, edit_file: 10 });
+	assert.equal(total, 5);
+});
+
+test('countDelegationToolCalls: matches sub-agent, agent-spawn, and case-insensitively', () => {
+	const total = countDelegationToolCalls({ 'Sub-Agent': 1, agent_spawn: 4, Delegate: 2, run_tests: 7 });
+	assert.equal(total, 7);
+});
+
+test('countDelegationToolCalls: returns 0 when no tools match', () => {
+	assert.equal(countDelegationToolCalls({ edit_file: 5, read_file: 3 }), 0);
+});
+
+test('countDelegationToolCalls: returns 0 for empty input', () => {
+	assert.equal(countDelegationToolCalls({}), 0);
 });


### PR DESCRIPTION
## Why

Sub-agent/multi-agent delegation ("created/using subsessions") is a strong fluency signal, but it was only partially wired in: Copilot CLI's data.db hierarchy fed `multiAgentParentSessions`, while Hermes had the same parent/child data sitting unused, and the existing `Delegation` task-classification category wasn't feeding the score or evidence at all.

## What changed

- **Hermes -> multiAgentParentSessions**: added `HermesDataAccess.getChildCounts()`/`getMultiAgentParentCount()` (querying `sessions` by `parent_session_id`), wired into `extension.ts`'s multi-agent enrichment alongside the existing Copilot CLI path.
- **Delegation sessions -> score**: added `UsageAnalysisPeriod.delegationSessions`, incremented per-period during session aggregation, and a new Agentic-score booster (`_agApplyDelegationBooster`, Stage 3 at 2+, Stage 4 at 5+ delegation sessions) - a lower-bar, adapter-agnostic complement to the hierarchy-based signal.
- **Tool-call volume evidence**: `countDelegationToolCalls()` in `taskClassification.ts` now surfaces evidence text like "sub-agent/delegate tool calls executed (avg X per delegating session)".
- **New insight rule**: `subagent-delegation` celebration, gated on `multiAgentParentSessions < 3` so it doesn't double-fire with the existing `multi-agent-orchestration` rule.
- **Centralized threshold**: the "2+ children counts as multi-agent" rule now lives once in `STAGE_THRESHOLDS.agentic.multiAgentMinChildren` instead of being hardcoded in three places.
- **New: Multi-Agent Usage sparkline** on the Fluency dashboard's Agentic category card - a small inline SVG trend of daily multi-agent-parent sessions and delegation sessions over the last ~30 days. Built by day-bucketing the same hierarchy lookups used for the aggregate count (no extra queries), so it's cheap to compute alongside the existing scoring pass.

## Notes for reviewers

- The two multi-agent signals (`multiAgentParentSessions` vs `delegationSessions`) are intentionally kept separate: one requires hierarchy data (data.db/Hermes, stronger signal, 2+ actual children), the other is adapter-agnostic tool-name matching with a lower bar (1+ per session). This is why the insight rules and score boosters check both independently.
- The sparkline is inline hand-rolled SVG (no charting library), consistent with the existing radar chart in the same webview.
- Verified with `npm run compile` (0 errors/warnings) and the full `npm run test:node` suite (all green).