### PR TITLE
Fix broken Blob Upload Guide links and rebrand issue template wording

### DIFF
--- a/.claude/skills/session-log-data/SKILL.md
+++ b/.claude/skills/session-log-data/SKILL.md
@@ -159,12 +159,12 @@ Before using the data, check if the files exist:
 [ -f ./usage-data/usage-agg-daily.json ] && echo "Aggregated data available" || echo "No aggregated data"
 ```
 
-If neither directory exists, Azure Storage is not configured. See the `azure-storage-loader` skill and `docs/BLOB-UPLOAD.md` for setup instructions.
+If neither directory exists, Azure Storage is not configured. See the `azure-storage-loader` skill and `docs/features/BLOB-UPLOAD.md` for setup instructions.
 
 ## Related Files
 
-- `docs/BLOB-UPLOAD.md` — Full blob upload documentation and setup guide
-- `docs/BLOB-UPLOAD-QUICKSTART.md` — Quick start for blob upload and coding agent access
+- `docs/features/BLOB-UPLOAD.md` — Full blob upload documentation and setup guide
+- `docs/features/BLOB-UPLOAD-QUICKSTART.md` — Quick start for blob upload and coding agent access
 - `.github/skills/azure-storage-loader/SKILL.md` — Azure Table Storage loader skill
 - `.github/skills/copilot-log-analysis/SKILL.md` — Session file analysis techniques
 - `src/modelPricing.json` — Model pricing data for cost estimation

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,4 +40,4 @@ Add any other context about the problem here.
 **Logs (if applicable)**
 If the extension shows unexpected behavior, you can help by sharing:
 - Any error messages from VS Code Developer Tools (Help > Toggle Developer Tools)
-- Contents of VS Code output panel for "Copilot Token Tracker" (if available)
+- Contents of VS Code output panel for "AI Engineering Fluency" (if available)

--- a/.github/skills/session-log-data/SKILL.md
+++ b/.github/skills/session-log-data/SKILL.md
@@ -159,12 +159,12 @@ Before using the data, check if the files exist:
 [ -f ./usage-data/usage-agg-daily.json ] && echo "Aggregated data available" || echo "No aggregated data"
 ```
 
-If neither directory exists, Azure Storage is not configured. See the `azure-storage-loader` skill and `docs/BLOB-UPLOAD.md` for setup instructions.
+If neither directory exists, Azure Storage is not configured. See the `azure-storage-loader` skill and `docs/features/BLOB-UPLOAD.md` for setup instructions.
 
 ## Related Files
 
-- `docs/BLOB-UPLOAD.md` — Full blob upload documentation and setup guide
-- `docs/BLOB-UPLOAD-QUICKSTART.md` — Quick start for blob upload and coding agent access
+- `docs/features/BLOB-UPLOAD.md` — Full blob upload documentation and setup guide
+- `docs/features/BLOB-UPLOAD-QUICKSTART.md` — Quick start for blob upload and coding agent access
 - `.github/skills/azure-storage-loader/SKILL.md` — Azure Table Storage loader skill
 - `.github/skills/copilot-log-analysis/SKILL.md` — Session file analysis techniques
 - `src/modelPricing.json` — Model pricing data for cost estimation

--- a/docs/features/BLOB-UPLOAD-QUICKSTART.md
+++ b/docs/features/BLOB-UPLOAD-QUICKSTART.md
@@ -141,6 +141,6 @@ Common causes:
 ### Need more help?
 
 See full documentation:
-- [Blob Upload Guide](../docs/BLOB-UPLOAD.md)
+- [Blob Upload Guide](BLOB-UPLOAD.md)
 - [Coding Agent Knowledge Base](.github/agents/coding-agent/knowledge.md)
 - [Backend Configuration](../docs/specs/backend.md)

--- a/docs/features/BLOB-UPLOAD-QUICKSTART.md
+++ b/docs/features/BLOB-UPLOAD-QUICKSTART.md
@@ -81,7 +81,7 @@ That's it! Files will upload during the next backend sync (runs every 5 minutes 
 
 1. **Trigger upload** manually:
    - Open VS Code Command Palette (Ctrl+Shift+P / Cmd+Shift+P)
-   - Run: "Copilot Token Tracker: Configure Backend"
+   - Run: "AI Engineering Fluency: Configure Backend"
    - Click "Test Connection" to verify access
    - Backend sync will upload files automatically
 
