### PR TITLE
Collapsible By Editor breakdown in Chart view + fix stuck reopen bug

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6482,15 +6482,21 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.chartPanel = undefined;
 		});
 
-		// If we only have 30-day data, compute the full year in the background and push an update
+		// If we only have 30-day data, compute the full year in the background and push an update.
+		// This must NOT be awaited here: showChart() is wrapped in dispatch()'s in-flight guard, which
+		// only releases the 'showChart' key once this function returns. Awaiting the (potentially long)
+		// full-year calculation would keep that key locked — if the user closes the panel and reopens it
+		// before the calculation finishes, the reopen would be silently dropped as "already in flight".
 		if (!hasFullData) {
-			const fullStats = await this.calculateDailyStats();
-			if (this.chartPanel) {
-				void this.chartPanel.webview.postMessage({
-					command: 'updateChartData',
-					data: { ...this.buildChartData(fullStats), periodsReady: true, compactNumbers: this.getCompactNumbersSetting() }
-				});
-			}
+			void (async () => {
+				const fullStats = await this.calculateDailyStats();
+				if (this.chartPanel) {
+					void this.chartPanel.webview.postMessage({
+						command: 'updateChartData',
+						data: { ...this.buildChartData(fullStats), periodsReady: true, compactNumbers: this.getCompactNumbersSetting() }
+					});
+				}
+			})();
 		}
 	}
 

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -129,6 +129,8 @@ type ChartWebviewState = {
 	metric: 'tokens' | 'output' | 'cost' | 'sessions';
 	split: 'total' | 'model' | 'editor' | 'repository' | 'language' | 'provider' | 'taskCategory';
 	displayMode: DisplayMode;
+	/** Whether the per-editor breakdown cards under the Summary section are collapsed. */
+	editorListCollapsed: boolean;
 	/** @deprecated Use metric + split instead. Kept for migration of old saved state. */
 	view?: 'total' | 'model' | 'editor' | 'repository' | 'cost';
 };
@@ -139,10 +141,13 @@ const chartState = createViewStateManager<ChartWebviewState>(vscode, {
 	metric: 'tokens',
 	split: 'total',
 	displayMode: 'actual',
+	editorListCollapsed: false,
 });
 
+let editorListCollapsed = false;
+
 function saveWebviewState(): void {
-	chartState.save({ period: currentPeriod, timeWindow: currentTimeWindow, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode });
+	chartState.save({ period: currentPeriod, timeWindow: currentTimeWindow, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode, editorListCollapsed });
 }
 
 function getWindowStartDate(timeWindow: ChartTimeWindow, now: Date): string {
@@ -534,8 +539,8 @@ function renderLayout(data: InitialChartData): void {
 	const periodMeta = PERIOD_LABELS[currentPeriod];
 	const summarySection = el('div', 'section');
 	summarySection.append(iconHeading('h3', 'graph', 'Summary'), buildSummaryCards(periodData, periodMeta));
-	const editorCards = buildEditorCards(data.editorTotalsMap);
-	if (editorCards) { summarySection.append(editorCards); }
+	const editorSection = buildEditorSection(data.editorTotalsMap);
+	if (editorSection) { summarySection.append(editorSection); }
 	const chartSectionHeader = el('div', 'chart-section-header');
 	chartSectionHeader.append(iconHeading('h3', 'graph-line', 'Charts'));
 	const canvasWrap = el('div', 'canvas-wrap');
@@ -569,6 +574,7 @@ function buildEditorCards(editorTotals: Record<string, number>): HTMLElement | n
 		return null;
 	}
 	const wrap = el('div', 'cards');
+	wrap.id = 'editor-cards';
 	entries.forEach(([editor, tokens]) => {
 		const card = buildCard(`editor-${editor}`, editor, formatCompact(tokens));
 		// JetBrains only persists user messages + assistant text in its JSONL
@@ -587,6 +593,27 @@ function buildEditorCards(editorTotals: Record<string, number>): HTMLElement | n
 		wrap.append(card);
 	});
 	return wrap;
+}
+
+/** Builds the "By Editor" breakdown as a collapsible section: a toggle header plus the card grid. The collapsed state is persisted via webview state so it survives restarts. */
+function buildEditorSection(editorTotals: Record<string, number>): HTMLElement | null {
+	const cards = buildEditorCards(editorTotals);
+	if (!cards) { return null; }
+	if (editorListCollapsed) { cards.classList.add('hidden'); }
+
+	const header = el('div', 'editor-section-header');
+	const toggle = el('button', 'editor-list-toggle');
+	toggle.id = 'editor-list-toggle';
+	toggle.setAttribute('aria-expanded', String(!editorListCollapsed));
+	toggle.setAttribute('aria-controls', 'editor-cards');
+	toggle.title = editorListCollapsed ? 'Show per-editor breakdown' : 'Hide per-editor breakdown';
+	const chevron = el('span', 'editor-list-chevron', editorListCollapsed ? '▸' : '▾');
+	toggle.append(chevron, document.createTextNode(' By Editor'));
+	header.append(toggle);
+
+	const section = el('div', 'editor-section');
+	section.append(header, cards);
+	return section;
 }
 
 function updateSummaryCards(data: InitialChartData): void {
@@ -622,7 +649,25 @@ function updateSummaryCards(data: InitialChartData): void {
 	}
 }
 
