### PR TITLE
fix(jetbrains): replace internal PluginManagerCore.getPlugin API usage

### DIFF
--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.4.1
+pluginVersion = 0.4.2
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -1,9 +1,8 @@
 package com.github.rajbos.aiengineeringfluency
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.util.io.createDirectories
 import com.intellij.util.system.OS
 import java.io.IOException
@@ -174,7 +173,7 @@ object CliBridge {
 
     /** Plugin version string, used to version the extraction directory so upgrades don't reuse stale binaries. */
     private val pluginVersion: String by lazy {
-        PluginManagerCore.getPlugin(PluginId.getId("com.github.rajbos.ai-engineering-fluency"))
+        PluginManager.getPluginByClass(CliBridge::class.java)
             ?.version
             ?: "unknown"
     }


### PR DESCRIPTION
## Root cause

JetBrains' Plugin Verifier flagged one Internal API usage on the v0.4.0/v0.4.1 releases:

> `PluginManagerCore.getPlugin(PluginId)` — private API that must not be used outside the IntelliJ Platform itself.

## Fix

Confirmed via bytecode inspection against a local IntelliJ IDEA 2025.2.6.2 install that `com.intellij.ide.plugins.PluginManager.getPluginByClass(Class<?>)` is the public, non-internal replacement for resolving a plugin's own descriptor (no Deprecated/Internal/Experimental annotations on it).

Replaced the `PluginId.getId("com.github.rajbos.ai-engineering-fluency")` + `PluginManagerCore.getPlugin(...)` lookup in `CliBridge.kt` with `PluginManager.getPluginByClass(CliBridge::class.java)` — this also drops the hardcoded plugin-id string literal (one less thing to keep in sync with `gradle.properties`/`plugin.xml`).

Verified `./gradlew compileKotlin` succeeds.

## Included

Also bumps `pluginVersion` to `0.4.2` (patch) so this can ship as its own release once merged.