### PR TITLE
Fix code-scanning alert #95: sever file-to-network taint flow in sync-changelog.js

### DIFF
--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -42,13 +42,25 @@ const TEST_RELEASES = [
   }
 ];
 
+// The only GitHub owner/repo this script is ever meant to talk to. Kept as
+// hardcoded constants (not read from a file) so the values actually embedded
+// in outbound GitHub API requests never carry file-derived data — see
+// getGitHubOwnerRepo() below for why this matters.
+const EXPECTED_OWNER = 'rajbos';
+const EXPECTED_REPO = 'ai-engineering-fluency';
+
 /**
- * Read package.json and extract a validated GitHub `owner`/`repo` pair from its
- * `repository.url` field. The extracted values are later embedded in outbound
- * GitHub API requests (and a `gh api` command line), so they are restricted to
- * the character set GitHub actually allows in owner/repo names — this rejects
- * anything unexpected in package.json rather than passing arbitrary file
- * content into a network request or shell command.
+ * Read package.json and confirm its `repository.url` field points at the
+ * expected GitHub repo, then return the hardcoded EXPECTED_OWNER/EXPECTED_REPO
+ * constants — not the strings extracted from package.json.
+ *
+ * This script only ever needs to call the GitHub API for this one repo, so
+ * package.json is used purely as a sanity check, never as the source of the
+ * values embedded in outbound requests (and the `gh api` command line).
+ * Returning the file-derived strings directly would mean file content flows
+ * into a network request/shell command; returning the hardcoded constants
+ * instead — after validating they match — avoids that entirely, regardless of
+ * what package.json happens to contain.
  */
 function getGitHubOwnerRepo() {
   const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
@@ -58,7 +70,12 @@ function getGitHubOwnerRepo() {
     throw new Error('Could not extract repository information from package.json');
   }
   const [, owner, repo] = match;
-  return { owner, repo };
+  if (owner !== EXPECTED_OWNER || repo !== EXPECTED_REPO) {
+    throw new Error(
+      `package.json repository (${owner}/${repo}) does not match the expected ${EXPECTED_OWNER}/${EXPECTED_REPO}; refusing to use it`
+    );
+  }
+  return { owner: EXPECTED_OWNER, repo: EXPECTED_REPO };
 }
 
 async function fetchGitHubReleases() {


### PR DESCRIPTION
## Problem

Code-scanning alert #95 (`js/file-access-to-http`, "File data in outbound network request") kept flagging `scripts/sync-changelog.js:119` even after commit `158e8b0a` added regex-based allowlisting of the `owner`/`repo` values extracted from `package.json`.

Root cause: `js/file-access-to-http` is a pure taint-tracking heuristic — it has no concept of "validate then use". Any value derived from a file read is still considered tainted when it reaches an HTTP request/URL, regardless of intervening validation logic (confirmed by reading the [CodeQL query source](https://github.com/github/codeql/blob/main/javascript/ql/src/Security/CWE-200/FileAccessToHttpQuery.qll) — no barrier-guard predicates are defined for this query, only two unrelated hardcoded sanitizers).

## Fix

`getGitHubOwnerRepo()` in `scripts/sync-changelog.js` now:
- Still reads `package.json` and regex-extracts `owner`/`repo` from `repository.url`.
- Uses that extracted value only as a **sanity check** against hardcoded constants `EXPECTED_OWNER = 'rajbos'` / `EXPECTED_REPO = 'ai-engineering-fluency'` (this script only ever targets this one repo), throwing if they don't match.
- Returns the **hardcoded constants**, not the file-derived strings.

Both call sites (the `gh api repos/${owner}/${repo}/...` command and the `https.request` options) already consume this function's return value, so no other code changes are needed. Because the values reaching the outbound request now originate from string literals rather than file content, the CodeQL taint path is fully broken rather than just validated.

## Testing

- `node --check scripts/sync-changelog.js` — syntax OK.
- Verified `getGitHubOwnerRepo()` behavior directly against a temporary `package.json`:
  - Matching repo → returns `{owner: 'rajbos', repo: 'ai-engineering-fluency'}`.
  - Mismatched repo → throws the expected validation error.

Resolves code-scanning alert #95.