### PR TITLE
fix(jetbrains): check CLI bundles inside nested plugin jar, fix stale WebBridge path

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -363,22 +363,34 @@ jobs:
       - name: Assert all CLI bundles are present in the ZIP
         run: |
           ZIP=$(find jetbrains-plugin/build/distributions/ -name "*.zip" | head -1)
+          # The plugin ZIP only contains the plugin's lib/*.jar files at its top level.
+          # Gradle's `sourceSets.main.resources` bundling packs our CLI/webview assets
+          # *inside* the main plugin jar (so the plugin can load them via the
+          # classloader), not as loose files in the outer ZIP. So we must inspect the
+          # nested jar's entries, not the outer ZIP's.
+          WORKDIR=$(mktemp -d)
+          unzip -q "$ZIP" -d "$WORKDIR"
+          JAR=$(find "$WORKDIR" -name "*.jar" ! -name "*-searchableOptions.jar" | head -1)
+          if [ -z "$JAR" ]; then
+            echo "❌ Could not find the plugin's main jar inside $ZIP"
+            exit 1
+          fi
           MISSING=()
           for ENTRY in \
             "cli-bundle/win-x64/copilot-token-tracker.exe" \
             "cli-bundle/darwin-arm64/copilot-token-tracker" \
             "cli-bundle/darwin-x64/copilot-token-tracker" \
             "cli-bundle/linux-x64/copilot-token-tracker"; do
