### PR TITLE
ci(codeql): cover C# and Kotlin components, use security-extended suite

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,18 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    # java-kotlin is marked experimental below: CodeQL (bundle 2.26.1, the
+    # default for codeql-action v4.37.3) rejects the plugin's Kotlin 2.4.10
+    # toolchain with "Kotlin version 2.4.10 is too recent. CodeQL currently
+    # supports versions below 2.4.10". CodeQL 2.26.0 added Kotlin 2.4.0
+    # support but hasn't caught up to 2.4.10 in any released bundle yet (the
+    # only newer bundle, codeql-bundle-v2.26.2, is an unreleased pre-release
+    # with no published CLI binaries — not safe to pin in CI). continue-on-error
+    # keeps this one matrix entry from blocking the workflow/PR while the
+    # other three languages remain fully enforced. Remove `experimental` from
+    # the java-kotlin matrix entry once a released CodeQL bundle supports
+    # Kotlin 2.4.10 (or jetbrains-plugin downgrades its Kotlin version).
+    continue-on-error: ${{ matrix.experimental || false }}
 
     strategy:
       fail-fast: false
@@ -56,6 +68,7 @@ jobs:
               .github
           - language: java-kotlin
             build-mode: manual
+            experimental: true # see continue-on-error comment above: Kotlin 2.4.10 vs CodeQL's ceiling
             sparse-checkout: |
               jetbrains-plugin
               .github

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,6 +81,10 @@ jobs:
             api.adoptium.net:443
             api.github.com:443
             cache-redirector.jetbrains.com:443
+            # d2cico3c979uwg.cloudfront.net is the CloudFront distribution that
+            # download-cdn.jetbrains.com itself resolves/redirects to when the
+            # IntelliJ Platform Gradle plugin fetches the IC IDE distribution.
+            d2cico3c979uwg.cloudfront.net:443
             data.services.jetbrains.com:443
             download-cdn.jetbrains.com:443
             download.jetbrains.com:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,39 +35,69 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["actions", "typescript"]
         # CodeQL supports [ $supported-codeql-languages ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        #
+        # Each entry only checks out and sets up the toolchain its own language
+        # needs (see the sparse-checkout / conditional setup steps below):
+        #   - actions / typescript: repo-wide, no compiled build required.
+        #   - csharp: build-mode "none" (the CodeQL C# extractor can analyze the
+        #     visualstudio-extension/ source without an MSBuild/dotnet build).
+        #   - java-kotlin: build-mode "manual", built via the jetbrains-plugin/
+        #     Gradle wrapper (compileKotlin only — buildPlugin isn't needed for
+        #     extraction and would pull down the full IntelliJ Platform SDK).
+        include:
+          - language: actions
+          - language: typescript
+          - language: csharp
+            build-mode: none
+            sparse-checkout: |
+              visualstudio-extension
+              .github
+          - language: java-kotlin
+            build-mode: manual
+            sparse-checkout: |
+              jetbrains-plugin
+              .github
 
     steps:
-      - name: Harden the runner (Block all outbound calls except allowed)
+      - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: block
-          # Allowlist inferred from the harden-runner audit output of the 10 most
-          # recent successful runs of this workflow (run ids 28795598756..28802374085).
-          # Use a wildcard for the rotating Actions results storage account names.
-          # The *.githubusercontent.com hosts serve the CodeQL bundle download when
-          # the requested version is not in the runner's toolcache (release
-          # downloads on github.com redirect there) — without them, init fails
-          # with ECONNREFUSED on runner images that lack the pinned version.
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            productionresultssa*.blob.core.windows.net:443
-            results-receiver.actions.githubusercontent.com:443
-            uploads.github.com:443
+          # Audit rather than a curated block-list: the java-kotlin matrix entry
+          # runs a real Gradle build (Gradle wrapper, Gradle Plugin Portal, Maven
+          # Central, JetBrains' IntelliJ Platform repositories), whose full set of
+          # egress endpoints isn't practical to enumerate and pin here. This
+          # matches the egress-policy used by the repo's other build-heavy
+          # workflows (build.yml, visualstudio-build.yml, jetbrains-publish.yml).
+          egress-policy: audit
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: ${{ matrix.sparse-checkout }}
+
+      - name: Set up Java 21 (Temurin)
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        if: matrix.language == 'java-kotlin'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Use the broader security-extended query suite (adds lower-precision /
+          # lower-severity security queries on top of the default security-and-quality
+          # set) across every language in the matrix.
+          queries: security-extended
           # Exclude committed *generated* build artifacts (the minified Visual
           # Studio webview bundles) from analysis. Their hand-written TypeScript
           # source in vscode-extension/src/webview/** is still scanned. See the
@@ -77,9 +107,20 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
+      # build-mode: manual — trace the JetBrains plugin's own Gradle wrapper build.
+      # compileKotlin/compileTestKotlin is enough for extraction; buildPlugin would
+      # additionally download and assemble the full IntelliJ Platform distribution.
+      - name: Build JetBrains plugin (Gradle)
+        if: matrix.language == 'java-kotlin'
+        working-directory: jetbrains-plugin
+        run: ./gradlew compileKotlin compileTestKotlin --no-daemon
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java)
+      # that aren't otherwise handled above. csharp uses build-mode: none (no
+      # build required) and java-kotlin is built manually above, so this only
+      # ever runs for languages that fall through to CodeQL's default build-mode.
       - name: Autobuild
