### PR TITLE
security: declare workspace trust and virtual workspace capabilities

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -23,6 +23,16 @@
     "onStartupFinished"
   ],
   "main": "./dist/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Repository hygiene analysis runs `git` commands and scans files inside the workspace folder, so it is disabled in untrusted workspaces. Token/session usage tracking, dashboards, and insights only read AI session logs from your user home directory and continue to work normally."
+    },
+    "virtualWorkspaces": {
+      "supported": "limited",
+      "description": "Repository hygiene analysis relies on a local `git` checkout and workspace filesystem access, so it is disabled for virtual workspaces. Token/session usage tracking, dashboards, and insights only read AI session logs from your user home directory and continue to work normally."
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6673,6 +6673,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private async runRepoHygieneAnalysis(workspacePath?: string): Promise<any> {
+		this.ensureWorkspaceTrustedForGitAccess();
 		const workspaceRoot = this.resolveWorkspaceRoot(workspacePath);
 		const { branchName, repoName } = this.getGitRepoInfo(workspaceRoot);
 		const fileTree = await this.getWorkspaceFileTree(workspaceRoot);
@@ -6771,6 +6772,22 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 			return fullResponse;
 		} finally {
 			cts.dispose();
+		}
+	}
+
+	/**
+	 * Repository hygiene analysis runs `git` (via child_process.execSync) and scans files
+	 * inside the workspace folder, so it must not run in untrusted or virtual workspaces
+	 * (see package.json `capabilities.untrustedWorkspaces`/`virtualWorkspaces`, both "limited").
+	 * This check runs fresh on every invocation (no cached result), so it automatically
+	 * reflects the current trust state — including right after the user grants trust.
+	 */
+	private ensureWorkspaceTrustedForGitAccess(): void {
+		if (!vscode.workspace.isTrusted) {
+			throw new Error('Repository hygiene analysis requires a trusted workspace because it runs git commands and reads workspace files. Grant workspace trust to enable it.');
+		}
+		if (vscode.workspace.workspaceFolders?.some(folder => folder.uri.scheme !== 'file')) {
+			throw new Error('Repository hygiene analysis is not available for virtual workspaces because it requires local git and filesystem access.');
 		}
 	}
 

