### PR TITLE
security: add SECURITY.md and ignore npm install scripts in CI

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -252,12 +252,12 @@ jobs:
       - name: Build PR head
         working-directory: pr/vscode-extension
         continue-on-error: true
-        run: npm ci && npm run compile-tests
+        run: npm ci --ignore-scripts && npm run compile-tests
 
       - name: Build base
         working-directory: base/vscode-extension
         continue-on-error: true
-        run: npm ci && npm run compile-tests
+        run: npm ci --ignore-scripts && npm run compile-tests
 
       - name: Run benchmarks (PR and base)
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         
     - name: Install dependencies
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
       
     - name: Validate JSON files
       working-directory: vscode-extension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         
     - name: Install dependencies
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
       
     - name: Validate JSON files
       working-directory: vscode-extension
@@ -162,7 +162,7 @@ jobs:
         
     - name: Install dependencies
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
       
     - name: Package extension
       working-directory: vscode-extension

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -54,11 +54,11 @@ jobs:
 
       - name: Install extension dependencies
         working-directory: vscode-extension
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build CLI
         working-directory: cli

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -57,11 +57,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install extension dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: vscode-extension
 
       - name: Install CLI dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build production bundle
         run: npm run build:production

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Install JavaScript dependencies
         run: |
-          cd vscode-extension && npm ci
-          cd ../cli && npm ci
+          cd vscode-extension && npm ci --ignore-scripts
+          cd ../cli && npm ci --ignore-scripts
 
       # Download session log files from Azure Blob Storage (optional)
       # This step only runs if Azure Storage credentials are configured in the `copilot` environment
@@ -138,7 +138,7 @@ jobs:
         if: ${{ vars.COPILOT_STORAGE_ACCOUNT != '' }}
         run: |
           cd .github/skills/azure-storage-loader
-          npm ci --production
+          npm ci --ignore-scripts --production
 
       - name: Download aggregated usage data from Azure Table Storage
         if: ${{ vars.COPILOT_STORAGE_ACCOUNT != '' }}

--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build and bundle Windows executable
         working-directory: cli
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build production bundle
         working-directory: cli
@@ -148,7 +148,7 @@ jobs:
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build production bundle
         working-directory: cli
@@ -197,7 +197,7 @@ jobs:
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build production bundle
         working-directory: cli
@@ -245,7 +245,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: vscode-extension
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build webview bundles
         working-directory: vscode-extension

--- a/.github/workflows/mutation-benchmark.yml
+++ b/.github/workflows/mutation-benchmark.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install dependencies
       if: steps.gate.outputs.should_run == 'true'
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
 
     - name: Compile tests
       if: steps.gate.outputs.should_run == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
     - name: Install dependencies
       if: inputs.vs_only != true
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
       
     - name: Run linting
       if: inputs.vs_only != true
@@ -436,7 +436,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
 
     - name: Download VSIXs from release
       id: download_vsix
@@ -598,11 +598,11 @@ jobs:
     # ── Install dependencies ────────────────────────────────────────────────
 
     - name: Install vscode-extension dependencies
-      run: npm ci
+      run: npm ci --ignore-scripts
       working-directory: vscode-extension
 
     - name: Install CLI dependencies
-      run: npm ci
+      run: npm ci --ignore-scripts
       working-directory: cli
 
     # ── Build CLI (production bundle + Windows .exe) ───────────────────────

--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: sharing-server
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Type-check
         working-directory: sharing-server

--- a/.github/workflows/update-model-data.yml
+++ b/.github/workflows/update-model-data.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: vscode-extension
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Validate JSON files
         working-directory: vscode-extension

--- a/.github/workflows/visualstudio-build.yml
+++ b/.github/workflows/visualstudio-build.yml
@@ -47,11 +47,11 @@ jobs:
       # ── Install dependencies ────────────────────────────────────────────────
 
       - name: Install vscode-extension dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: vscode-extension
 
       - name: Install CLI dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: cli
 
       # ── Build & validate CLI (js bundle) ───────────────────────────────────

