### PR TITLE
Fix Diagnostics reload being much slower than initial extension load

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,13 @@ export interface SessionFileCache {
   lastInteraction?: string | null; // ISO timestamp of last interaction
   title?: string; // Session title (customTitle from session file)
   repository?: string; // Git remote origin URL for the session's workspace
+  /**
+   * True once a full parse has attempted repository extraction for this cache entry.
+   * `repository` can legitimately stay undefined afterward (e.g. no resolvable repo) —
+   * this flag is what distinguishes "resolved to nothing" from "never attempted", so a
+   * repo-less session doesn't get re-parsed on every single cache read forever.
+   */
+  repositoryResolved?: boolean;
   workspaceFolderPath?: string; // Full local path to the workspace folder (optional)
   thinkingTokens?: number; // Estimated thinking/reasoning tokens
   actualTokens?: number; // Actual token count from LLM API usage data (when available)

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5244,6 +5244,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return undefined;
 		}
 
+		// Cache entries written before repository extraction was attempted need one full
+		// re-parse to backfill the field. Key this off `repositoryResolved`, NOT off
+		// `repository === undefined` — the latter is also the correct, permanent value for
+		// sessions that genuinely have no resolvable repository, and treating it as "needs
+		// reparse" forced a full re-parse (including costly JSONL delta reconstruction and
+		// ecosystem adapter calls) on every single Diagnostics reload, forever, for any
+		// repo-less .jsonl session.
+		if (sessionFile.endsWith('.jsonl') && !cached.repositoryResolved) {
+			return undefined;
+		}
+
 		// Use the cached lastInteraction from session content directly.
 		// Do NOT fall back to file mtime here: mtime is updated whenever VS Code writes the
 		// session file (e.g. finalising a session just after midnight), which would shift
@@ -5317,6 +5328,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 			lastInteraction: details.lastInteraction,
 			title: details.title,
 			repository: details.repository,
+			// This function only runs after a full parse, which always attempts repository
+			// extraction — so `repository` above is the definitive result (possibly undefined
+			// because none was found), not "not yet checked". See SessionFileCache.repositoryResolved.
+			repositoryResolved: true,
 			workspaceFolderPath: this.resolveCachedWorkspacePath(details, existingCache),
 		};
 
@@ -5380,7 +5395,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const stat = existingStat ?? await this.statSessionFile(sessionFile);
 
 		const cachedDetails = await this.getSessionFileDetailsFromCache(sessionFile, stat);
-		if (cachedDetails && !(cachedDetails.repository === undefined && sessionFile.endsWith('.jsonl'))) {
+		if (cachedDetails) {
 			this._cacheHits++;
 			return cachedDetails;
 		}


### PR DESCRIPTION
## Summary

- The Diagnostics panel's session-detail cache treated any `.jsonl` session with an undefined `repository` field as stale and forced a full re-parse on every read — including the expensive JSONL delta reconstruction (`_reconstructJsonlStateAsync`) and ecosystem adapter calls (`getMeta`/`getTokens`/`countInteractions`/`getModelUsage`).
- Problem: `repository === undefined` is also the correct, *permanent* value for sessions that genuinely have no resolvable repository (common for CLI sessions run outside a git repo). Those sessions got fully re-parsed on **every single Diagnostics panel reopen/reload, forever** — unlike extension activation, which deliberately uses a lightweight preload path (cache hit or minimal stub) and never hits this full-parse path.
- Fix: added a `repositoryResolved` flag to `SessionFileCache`, set once after any full parse. The cache-invalidation check now keys off this flag instead of `repository === undefined`, so "resolved to nothing" is correctly distinguished from "never attempted."

## Why

Diagnosed via `showDiagnosticReport()` → `loadDiagnosticDataInBackground()` → `loadSessionFilesInBackground()`, which always calls the full `getSessionFileDetails()` for up to 500 session files on every panel open/reveal — unlike the extension-activation preload path (`_preloadSessionFiles`), which explicitly avoids the expensive parse via a lightweight stub/cache-only lookup. The stale `repository === undefined` check (originally added as a one-time cache-migration guard for the repository-extraction feature) meant that guard never actually cleared for repo-less sessions.

## Changes

- `src/types.ts`: add `repositoryResolved?: boolean` to `SessionFileCache`.
- `vscode-extension/src/extension.ts`:
  - `getSessionFileDetailsFromCache`: invalidate on `!cached.repositoryResolved` instead of `repository === undefined`.
  - `updateCacheWithSessionDetails`: stamp `repositoryResolved: true` (only runs after a full parse).
  - `getSessionFileDetails`: simplified now that the invalidation logic lives in the cache lookup.

## Test plan

- [x] `tsc --noEmit` passes.
- [x] `npm test` (project's real Node unit-test runner) — all 40 suites pass.
- [ ] Manually verify: open Diagnostics panel, close and reopen (or hit the panel's reveal path) — second load should be noticeably faster once the cache is warm, especially in workspaces with many CLI/repo-less sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)