### PR TITLE
Fix Dependabot alerts: pin MessagePack and Microsoft.IO.Redist versions

### DIFF
--- a/visualstudio-extension/src/AIEngineeringFluency/AIEngineeringFluency.csproj
+++ b/visualstudio-extension/src/AIEngineeringFluency/AIEngineeringFluency.csproj
@@ -135,6 +135,9 @@
     <PackageReference Include="Community.VisualStudio.Toolkit" Version="17.0.76.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <!-- Pinned to override vulnerable transitive versions pulled in via the VS SDK (Dependabot alerts #138-150) -->
+    <PackageReference Include="MessagePack" Version="2.5.301" />
+    <PackageReference Include="Microsoft.IO.Redist" Version="6.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />


### PR DESCRIPTION
## Summary
Resolves all 13 open Dependabot alerts, all in `visualstudio-extension/src/AIEngineeringFluency/AIEngineeringFluency.csproj`. Neither package was directly referenced — both are transitive dependencies pulled in via the VS SDK — so this pins them to patched versions via explicit `PackageReference` entries (NuGet's nearest-wins rule makes the direct reference override the vulnerable transitive one).

- `MessagePack` → `2.5.301` (resolves alerts **#139–150**)
- `Microsoft.IO.Redist` → `6.0.1` (resolves alert **#138**)

## Verification
- `dotnet restore` confirms both packages now resolve to the pinned patched versions (checked `project.assets.json`).
- `./build.ps1 -Project visualstudio` builds cleanly via MSBuild.
- `./build.ps1 -Project visualstudio -Target test` — all 78 unit tests pass.

## Resolved alert numbers
138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150

No other files were touched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>