-            if ! unzip -l "$ZIP" | grep -q "$ENTRY"; then
+            if ! unzip -l "$JAR" | grep -q "$ENTRY"; then
               MISSING+=("$ENTRY")
             fi
           done
           if [ ${#MISSING[@]} -gt 0 ]; then
-            echo "❌ Missing CLI bundle entries in plugin ZIP:"
+            echo "❌ Missing CLI bundle entries in plugin jar ($JAR):"
             for M in "${MISSING[@]}"; do echo "  - $M"; done
             exit 1
           fi
-          echo "✅ All CLI bundles present in plugin ZIP"
+          echo "✅ All CLI bundles present in plugin jar"
 
       - name: Publish to JetBrains Marketplace
         # Publish on tag push, or on workflow_dispatch when explicitly requested

--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -298,15 +298,17 @@ jobs:
           mkdir -p cli/dist vscode-extension/dist/webview
 
           # CLI binaries (sql-wasm.wasm is the same on all platforms; one copy suffices)
-          # Note: artifact paths preserve the source directory structure
-          cp artifacts/cli-windows/cli/dist/copilot-token-tracker.exe      cli/dist/
-          cp artifacts/cli-windows/cli/dist/sql-wasm.wasm                  cli/dist/
-          cp artifacts/cli-macos-arm64/cli/dist/copilot-token-tracker-macos-arm64  cli/dist/
-          cp artifacts/cli-macos-x64/cli/dist/copilot-token-tracker-macos-x64      cli/dist/
-          cp artifacts/cli-linux/cli/dist/copilot-token-tracker-linux       cli/dist/
+          # Note: actions/upload-artifact strips the common leading directory of the
+          # listed paths, so files land flat at the artifact root (not under cli/dist/).
+          cp artifacts/cli-windows/copilot-token-tracker.exe      cli/dist/
+          cp artifacts/cli-windows/sql-wasm.wasm                  cli/dist/
+          cp artifacts/cli-macos-arm64/copilot-token-tracker-macos-arm64  cli/dist/
+          cp artifacts/cli-macos-x64/copilot-token-tracker-macos-x64      cli/dist/
+          cp artifacts/cli-linux/copilot-token-tracker-linux       cli/dist/
 
-          # Webview JS bundles (built by vscode-extension)
-          cp artifacts/webview-bundles/vscode-extension/dist/webview/*  vscode-extension/dist/webview/
+          # Webview JS bundles (built by vscode-extension; also flattened at upload)
+          # -r because the bundle includes the codicons/ subdirectory
+          cp -r artifacts/webview-bundles/*  vscode-extension/dist/webview/
 
           # Make unix binaries executable
           chmod +x cli/dist/copilot-token-tracker-macos-arm64 cli/dist/copilot-token-tracker-macos-x64 cli/dist/copilot-token-tracker-linux

--- a/.github/workflows/visualstudio-publish.yml
+++ b/.github/workflows/visualstudio-publish.yml
@@ -181,17 +181,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $tag = "vs/v${{ steps.version.outputs.local_version }}"
+          $notesPath = Join-Path $env:RUNNER_TEMP "release_notes.md"
           Write-Host "Generating release notes for $tag ..."
           $notes = gh api repos/${{ github.repository }}/releases/generate-notes `
             -f tag_name="$tag" `
             --jq '.body' 2>$null
           if ($LASTEXITCODE -eq 0 -and $notes) {
-            $notes | Out-File -FilePath /tmp/release_notes.md -Encoding utf8
+            $notes | Out-File -FilePath $notesPath -Encoding utf8
             Write-Host "✅ Generated release notes from merged PRs"
           } else {
-            "Visual Studio Extension v${{ steps.version.outputs.local_version }}" | Out-File -FilePath /tmp/release_notes.md -Encoding utf8
+            "Visual Studio Extension v${{ steps.version.outputs.local_version }}" | Out-File -FilePath $notesPath -Encoding utf8
             Write-Host "⚠️ Could not auto-generate notes, using fallback"
           }
+          echo "notes_path=$notesPath" >> $env:GITHUB_OUTPUT
 
       - name: Create GitHub release
         if: ${{ steps.version.outputs.is_tag == 'true' && inputs.dry_run != true }}
@@ -204,7 +206,7 @@ jobs:
           Write-Host "Creating release $tag with $vsix ..."
           gh release create "$tag" `
             --title "Visual Studio Extension v${{ steps.version.outputs.local_version }}" `
-            --notes-file /tmp/release_notes.md `
+            --notes-file "${{ steps.release_notes.outputs.notes_path }}" `
             "$vsix"
           Write-Host "✅ GitHub release created: $tag"
 

--- a/jetbrains-plugin/build.gradle.kts
+++ b/jetbrains-plugin/build.gradle.kts
@@ -98,7 +98,7 @@ val prepareBundledAssets by tasks.registering(Copy::class) {
     }
 
     // 2. The vscode-shim that fakes acquireVsCodeApi() — same file the VS extension uses.
-    from("$repoRoot/visualstudio-extension/src/CopilotTokenTracker/WebBridge") {
+    from("$repoRoot/visualstudio-extension/src/AIEngineeringFluency/WebBridge") {
         include("vscode-shim.js")
         into("webview")
     }


### PR DESCRIPTION
## Root cause

The "Assert all CLI bundles are present in the ZIP" step in `jetbrains-publish.yml` ran `unzip -l` on the **outer** plugin ZIP. But the IntelliJ Platform Gradle Plugin packs everything registered via `sourceSets.main.resources` (our `cli-bundle/*` and `webview/*` assets) **inside the main plugin jar** (`lib/ai-engineering-fluency-x.x.x.jar`), not as loose files in the outer ZIP — that's intentional, so the plugin can load them at runtime via the classloader.

So the assertion was checking the wrong file and could never find the `cli-bundle/*` entries, even when bundling worked correctly. This caused every recent JetBrains publish to fail at this step.

## Verification

Reproduced locally end-to-end with dummy CLI binaries:
- `./gradlew prepareBundledAssets` → confirmed `build/bundled-assets/cli-bundle/<platform>/...` populated correctly.
- `./gradlew buildPlugin` → confirmed the built ZIP's **nested jar** (`lib/ai-engineering-fluency-0.4.0.jar`) contains all `cli-bundle/*` and `webview/*` entries.
- Verified the new assertion logic (extract ZIP → find main jar → `unzip -l` on the jar) correctly finds all 4 required entries.

## Also fixed

`prepareBundledAssets` in `build.gradle.kts` referenced a stale path for `vscode-shim.js`:
`visualstudio-extension/src/CopilotTokenTracker/WebBridge` — left over from the VS project rename to `AIEngineeringFluency`. This didn't hard-fail (Gradle's `from()` on a missing dir silently contributes nothing), but meant the shim was never bundled for JetBrains. Corrected to `visualstudio-extension/src/AIEngineeringFluency/WebBridge`.

Both bugs verified via local `java`/`gradlew` build during this session — no CI dependency required to confirm the fix.