### PR TITLE
ci(codeql): fix Java/Kotlin "no source seen" by disabling Gradle build cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -117,6 +117,15 @@ jobs:
       - name: Setup Gradle
         if: matrix.language == 'java-kotlin'
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          # CodeQL needs to observe an actual compiler invocation between the
+          # init and analyze steps. If this action restores a previous run's
+          # Gradle User Home (including the local build cache), Gradle can mark
+          # compileKotlin/compileTestKotlin as UP-TO-DATE without ever invoking
+          # kotlinc — CodeQL then sees no compilation and fails with "No source
+          # code was seen during the build" / exit code 32. Disable caching for
+          # this job so the build always compiles for real under the tracer.
+          cache-disabled: true
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -143,7 +152,11 @@ jobs:
       - name: Build JetBrains plugin (Gradle)
         if: matrix.language == 'java-kotlin'
         working-directory: jetbrains-plugin
-        run: ./gradlew compileKotlin compileTestKotlin --no-daemon
+        # --rerun-tasks / --no-build-cache force Gradle to actually invoke the
+        # Kotlin/Java compilers rather than restoring UP-TO-DATE task outputs
+        # from the (now-disabled, but belt-and-braces) build cache — see the
+        # comment on the "Setup Gradle" step above for why that matters to CodeQL.
+        run: ./gradlew compileKotlin compileTestKotlin --no-daemon --rerun-tasks --no-build-cache
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java)
       # that aren't otherwise handled above. csharp uses build-mode: none (no


### PR DESCRIPTION
## Root cause

The `java-kotlin` CodeQL matrix entry uses `build-mode: manual` and traces a hand-run `./gradlew compileKotlin compileTestKotlin` (added in #1764). That step is set up correctly (it runs between `init` and `analyze`), so the failure wasn't a missing/misconfigured build step.

The actual problem is caching: `gradle/actions/setup-gradle` restores the Gradle User Home **including the local build cache** across CI runs (this is documented behavior — see [setup-gradle docs](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#caching-build-state-between-jobs)). Once `compileKotlin`/`compileTestKotlin` had compiled successfully on an earlier run, a later run for the same/unchanged source restores that cache and Gradle marks the tasks `UP-TO-DATE` **without ever invoking `kotlinc`/`javac`**.

CodeQL's tracer only observes compiler processes that run between the `init` and `analyze` steps. With no compiler invocation at all, it fails with:

```
CodeQL could not process any code written in Java/Kotlin.
Error: ... Exit code was 32 ...
```

This matches GitHub's documented cause #4 for this error ("Cached components not detected") in the [troubleshooting guide](https://docs.github.com/en/code-security/reference/code-scanning/troubleshoot-analysis-errors/no-source-code-seen-during-build).

## Fix

- `Setup Gradle` step: added `cache-disabled: true` so this job never restores a Gradle User Home/build cache that could hide the compile from CodeQL's tracer.
- `Build JetBrains plugin (Gradle)` step: added `--rerun-tasks --no-build-cache` as a belt-and-braces guard, forcing Gradle to always execute (not skip) the compile tasks.

## Validation

Ran the exact updated build command locally in `jetbrains-plugin/`:

```
./gradlew compileKotlin compileTestKotlin --no-daemon --rerun-tasks --no-build-cache
```

Confirmed `:compileKotlin` executes for real (not `UP-TO-DATE`/skipped) and `BUILD SUCCESSFUL`. Did not run the actual CodeQL action locally (not possible), but the change is minimal and directly targets the documented root cause.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>