+        if: matrix.language != 'csharp' && matrix.language != 'java-kotlin'
         uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,8 +81,10 @@ jobs:
             api.adoptium.net:443
             api.github.com:443
             cache-redirector.jetbrains.com:443
+            data.services.jetbrains.com:443
             download.jetbrains.com:443
             github.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             plugins-artifacts.gradle.org:443
             plugins.gradle.org:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,18 +31,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    # java-kotlin is marked experimental below: CodeQL (bundle 2.26.1, the
-    # default for codeql-action v4.37.3) rejects the plugin's Kotlin 2.4.10
-    # toolchain with "Kotlin version 2.4.10 is too recent. CodeQL currently
-    # supports versions below 2.4.10". CodeQL 2.26.0 added Kotlin 2.4.0
-    # support but hasn't caught up to 2.4.10 in any released bundle yet (the
-    # only newer bundle, codeql-bundle-v2.26.2, is an unreleased pre-release
-    # with no published CLI binaries — not safe to pin in CI). continue-on-error
-    # keeps this one matrix entry from blocking the workflow/PR while the
-    # other three languages remain fully enforced. Remove `experimental` from
-    # the java-kotlin matrix entry once a released CodeQL bundle supports
-    # Kotlin 2.4.10 (or jetbrains-plugin downgrades its Kotlin version).
-    continue-on-error: ${{ matrix.experimental || false }}
 
     strategy:
       fail-fast: false
@@ -68,7 +56,6 @@ jobs:
               .github
           - language: java-kotlin
             build-mode: manual
-            experimental: true # see continue-on-error comment above: Kotlin 2.4.10 vs CodeQL's ceiling
             sparse-checkout: |
               jetbrains-plugin
               .github

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,16 +61,39 @@ jobs:
               .github
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block all outbound calls except allowed)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          # Audit rather than a curated block-list: the java-kotlin matrix entry
-          # runs a real Gradle build (Gradle wrapper, Gradle Plugin Portal, Maven
-          # Central, JetBrains' IntelliJ Platform repositories), whose full set of
-          # egress endpoints isn't practical to enumerate and pin here. This
-          # matches the egress-policy used by the repo's other build-heavy
-          # workflows (build.yml, visualstudio-build.yml, jetbrains-publish.yml).
-          egress-policy: audit
+          egress-policy: block
+          # Allowlist inferred from the harden-runner audit output of the 10 most
+          # recent successful runs of this workflow (run ids 28795598756..28802374085),
+          # plus the well-known endpoints the csharp/java-kotlin matrix entries added
+          # below need (Gradle wrapper distribution, Gradle Plugin Portal, Maven
+          # Central, JetBrains' IntelliJ Platform repositories, Temurin JDK). These
+          # were proactively added and then trued up against real run failures — see
+          # the PR description for the endpoints actually observed as blocked.
+          # Use a wildcard for the rotating Actions results storage account names.
+          # The *.githubusercontent.com hosts serve the CodeQL bundle download when
+          # the requested version is not in the runner's toolcache (release
+          # downloads on github.com redirect there) — without them, init fails
+          # with ECONNREFUSED on runner images that lack the pinned version.
+          allowed-endpoints: >
+            api.adoptium.net:443
+            api.github.com:443
+            cache-redirector.jetbrains.com:443
+            download.jetbrains.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            productionresultssa*.blob.core.windows.net:443
+            release-assets.githubusercontent.com:443
+            repo.maven.apache.org:443
+            repo1.maven.org:443
+            results-receiver.actions.githubusercontent.com:443
+            services.gradle.org:443
+            uploads.github.com:443
+            www.jetbrains.com:443
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,6 +82,7 @@ jobs:
             api.github.com:443
             cache-redirector.jetbrains.com:443
             data.services.jetbrains.com:443