--- a/vscode-extension/test/unit/vscode-shim-register.ts
+++ b/vscode-extension/test/unit/vscode-shim-register.ts
@@ -5,7 +5,8 @@ type ConfigStore = Record<string, unknown>;
 
 type VscodeMockState = {
 	config: ConfigStore;
-	workspaceFolders: Array<{ uri: { fsPath: string; toString: () => string } }> | undefined;
+	workspaceFolders: Array<{ uri: { fsPath: string; scheme?: string; toString: () => string } }> | undefined;
+	isTrusted: boolean;
 	clipboardText: string;
 	clipboardThrow: boolean;
 	lastInfoMessages: string[];
@@ -18,6 +19,7 @@ type VscodeMockState = {
 const state: VscodeMockState = {
 	config: {},
 	workspaceFolders: undefined,
+	isTrusted: true,
 	clipboardText: '',
 	clipboardThrow: false,
 	lastInfoMessages: [],
@@ -85,6 +87,7 @@ function attachMock(target: any): void {
 		reset(): void {
 			state.config = {};
 			state.workspaceFolders = undefined;
+			state.isTrusted = true;
 			state.clipboardText = '';
 			state.clipboardThrow = false;
 			state.lastInfoMessages = [];
@@ -96,13 +99,17 @@ function attachMock(target: any): void {
 		setConfig(values: ConfigStore): void {
 			state.config = { ...values };
 		},
-		setWorkspaceFolders(folders: Array<{ fsPath: string; uriString?: string }>): void {
+		setWorkspaceFolders(folders: Array<{ fsPath: string; uriString?: string; scheme?: string }>): void {
 			state.workspaceFolders = folders.map((f) => ({
 				uri: {
 					fsPath: f.fsPath,
+					scheme: f.scheme ?? 'file',
 					toString: () => f.uriString ?? `file://${f.fsPath.replace(/\\/g, '/')}`
 				}
 			}));
+		},
+		setIsTrusted(trusted: boolean): void {
+			state.isTrusted = trusted;
 		},
 		setNextPick(value: string | undefined): void {
 			state.nextPick = value;
@@ -156,6 +163,14 @@ function attachMock(target: any): void {
 		},
 		set(folders: any) {
 			state.workspaceFolders = folders;
+		}
+	});
+	Object.defineProperty(target.workspace, 'isTrusted', {
+		get() {
+			return state.isTrusted;
+		},
+		set(trusted: boolean) {
+			state.isTrusted = trusted;
 		}
 	});
 


### PR DESCRIPTION
## Summary

Today `vscode-extension/package.json` has no `capabilities` key. VS Code treats that as "not evaluated" and, depending on user Restricted Mode settings, can leave the extension effectively disabled with no explanation — the extension never surfaces why some features silently don't work.

This PR adds an explicit `capabilities` declaration:

```json
"capabilities": {
  "untrustedWorkspaces": { "supported": "limited", "description": "..." },
  "virtualWorkspaces": { "supported": "limited", "description": "..." }
}
```

### Investigation

I audited every place the extension touches workspace content:

- `child_process.execSync('git rev-parse ...')` / `execSync('git remote get-url origin')` in `getGitRepoInfo()`, called from `runRepoHygieneAnalysis()` (the repository hygiene / Copilot analysis feature), run with `cwd` set to the **workspace folder**. This is the one path that genuinely needs a trusted, real (non-virtual) filesystem.
- The other two `execSync('git ...')` calls, in `initializeOutputChannel()`, run against `context.extensionUri.fsPath` (the extension's own install directory, dev-mode only) — not workspace content, so no trust concern there.
- The extension's core value — usage tracking, dashboards, insights, tool analysis — reads AI session logs from the **user's home directory** (`~/.copilot`, `~/.claude`, etc.), which is workspace-independent.

### Decision: "limited" support, not `false`

Since only one feature (repository hygiene analysis) touches workspace content, and the gating is a single, small, well-contained check, I chose `"supported": "limited"` over `false` for both `untrustedWorkspaces` and `virtualWorkspaces`. This lets the extension keep activating and keep its core functionality (which is workspace-independent) working even in Restricted Mode / virtual workspaces, rather than disabling the whole extension over one feature.

### Code paths gated

Added `CopilotTokenTracker.ensureWorkspaceTrustedForGitAccess()` in `vscode-extension/src/extension.ts`, called at the top of `runRepoHygieneAnalysis()` (the only caller of `getGitRepoInfo()`/workspace-rooted `execSync`). It throws if:
- `vscode.workspace.isTrusted` is `false`, or
- any workspace folder's URI scheme isn't `file` (virtual workspace)

The check runs fresh on every call (no cached result), so it automatically reflects the current trust state, including immediately after the user grants trust — no extra listener/state needed. The existing try/catch in `handleAnalyseRepository()` already surfaces thrown errors to the webview as `repoAnalysisError`, so no other code needed to change.

No other code paths were touched: activation, the exported public API (`registerButton`, etc.), and all `aiEngineeringFluency.*` command registrations are unaffected and still run identically in trusted workspaces.

## Test plan

- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes
- [x] `npm run lint:json` — `package.json` validates
- [x] `npm run test:node` — full unit suite passes, including `extension.test.js` which asserts the extension activates and all expected commands register
- [x] Extended `test/unit/vscode-shim-register.ts` with `workspace.isTrusted` (get/set + `__mock.setIsTrusted`) and folder `scheme` support for future trust-related tests
- [ ] Manual: open the extension in a folder with Restricted Mode enabled and confirm the extension still activates, the status bar/dashboards work, and repository hygiene analysis reports a clear error instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)