### PR TITLE
Fix Efficiency view stuck lock and Today-stats showing 0

### DIFF
--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -183,6 +183,43 @@ function scaleModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {
 }
 
 /**
+ * Last-resort single-day rollup for sessions with no per-request timestamps at all
+ * (e.g. an ecosystem adapter with no `getDailyFractions()`, such as Claude Desktop).
+ * Buckets the whole session's tokens/interactions under one day, keyed by
+ * `activityTimestamp` (mutates `dailyRollups` in place).
+ *
+ * Callers must pass the session's *last* known activity timestamp (falling back to
+ * the first, only if no last timestamp is available) — never `firstInteraction` alone.
+ * A multi-day session (started days ago, still active today) must show up as
+ * "today"'s activity; bucketing by first-interaction silently buries all
+ * subsequent days — including "today" — under the session's start date, making
+ * Today/Details period stats show 0 despite real recent activity.
+ */
+export function computeFallbackDailyRollup(
+	dailyRollups: Record<string, DailyRollupEntry>,
+	activityTimestamp: string | null,
+	tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number },
+	modelUsage: ModelUsage,
+	interactions: number,
+): void {
+	if (!tokenResult.tokens || !activityTimestamp) { return; }
+	try {
+		const interactionDate = new Date(activityTimestamp);
+		if (isNaN(interactionDate.getTime())) { return; }
+		const dayKey = toLocalDayKey(interactionDate);
+		const dayModelUsage = scaleModelUsage(modelUsage, 1);
+		dailyRollups[dayKey] = {
+			tokens: tokenResult.tokens,
+			actualTokens: tokenResult.actualTokens || 0,
+			thinkingTokens: tokenResult.thinkingTokens || 0,
+			cachedReadTokens: 0,
+			interactions: Math.max(1, interactions),
+			modelUsage: dayModelUsage,
+		};
+	} catch { /* ignore */ }
+}
+
+/**
  * Distributes a session-level model usage breakdown across the session's daily
  * rollups, weighted by each day's interaction count, and re-syncs each day's
  * `actualTokens` to that day's distributed input+output total.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7984,11 +7984,18 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 		panel.webview.html = this.getLoadingHtml(panel.webview);
 		void panel.webview.postMessage({ command: 'loadingStep', step: 'computing' });
 
-		const data = await this.buildEfficiencyViewData();
-		// The user may have closed the panel while the data was being computed.
-		if (this.efficiencyPanel !== panel) { return; }
-		panel.webview.html = this.getEfficiencyHtml(panel.webview, data);
-		this.log('⚡ Efficiency view rendered');
+		// Build the data in the background rather than awaiting it here: showEfficiency() is
+		// wrapped in dispatch()'s in-flight guard, which only releases the 'showEfficiency' key
+		// once this function returns. Awaiting the (potentially long) data build would keep that
+		// key locked — if the user closes the panel and reopens it before the build finishes, the
+		// reopen would be silently dropped as "already in flight" (same fix as showChart above).
+		void (async () => {
+			const data = await this.buildEfficiencyViewData();
+			// The user may have closed the panel while the data was being computed.
+			if (this.efficiencyPanel !== panel) { return; }
+			panel.webview.html = this.getEfficiencyHtml(panel.webview, data);
+			this.log('⚡ Efficiency view rendered');
+		})();
 	}
 
 	private async refreshEfficiencyPanel(): Promise<void> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -207,7 +207,7 @@ import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceFor
 import { classifySessionTask, buildClassificationInputFromUsageAnalysis, type TaskCategory } from '../../src/taskClassification';
 
 // --- Stats helpers ---
-import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, reconcileModelUsageToActualTokens, distributeModelUsageToDays, type SessionAggregateInput } from '../../src/statsHelpers';
+import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, reconcileModelUsageToActualTokens, distributeModelUsageToDays, computeFallbackDailyRollup as _computeFallbackDailyRollup, type SessionAggregateInput } from '../../src/statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -5160,19 +5160,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// firstInteraction here silently buried all subsequent days' activity — including
 		// "today" — under the session's start date, making Today/Details show 0.
 		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
-		this.computeFallbackDailyRollup(dailyRollups, sessionMeta.lastInteraction ?? sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
+		_computeFallbackDailyRollup(dailyRollups, sessionMeta.lastInteraction ?? sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
 		return { dailyRollups, totalInteractions };
-	}
-
-	private computeFallbackDailyRollup(dailyRollups: { [localDayKey: string]: DailyRollupEntry }, activityTimestamp: string | null, tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number }, modelUsage: ModelUsage, interactions: number): void {
-		if (!tokenResult.tokens || !activityTimestamp) { return; }
-		try {
-			const interactionDate = new Date(activityTimestamp);
-			if (isNaN(interactionDate.getTime())) { return; }
-			const dayKey = toLocalDayKey(interactionDate);
-			const dayModelUsage = this.scaledModelUsage(modelUsage, 1);
-			dailyRollups[dayKey] = { tokens: tokenResult.tokens, actualTokens: tokenResult.actualTokens || 0, thinkingTokens: tokenResult.thinkingTokens || 0, cachedReadTokens: 0, interactions: Math.max(1, interactions), modelUsage: dayModelUsage };
-		} catch { /* ignore */ }
 	}
 
 	private scaledModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5132,7 +5132,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 
 	private computeDailyRollups(
-		sessionMeta: { firstInteraction: string | null; dailyInteractions: { [localDayKey: string]: number }; dailyFractions?: Record<string, number> },
+		sessionMeta: { firstInteraction: string | null; lastInteraction: string | null; dailyInteractions: { [localDayKey: string]: number }; dailyFractions?: Record<string, number> },
 		tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number; copilotNanoAiu?: number },
 		modelUsage: ModelUsage,
 		interactions: number