--- a/.github/workflows/visualstudio-publish.yml
+++ b/.github/workflows/visualstudio-publish.yml
@@ -85,11 +85,11 @@ jobs:
       # ── Install dependencies ────────────────────────────────────────────────
 
       - name: Install vscode-extension dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: vscode-extension
 
       - name: Install CLI dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: cli
 
       # ── Build CLI (production bundle + Windows .exe) ───────────────────────

--- a/.github/workflows/vscode-nightly-prerelease.yml
+++ b/.github/workflows/vscode-nightly-prerelease.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Install dependencies
       if: steps.check_changes.outputs.has_changes == 'true'
       working-directory: vscode-extension
-      run: npm ci
+      run: npm ci --ignore-scripts
 
     - name: Run linting
       if: steps.check_changes.outputs.has_changes == 'true'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of each component is supported with security fixes:
+
+- **VS Code extension** — latest version published on the [VS Code Marketplace](https://marketplace.visualstudio.com/) and [Open VSX Registry](https://open-vsx.org/)
+- **CLI** — latest version published on [npm](https://www.npmjs.com/)
+- **JetBrains plugin** — latest version published on the [JetBrains Marketplace](https://plugins.jetbrains.com/)
+- **Visual Studio extension** — latest version published on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/)
+
+Older releases do not receive security patches. Please upgrade to the latest version before reporting a vulnerability.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please **do not** open a public GitHub issue.
+
+Instead, report it privately using GitHub's [private vulnerability reporting](https://github.com/rajbos/ai-engineering-fluency/security/advisories/new) feature. This creates a private draft security advisory that only the maintainers can see, so the issue can be discussed and fixed before it's disclosed publicly.
+
+Please include as much detail as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce it (affected component, version, and environment)
+- Any relevant logs, screenshots, or proof-of-concept code
+
+We aim to acknowledge reports promptly and will keep you updated as the issue is investigated and resolved.
+
+## Other Security Features
+
+- [Secret scanning](https://docs.github.com/en/code-security/secret-scanning) is enabled on this repository.
+- Dependencies are kept up to date via Dependabot and reviewed with `dependency-review` on pull requests.
+
+For general bug reports and support questions that are not security-related, please use [GitHub Issues](https://github.com/rajbos/ai-engineering-fluency/issues) as described in [SUPPORT.md](./SUPPORT.md).


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` documenting supported versions (latest released VS Code extension / CLI / JetBrains plugin / Visual Studio extension) and how to report vulnerabilities via [GitHub private vulnerability reporting](https://github.com/rajbos/ai-engineering-fluency/security/advisories/new).
- Harden CI npm installs against malicious install/postinstall scripts by adding `--ignore-scripts` to every `npm ci` (and the one `npm ci --production`) across `.github/workflows/*.yml`, including `copilot-setup-steps.yml`. This covers `vscode-extension/`, `cli/`, `sharing-server/`, and the `azure-storage-loader` helper.

No environment gates, approval gates, or branch-protection config were added, per repo owner preference — secret scanning and private vulnerability reporting are already enabled.

## Verification

Ran the same install+build steps CI uses, locally, from a clean `node_modules`:

- `cd vscode-extension && npm ci --ignore-scripts && npm run compile` — tsc, eslint, and esbuild all succeed.
- `cd cli && npm ci --ignore-scripts && npm run build` — esbuild succeeds, `dist/cli.js` produced.

`esbuild` (used by all three packages) has a `postinstall` script, but it resolves its platform binary via an `optionalDependency` (e.g. `@esbuild/win32-x64`) at require-time rather than relying on that script, so `--ignore-scripts` does not break the build — no rebuild exception was needed. No other package in these workflows carries an install/postinstall script.

## Test plan

- [x] `vscode-extension`: clean `npm ci --ignore-scripts` + `npm run compile` succeeds
- [x] `cli`: clean `npm ci --ignore-scripts` + `npm run build` succeeds
- [ ] CI matrix (Build workflow: ubuntu/windows/macos x node 22/24) confirms cross-platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)