### PR TITLE
chore: bump versions for release (vscode-extension 0.16.1, cli 0.5.1)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rajbos/ai-engineering-fluency",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "bin": {
         "ai-engineering-fluency": "dist/cli.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rajbos/ai-engineering-fluency",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI Engineering Fluency - CLI tool to analyze GitHub Copilot token usage from local session files",
   "license": "MIT",
   "author": "RobBos",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@azure/arm-resources": "^8.0.0",
         "@azure/arm-resources-subscriptions": "^3.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Summary
Prepping patch releases for **vscode-extension** and **cli**.

| Component | Change |
|---|---|
| vscode-extension | `0.16.0` → `0.16.1` |
| cli | `0.5.0` → `0.5.1` |
| visualstudio-extension | unchanged (`1.3.0`) — no changes since last tag |
| jetbrains-plugin | unchanged (`0.4.2`) — only a CI/CodeQL workflow change, no functional/shared-code impact |

## Why cli is bumped too
`cli/` had no user-facing changes of its own since `cli/v0.5.0` (only a dev-dependency bump), but it directly consumes shared `src/` code (`src/adapters/**`, `src/toolNames.json`, etc.). Since `cli/v0.5.0`, `src/` received:
- Prototype-pollution / oversized-file security hardening in session adapters (#1767, #1772)
- New friendly tool names in `src/toolNames.json`

Since the CLI parses the same untrusted session files with the same shared parsing code, it currently ships the same unpatched vulnerability that was just fixed for the VS Code extension — this release closes that gap for the npm package too.

## What changed in vscode-extension since v0.16.0
- security: prototype-pollution guards extended to remaining adapters (#1772, #1767)
- fix: recognize MCP tools by family+action, stop unknown-tool duplicates (#1771)
- fix: correct fixture path in test (#1773)
- security: declare workspace trust / virtual workspace capabilities (#1765)
- fix: broken doc links + rebrand issue template wording (#1754)
- feat: friendly names from issue #1768 (#1775)

## Post-merge steps
1. **VS Code Extension** — run the `Extensions - Release` workflow (`release.yml`) with `vscode_only=true`, `create_tag=true`, `publish_marketplace=true` to publish v0.16.1.
2. **CLI** — after merge, tag `cli/v0.5.1` on `main` and push the tag (`git tag -a cli/v0.5.1 <sha> -m "Release cli/v0.5.1" && git push origin cli/v0.5.1`) to trigger `cli-publish.yml` and publish to npm.
3. No action needed for `visualstudio-build.yml`/`visualstudio-publish.yml` or `jetbrains-publish.yml` this round.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>