### PR TITLE
ci(codeql): allow NuGet endpoints for C# build-mode none restore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,9 +77,17 @@ jobs:
           # the requested version is not in the runner's toolcache (release
           # downloads on github.com redirect there) — without them, init fails
           # with ECONNREFUSED on runner images that lack the pinned version.
+          # api.nuget.org / globalcdn.nuget.org: CodeQL's C# build-mode "none"
+          # extractor restores NuGet dependencies itself (from *.csproj/*.sln) to
+          # resolve external types before extraction — see
+          # https://docs.github.com/en/code-security/reference/code-scanning/codeql/build-options-for-compiled-languages#no-build-for-c
+          # Without these, that restore is silently blocked by egress-policy,
+          # degrading database quality ("Low C# analysis quality" / percentage of
+          # calls with call target below the 85% threshold).
           allowed-endpoints: >
             api.adoptium.net:443
             api.github.com:443
+            api.nuget.org:443
             cache-redirector.jetbrains.com:443
             # d2cico3c979uwg.cloudfront.net is the CloudFront distribution that
             # download-cdn.jetbrains.com itself resolves/redirects to when the
@@ -89,6 +97,7 @@ jobs:
             download-cdn.jetbrains.com:443
             download.jetbrains.com:443
             github.com:443
+            globalcdn.nuget.org:443
             hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             plugins-artifacts.gradle.org:443


### PR DESCRIPTION
## Why

The C# analysis job in `.github/workflows/codeql.yml` was flagged by CodeQL with a "Low C# analysis quality" warning:

> Percentage of calls with call target: 82% (threshold 85%). Percentage of expressions with known type: 94% (threshold 85%).

## Root cause

The `csharp` matrix entry uses `build-mode: none`. Per [GitHub's docs](https://docs.github.com/en/code-security/reference/code-scanning/codeql/build-options-for-compiled-languages#no-build-for-c), CodeQL's C# "no build" extractor restores NuGet dependencies internally (from `*.csproj`/`*.sln`) to resolve external types before extraction.

This workflow also runs `step-security/harden-runner` with `egress-policy: block` and an explicit endpoint allowlist. That allowlist had no NuGet endpoints in it, so CodeQL's internal dependency restore was silently blocked, leaving external types (e.g. from `Microsoft.VisualStudio.SDK`, `Newtonsoft.Json`, `MessagePack`, etc.) unresolved during extraction — degrading call-target and type-resolution accuracy.

Switching the C# job to `autobuild`/`manual` isn't viable here: the `visualstudio-extension` project is a legacy VSSDK-style `.csproj` that requires Visual Studio's MSBuild toolchain and can't be built with `dotnet build` on `ubuntu-latest` (see `.github/instructions/visualstudio-extension.instructions.md`).

## Fix

Add `api.nuget.org:443` and `globalcdn.nuget.org:443` to the harden-runner allowlist so CodeQL's built-in NuGet restore can succeed, without needing a real build.

## Verification

- Confirmed `dotnet restore` against `visualstudio-extension/AIEngineeringFluency.sln` succeeds and resolves all `PackageReference`s.
- Validated the updated workflow YAML parses correctly.
- Effect on database quality will be visible in the next scheduled/PR CodeQL run for this branch.