+            download-cdn.jetbrains.com:443
             download.jetbrains.com:443
             github.com:443
             hosted-compute-watchdog-prod-*.githubapp.com:443

--- a/jetbrains-plugin/build.gradle.kts
+++ b/jetbrains-plugin/build.gradle.kts
@@ -12,7 +12,11 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    kotlin("jvm") version "2.4.10"
+    // Pinned below CodeQL's Kotlin version ceiling: CodeQL (bundle 2.26.1, used by
+    // codeql-action v4.37.3 in .github/workflows/codeql.yml) only supports Kotlin
+    // versions up to 2.4.0 — 2.4.10 fails extraction with "Kotlin version 2.4.10
+    // is too recent". Bump back to 2.4.10+ once CodeQL adds support for it.
+    kotlin("jvm") version "2.4.0"
     id("org.jetbrains.intellij.platform") version "2.18.1"
 }
 


### PR DESCRIPTION
## Summary

CodeQL previously only covered `actions` and `typescript`, leaving the
Visual Studio extension (C#) and JetBrains plugin (Kotlin) with zero
static-analysis coverage. This expands `.github/workflows/codeql.yml`:

- **Add `csharp`** for `visualstudio-extension/`, using `build-mode: none`
  — the CodeQL C# extractor can analyze the source without an MSBuild/dotnet
  build, so no `.NET`/MSBuild setup is added to this job.
- **Add `java-kotlin`** for `jetbrains-plugin/`, using `build-mode: manual`.
  It's built via the plugin's own Gradle wrapper (`./gradlew compileKotlin
  compileTestKotlin`), reusing the same pinned `actions/setup-java` (Temurin
  21) and `gradle/actions/setup-gradle` versions already used in
  `jetbrains-publish.yml`. Only `compileKotlin`/`compileTestKotlin` are run
  (not `buildPlugin`), since extraction doesn't need the full IntelliJ
  Platform SDK download that `buildPlugin` would trigger.
- **Switch the query suite to `security-extended`** via the `queries:` input
  on the `init` step, for all four languages.
- **Per-language checkout efficiency**: the two new matrix entries use
  `actions/checkout`'s `sparse-checkout` to only pull `visualstudio-extension/`
  or `jetbrains-plugin/` (plus `.github/` for the CodeQL config), instead of
  checking out the whole monorepo. `actions`/`typescript` keep a full
  checkout since they scan repo-wide. Java/Gradle setup steps are gated with
  `if: matrix.language == 'java-kotlin'` so they don't run for the other
  three entries.
- All new/changed actions are pinned by full commit SHA with a version
  comment, and `step-security/harden-runner` remains the first step of the
  job, matching this repo's existing convention.

## Egress: kept `block`, allowlist learned from real runs

Per feedback, `egress-policy` stays `block` (not `audit`). The Gradle build
needs a wider set of endpoints than the job previously used, so the
allowlist below was iterated against real harden-runner failures on this PR
(not guessed):

```
api.adoptium.net:443
api.github.com:443
cache-redirector.jetbrains.com:443
d2cico3c979uwg.cloudfront.net:443   # CloudFront distro behind download-cdn.jetbrains.com
data.services.jetbrains.com:443     # IntelliJ Platform Gradle plugin: release metadata
download-cdn.jetbrains.com:443      # IntelliJ Platform Gradle plugin: IDE distribution download
download.jetbrains.com:443
github.com:443
hosted-compute-watchdog-prod-*.githubapp.com:443   # already allowlisted this way in ci.yml
objects.githubusercontent.com:443
plugins-artifacts.gradle.org:443
plugins.gradle.org:443
productionresultssa*.blob.core.windows.net:443
release-assets.githubusercontent.com:443
repo.maven.apache.org:443
repo1.maven.org:443
results-receiver.actions.githubusercontent.com:443
services.gradle.org:443
uploads.github.com:443
www.jetbrains.com:443
```

Iteration log (each round re-ran the CodeQL workflow on this PR and grepped
harden-runner's job log for `domain not allowed`):

1. Proactively seeded the list with the well-known Gradle/Maven/JetBrains/
   Temurin hosts, plus the pre-existing CodeQL-bundle allowlist — run failed,
   blocked `data.services.jetbrains.com` (+ benign `hosted-compute-watchdog-*`).
2. Added `data.services.jetbrains.com` and the watchdog wildcard — run failed,
   blocked `download-cdn.jetbrains.com`.
3. Added `download-cdn.jetbrains.com` — run failed, blocked
   `d2cico3c979uwg.cloudfront.net` (the CDN's actual CloudFront backend).
4. Added `d2cico3c979uwg.cloudfront.net` — **no more blocked-domain errors**;
   the build reached actual Kotlin compilation.

`actions`, `typescript`, and `csharp` are all green with `egress-policy:
block` as of the latest run:
https://github.com/rajbos/ai-engineering-fluency/actions/runs/30458748576

## java-kotlin: fixed for real via a Kotlin toolchain downgrade (2.4.10 → 2.4.0)

The `java-kotlin` matrix entry originally failed for a genuine, non-network
reason:

```
Caused by: com.semmle.extractor.java.interceptors.KotlinInterceptor$KotlinVersionTooRecentError:
Kotlin version 2.4.10 is too recent. CodeQL currently supports versions below 2.4.10
```

I first checked whether a newer released CodeQL supports it:

- `gh release list -R github/codeql-action` — latest release is `v4.37.3`
  (already pinned here), no newer tag exists.
- Its default bundle is `codeql-bundle-v2.26.1` (`src/defaults.json` at that
  tag). Per the [CodeQL 2.26.0 changelog](https://github.blog/changelog/2026-07-10-codeql-2-26-0-adds-kotlin-2-4-0-support-and-ai-prompt-injection-detection/),
  2.26.0 added Kotlin support only up to **2.4.0** — not 2.4.10.
- The only newer bundle, `codeql-bundle-v2.26.2`, is a **pre-release** with
  no public CLI binary release yet (404 on `codeql-cli-binaries`). Not safe
  to pin `tools:` to it.

No released CodeQL supports 2.4.10, so as directed I downgraded the plugin's
own Kotlin toolchain instead: `jetbrains-plugin/build.gradle.kts` now pins
`kotlin("jvm") version "2.4.0"` (the newest stable Kotlin release below
2.4.10, per [JetBrains/kotlin releases](https://api.github.com/repos/JetBrains/kotlin/releases) —
the only other candidates were `2.4.10-RC`/`2.4.10-RC2`/`2.4.20-Beta*`, none
of which are stable). A code comment on the `kotlin("jvm")` line explains
why and notes to bump back up once CodeQL adds 2.4.10 support.

**Verified locally** (`jetbrains-plugin/gradlew.bat compileKotlin
compileTestKotlin --no-daemon`, the same command the workflow runs):
`BUILD SUCCESSFUL`. I also ran the full `test` task out of caution; it fails
on an unrelated `:instrumentCode`/`:instrumentTestCode` `"1 >= 1"` error from
the IntelliJ Platform Gradle plugin's bytecode instrumentation — confirmed
via a clean `--rerun-tasks` build that this reproduces **identically on the
original, unmodified Kotlin 2.4.10** too, so it's pre-existing and unrelated
to this downgrade. The CodeQL workflow only runs `compileKotlin`/
`compileTestKotlin`, not the full `test` task, so it isn't affected either way.

Removed the `continue-on-error`/`experimental` fallback from
`.github/workflows/codeql.yml` now that `java-kotlin` passes for real.

**Result — all four matrix entries green, no new egress-policy: block
endpoints needed for the 2.4.0 toolchain:**
https://github.com/rajbos/ai-engineering-fluency/actions/runs/30462957711

**Follow-up (not in this PR):** bump `jetbrains-plugin/build.gradle.kts`'s
Kotlin version back to 2.4.10+ once a released CodeQL bundle supports it.

## Test plan

- [x] `actionlint .github/workflows/codeql.yml` passes with no findings
- [x] `jetbrains-plugin/gradlew.bat compileKotlin compileTestKotlin` succeeds
      locally on Kotlin 2.4.0
- [x] CodeQL workflow run on this PR: all four matrix entries (`actions`,
      `typescript`, `csharp`, `java-kotlin`) pass as required checks under
      `egress-policy: block`
- [ ] Security tab shows `security-extended` results for the new C# and
      Kotlin entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
