### PR TITLE
fix(jetbrains): replace obsolete SystemInfo OS checks with util.system.OS

### DIFF
--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.4.0
+pluginVersion = 0.4.1
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -4,8 +4,8 @@ import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.PluginId
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.createDirectories
+import com.intellij.util.system.OS
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -185,7 +185,7 @@ object CliBridge {
             cachedExePath?.let { return it }
 
             val osDir = osBundleDir()
-            val exeName = if (SystemInfo.isWindows) "copilot-token-tracker.exe" else "copilot-token-tracker"
+            val exeName = if (OS.CURRENT == OS.Windows) "copilot-token-tracker.exe" else "copilot-token-tracker"
             val resourcePrefix = "/cli-bundle/$osDir"
 
             // Include plugin version in the path so each upgrade extracts a fresh copy
@@ -197,7 +197,7 @@ object CliBridge {
             // sql-wasm.wasm sits next to the binary; loaded at runtime by the CLI.
             copyResourceIfPresent("$resourcePrefix/sql-wasm.wasm", targetDir.resolve("sql-wasm.wasm"))
 
-            if (!SystemInfo.isWindows) {
+            if (OS.CURRENT != OS.Windows) {
                 exePath.toFile().setExecutable(true, /* ownerOnly = */ false)
             }
 
@@ -243,10 +243,10 @@ object CliBridge {
     }
 
     private fun osBundleDir(): String = when {
-        SystemInfo.isWindows -> "win-x64"
-        SystemInfo.isMac -> if (isArm64Runtime()) "darwin-arm64" else "darwin-x64"
-        SystemInfo.isLinux -> "linux-x64"
-        else -> throw IllegalStateException("Unsupported OS: ${SystemInfo.OS_NAME}")
+        OS.CURRENT == OS.Windows -> "win-x64"
+        OS.CURRENT == OS.macOS -> if (isArm64Runtime()) "darwin-arm64" else "darwin-x64"
+        OS.CURRENT == OS.Linux -> "linux-x64"
+        else -> throw IllegalStateException("Unsupported OS: ${OS.CURRENT}")
     }
 
     /**


### PR DESCRIPTION
## Context

After the JetBrains Plugin was published (v0.4.0), JetBrains' Plugin Verifier flagged API health issues on the Marketplace: 4 usages of deprecated API, 2 usages of experimental API, and 6 usages of internal API (across supported IDE versions), with the internal-API usage specifically called out as blocking further approval.

## What I found and fixed

I don't have network access to the Marketplace's own verifier report page, so I confirmed the concrete issue via direct bytecode inspection against a local **IntelliJ IDEA Community Edition 2025.2.6.2** install — one of the exact target versions in the verifier's compatibility matrix.

Confirmed: `com.intellij.openapi.util.SystemInfo.isWindows` / `.isMac` / `.isLinux` / `.OS_NAME` all carry the `@ApiStatus.Obsolete` annotation in the platform. They still function, but the IntelliJ Platform team has an explicit preferred replacement: `com.intellij.util.system.OS`.

`CliBridge.kt` used these fields 6 times for OS-based CLI binary selection. Replaced all of them with `OS.CURRENT == OS.Windows / OS.macOS / OS.Linux` — verified via the same bytecode inspection that `OS.CURRENT`/`.Windows`/`.macOS`/`.Linux` carry **no** Obsolete/Internal/Experimental annotations.

Verified `./gradlew compileKotlin` and `./gradlew test` both succeed after the change.

## What I could NOT confirm

I checked every other platform API our code calls directly (`JBCefBrowser`, `JBCefBrowserBase`, `JBCefJSQuery`, `PluginManagerCore.getPlugin`, `PathKt.createDirectories`, `PropertiesComponent`, `Logger`) against the local 2025.2.6.2 install, and none of the specific members we call carry `@ApiStatus.Internal`. So this PR fixes the confirmed **Obsolete/deprecated** usage, but I could not pinpoint the exact **Internal API** symbol the verifier flagged without access to its full report page (linked from the verification email) — that page lists the exact class + method per IDE version, which would let us target the fix precisely. Worth checking that page before re-publishing to confirm whether this fix alone is sufficient.