### PR TITLE
fix(test): correct fixture path in sessionParser integration test

### DIFF
--- a/vscode-extension/test/unit/sessionParser-integration.test.ts
+++ b/vscode-extension/test/unit/sessionParser-integration.test.ts
@@ -12,7 +12,9 @@ import { parseSessionFileContent } from '../../../src/sessionParser';
  * data in test/fixtures/sample-session-data/chatSessions/.
  */
 
-const SAMPLES_DIR = path.resolve(__dirname, '..', '..', '..', 'test', 'fixtures', 'sample-session-data', 'chatSessions');
+// Compiled tests run from out/vscode-extension/test/unit (rootDir is the repo
+// root), so four levels up reaches vscode-extension/ where the fixtures live.
+const SAMPLES_DIR = path.resolve(__dirname, '..', '..', '..', '..', 'test', 'fixtures', 'sample-session-data', 'chatSessions');
 
 function estimateTokensByLength(text: string): number {
 	return text.length;
@@ -36,6 +38,10 @@ function getModelFromRequest(req: any): string {
 const sampleFiles = fs.existsSync(SAMPLES_DIR)
 	? fs.readdirSync(SAMPLES_DIR).filter(f => f.endsWith('.json'))
 	: [];
+
+test('integration: sample fixture files are found', () => {
+	assert.ok(sampleFiles.length > 0, `no .json fixtures found in ${SAMPLES_DIR} — fixture path is likely broken`);
+});
 
 for (const fileName of sampleFiles) {
 	test(`integration: ${fileName} parses without error and returns non-zero tokens`, () => {


### PR DESCRIPTION
## What changed

Fixes a pre-existing path-resolution bug in `vscode-extension/test/unit/sessionParser-integration.test.ts`:

- The fixture-loading path was one `..` segment short. Tests compile with `rootDir` at the repo root (`tsconfig.tests.json`), so the compiled test runs from `out/vscode-extension/test/unit/` — four levels below `vscode-extension/`, not three. The old path resolved to `out/vscode-extension/test/fixtures/...`, which doesn't exist.
- Because of the `fs.existsSync` guard, the fixture list was silently empty: the per-fixture smoke-test loop generated **zero tests** and the suite stayed green while exercising nothing.
- Added a `sample fixture files are found` test asserting at least one `.json` fixture was discovered, so a future path break fails loudly instead of no-opping.

## Verification

`npm run test:node` passes. Running the integration file alone now shows all five session fixtures parsing: 10 tests, 10 pass, including the five per-fixture smoke tests that previously never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)