### PR TITLE
fix: correct artifact paths in jetbrains-publish and Windows /tmp path in visualstudio-publish

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -298,15 +298,17 @@ jobs:
           mkdir -p cli/dist vscode-extension/dist/webview
 
           # CLI binaries (sql-wasm.wasm is the same on all platforms; one copy suffices)
-          # Note: artifact paths preserve the source directory structure
-          cp artifacts/cli-windows/cli/dist/copilot-token-tracker.exe      cli/dist/
-          cp artifacts/cli-windows/cli/dist/sql-wasm.wasm                  cli/dist/
-          cp artifacts/cli-macos-arm64/cli/dist/copilot-token-tracker-macos-arm64  cli/dist/
-          cp artifacts/cli-macos-x64/cli/dist/copilot-token-tracker-macos-x64      cli/dist/
-          cp artifacts/cli-linux/cli/dist/copilot-token-tracker-linux       cli/dist/
+          # Note: actions/upload-artifact strips the common leading directory of the
+          # listed paths, so files land flat at the artifact root (not under cli/dist/).
+          cp artifacts/cli-windows/copilot-token-tracker.exe      cli/dist/
+          cp artifacts/cli-windows/sql-wasm.wasm                  cli/dist/
+          cp artifacts/cli-macos-arm64/copilot-token-tracker-macos-arm64  cli/dist/
+          cp artifacts/cli-macos-x64/copilot-token-tracker-macos-x64      cli/dist/
+          cp artifacts/cli-linux/copilot-token-tracker-linux       cli/dist/
 
-          # Webview JS bundles (built by vscode-extension)
-          cp artifacts/webview-bundles/vscode-extension/dist/webview/*  vscode-extension/dist/webview/
+          # Webview JS bundles (built by vscode-extension; also flattened at upload)
+          # -r because the bundle includes the codicons/ subdirectory
+          cp -r artifacts/webview-bundles/*  vscode-extension/dist/webview/
 
           # Make unix binaries executable
           chmod +x cli/dist/copilot-token-tracker-macos-arm64 cli/dist/copilot-token-tracker-macos-x64 cli/dist/copilot-token-tracker-linux

--- a/.github/workflows/visualstudio-publish.yml
+++ b/.github/workflows/visualstudio-publish.yml
@@ -181,17 +181,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $tag = "vs/v${{ steps.version.outputs.local_version }}"
+          $notesPath = Join-Path $env:RUNNER_TEMP "release_notes.md"
           Write-Host "Generating release notes for $tag ..."
           $notes = gh api repos/${{ github.repository }}/releases/generate-notes `
             -f tag_name="$tag" `
             --jq '.body' 2>$null
           if ($LASTEXITCODE -eq 0 -and $notes) {
-            $notes | Out-File -FilePath /tmp/release_notes.md -Encoding utf8
+            $notes | Out-File -FilePath $notesPath -Encoding utf8
             Write-Host "✅ Generated release notes from merged PRs"
           } else {
-            "Visual Studio Extension v${{ steps.version.outputs.local_version }}" | Out-File -FilePath /tmp/release_notes.md -Encoding utf8
+            "Visual Studio Extension v${{ steps.version.outputs.local_version }}" | Out-File -FilePath $notesPath -Encoding utf8
             Write-Host "⚠️ Could not auto-generate notes, using fallback"
           }
+          echo "notes_path=$notesPath" >> $env:GITHUB_OUTPUT
 
       - name: Create GitHub release
         if: ${{ steps.version.outputs.is_tag == 'true' && inputs.dry_run != true }}
@@ -204,7 +206,7 @@ jobs:
           Write-Host "Creating release $tag with $vsix ..."
           gh release create "$tag" `
             --title "Visual Studio Extension v${{ steps.version.outputs.local_version }}" `
-            --notes-file /tmp/release_notes.md `
+            --notes-file "${{ steps.release_notes.outputs.notes_path }}" `
             "$vsix"
           Write-Host "✅ GitHub release created: $tag"
 


### PR DESCRIPTION
## What's broken

Both `jetbrains/v0.4.0` and `vs/v1.3.0` tag-triggered publish runs failed before reaching the actual publish step.

### JetBrains Plugin - Publish
`actions/upload-artifact` strips the shared leading directory when uploading multiple explicit file paths (e.g. `cli/dist/copilot-token-tracker.exe`, `cli/dist/sql-wasm.wasm`), so the downloaded artifacts land flat at the artifact root instead of nested under `cli/dist/`. The "Place CLI binaries and webview bundles" step assumed the nested paths and failed with `No such file or directory`.

This isn't new — the last 3 `jetbrains/v*` tag pushes (v0.2.0, v0.3.0, v0.4.0) have all failed the same way.

### Visual Studio Extension - Publish
The release-notes steps hardcode `/tmp/release_notes.md`, but this job runs on `windows-latest`, where `/tmp` doesn't exist. Switched to `$env:RUNNER_TEMP`.

## Fix

- `jetbrains-publish.yml`: corrected the `cp` source paths to match the flattened artifact layout, and used `cp -r` for the webview bundle (it includes a `codicons/` subdirectory).
- `visualstudio-publish.yml`: use `$env:RUNNER_TEMP` instead of hardcoded `/tmp`, passed between steps via a job output.

## After merging

Re-run (via tag re-push or workflow re-run) `jetbrains/v0.4.0` and `vs/v1.3.0` to complete the pending releases.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>