### PR TITLE
chore: bump vscode-extension version for release (patch, 0.17.0 -> 0.17.1)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the VS Code extension will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-31
+
+### Bug Fixes
+- Fix Efficiency view stuck 'already in flight' after close+reopen (#1797)
+- Fix Today stats showing 0 for multi-day adapter sessions with ongoing activity (#1797)
+
 ## [0.17.0] - 2026-07-30
 
 ### Features

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@azure/arm-resources": "^8.0.0",
         "@azure/arm-resources-subscriptions": "^3.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — VS Code extension patch bump

This PR bumps the **VS Code extension** version only, per the standard release-prep process. No other components (CLI, Visual Studio extension, JetBrains plugin) are touched.

| Component | Old version | New version |
|-----------|-------------|--------------|
| VS Code extension | v0.17.0 | v0.17.1 |

### Changes included since `vscode/v0.17.0`
- Fix Efficiency view stuck 'already in flight' after close+reopen (#1797)
- Fix Today stats showing 0 for multi-day adapter sessions with ongoing activity (#1797)

### Files changed
- `vscode-extension/package.json` (version bump)
- `vscode-extension/package-lock.json` (version bump)
- `vscode-extension/CHANGELOG.md` (new `[0.17.1]` entry)

### After merging, run this workflow
- **Actions → Extensions - Release (`release.yml`) → Run workflow** (on `main`)
  - `create_tag=true`
  - `publish_marketplace=true`
  - `vscode_only=true` (Visual Studio extension was NOT bumped in this release, do not rebuild/republish it)
  - `vs_only=false`
  - `publish_pre_release=false`

This publishes VS Code extension **v0.17.1** to the VS Code Marketplace.