### PR TITLE
Fix lint-toolnames: fetch full history for BASE_SHA diff

### DIFF
--- a/.github/workflows/lint-toolnames.yml
+++ b/.github/workflows/lint-toolnames.yml
@@ -42,6 +42,11 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history is required so BASE_SHA (the PR/push base commit)
+          # is actually present locally for the `git show` diff below;
+          # the default shallow depth=1 checkout only fetches the head commit.
+          fetch-depth: 0
 
       - name: Check for duplicate-like entries
         id: check


### PR DESCRIPTION
## Why

The `lint-toolnames` workflow's "Check for duplicate-like entries" step compares `src/toolNames.json` against its version at the PR/push base commit via `git show BASE_SHA:src/toolNames.json`. The `Checkout repository` step used the default shallow `fetch-depth: 1`, which only fetches the head commit. Since `BASE_SHA` was never fetched, git couldn't resolve it and failed with a misleading error:

```
fatal: path 'src/toolNames.json' exists on disk, but not in '<sha>'
Error: Process completed with exit code 128.
```

(git falls back to interpreting the argument as an ambiguous path/rev when the sha can't be resolved, since the file exists in the working tree from the shallow head checkout.)

## Fix

Set `fetch-depth: 0` on the checkout step so the base commit is available locally for the `git show` diff.