### PR TITLE
security(parsers): bound untrusted session-file reads and guard JSON merges

### DIFF
--- a/src/adapters/copilotChatAdapter.ts
+++ b/src/adapters/copilotChatAdapter.ts
@@ -50,6 +50,7 @@ import {
 import { isCopilotChatNonSessionFile } from './adapterPredicates';
 import { normalizePath } from '../utils/pathUtils';
 import { pathExists } from '../utils/fsAsync';
+import { readTextFileWithSizeGuard } from '../utils/safeFileRead';
 
 /** VS Code variants probed across all platforms. */
 const VSCODE_VARIANTS = [
@@ -256,7 +257,10 @@ export class CopilotChatAdapter implements IEcosystemAdapter, IDiscoverableEcosy
 
 	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
 		try {
-			const content = await fs.promises.readFile(sessionFile, 'utf8');
+			const content = await readTextFileWithSizeGuard(sessionFile, 'copilotChatAdapter');
+			if (content === undefined) {
+				return { tokens: 0, thinkingTokens: 0, actualTokens: 0 };
+			}
 			if (isUuidPointerFile(content)) {
 				return { tokens: 0, thinkingTokens: 0, actualTokens: 0 };
 			}

--- a/src/adapters/copilotCliAdapter.ts
+++ b/src/adapters/copilotCliAdapter.ts
@@ -30,6 +30,7 @@ import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis } from '../usageAnalysis';
 import { normalizePath } from '../utils/pathUtils';
 import { pathExists } from '../utils/fsAsync';
+import { readTextFileWithSizeGuard } from '../utils/safeFileRead';
 
 /** Returns the canonical Copilot CLI session-state directory (~/.copilot/session-state). */
 export function getCopilotCliSessionStateDir(): string {
@@ -96,14 +97,11 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 	 */
 	async getWorkspacePathForDiscoveredPath(sessionFile: string): Promise<string | undefined> {
 		const yamlPath = path.join(path.dirname(sessionFile), 'workspace.yaml');
-		try {
-			const content = await fs.promises.readFile(yamlPath, 'utf8');
-			const match = content.match(/^cwd:\s*(.+)$/m);
-			const cwd = match?.[1]?.trim();
-			return cwd || undefined;
-		} catch {
-			return undefined;
-		}
+		const content = await readTextFileWithSizeGuard(yamlPath, 'copilotCliAdapter');
+		if (content === undefined) { return undefined; }
+		const match = content.match(/^cwd:\s*(.+)$/m);
+		const cwd = match?.[1]?.trim();
+		return cwd || undefined;
 	}
 
 	/**
@@ -228,17 +226,16 @@ export class CopilotCliAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 	 */
 	private async _tryMarkScoutFromWorkspaceYaml(uuidDir: string, uuid: string): Promise<void> {
 		const yamlPath = path.join(uuidDir, 'workspace.yaml');
-		try {
-			const content = await fs.promises.readFile(yamlPath, 'utf8');
-			const cwdMatch = content.match(/^cwd:\s*(.+)$/m);
-			if (cwdMatch && isMicrosoftScoutCwd(cwdMatch[1].trim())) {
-				this._scoutSessionIds.add(uuid);
-			}
-			const clientMatch = content.match(/^client_name:\s*(.+)$/m);
-			if (clientMatch && isCopilotAppClientName(clientMatch[1].trim())) {
-				this._appSessionIds.add(uuid);
-			}
-		} catch { /* workspace.yaml may not exist */ }
+		const content = await readTextFileWithSizeGuard(yamlPath, 'copilotCliAdapter');
+		if (content === undefined) { return; }
+		const cwdMatch = content.match(/^cwd:\s*(.+)$/m);
+		if (cwdMatch && isMicrosoftScoutCwd(cwdMatch[1].trim())) {
+			this._scoutSessionIds.add(uuid);
+		}
+		const clientMatch = content.match(/^client_name:\s*(.+)$/m);
+		if (clientMatch && isCopilotAppClientName(clientMatch[1].trim())) {
+			this._appSessionIds.add(uuid);
+		}
 	}
 
 	getCandidatePaths(): CandidatePath[] {

--- a/src/adapters/jetbrainsAdapter.ts
+++ b/src/adapters/jetbrainsAdapter.ts
@@ -34,6 +34,7 @@ import type {
 import { parseJetBrainsPartition, type JetBrainsParsedSession, type JetBrainsToolCall, type JetBrainsTurn } from '../jetbrains';
 import { normalizePath } from '../utils/pathUtils';
 import { pathExists } from '../utils/fsAsync';
+import { readTextFileWithSizeGuard } from '../utils/safeFileRead';
 
 /** Returns the canonical JetBrains Copilot session directory (~/.copilot/jb). */
 export function getJetBrainsSessionDir(): string {
@@ -69,7 +70,8 @@ export class JetBrainsAdapter implements IEcosystemAdapter, IDiscoverableEcosyst
 	 */
 	private async parsePartition(sessionFile: string): Promise<JetBrainsParsedSession | null> {
 		try {
-			const content = await fs.promises.readFile(sessionFile, 'utf8');
+			const content = await readTextFileWithSizeGuard(sessionFile, 'jetbrainsAdapter');
+			if (content === undefined) { return null; }
 			return parseJetBrainsPartition(content);
 		} catch {
 			return null;

--- a/src/adapters/openCodeAdapter.ts
+++ b/src/adapters/openCodeAdapter.ts
@@ -7,6 +7,7 @@ import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
 import { withErrorRecovery } from '../utils/errors';
 import { pathExists } from '../utils/fsAsync';
+import { readTextFileWithSizeGuard } from '../utils/safeFileRead';
 
 export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'opencode';
@@ -76,7 +77,10 @@ export class OpenCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosyste
 			return this.openCode.readOpenCodeDbSession(sessionId);
 		}
 		return withErrorRecovery(
-			async () => JSON.parse(await fs.promises.readFile(sessionFile, 'utf8')),
+			async () => {
+				const content = await readTextFileWithSizeGuard(sessionFile, 'openCodeAdapter');
+				return content === undefined ? null : JSON.parse(content);
+			},
 			null,
 			`openCodeAdapter getMeta readFile(${sessionFile})`
 		);

--- a/src/antigravity.ts
+++ b/src/antigravity.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import type { ChatTurn, ModelUsage } from './types';
 import { createEmptyContextRefs } from './tokenEstimation';
 import { normalizePathForComparison } from './workspaceHelpers';
+import { readTextFileWithSizeGuard } from './utils/safeFileRead';
 
 // ---------------------------------------------------------------------------
 // Transcript entry interfaces
@@ -202,10 +203,8 @@ const userEntries: AntigravityEntry[] = [];
 const modelEntries: AntigravityEntry[] = [];
 const allEntries: AntigravityEntry[] = [];
 
-let rawContent: string;
-try {
-rawContent = await fs.promises.readFile(filePath, 'utf8');
-} catch {
+const rawContent = await readTextFileWithSizeGuard(filePath, 'antigravity');
+if (rawContent === undefined) {
 return { sessionId, userEntries, modelEntries, allEntries };
 }
 

--- a/src/claudecode.ts
+++ b/src/claudecode.ts
@@ -11,6 +11,8 @@ import type { ModelUsage } from './types';
 import { withErrorRecovery } from './utils/errors';
 import { normalizePathForComparison } from './workspaceHelpers';
 import { toLocalDayKey } from './utils/dayKeys';
+import { isUnsafeObjectKey } from './utils/protoGuard';
+import { readTextFileWithSizeGuard } from './utils/safeFileRead';
 
 /**
  * Normalize a Claude Code API model ID to the dot-notation format used throughout this codebase.
@@ -131,7 +133,8 @@ export class ClaudeCodeDataAccess {
 	private async readSessionEvents(sessionFilePath: string): Promise<any[]> {
 		return withErrorRecovery(
 			async () => {
-				const content = await fs.promises.readFile(sessionFilePath, 'utf8');
+				const content = await readTextFileWithSizeGuard(sessionFilePath, 'claudecode');
+				if (content === undefined) { return []; }
 				const lines = content.trim().split('\n');
 				const events: any[] = [];
 				for (const line of lines) {
@@ -370,6 +373,9 @@ export class ClaudeCodeDataAccess {
 		model: string,
 		usage: any
 	): void {
+		// Untrusted `model` string from parsed session JSON — refuse keys that would
+		// resolve through the prototype chain instead of an own property (see protoGuard.ts).
+		if (isUnsafeObjectKey(model)) { return; }
 		if (!modelUsage[model]) {
 			modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 };
 		}

--- a/src/copilotCliOtel.ts
+++ b/src/copilotCliOtel.ts
@@ -14,6 +14,7 @@ import * as os from 'os';
 import { Worker } from 'worker_threads';
 import type { ModelUsage } from './types';
 import { CopilotCliStoreAccess } from './copilotCliStore';
+import { isUnsafeObjectKey } from './utils/protoGuard';
 
 /** Per-session usage aggregated from OTel `chat <model>` spans. */
 export interface CopilotCliOtelSessionUsage {
@@ -98,6 +99,8 @@ function accumulateOtelChatSpanUsage(index: Map<string, CopilotCliOtelSessionUsa
 		index.set(sessionId, { modelUsage: {}, actualTokens: 0, cacheReadTokens: 0, nanoAiu: 0 });
 	}
 	const entry = index.get(sessionId)!;
+	// Untrusted `model` string read from OTel span attributes — see protoGuard.ts.
+	if (isUnsafeObjectKey(usage.model)) { return; }
 	if (!entry.modelUsage[usage.model]) { entry.modelUsage[usage.model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
 	const modelEntry = entry.modelUsage[usage.model];
 

--- a/src/copilotCliStore.ts
+++ b/src/copilotCliStore.ts
@@ -21,6 +21,7 @@ import * as os from 'os';
 import initSqlJs from 'sql.js';
 import type { ModelUsage } from './types';
 import { toLocalDayKey } from './utils/dayKeys';
+import { isUnsafeObjectKey } from './utils/protoGuard';
 
 // Access SqlJsStatic and Database via the globally declared initSqlJs namespace
 // (made available by the /// <reference types="sql.js" /> directive above).
@@ -513,6 +514,8 @@ export class CopilotCliStoreAccess {
 
 	/** Merge a single usage event into the per-model accumulator (cache fields only when > 0). */
 	private addUsageEventToModelUsage(modelUsage: ModelUsage, event: UsageEventRow): void {
+		// Untrusted `model` string read from session-store.db rows — see protoGuard.ts.
+		if (isUnsafeObjectKey(event.model)) { return; }
 		if (!modelUsage[event.model]) { modelUsage[event.model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
 		const usage = modelUsage[event.model];
 		usage.inputTokens += event.inputTokens;

--- a/src/geminicli.ts
+++ b/src/geminicli.ts
@@ -5,6 +5,8 @@ import type { ChatTurn, ModelUsage, PromptTokenDetail } from './types';
 import { createEmptyContextRefs } from './tokenEstimation';
 import { normalizePathForComparison, normalizePath } from './workspaceHelpers';
 import { toLocalDayKey } from './utils/dayKeys';
+import { isUnsafeObjectKey } from './utils/protoGuard';
+import { readTextFileWithSizeGuard, MAX_SESSION_FILE_BYTES } from './utils/safeFileRead';
 
 interface GeminiCliSessionHeader {
 	sessionId: string;
@@ -398,6 +400,8 @@ export class GeminiCliDataAccess {
 
 		for (const assistant of session.assistantRecords) {
 			const model = normalizeGeminiModelId(assistant.model || 'unknown');
+			// Untrusted `model` string from parsed session JSON — see protoGuard.ts.
+			if (isUnsafeObjectKey(model)) { continue; }
 			const tokenData = this.getTokenBreakdown(assistant.tokens);
 
 			if (!modelUsage[model]) {
@@ -563,14 +567,12 @@ export class GeminiCliDataAccess {
 	}
 
 	private async readJsonlLines(sessionFilePath: string): Promise<string[]> {
-		try {
-			return (await fs.promises.readFile(sessionFilePath, 'utf8'))
-				.split(/\r?\n/)
-				.map(line => line.trim())
-				.filter(line => line.length > 0);
-		} catch {
-			return [];
-		}
+		const content = await readTextFileWithSizeGuard(sessionFilePath, 'geminicli');
+		if (content === undefined) { return []; }
+		return content
+			.split(/\r?\n/)
+			.map(line => line.trim())
+			.filter(line => line.length > 0);
 	}
 
 	private getProjectBucketFromPath(sessionFilePath: string): string | undefined {
@@ -622,6 +624,10 @@ export class GeminiCliDataAccess {
 		const readPromise = (async (): Promise<Map<string, string>> => {
 			const mappings = new Map<string, string>();
 			try {
+				if (stats.size > MAX_SESSION_FILE_BYTES) {
+					console.debug(`[geminicli] Skipping oversized projects index (${stats.size} bytes): ${projectsPath}`);
+					return mappings;
+				}
 				const raw = JSON.parse(await fs.promises.readFile(projectsPath, 'utf8'));
 				if (Array.isArray(raw)) {
 					for (const entry of raw) {

--- a/src/jetbrains.ts
+++ b/src/jetbrains.ts
@@ -28,6 +28,7 @@
  */
 import type { ModelUsage } from './types';
 import { estimateTokensFromText } from './tokenEstimation';
+import { isUnsafeObjectKey } from './utils/protoGuard';
 
 export type JetBrainsMode = 'ask' | 'agent';
 
@@ -406,7 +407,8 @@ function _jbpFinalizeSession(result: JetBrainsParsedSession, state: JbpState): v
 	result.turns = Array.from(state.turnById.values());
 	result.messageIds = [...state.messageIds];
 	
-	if (result.tokens > 0 && result.modelHint !== 'unknown') {
+	// Untrusted `modelHint` string from parsed session JSON — see protoGuard.ts.
+	if (result.tokens > 0 && result.modelHint !== 'unknown' && !isUnsafeObjectKey(result.modelHint)) {
 		result.modelUsage[result.modelHint] = { inputTokens: state.inputTokens, outputTokens: state.outputTokens, sessions: 0 };
 	}
 }

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -9,6 +9,8 @@ import * as os from 'os';
 import initSqlJs from 'sql.js';
 import type { ModelUsage, ModelId } from './types';
 import { normalizePathForComparison } from './workspaceHelpers';
+import { isUnsafeObjectKey } from './utils/protoGuard';
+import { readTextFileWithSizeGuardSync } from './utils/safeFileRead';
 
 // Access SqlJsStatic and Database via the globally declared initSqlJs namespace.
 type SqlJsStatic = initSqlJs.SqlJsStatic;
@@ -370,7 +372,8 @@ export class OpenCodeDataAccess {
 			for (const entry of entries) {
 				if (!entry.isFile() || !entry.name.endsWith('.json')) { continue; }
 				try {
-					const content = fs.readFileSync(path.join(messageDir, entry.name), 'utf8');
+					const content = readTextFileWithSizeGuardSync(path.join(messageDir, entry.name), 'opencode');
+					if (content === undefined) { continue; }
 					const msg = JSON.parse(content);
 					messages.push(msg);
 				} catch {
@@ -400,7 +403,8 @@ export class OpenCodeDataAccess {
 			for (const entry of entries) {
 				if (!entry.isFile() || !entry.name.endsWith('.json')) { continue; }
 				try {
-					const content = fs.readFileSync(path.join(partDir, entry.name), 'utf8');
+					const content = readTextFileWithSizeGuardSync(path.join(partDir, entry.name), 'opencode');
+					if (content === undefined) { continue; }
 					const part = JSON.parse(content);
 					parts.push(part);
 				} catch {
@@ -537,6 +541,8 @@ export class OpenCodeDataAccess {
 			const turnTokens = turnCumTotal - prevTotal;
 			if (turnTokens <= 0) { prevTotal = turnCumTotal; continue; }
 			const model = turnAssistantMsgs[0].modelID || turnAssistantMsgs[0].model?.modelID || 'unknown';
+			// Untrusted `model` string from parsed session JSON — see protoGuard.ts.
+			if (isUnsafeObjectKey(model)) { prevTotal = turnCumTotal; continue; }
 			if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
 			const turnOutput = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.output || 0) + (m.tokens?.reasoning || 0), 0);
 			modelUsage[model].inputTokens += Math.max(0, turnTokens - turnOutput);
@@ -579,10 +585,13 @@ export class OpenCodeDataAccess {
 			if (turnAssistantMsgs.length === 0) { continue; }
 
 			const model = turnAssistantMsgs[0].modelID || turnAssistantMsgs[0].model?.modelID || 'unknown';
+			// Untrusted `model` string from parsed session JSON — see protoGuard.ts.
+			if (isUnsafeObjectKey(model)) { continue; }
 			modelInteractions[model] = (modelInteractions[model] || 0) + 1;
 		}
 
-		// Merge interaction counts into model usage
+		// Merge interaction counts into model usage. baseModelUsage's own keys are already
+		// guarded (see getOpenCodeModelUsageFromMessages), so Object.entries only yields safe keys.
 		const modelUsage: OpenCodeModelUsageWithInteractions = {};
 		for (const [model, usage] of Object.entries(baseModelUsage)) {
 			modelUsage[model] = {

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -55,6 +55,7 @@ import { isJetBrainsSessionPath } from './adapters/adapterPredicates';
 import { detectJetBrainsModeFromContent, type JetBrainsMode } from './jetbrains';
 import type { IEcosystemAdapter } from './ecosystemAdapter';
 import { isAnalyzable } from './ecosystemAdapter';
+import { isUnsafeObjectKey } from './utils/protoGuard';
 
 
 // ---------------------------------------------------------------------------
@@ -2465,6 +2466,8 @@ function _gmusProcessJsonlLine(event: any, state: GmusJsonlState, modelUsage: Mo
 	}
 	_gmusUpdateDefaultModelFromEvent(event, state);
 	const model = event.data?.model || event.model || state.defaultModel;
+	// Untrusted `model` string from parsed session JSONL — see protoGuard.ts.
+	if (isUnsafeObjectKey(model)) { return; }
 	if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
 	if (!state.isDeltaBased) { _gmusProcessCliEventLine(event, model, state, modelUsage, deps); }
 }

--- a/src/utils/protoGuard.ts
+++ b/src/utils/protoGuard.ts
@@ -1,0 +1,28 @@
+/**
+ * Guards against prototype-pollution when a string pulled from untrusted, parsed
+ * JSON (e.g. a "model" field from a session-log file) is used as a bracket-notation
+ * key into a plain JS object (`obj[key] = ...`).
+ *
+ * Why this matters: `obj['__proto__']` does not create/read an own property named
+ * "__proto__" — it resolves through the inherited accessor on Object.prototype and
+ * returns the object's actual [[Prototype]] (Object.prototype for plain object
+ * literals). A common accumulator pattern like:
+ *
+ *   if (!map[key]) { map[key] = { inputTokens: 0, ... }; }
+ *   map[key].inputTokens += n;
+ *
+ * is safe for ordinary keys, but when key === '__proto__', `map[key]` reads the
+ * *real*, shared Object.prototype (which is truthy), so the initializer is skipped
+ * and `map[key].inputTokens += n` mutates Object.prototype directly — corrupting
+ * every plain object in the process, not just this map. "constructor" / "prototype"
+ * keys enable related gadgets (e.g. reaching a shared class prototype).
+ *
+ * Session-log parsers should check untrusted keys with {@link isUnsafeObjectKey}
+ * before using them as an index into a plain accumulator object, and skip the
+ * entry (same as any other malformed/unrecognised data) when it's unsafe.
+ */
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function isUnsafeObjectKey(key: string): boolean {
+	return UNSAFE_OBJECT_KEYS.has(key);
+}

--- a/src/utils/safeFileRead.ts
+++ b/src/utils/safeFileRead.ts
@@ -1,0 +1,68 @@
+/**
+ * Bounded reads for untrusted, on-disk session-log files written by other tools
+ * (Copilot Chat, Copilot CLI, Claude Code, JetBrains, Gemini CLI, Antigravity,
+ * OpenCode, ...). These files are attacker-influenceable — a corrupted, crafted,
+ * or runaway log file should never be able to force the extension to load an
+ * unbounded amount of data into memory.
+ *
+ * Real-world JSONL/JSON session files are KBs to tens of MBs. 100 MB is a
+ * generous cap that comfortably covers legitimate long-running sessions while
+ * still bounding worst-case memory use for a single file.
+ */
+import * as fs from 'fs';
+
+/** Maximum number of bytes read from a single untrusted session-log file. */
+export const MAX_SESSION_FILE_BYTES = 100 * 1024 * 1024; // 100 MB
+
+/**
+ * Reads a UTF-8 text file, refusing to load files larger than `maxBytes`.
+ * Returns `undefined` (after a debug-level log) when the file is over the cap
+ * or can't be read/stat'd — callers should treat this the same as "file missing
+ * or unparsable" and fall back to their existing empty/default result.
+ */
+export async function readTextFileWithSizeGuard(
+	filePath: string,
+	context: string,
+	maxBytes: number = MAX_SESSION_FILE_BYTES
+): Promise<string | undefined> {
+	try {
+		const stat = await fs.promises.stat(filePath);
+		if (stat.size > maxBytes) {
+			console.debug(`[${context}] Skipping oversized file (${stat.size} bytes > ${maxBytes} byte cap): ${filePath}`);
+			return undefined;
+		}
+	} catch (err) {
+		console.error(`[${context}] Failed to stat ${filePath}:`, err);
+		return undefined;
+	}
+	try {
+		return await fs.promises.readFile(filePath, 'utf8');
+	} catch (err) {
+		console.error(`[${context}] Failed to read ${filePath}:`, err);
+		return undefined;
+	}
+}
+
+/** Synchronous counterpart of {@link readTextFileWithSizeGuard}, for call sites that can't go async. */
+export function readTextFileWithSizeGuardSync(
+	filePath: string,
+	context: string,
+	maxBytes: number = MAX_SESSION_FILE_BYTES
+): string | undefined {
+	try {
+		const stat = fs.statSync(filePath);
+		if (stat.size > maxBytes) {
+			console.debug(`[${context}] Skipping oversized file (${stat.size} bytes > ${maxBytes} byte cap): ${filePath}`);
+			return undefined;
+		}
+	} catch (err) {
+		console.error(`[${context}] Failed to stat ${filePath}:`, err);
+		return undefined;
+	}
+	try {
+		return fs.readFileSync(filePath, 'utf8');
+	} catch (err) {
+		console.error(`[${context}] Failed to read ${filePath}:`, err);
+		return undefined;
+	}
+}

--- a/vscode-extension/test/unit/parserRobustness.test.ts
+++ b/vscode-extension/test/unit/parserRobustness.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Robustness tests for session-log parsers/adapters that read untrusted,
+ * on-disk files written by other tools (Copilot Chat, Copilot CLI, Claude
+ * Code, JetBrains, Gemini CLI, Antigravity, OpenCode).
+ *
+ * These exercise the hardening added for:
+ *   - resource exhaustion: a single oversized file must not be read unbounded
+ *     (see src/utils/safeFileRead.ts)
+ *   - prototype pollution: a "model" (or similar) string pulled from parsed
+ *     JSON must not be usable to write through Object.prototype via bracket
+ *     notation (see src/utils/protoGuard.ts)
+ *
+ * Every test asserts the parser does not throw and does not pollute
+ * Object.prototype, and that malformed/oversized input degrades to an
+ * empty/default result rather than partial or corrupted data.
+ */
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { ClaudeCodeDataAccess } from '../../../src/claudecode';
+import { GeminiCliDataAccess } from '../../../src/geminicli';
+import { AntigravityDataAccess } from '../../../src/antigravity';
+import { OpenCodeDataAccess } from '../../../src/opencode';
+import { parseJetBrainsPartition } from '../../../src/jetbrains';
+import { CopilotChatAdapter } from '../../../src/adapters/copilotChatAdapter';
+import { MAX_SESSION_FILE_BYTES } from '../../../src/utils/safeFileRead';
+import { isUnsafeObjectKey } from '../../../src/utils/protoGuard';
+
+function assertNoPrototypePollution(): void {
+	assert.equal(({} as any).polluted, undefined, 'Object.prototype must not be polluted');
+	assert.equal(Object.prototype.hasOwnProperty.call(Object.prototype, 'polluted'), false);
+}
+
+/** Builds a deeply nested JSON string of `depth` levels without recursive construction. */
+function buildDeeplyNestedJson(depth: number): string {
+	return '{"a":'.repeat(depth) + '1' + '}'.repeat(depth);
+}
+
+function mkTmpDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function rm(dir: string): void {
+	try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+/** Writes `size` bytes of filler efficiently (no huge in-memory JS string concatenation). */
+function writeOversizedFile(filePath: string, size: number): void {
+	const fd = fs.openSync(filePath, 'w');
+	try {
+		const chunk = Buffer.alloc(1024 * 1024, 0x78); // 1 MiB of 'x'
+		let written = 0;
+		while (written < size) {
+			const remaining = size - written;
+			const toWrite = remaining < chunk.length ? chunk.subarray(0, remaining) : chunk;
+			fs.writeSync(fd, toWrite);
+			written += toWrite.length;
+		}
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code
+// ---------------------------------------------------------------------------
+
+test('ClaudeCode: truncated JSONL line is skipped without throwing', async () => {
+	const tmpDir = mkTmpDir('claudecode-robust-');
+	try {
+		const projectDir = path.join(tmpDir, '.claude', 'projects', 'p');
+		fs.mkdirSync(projectDir, { recursive: true });
+		const file = path.join(projectDir, 's.jsonl');
+		fs.writeFileSync(file, '{"type":"assistant","message":{"model":"claude-sonnet-4-6","usage":{"input_to', 'utf8');
+		const cc = new ClaudeCodeDataAccess();
+		const result = await cc.getTokensFromClaudeCodeSession(file);
+		assert.equal(result.tokens, 0);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('ClaudeCode: file over the size cap is skipped, not read into memory', async () => {
+	const tmpDir = mkTmpDir('claudecode-robust-');
+	try {
+		const projectDir = path.join(tmpDir, '.claude', 'projects', 'p');
+		fs.mkdirSync(projectDir, { recursive: true });
+		const file = path.join(projectDir, 'huge.jsonl');
+		writeOversizedFile(file, MAX_SESSION_FILE_BYTES + 1024);
+		const cc = new ClaudeCodeDataAccess();
+		const result = await cc.getTokensFromClaudeCodeSession(file);
+		assert.equal(result.tokens, 0);
+		assert.equal(result.thinkingTokens, 0);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('ClaudeCode: deeply nested JSON does not crash the process', async () => {
+	const tmpDir = mkTmpDir('claudecode-robust-');
+	try {
+		const projectDir = path.join(tmpDir, '.claude', 'projects', 'p');
+		fs.mkdirSync(projectDir, { recursive: true });
+		const file = path.join(projectDir, 's.jsonl');
+		fs.writeFileSync(file, buildDeeplyNestedJson(100_000), 'utf8');
+		const cc = new ClaudeCodeDataAccess();
+		const result = await cc.getTokensFromClaudeCodeSession(file);
+		assert.equal(result.tokens, 0); // malformed line for this schema — skipped, not a crash
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('ClaudeCode: __proto__ model key does not pollute Object.prototype', async () => {
+	const tmpDir = mkTmpDir('claudecode-robust-');
+	try {
+		const projectDir = path.join(tmpDir, '.claude', 'projects', 'p');
+		fs.mkdirSync(projectDir, { recursive: true });
+		const file = path.join(projectDir, 's.jsonl');
+		const events = [
+			{
+				type: 'assistant',
+				message: {
+					model: '__proto__',
+					stop_reason: 'end_turn',
+					usage: { input_tokens: 10, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
+				}
+			}
+		];
+		fs.writeFileSync(file, events.map(e => JSON.stringify(e)).join('\n'), 'utf8');
+		const cc = new ClaudeCodeDataAccess();
+		const modelUsage = await cc.getClaudeCodeModelUsage(file);
+		assertNoPrototypePollution();
+		assert.equal(Object.prototype.hasOwnProperty.call(modelUsage, '__proto__'), false);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Copilot Chat
+// ---------------------------------------------------------------------------
+
+test('CopilotChatAdapter: truncated JSONL line is handled without throwing', async () => {
+	const tmpDir = mkTmpDir('copilotchat-robust-');
+	try {
+		const file = path.join(tmpDir, 'session.jsonl');
+		fs.writeFileSync(file, '{"kind":1,"data":{"model":"gpt-4o","requestI', 'utf8');
+		const adapter = new CopilotChatAdapter();
+		const result = await adapter.getTokens(file);
+		assert.equal(typeof result.tokens, 'number');
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('CopilotChatAdapter: file over the size cap is skipped', async () => {
+	const tmpDir = mkTmpDir('copilotchat-robust-');
+	try {
+		const file = path.join(tmpDir, 'session.jsonl');
+		writeOversizedFile(file, MAX_SESSION_FILE_BYTES + 1024);
+		const adapter = new CopilotChatAdapter();
+		const result = await adapter.getTokens(file);
+		assert.equal(result.tokens, 0);
+		assert.equal(result.actualTokens, 0);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// JetBrains
+// ---------------------------------------------------------------------------
+
+test('JetBrains: truncated JSONL line does not throw', () => {
+	const parsed = parseJetBrainsPartition('{"type":"user.message","data":{"content":"trunca');
+	assert.ok(parsed);
+	assert.equal(parsed.tokens, 0);
+});
+
+test('JetBrains: deeply nested JSON line does not crash the process', () => {
+	const content = buildDeeplyNestedJson(100_000);
+	assert.doesNotThrow(() => parseJetBrainsPartition(content));
+});
+
+test('JetBrains: __proto__ modelHint does not pollute Object.prototype', () => {
+	// modelHint is derived internally from turn-start events, not attacker-set text directly,
+	// but the finalize step still guards any dangerous key before indexing modelUsage.
+	const content = [
+		JSON.stringify({ type: 'assistant.turn_start', data: { model: '__proto__' } }),
+		JSON.stringify({ type: 'tool.execution_start', data: {} }),
+		JSON.stringify({ type: 'assistant.message', data: { content: 'hi' } }),
+	].join('\n');
+	const parsed = parseJetBrainsPartition(content);
+	assertNoPrototypePollution();
+	assert.equal(Object.prototype.hasOwnProperty.call(parsed.modelUsage, '__proto__'), false);
+});
+
+// ---------------------------------------------------------------------------
+// Gemini CLI
+// ---------------------------------------------------------------------------
+
+function createTempGeminiSession(records: unknown[]): { file: string; tmpDir: string } {
+	const tmpDir = mkTmpDir('gemini-robust-');
+	const chatsDir = path.join(tmpDir, '.gemini', 'tmp', 'demo-project', 'chats');
+	fs.mkdirSync(chatsDir, { recursive: true });
+	const file = path.join(chatsDir, 'session.jsonl');
+	fs.writeFileSync(file, records.map(r => JSON.stringify(r)).join('\n'), 'utf8');
+	return { file, tmpDir };
+}
+
+test('GeminiCli: truncated JSONL line is skipped without throwing', async () => {
+	const tmpDir = mkTmpDir('gemini-robust-');
+	try {
+		const chatsDir = path.join(tmpDir, '.gemini', 'tmp', 'demo-project', 'chats');
+		fs.mkdirSync(chatsDir, { recursive: true });
+		const file = path.join(chatsDir, 'session.jsonl');
+		fs.writeFileSync(file, '{"id":"assistant-1","type":"gemini","tokens":{"inp', 'utf8');
+		const gemini = new GeminiCliDataAccess();
+		const modelUsage = await gemini.getGeminiCliModelUsage(file);
+		assert.deepEqual(modelUsage, {});
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('GeminiCli: file over the size cap is skipped', async () => {
+	const tmpDir = mkTmpDir('gemini-robust-');
+	try {
+		const chatsDir = path.join(tmpDir, '.gemini', 'tmp', 'demo-project', 'chats');
+		fs.mkdirSync(chatsDir, { recursive: true });
+		const file = path.join(chatsDir, 'session.jsonl');
+		writeOversizedFile(file, MAX_SESSION_FILE_BYTES + 1024);
+		const gemini = new GeminiCliDataAccess();
+		const modelUsage = await gemini.getGeminiCliModelUsage(file);
+		assert.deepEqual(modelUsage, {});
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('GeminiCli: deeply nested JSON line does not crash the process', async () => {
+	const { file, tmpDir } = createTempGeminiSession([]);
+	try {
+		fs.appendFileSync(file, '\n' + buildDeeplyNestedJson(100_000), 'utf8');
+		const gemini = new GeminiCliDataAccess();
+		const modelUsage = await gemini.getGeminiCliModelUsage(file);
+		assert.deepEqual(modelUsage, {});
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('GeminiCli: __proto__ model key does not pollute Object.prototype', async () => {
+	const { file, tmpDir } = createTempGeminiSession([
+		{
+			id: 'assistant-1',
+			type: 'gemini',
+			model: '__proto__',
+			tokens: { input: 10, output: 5, cached: 0, thoughts: 0, tool: 0, total: 15 },
+		},
+	]);
+	try {
+		const gemini = new GeminiCliDataAccess();
+		const modelUsage = await gemini.getGeminiCliModelUsage(file);
+		assertNoPrototypePollution();
+		assert.equal(Object.prototype.hasOwnProperty.call(modelUsage, '__proto__'), false);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Antigravity
+// ---------------------------------------------------------------------------
+
+test('Antigravity: truncated JSONL line is skipped without throwing', async () => {
+	const tmpDir = mkTmpDir('antigravity-robust-');
+	try {
+		const file = path.join(tmpDir, 'transcript.jsonl');
+		fs.writeFileSync(file, '{"type":"USER_INPUT","source":"USER_EXPL', 'utf8');
+		const antigravity = new AntigravityDataAccess();
+		const session = await antigravity.readAntigravitySession(file);
+		assert.deepEqual(session.allEntries, []);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('Antigravity: file over the size cap is skipped', async () => {
+	const tmpDir = mkTmpDir('antigravity-robust-');
+	try {
+		const file = path.join(tmpDir, 'transcript.jsonl');
+		writeOversizedFile(file, MAX_SESSION_FILE_BYTES + 1024);
+		const antigravity = new AntigravityDataAccess();
+		const session = await antigravity.readAntigravitySession(file);
+		assert.deepEqual(session.allEntries, []);
+		assert.deepEqual(session.userEntries, []);
+		assert.deepEqual(session.modelEntries, []);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('Antigravity: deeply nested JSON line does not crash the process', async () => {
+	const tmpDir = mkTmpDir('antigravity-robust-');
+	try {
+		const file = path.join(tmpDir, 'transcript.jsonl');
+		fs.writeFileSync(file, buildDeeplyNestedJson(100_000), 'utf8');
+		const antigravity = new AntigravityDataAccess();
+		const session = await antigravity.readAntigravitySession(file);
+		assert.deepEqual(session.allEntries, []);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('Antigravity: __proto__ typed entries are ignored gracefully', async () => {
+	const tmpDir = mkTmpDir('antigravity-robust-');
+	try {
+		const file = path.join(tmpDir, 'transcript.jsonl');
+		const lines = [
+			JSON.stringify({ __proto__: { polluted: true }, type: 'USER_INPUT', source: 'USER_EXPLICIT' }),
+		];
+		fs.writeFileSync(file, lines.join('\n'), 'utf8');
+		const antigravity = new AntigravityDataAccess();
+		const session = await antigravity.readAntigravitySession(file);
+		assertNoPrototypePollution();
+		assert.equal(session.userEntries.length, 1);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// OpenCode
+// ---------------------------------------------------------------------------
+
+class TestableOpenCodeDataAccess extends OpenCodeDataAccess {
+	constructor(private readonly testDataDir: string) { super({ fsPath: '', path: '', scheme: 'file' }); }
+	override getOpenCodeDataDir(): string { return this.testDataDir; }
+}
+
+test('OpenCode: truncated JSON message file is skipped without throwing', () => {
+	const tmpDir = mkTmpDir('opencode-robust-');
+	try {
+		const messageDir = path.join(tmpDir, 'storage', 'message', 'ses_1');
+		fs.mkdirSync(messageDir, { recursive: true });
+		fs.writeFileSync(path.join(messageDir, 'msg_1.json'), '{"id":"msg_1","role":"assist', 'utf8');
+		const opencode = new TestableOpenCodeDataAccess(tmpDir);
+		const messages = opencode.readOpenCodeMessages('ses_1');
+		assert.deepEqual(messages, []);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('OpenCode: message file over the size cap is skipped', () => {
+	const tmpDir = mkTmpDir('opencode-robust-');
+	try {
+		const messageDir = path.join(tmpDir, 'storage', 'message', 'ses_1');
+		fs.mkdirSync(messageDir, { recursive: true });
+		writeOversizedFile(path.join(messageDir, 'msg_huge.json'), MAX_SESSION_FILE_BYTES + 1024);
+		const opencode = new TestableOpenCodeDataAccess(tmpDir);
+		const messages = opencode.readOpenCodeMessages('ses_1');
+		assert.deepEqual(messages, []);
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('OpenCode: deeply nested JSON message does not crash the process', () => {
+	const tmpDir = mkTmpDir('opencode-robust-');
+	try {
+		const messageDir = path.join(tmpDir, 'storage', 'message', 'ses_1');
+		fs.mkdirSync(messageDir, { recursive: true });
+		fs.writeFileSync(path.join(messageDir, 'msg_deep.json'), buildDeeplyNestedJson(100_000), 'utf8');
+		const opencode = new TestableOpenCodeDataAccess(tmpDir);
+		assert.doesNotThrow(() => opencode.readOpenCodeMessages('ses_1'));
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+test('OpenCode: __proto__ modelID does not pollute Object.prototype', () => {
+	const tmpDir = mkTmpDir('opencode-robust-');
+	try {
+		const messageDir = path.join(tmpDir, 'storage', 'message', 'ses_1');
+		fs.mkdirSync(messageDir, { recursive: true });
+		const userMsg = { id: 'u1', role: 'user', time: { created: 1 } };
+		const assistantMsg = {
+			id: 'a1', role: 'assistant', parentID: 'u1', modelID: '__proto__',
+			tokens: { output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+			time: { created: 2, completed: 3 },
+		};
+		fs.writeFileSync(path.join(messageDir, 'u1.json'), JSON.stringify(userMsg), 'utf8');
+		fs.writeFileSync(path.join(messageDir, 'a1.json'), JSON.stringify(assistantMsg), 'utf8');
+		const opencode = new TestableOpenCodeDataAccess(tmpDir);
+		const messages = opencode.readOpenCodeMessages('ses_1');
+		assert.equal(messages.length, 2);
+		assertNoPrototypePollution();
+	} finally {
+		rm(tmpDir);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Shared helper sanity checks (used by all adapters above)
+// ---------------------------------------------------------------------------
+
+test('isUnsafeObjectKey: flags the known prototype-pollution gadget keys', () => {
+	assert.equal(isUnsafeObjectKey('__proto__'), true);
+	assert.equal(isUnsafeObjectKey('constructor'), true);
+	assert.equal(isUnsafeObjectKey('prototype'), true);
+	assert.equal(isUnsafeObjectKey('claude-sonnet-4.6'), false);
+	assert.equal(isUnsafeObjectKey('gpt-4o'), false);
+	assert.equal(isUnsafeObjectKey('unknown'), false);
+});


### PR DESCRIPTION
## Summary

Session-log parsers/adapters read JSONL/JSON files written by other tools (Copilot Chat, Copilot CLI, Claude Code, JetBrains, Gemini CLI, Antigravity, OpenCode) as untrusted input. This hardens two classes of issue:

- **Resource exhaustion**: an oversized (or maliciously huge) session file could previously be read fully into memory with no bound. Added `src/utils/safeFileRead.ts` — stats the file first and skips (with a debug log) anything over a 100 MB cap, a generous margin over real session files (KBs–tens of MBs). Applied at the primary text-read sinks in the Claude Code, Copilot Chat, Copilot CLI, JetBrains, Gemini CLI, Antigravity, and OpenCode adapters.
- **Prototype pollution via untrusted keys**: several per-model token-usage accumulators index a plain object with a `model` string taken straight from parsed session JSON (`modelUsage[model] = {...}`). If that string is `"__proto__"`, bracket-notation access resolves through the prototype chain to the real, shared `Object.prototype` instead of an own property — so a subsequent `modelUsage[model].inputTokens += n` mutates `Object.prototype` itself. Added `src/utils/protoGuard.ts` (`isUnsafeObjectKey`) and applied it at the real sinks (skip the entry, same as any other malformed data) in Claude Code, Gemini CLI, JetBrains, OpenCode, and the shared Copilot Chat/CLI JSONL path.

No code-execution issue was found or is addressed here — this PR is scoped to resource exhaustion and object-integrity hardening.

## Test plan

- [x] Added `vscode-extension/test/unit/parserRobustness.test.ts`: for each adapter (Claude Code, Copilot Chat, JetBrains, Gemini CLI, Antigravity, OpenCode) — a truncated JSONL line, a file over the size cap, 100k-deep nested JSON, and `__proto__`-keyed entries — asserting no throw, no `Object.prototype` pollution, and graceful skip.
- [x] `npm run test:node` — full suite passes (existing + new tests), confirming legitimate-file parsing is unchanged.
- [x] `npm run lint` (eslint over `src` and `../src`) — clean.
- [x] `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)