@@ -5151,15 +5151,23 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return this.computeRollupsFromInteractionCounts(dailyInteractionMap, tokenResult, modelUsage, totalNanoAiu);
 		}
 
+		// Last-resort fallback for adapters/formats with no per-request timestamps at all
+		// (e.g. Claude Desktop, which has no getDailyFractions()). Bucket the whole session
+		// under its *last* activity day, not its first: a multi-day session (started days ago,
+		// still active today) must show up as "today"'s activity, matching the mtime-based
+		// fallback the CLI uses (see extractDailyFractions) and the lastInteraction-based
+		// fallback aggregatePeriodStats itself uses when dailyRollups is absent. Using
+		// firstInteraction here silently buried all subsequent days' activity — including
+		// "today" — under the session's start date, making Today/Details show 0.
 		const dailyRollups: { [localDayKey: string]: DailyRollupEntry } = {};
-		this.computeFallbackDailyRollup(dailyRollups, sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
+		this.computeFallbackDailyRollup(dailyRollups, sessionMeta.lastInteraction ?? sessionMeta.firstInteraction, tokenResult, modelUsage, interactions);
 		return { dailyRollups, totalInteractions };
 	}
 
-	private computeFallbackDailyRollup(dailyRollups: { [localDayKey: string]: DailyRollupEntry }, firstInteraction: string | null, tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number }, modelUsage: ModelUsage, interactions: number): void {
-		if (!tokenResult.tokens || !firstInteraction) { return; }
+	private computeFallbackDailyRollup(dailyRollups: { [localDayKey: string]: DailyRollupEntry }, activityTimestamp: string | null, tokenResult: { tokens: number; actualTokens?: number; thinkingTokens?: number }, modelUsage: ModelUsage, interactions: number): void {
+		if (!tokenResult.tokens || !activityTimestamp) { return; }
 		try {
-			const interactionDate = new Date(firstInteraction);
+			const interactionDate = new Date(activityTimestamp);
 			if (isNaN(interactionDate.getTime())) { return; }
 			const dayKey = toLocalDayKey(interactionDate);
 			const dayModelUsage = this.scaledModelUsage(modelUsage, 1);

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -12,10 +12,11 @@ reconcileModelUsageToTotal,
 reconcileModelUsageToActualTokens,
 distributeModelUsageToDays,
 sumModelUsageTokens,
+computeFallbackDailyRollup,
 type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../../src/statsHelpers';
-import type { ModelUsage, EditorUsage, SessionFileCache } from '../../../src/types';
+import type { ModelUsage, EditorUsage, SessionFileCache, DailyRollupEntry } from '../../../src/types';
 
 // ── Helper factory ───────────────────────────────────────────────────────────
 
@@ -1173,4 +1174,55 @@ test('aggregatePeriodStats: stale rollup tokens with debug-log modelUsage reprod
 	const inputTokens = Object.values(result.last30DaysStats.modelUsage).reduce((s, u) => s + u.inputTokens, 0);
 	assert.ok(inputTokens > result.last30DaysStats.tokens,
 		'unsynced rollups make Input exceed Total — this is why distributeModelUsageToDays must re-sync actualTokens');
+});
+
+// ── computeFallbackDailyRollup ───────────────────────────────────────────────
+// Guards against a regression where a multi-day session (no per-request
+// timestamps, e.g. an adapter with no getDailyFractions() such as Claude
+// Desktop) had its entire token/interaction count bucketed under
+// firstInteraction's day. An ongoing session (started days ago, still active
+// today) then showed 0 for "Today" everywhere, even with real activity today.
+
+test('computeFallbackDailyRollup: buckets under the last-activity day, not the first (regression)', () => {
+	const dailyRollups: Record<string, DailyRollupEntry> = {};
+	const modelUsage: ModelUsage = { 'gpt-4.1': { inputTokens: 1000, outputTokens: 500, sessions: 1 } };
+	const firstInteraction = '2025-03-10T09:00:00.000Z';
+	const lastInteraction = '2025-03-15T09:00:00.000Z'; // "today" in this scenario
+
+	void firstInteraction; // not used directly — documents the bug scenario's start date
+	computeFallbackDailyRollup(
+		dailyRollups,
+		lastInteraction,
+		{ tokens: 5000, actualTokens: 4500, thinkingTokens: 0 },
+		modelUsage,
+		3,
+	);
+
+	assert.ok(dailyRollups['2025-03-15'], 'session activity must be attributed to the last-activity day ("today")');
+	assert.ok(!dailyRollups['2025-03-10'], 'session activity must NOT be attributed to the first-interaction day');
+	assert.equal(dailyRollups['2025-03-15'].tokens, 5000);
+	assert.equal(dailyRollups['2025-03-15'].interactions, 3);
+});
+
+test('computeFallbackDailyRollup: falls back to firstInteraction when no lastInteraction is available', () => {
+	const dailyRollups: Record<string, DailyRollupEntry> = {};
+	const firstInteraction = '2025-03-10T09:00:00.000Z';
+	const lastInteraction: string | null = null;
+	computeFallbackDailyRollup(
+		dailyRollups,
+		lastInteraction ?? firstInteraction,
+		{ tokens: 100, actualTokens: 100, thinkingTokens: 0 },
+		{},
+		1,
+	);
+	assert.ok(dailyRollups['2025-03-10'], 'must still fall back to firstInteraction when lastInteraction is unavailable');
+});
+
+test('computeFallbackDailyRollup: no-ops when tokens or timestamp are missing', () => {
+	const dailyRollups: Record<string, DailyRollupEntry> = {};
+	computeFallbackDailyRollup(dailyRollups, null, { tokens: 100 }, {}, 1);
+	assert.equal(Object.keys(dailyRollups).length, 0, 'no timestamp means no rollup entry');
+
+	computeFallbackDailyRollup(dailyRollups, '2025-03-10T09:00:00.000Z', { tokens: 0 }, {}, 1);
+	assert.equal(Object.keys(dailyRollups).length, 0, 'zero tokens means no rollup entry');
 });


### PR DESCRIPTION
## Why

Two related bugs reported against the VS Code extension:

1. Closing and reopening the Efficiency view could get it permanently stuck showing "Command 'showEfficiency' already in flight, skipping" in the logs, with the panel stuck loading.
2. "Today" stats showed 0 everywhere (toolbar, Details view, Efficiency view) for a user who had been actively using Copilot CLI and Claude Desktop Cowork all day, while the CLI tool (`cli/`), which reads the same underlying session files, correctly showed today's activity.

## What changed

**Efficiency view stuck lock**: `showEfficiency()` used to fully await the slow `buildEfficiencyViewData()` computation while holding the `dispatch()` in-flight lock for that command. If it was slow (or the panel was closed mid-computation), reopening the view was silently dropped as "already in flight" with no way to recover short of reloading the window. Fixed by creating the panel + loading screen synchronously (releasing the lock immediately) and moving the data build into a detached background task, guarded against a closed/replaced panel - mirroring the existing pattern already used by `showChart()`.

**Today stats showing 0**: Traced to `computeDailyRollups()`'s last-resort fallback for sessions whose ecosystem adapter has no `getDailyFractions()` (e.g. Claude Desktop). It bucketed the *entire* session's tokens/interactions under the day of the session's **first** interaction. For an ongoing multi-day session (started days ago, still active today), all of today's activity was silently buried under the session's start date, so Today/Details/toolbar showed 0 despite real activity. Fixed to bucket under the **last**-known-activity day instead (falling back to first only if no last timestamp exists), matching the convention used elsewhere (`aggregatePeriodStats`'s own fallback, and the CLI's mtime-based fallback in `extractDailyFractions`).

**Regression test coverage**: `computeFallbackDailyRollup` was a private method on the large, untested `GitHubCopilotTokenTracker` class in `extension.ts`. Extracted it into the shared, pure `src/statsHelpers.ts` module (which `extension.ts` now delegates to) so it can be unit tested directly. Added tests covering: bucketing under last-activity day (the bug), correct fallback to first-interaction when no last-interaction exists, and no-op behavior when tokens/timestamp are missing.

## Verification

- `npm run compile` - clean (only 2 pre-existing complexity warnings, unrelated to this change).
- `npm run test:node` - full suite passes, including new regression tests in `statsHelpers.test.ts`.