+/** Wires up the collapsible "By Editor" breakdown toggle; the collapsed state is persisted via webview state so it survives restarts. */
+function wireEditorListToggle(): void {
+	const toggle = document.getElementById('editor-list-toggle');
+	const cards = document.getElementById('editor-cards');
+	if (!toggle || !cards) { return; }
+	const chevron = toggle.querySelector('.editor-list-chevron');
+	toggle.addEventListener('click', () => {
+		editorListCollapsed = !editorListCollapsed;
+		cards.classList.toggle('hidden', editorListCollapsed);
+		toggle.setAttribute('aria-expanded', String(!editorListCollapsed));
+		toggle.title = editorListCollapsed ? 'Show per-editor breakdown' : 'Hide per-editor breakdown';
+		if (chevron) { chevron.textContent = editorListCollapsed ? '▸' : '▾'; }
+		chartState.patch({ editorListCollapsed });
+	});
+}
+
 function wireInteractions(data: InitialChartData): void {
+	wireEditorListToggle();
+
 	const refresh = document.getElementById('btn-refresh');
 	refresh?.addEventListener('click', () => vscode.postMessage({ command: 'refresh' }));
 
@@ -1364,6 +1409,7 @@ function restoreChartState(initialData: InitialChartData): void {
 	currentPeriod = saved.period;
 	currentTimeWindow = saved.timeWindow ?? 'last30';
 	currentDisplayMode = saved.displayMode;
+	editorListCollapsed = saved.editorListCollapsed ?? false;
 	if (saved.view && !saved.metric) {
 		const m = migrateViewKey(saved.view);
 		currentMetric = m.metric; currentSplit = m.split;

--- a/vscode-extension/src/webview/chart/styles.css
+++ b/vscode-extension/src/webview/chart/styles.css
@@ -72,6 +72,38 @@ body {
 	margin-top: 16px;
 }
 
+.editor-section {
+	margin-top: 16px;
+}
+
+.editor-section-header {
+	display: flex;
+	justify-content: flex-start;
+}
+
+.editor-list-toggle {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0 0 8px;
+	margin: 0;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.editor-list-toggle:hover {
+	color: var(--text-secondary);
+}
+
+.editor-list-chevron {
+	font-size: 10px;
+	color: var(--text-secondary);
+}
+
 .card {
 	background: var(--bg-tertiary);
 	border: 1px solid var(--border-subtle);


### PR DESCRIPTION
## Why

The Chart view's Summary section shows a per-editor token breakdown grid that grows with the number of editors/tools in use (already 4 rows for the reporter). This ate up a lot of vertical space above the actual charts.

While validating this, we also found that closing the Chart panel while its background full-year calculation was still running left the Chart view unable to reopen (clicks were silently dropped).

## What changed

- Added a "By Editor" toggle button above the per-editor cards grid in the Chart view's Summary section. Clicking it collapses/expands just that grid, leaving the top-level stat cards (Total Days, Total Tokens, etc.) visible.
- The collapsed/expanded state is persisted through the existing webview state manager, so it's restored the next time the Chart view is opened, including after a VS Code restart.
- Fixed a pre-existing bug in `showChart()`: when only 30-day data was cached, the function awaited the full-year background calculation before returning, which kept the shared `showChart` in-flight dedup lock held for the whole calculation. If the panel was closed mid-calculation, every subsequent attempt to reopen it was silently skipped as "already in flight" until that calculation finished. The background calculation is now fire-and-forget, so `showChart()` returns as soon as the panel is created/rendered.

## Verification

- `npm run compile` (tsc + eslint + esbuild) passes.
- Full `npm run test:node` suite passes.