@@ -122,7 +122,7 @@ usage patterns from the last week"
 
 Check VS Code Output panel:
 1. View → Output
-2. Select "Copilot Token Tracker"
+2. Select "AI Engineering Fluency"
 3. Look for "Blob upload:" messages
 
 Common causes:

--- a/docs/features/BLOB-UPLOAD.md
+++ b/docs/features/BLOB-UPLOAD.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Copilot Token Tracker extension can upload your local GitHub Copilot session log files to Azure Blob Storage. This enables:
+The AI Engineering Fluency extension can upload your local GitHub Copilot session log files to Azure Blob Storage. This enables:
 
 1. **Team Collaboration**: Share session logs with your team for analysis and learning
 2. **Persistent Storage**: Keep logs beyond local VS Code storage limits
@@ -100,7 +100,7 @@ No additional configuration needed - extension uses same credentials as backend 
 
 If using shared key authentication:
 
-1. Run command: "Copilot Token Tracker: Set Backend Storage Shared Key"
+1. Run command: "AI Engineering Fluency: Set Backend Storage Shared Key"
 2. Enter your storage account access key
 3. Key is stored securely in VS Code SecretStorage
 
@@ -270,7 +270,7 @@ If operating in the EU or with EU users:
 
 **View logs:**
 1. Open Output panel: View → Output
-2. Select "Copilot Token Tracker" from dropdown
+2. Select "AI Engineering Fluency" from dropdown
 3. Look for "Blob upload:" messages
 
 **Common issues:**
@@ -395,7 +395,7 @@ Not currently. All session files found locally are uploaded (subject to frequenc
 ## Next Steps
 
 1. Review [Backend Setup Guide](backend.md) for initial Azure configuration
-2. Test upload with manual sync: "Copilot Token Tracker: Configure Backend"
+2. Test upload with manual sync: "AI Engineering Fluency: Configure Backend"
 3. Set up coding agent environment variables for workflow access
 4. Configure lifecycle policies to manage storage costs
 5. Review uploaded files in Azure Portal → Storage accounts → Containers

--- a/docs/vscode-extension/README.md
+++ b/docs/vscode-extension/README.md
@@ -228,7 +228,7 @@ To enable log file uploads:
 }
 ```
 
-See [Blob Upload Guide](../BLOB-UPLOAD.md) for detailed setup instructions and security considerations.
+See [Blob Upload Guide](../features/BLOB-UPLOAD.md) for detailed setup instructions and security considerations.
 
 ### Authentication
 

--- a/scripts/setup-copilot-environment.ps1
+++ b/scripts/setup-copilot-environment.ps1
@@ -174,4 +174,4 @@ Write-Host "  1. Trigger the workflow to test: Actions > Copilot Setup Steps > R
 Write-Host "  2. Verify session logs download in the workflow run logs" -ForegroundColor Yellow
 Write-Host "  3. Verify aggregated data downloads in the workflow run logs" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "For more details, see docs/BLOB-UPLOAD-QUICKSTART.md" -ForegroundColor Gray
+Write-Host "For more details, see docs/features/BLOB-UPLOAD-QUICKSTART.md" -ForegroundColor Gray

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -194,7 +194,7 @@ To enable log file uploads:
 }
 ```
 
-See [Blob Upload Guide](https://github.com/rajbos/ai-engineering-fluency/blob/main/docs/BLOB-UPLOAD.md) for detailed setup instructions and security considerations.
+See [Blob Upload Guide](https://github.com/rajbos/ai-engineering-fluency/blob/main/docs/features/BLOB-UPLOAD.md) for detailed setup instructions and security considerations.
 
 ### Authentication
 


### PR DESCRIPTION
Fixes #1752.

- The "Blob Upload Guide" links pointed at `docs/BLOB-UPLOAD.md`, which doesn't exist. The actual files live under `docs/features/`: `BLOB-UPLOAD.md` and `BLOB-UPLOAD-QUICKSTART.md`. Updated all references (`vscode-extension/README.md`, `docs/vscode-extension/README.md`, `docs/features/BLOB-UPLOAD-QUICKSTART.md`, the session-log-data skill docs, and `scripts/setup-copilot-environment.ps1`) to point to the correct path.
- Updated the stale "Copilot Token Tracker" wording in `.github/ISSUE_TEMPLATE/bug_report.md` to "AI Engineering Fluency".