### PR TITLE
Add Cost by Model and Tokens by Provider chart splits

### DIFF
--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -379,6 +379,82 @@ export function getPricingSourceForBillingGroup(group: string): 'provider' | 'co
 }
 
 /**
+ * Computes the estimated cost of one model's usage within a single day/bucket entry,
+ * applying the correct pricing source per editor the model was used from.
+ * Falls back to Copilot pricing when no per-editor breakdown is available.
+ */
+function computeModelCostForEntry(entry: DailyTokenStats, model: string, deps: ChartDataBuilderDeps): number {
+	const editorModelUsage = entry.editorModelUsage;
+	if (!editorModelUsage) {
+		const usage = entry.modelUsage[model];
+		return usage ? deps.calculateEstimatedCost({ [model]: usage }, 'copilot') : 0;
+	}
+	let total = 0;
+	for (const [editor, modelUsage] of Object.entries(editorModelUsage)) {
+		const usage = modelUsage[model];
+		if (usage) { total += deps.calculateEstimatedCost({ [model]: usage }, getPricingSourceForEditor(editor)); }
+	}
+	return total;
+}
+
+/**
+ * Builds cost datasets split by model — one dataset per top model (by total cost),
+ * with a combined "Other models" dataset for the remainder.
+ * Each model's usage is priced using the correct pricing source per editor it was used from
+ * (e.g. the same Claude model costs differently via GitHub Copilot vs. a direct API surface).
+ */
+function buildModelCostDatasets(entries: DailyTokenStats[], deps: ChartDataBuilderDeps) {
+	const allModels = new Set<string>();
+	entries.forEach(e => Object.keys(e.modelUsage).forEach(m => allModels.add(m)));
+	const modelCostTotals = new Map<string, number>();
+	for (const model of allModels) {
+		const total = entries.reduce((sum, e) => sum + computeModelCostForEntry(e, model, deps), 0);
+		modelCostTotals.set(model, total);
+	}
+	const sortedModels = Array.from(allModels).sort((a, b) => (modelCostTotals.get(b) || 0) - (modelCostTotals.get(a) || 0));
+	const topModels = sortedModels.slice(0, 5);
+	const otherModels = sortedModels.slice(5);
+	const datasets = topModels.map((model, idx) => {
+		const color = getModelColor(idx);
+		return { label: getModelDisplayName(model), data: entries.map(e => computeModelCostForEntry(e, model, deps)), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
+	});
+	if (otherModels.length > 0) {
+		datasets.push({ label: 'Other models', data: entries.map(e => otherModels.reduce((sum, m) => sum + computeModelCostForEntry(e, m, deps), 0)), backgroundColor: 'rgba(150, 150, 150, 0.5)', borderColor: 'rgba(150, 150, 150, 0.8)', borderWidth: 1 });
+	}
+	return datasets;
+}
+
+/** Aggregates per-editor-model token counts up to billing provider groups. */
+function aggregateBillingGroupTokens(entry: DailyTokenStats): Record<string, number> {
+	const result: Record<string, number> = {};
+	const editorModelUsage = entry.editorModelUsage;
+	if (!editorModelUsage) { return result; }
+	for (const [editor, modelUsage] of Object.entries(editorModelUsage)) {
+		for (const [modelId, usage] of Object.entries(modelUsage)) {
+			const group = getBillingGroup(editor, modelId);
+			result[group] = (result[group] ?? 0) + usage.inputTokens + usage.outputTokens;
+		}
+	}
+	return result;
+}
+
+/** Builds token datasets split by billing/hosting provider. */
+function buildProviderTokensDatasets(entries: DailyTokenStats[]) {
+	const allGroups = new Set<string>();
+	entries.forEach(e => Object.keys(aggregateBillingGroupTokens(e)).forEach(g => allGroups.add(g)));
+	const groupTotals = new Map<string, number>();
+	for (const group of allGroups) {
+		const total = entries.reduce((sum, e) => sum + (aggregateBillingGroupTokens(e)[group] ?? 0), 0);
+		groupTotals.set(group, total);
+	}
+	const sortedGroups = Array.from(allGroups).sort((a, b) => (groupTotals.get(b) || 0) - (groupTotals.get(a) || 0));
+	return sortedGroups.map((group, idx) => {
+		const color = getModelColor(idx);
+		return { label: group, data: entries.map(e => aggregateBillingGroupTokens(e)[group] ?? 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
+	});
+}
+
+/**
  * Builds cost datasets split by billing/hosting provider.
  * One dataset per billing group (e.g. "GitHub Copilot", "Anthropic", "Google", …),
  * using the correct pricing source for each group.
@@ -457,16 +533,18 @@ function buildPeriodData(buckets: BucketEntry[], deps: ChartDataBuilderDeps) {
 	});
 	const editorCostDatasets = buildEditorCostDatasets(entries, deps);
 	const billingGroupCostDatasets = buildBillingGroupCostDatasets(entries, deps);
+	const modelCostDatasets = buildModelCostDatasets(entries, deps);
 	const modelSessionsDatasets = buildModelSessionsDatasets(entries);
 	const editorSessionsDatasets = buildEditorSessionsDatasets(entries);
 	const providerSessionsDatasets = buildProviderSessionsDatasets(entries);
+	const providerTokensDatasets = buildProviderTokensDatasets(entries);
 	const allTaskCategories = new Set<string>();
 	entries.forEach(e => Object.keys(e.taskCategoryUsage ?? {}).forEach(tc => allTaskCategories.add(tc)));
 	const taskCategoryDatasets = Array.from(allTaskCategories).map((category, idx) => {
 		const color = getModelColor(idx);
 		return { label: category, data: entries.map(e => e.taskCategoryUsage?.[category]?.tokens || 0), backgroundColor: color.bg, borderColor: color.border, borderWidth: 1 };
 	});
-	return { labels, periodKeys, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, modelSessionsDatasets, editorSessionsDatasets, providerSessionsDatasets, taskCategoryDatasets };
+	return { labels, periodKeys, tokensData, sessionsData, modelDatasets, editorDatasets, repositoryDatasets, periodCount, totalTokens, totalSessions, avgPerPeriod: periodCount > 0 ? Math.round(totalTokens / periodCount) : 0, costData, totalCost, avgCostPerPeriod: periodCount > 0 ? totalCost / periodCount : 0, locData, linesAddedData, linesRemovedData, languageDatasets, locEditorDatasets, locRepositoryDatasets, totalLinesAdded, totalLinesRemoved, avgLocPerPeriod, editorCostDatasets, billingGroupCostDatasets, modelCostDatasets, modelSessionsDatasets, editorSessionsDatasets, providerSessionsDatasets, providerTokensDatasets, taskCategoryDatasets };
 }
 
 function computeSummaryTotals(dailyBuckets: BucketEntry[], deps: ChartDataBuilderDeps) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,12 +225,20 @@ export interface ChartPeriodData {
    * Copilot group uses AI-Credit pricing; all others use direct provider pricing.
    */
   billingGroupCostDatasets?: object[];
+  /**
+   * Cost datasets split by model — one dataset per top model (by total cost), plus an
+   * "Other models" dataset for the remainder. Each model's usage is priced using the
+   * correct pricing source per editor it was used from.
+   */
+  modelCostDatasets?: object[];
   /** Session-count datasets split by model — one stacked-bar dataset per model. */
   modelSessionsDatasets?: object[];
   /** Session-count datasets split by editor — one stacked-bar dataset per editor. */
   editorSessionsDatasets?: object[];
   /** Session-count datasets split by billing provider — one stacked-bar dataset per provider group. */
   providerSessionsDatasets?: object[];
+  /** Token datasets split by billing provider — one stacked-bar dataset per provider group. */
+  providerTokensDatasets?: object[];
   /** Token datasets split by task category (e.g. "Coding", "Debugging", "Testing") — one stacked-bar dataset per category. */
   taskCategoryDatasets?: object[];
 }

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -47,9 +47,11 @@ type ChartPeriodData = {
 	avgLocPerPeriod?: number;
 	editorCostDatasets?: ModelDataset[];
 	billingGroupCostDatasets?: ModelDataset[];
+	modelCostDatasets?: ModelDataset[];
 	modelSessionsDatasets?: ModelDataset[];
 	editorSessionsDatasets?: ModelDataset[];
 	providerSessionsDatasets?: ModelDataset[];
+	providerTokensDatasets?: ModelDataset[];
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
@@ -241,9 +243,11 @@ function copyFilteredDatasetFields(source: ChartPeriodData, target: ChartPeriodD
 		{ key: 'locRepositoryDatasets', source: source.locRepositoryDatasets },
 		{ key: 'editorCostDatasets', source: source.editorCostDatasets },
 		{ key: 'billingGroupCostDatasets', source: source.billingGroupCostDatasets },
+		{ key: 'modelCostDatasets', source: source.modelCostDatasets },
 		{ key: 'modelSessionsDatasets', source: source.modelSessionsDatasets },
 		{ key: 'editorSessionsDatasets', source: source.editorSessionsDatasets },
 		{ key: 'providerSessionsDatasets', source: source.providerSessionsDatasets },
+		{ key: 'providerTokensDatasets', source: source.providerTokensDatasets },
 		{ key: 'taskCategoryDatasets', source: source.taskCategoryDatasets },
 	];
 	for (const { key, source: ds } of datasetFields) {
@@ -308,7 +312,9 @@ function getChartTitle(): string {
 	}
 	if (currentMetric === 'cost') {
 		let titleText: string;
-		if (currentSplit === 'editor') {
+		if (currentSplit === 'model') {
+			titleText = periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Model');
+		} else if (currentSplit === 'editor') {
 			titleText = periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Editor');
 		} else if (currentSplit === 'provider') {
 			titleText = periodMeta.costTitle.replace('Est. Cost', 'Est. Cost by Provider');
@@ -369,9 +375,9 @@ const PERIOD_LABELS: Record<ChartPeriod, { title: string; footer: string; countL
 
 function isComboSupported(metric: string, split: string): boolean {
 	if (metric === 'sessions') { return split === 'total' || split === 'model' || split === 'editor' || split === 'provider'; }
-	if (metric === 'cost') { return split === 'total' || split === 'editor' || split === 'provider'; }
+	if (metric === 'cost') { return split === 'total' || split === 'model' || split === 'editor' || split === 'provider'; }
 	if (metric === 'output') { return split !== 'model' && split !== 'provider' && split !== 'taskCategory'; }
-	return split !== 'language' && split !== 'provider';
+	return split !== 'language';
 }
 
 function buildChartHeader(data: InitialChartData): HTMLElement {
@@ -744,7 +750,7 @@ async function switchPeriod(period: ChartPeriod, data: InitialChartData): Promis
 }
 
 function clampSplitForMetric(metric: typeof currentMetric): void {
-	if (metric === 'cost' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; return; }
+	if (metric === 'cost' && currentSplit !== 'model' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; return; }
 	if (metric === 'output' && currentSplit === 'model') { currentSplit = 'total'; return; }
 	if (metric === 'tokens' && currentSplit === 'language') { currentSplit = 'total'; return; }
 	if (metric === 'sessions' && currentSplit !== 'total' && currentSplit !== 'model' && currentSplit !== 'editor' && currentSplit !== 'provider') { currentSplit = 'total'; }
@@ -781,9 +787,9 @@ async function switchTimeWindow(timeWindow: ChartTimeWindow, data: InitialChartD
 
 function isSplitSupported(metric: typeof currentMetric, split: typeof currentSplit): boolean {
 	if (metric === 'sessions') { return split === 'total' || split === 'model' || split === 'editor' || split === 'provider'; }
-	return (metric === 'cost' && (split === 'total' || split === 'editor' || split === 'provider')) ||
+	return (metric === 'cost' && (split === 'total' || split === 'model' || split === 'editor' || split === 'provider')) ||
 		(metric === 'output' && split !== 'model' && split !== 'provider' && split !== 'taskCategory') ||
-		(metric === 'tokens' && split !== 'language' && split !== 'provider');
+		(metric === 'tokens' && split !== 'language');
 }
 
 async function reinitChart(data: InitialChartData): Promise<void> {
@@ -1104,6 +1110,35 @@ function buildCostEditorViewConfig(period: ChartPeriodData, baseOptions: ReturnT
 	} as ChartConfig;
 }
 
+function buildCostModelViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
+	const datasets = (period.modelCostDatasets ?? []) as ModelDataset[];
+	return {
+		type: 'bar' as const,
+		data: { labels: period.labels, datasets: datasets as any },
+		options: {
+			...baseOptions,
+			plugins: {
+				...baseOptions.plugins,
+				legend: { position: 'top' as const, labels: { color: c.textColor, font: { size: 11 } } },
+				tooltip: {
+					...baseOptions.plugins.tooltip,
+					callbacks: {
+						label: (ctx: any) => ` ${ctx.dataset.label}: $${Number(ctx.parsed.y).toFixed(4)}`,
+						footer: (items: any[]) => {
+							const total = items.reduce((sum: number, i: any) => sum + (Number(i.parsed.y) || 0), 0);
+							return `Total: $${total.toFixed(4)}`;
+						}
+					}
+				}
+			},
+			scales: {
+				x: { stacked: true, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 } } },
+				y: { stacked: true, type: 'linear' as const, display: true, position: 'left' as const, grid: { color: c.gridColor }, ticks: { color: c.textColor, font: { size: 11 }, callback: (value: any) => `$${Number(value).toFixed(2)}` }, title: { display: true, text: 'Estimated Cost (USD)', color: c.textColor, font: { size: 12, weight: 'bold' as const } } }
+			}
+		}
+	} as ChartConfig;
+}
+
 function buildCostViewConfig(period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors, monthlyBudget = 0): ChartConfig {
 	const isRolling = currentDisplayMode === 'rolling';
 	const costData = isRolling ? computeRollingAverage(period.costData, ROLLING_WINDOW[currentPeriod]) : period.costData;
@@ -1236,7 +1271,7 @@ function refreshHeatmapView(data: InitialChartData): void {
 }
 
 function buildStackedViewConfig(view: string, period: ChartPeriodData, baseOptions: ReturnType<typeof buildBaseOptions>, c: ChartColors): ChartConfig {
-	const datasets = view === 'model' ? period.modelDatasets : view === 'repository' ? period.repositoryDatasets : view === 'taskCategory' ? (period.taskCategoryDatasets ?? []) : period.editorDatasets;
+	const datasets = view === 'model' ? period.modelDatasets : view === 'repository' ? period.repositoryDatasets : view === 'taskCategory' ? (period.taskCategoryDatasets ?? []) : view === 'provider' ? (period.providerTokensDatasets ?? []) : period.editorDatasets;
 	const lastIdx = period.tokensData.length - 1;
 	const projExtra = lastIdx >= 0 ? computeProjectionExtra(period.tokensData[lastIdx], getCurrentPeriodFraction(currentPeriod)) : null;
 	const projDs = projExtra !== null ? [{ label: PROJECTION_LABELS[currentPeriod], data: period.tokensData.map((_: number, i: number) => i === lastIdx ? Math.round(projExtra) : 0), backgroundColor: 'rgba(200, 200, 200, 0.25)', borderColor: 'rgba(200, 200, 200, 0.5)', borderWidth: 1 }] : [];
@@ -1260,10 +1295,12 @@ function resolveTokensView(split: typeof currentSplit): string {
 	if (split === 'editor') { return 'editor'; }
 	if (split === 'repository') { return 'repository'; }
 	if (split === 'taskCategory') { return 'taskCategory'; }
+	if (split === 'provider') { return 'provider'; }
 	return 'total';
 }
 
 function resolveCostView(split: typeof currentSplit): string {
+	if (split === 'model') { return 'cost-model'; }
 	if (split === 'editor') { return 'cost-editor'; }
 	if (split === 'provider') { return 'cost-provider'; }
 	return 'cost';
@@ -1292,6 +1329,7 @@ function createConfig(data: InitialChartData): ChartConfig {
 	if (view.startsWith('sessions')) { return buildSessionsViewConfig(view, period, baseOptions, c); }
 	if (view === 'total') { return buildTotalViewConfig(period, baseOptions, c); }
 	if (view === 'cost') { return buildCostViewConfig(period, baseOptions, c, data.monthlyBudget ?? 0); }
+	if (view === 'cost-model') { return buildCostModelViewConfig(period, baseOptions, c); }
 	if (view === 'cost-editor') { return buildCostEditorViewConfig(period, baseOptions, c); }
 	if (view === 'cost-provider') { return buildCostProviderViewConfig(period, baseOptions, c); }
 	if (view.startsWith('output-')) { return buildOutputViewConfig(view, period, baseOptions, c); }

--- a/vscode-extension/test/unit/chartDataBuilder.test.ts
+++ b/vscode-extension/test/unit/chartDataBuilder.test.ts
@@ -181,3 +181,45 @@ test('buildChartData builds non-empty provider session datasets', () => {
 	assert.ok(copilotDataset, 'expected GitHub Copilot provider session dataset');
 	assert.equal((copilotDataset as any).data.reduce((a: number, b: number) => a + b, 0), 3);
 });
+
+// ── modelCostDatasets ─────────────────────────────────────────────────────────
+
+/** Test cost stub: $1 per input token + $2 per output token, doubled for 'provider' pricing source. */
+const costPerModelDeps = {
+	...testDeps,
+	calculateEstimatedCost: (usage: Record<string, { inputTokens: number; outputTokens: number }>, pricingSource: 'provider' | 'copilot') => {
+		const multiplier = pricingSource === 'provider' ? 2 : 1;
+		return Object.values(usage).reduce((sum, u) => sum + (u.inputTokens * 1 + u.outputTokens * 2) * multiplier, 0);
+	},
+};
+
+test('buildChartData builds non-empty model cost datasets', () => {
+	const data = buildChartData(testDailyStats, costPerModelDeps);
+	assert.ok(data.periods.day.modelCostDatasets);
+	const gptDataset = data.periods.day.modelCostDatasets!.find((d: any) => d.label.toLowerCase().includes('gpt-4o') || d.label.toLowerCase().includes('4o'));
+	assert.ok(gptDataset, 'expected a GPT-4o model cost dataset');
+	// Both days' gpt-4o usage is via VS Code (Copilot pricing, multiplier 1):
+	// day1: 400*1 + 100*2 = 600, day2: 300*1 + 200*2 = 700
+	assert.equal((gptDataset as any).data.reduce((a: number, b: number) => a + b, 0), 1300);
+});
+
+test('buildChartData model cost datasets sum to same total as billing group cost datasets', () => {
+	const data = buildChartData(testDailyStats, costPerModelDeps);
+	const modelTotal = (data.periods.day.modelCostDatasets ?? []).reduce((sum: number, ds: any) => sum + ds.data.reduce((a: number, b: number) => a + b, 0), 0);
+	const providerTotal = (data.periods.day.billingGroupCostDatasets ?? []).reduce((sum: number, ds: any) => sum + ds.data.reduce((a: number, b: number) => a + b, 0), 0);
+	assert.equal(modelTotal, providerTotal);
+});
+
+// ── providerTokensDatasets ────────────────────────────────────────────────────
+
+test('buildChartData builds non-empty provider token datasets', () => {
+	const data = buildChartData(testDailyStats, testDeps);
+	assert.ok(data.periods.day.providerTokensDatasets);
+	assert.ok(data.periods.day.providerTokensDatasets!.length > 0);
+	const copilotDataset = data.periods.day.providerTokensDatasets!.find((d: any) => d.label === 'GitHub Copilot');
+	assert.ok(copilotDataset, 'expected GitHub Copilot provider token dataset');
+	// All usage in testDailyStats comes from VS Code (a Copilot surface):
+	// day1: (400+100)+(300+200)=1000, day2: 300+200=500
+	assert.equal((copilotDataset as any).data.reduce((a: number, b: number) => a + b, 0), 1500);
+});
+


### PR DESCRIPTION
## Why

Charts previously only supported Cost splits by Editor/Provider (no Model), and Tokens splits by Model/Editor/Repository/Task (no Provider). This made it hard to answer "why did cost drop while token volume stayed flat?" — you couldn't see per-model cost or per-provider token mix side by side.

## What changed

- `src/chartDataBuilder.ts`:
  - `modelCostDatasets` — cost datasets split by model (top 5 by cost + "Other models"), each priced using the correct pricing source per editor the model was used from (a model can cost differently via GitHub Copilot vs. a direct API surface).
  - `providerTokensDatasets` — token datasets split by billing provider group ("GitHub Copilot", "Anthropic", "Google", etc.), mirroring the existing provider grouping used for cost/sessions.
- `src/types.ts`: added the two new optional fields to `ChartPeriodData`.
- `vscode-extension/src/webview/chart/main.ts`: wired the new splits into the Charts view — split button enablement, view resolution (`resolveCostView`/`resolveTokensView`), new `buildCostModelViewConfig`, provider case in `buildStackedViewConfig`, chart title text, and filtered-period copying for time-window slicing.
- `vscode-extension/test/unit/chartDataBuilder.test.ts`: added tests for both new dataset builders, including a cross-check that model-cost totals equal provider-cost totals.

## Testing

- `npm run compile` (tsc + eslint + esbuild) — clean
- `npm run compile-tests && node --test` on `chartDataBuilder.test.js` and `viewRegression.test.js` — 36/36 passing

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>