### PR TITLE
Add one-time Efficiency view notification popup

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1418,6 +1418,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				this.startBackendSyncAfterInitialAnalysis();
 				await this.checkAndShowOnboarding();
 				await this.showFluencyScoreNewsBanner();
+				await this.showEfficiencyTabNewsBanner();
 				await this.showUnknownMcpToolsBanner();
 			} catch (error) {
 				this.error('Error in initial update:', error);
@@ -1546,6 +1547,27 @@ class CopilotTokenTracker implements vscode.Disposable {
 		await this.context.globalState.update(dismissedKey, true);
 		if (choice === open) {
 			await this.showMaturity();
+		}
+	}
+
+	/**
+	 * Shows a one-time popup pointing users at the new Efficiency view. Fires once per
+	 * install: the dismissed flag is set immediately so the notification never reappears,
+	 * even if the user ignores it. Can be cleared from Diagnostics > Debug for re-testing.
+	 */
+	private async showEfficiencyTabNewsBanner(): Promise<void> {
+		const dismissedKey = 'news.efficiencyTab.v1.dismissed';
+		if (this.context.globalState.get<boolean>(dismissedKey)) {
+			return;
+		}
+		await this.context.globalState.update(dismissedKey, true);
+		const open = 'Open Efficiency';
+		const choice = await vscode.window.showInformationMessage(
+			'📈 New: Efficiency view — see whether you\'re working more efficiently with AI over time.',
+			open
+		);
+		if (choice === open) {
+			await this.showEfficiency();
 		}
 	}
 
@@ -9091,6 +9113,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     await this.context.globalState.update('extension.unknownMcpOpenCount', 0);
     await this.context.globalState.update('news.fluencyScoreBanner.v1.dismissed', false);
     await this.context.globalState.update('news.unknownMcpTools.dismissedVersion', undefined);
+    await this.context.globalState.update('news.efficiencyTab.v1.dismissed', false);
     vscode.window.showInformationMessage('Debug counters and dismissed flags have been reset.');
     await this.showDiagnosticReport();
   }
@@ -10536,6 +10559,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       unknownMcpOpenCount: this.context.globalState.get<number>('extension.unknownMcpOpenCount') ?? 0,
       fluencyBannerDismissed: this.context.globalState.get<boolean>('news.fluencyScoreBanner.v1.dismissed') ?? false,
       unknownMcpDismissedVersion: this.context.globalState.get<string>('news.unknownMcpTools.dismissedVersion') ?? '',
+      efficiencyTabBannerDismissed: this.context.globalState.get<boolean>('news.efficiencyTab.v1.dismissed') ?? false,
     };
 
     const initialData = JSON.stringify({

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -101,6 +101,7 @@ type GlobalStateCounters = {
   unknownMcpOpenCount: number;
   fluencyBannerDismissed: boolean;
   unknownMcpDismissedVersion: string;
+  efficiencyTabBannerDismissed: boolean;
 };
 
 type GitHubAuthStatus = {
@@ -807,7 +808,7 @@ function renderShareCardTab(detailedFiles: SessionFileDetails[], isLoadingSessio
 }
 
 function renderDebugTab(counters: GlobalStateCounters | undefined): string {
-  const c = counters ?? { openCount: 0, unknownMcpOpenCount: 0, fluencyBannerDismissed: false, unknownMcpDismissedVersion: '' };
+  const c = counters ?? { openCount: 0, unknownMcpOpenCount: 0, fluencyBannerDismissed: false, unknownMcpDismissedVersion: '', efficiencyTabBannerDismissed: false };
   return `
     <div id="tab-debug" class="tab-content">
       <div class="info-box">
@@ -824,6 +825,7 @@ function renderDebugTab(counters: GlobalStateCounters | undefined): string {
         <table><tbody>
           ${flagRow('news.fluencyScoreBanner.v1.dismissed', 'news.fluencyScoreBanner.v1.dismissed', c.fluencyBannerDismissed)}
           ${stringRow('news.unknownMcpTools.dismissedVersion', 'news.unknownMcpTools.dismissedVersion', c.unknownMcpDismissedVersion)}
+          ${flagRow('news.efficiencyTab.v1.dismissed', 'news.efficiencyTab.v1.dismissed', c.efficiencyTabBannerDismissed)}
         </tbody></table>
         <div style="margin-top: 16px;">
           <button class="button secondary" id="btn-reset-debug-counters"><span>🔄</span><span>Reset All Counters &amp; Dismissed Flags</span></button>


### PR DESCRIPTION
## Summary
Adds a one-time popup notification that points users at the new Efficiency view (added in #1791).

- Shows once via `vscode.window.showInformationMessage` with an "Open Efficiency" action.
- Uses a `news.efficiencyTab.v1.dismissed` globalState flag, set immediately on first show so it never reappears (mirrors the existing `news.fluencyScoreBanner.v1.dismissed` pattern for the Fluency Score banner).
- Wired into the same startup sequence as the other one-time banners (`scheduleInitialUpdate`).
- The flag is surfaced in Diagnostics → Debug → Dismissed Flags, and cleared by the existing "Reset All Counters & Dismissed Flags" button, same as the other banners.

## Testing
- `npm run compile` — clean (only 2 pre-existing complexity warnings, unrelated to this change)
- `npm run test:node` — all suites pass