### PR TITLE
fix(extension): cover cold-boot leader parse in follower resync chain

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -538,8 +538,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// window still shows fresh data (the "hybrid" freshness policy).
 	private static readonly FOLLOWER_MISS_BUDGET = 25;
 	// Bounded retry chain a follower uses to pick up the leader's snapshot when it
-	// started before any snapshot existed (cold simultaneous start).
-	private static readonly FOLLOWER_RESYNC_MAX_RETRIES = 4;
+	// started before any snapshot existed (cold simultaneous start). Must cover a
+	// worst-case cold-boot leader parse: with an empty cache the leader can need
+	// several minutes to parse thousands of session files before it publishes.
+	// 24 × 15s = 6 minutes of coverage; without this the follower shows partial
+	// (near-zero) stats until the 5-minute periodic refresh happens to fire.
+	private static readonly FOLLOWER_RESYNC_MAX_RETRIES = 24;
 	private static readonly FOLLOWER_RESYNC_DELAY_MS = 15 * 1000;
 	private _followerResyncTimer: NodeJS.Timeout | undefined;
 	private _refreshHeartbeat: NodeJS.Timeout | undefined;
@@ -2470,6 +2474,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		);
 		const missBudget = isLeader ? undefined : { remaining: CopilotTokenTracker.FOLLOWER_MISS_BUDGET };
 		const { sessionFiles, preloaded } = await this._preloadSessionFiles(fileLoadCutoffMs, progressCallback, discoveredEditorSet, missBudget);
+		if (!isLeader && preloaded.length < sessionFiles.length) {
+			this.log(`Follower with cold cache: stats below are partial (${preloaded.length}/${sessionFiles.length} files within date range parsed within the follower budget). Will resync once the leader publishes its snapshot.`);
+		}
 		try {
 			await this.storeDiscoveredEditorsAndNotify(discoveredEditorSet);
 		} catch (error) {


### PR DESCRIPTION
## Why

After a cold boot with multiple VS Code windows restored, the extension showed **0 tokens for today** (and 0 sessions for the current month) even though Copilot App and Claude Code sessions with several million tokens existed. Data only appeared after the 5-minute periodic refresh fired.

## Root cause

The multi-window leader/follower coordination from #1264 has a gap on a cold cache:

1. Both windows start with an empty cache ("No snapshot found, starting with empty cache").
2. One window wins the refresh-leader lock and starts a full cold parse (thousands of session files, takes minutes on a cold disk).
3. The other window becomes a **follower**: it serves cache hits freely but parses at most `FOLLOWER_MISS_BUDGET` (25) uncached files, to avoid N windows stampeding the disk. With an empty cache nearly everything is a miss, so only ~100 of 5,582 files are analyzed and today's sessions are typically not among them. The UI faithfully shows these partial (zero) stats.
4. The follower's recovery path, `scheduleFollowerResync()`, polls for the leader's shared snapshot every 15s but gave up after **4 retries (~60s)**. A cold leader parse takes much longer, so the chain expired before the snapshot existed.
5. Stats stayed at 0 until the 5-minute periodic timer ran, by which time the leader had published its snapshot and the follower's cache warmed to a 100% hit rate.

## Fix

- Bump `FOLLOWER_RESYNC_MAX_RETRIES` from 4 to **24** (24 x 15s = 6 minutes of coverage), so the resync chain survives a worst-case cold leader parse. Each retry is a cheap `fs.stat` on the snapshot path, so the cost of a longer chain is negligible.
- Log a message when a follower completes with a partial preload (`preloaded < sessionFiles`), so future output logs explain the temporary zeros themselves.

Existing fallback behavior is unchanged: if the leader never publishes (crash), the next periodic refresh steals the stale leader lock (>5 min threshold) and does a full parse.

## Validation

- `npm run compile` (tsc + eslint + esbuild) clean; only 2 pre-existing complexity warnings unrelated to this change.
- `cacheManager-snapshot` unit tests: 19/19 pass.