### PR TITLE
fix initial scan zero today usage

### DIFF
--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { execFileSync } from 'child_process';
 import type { SessionFileCache } from '../../src/types';
 import { type CachePolicy, VsCodeCachePolicy } from '../../src/cachePolicy';
 
@@ -242,12 +243,40 @@ export class CacheManager {
 		if (typeof pid !== 'number') { return true; }
 		try {
 			process.kill(pid, 0);
-			return true;
 		} catch (killErr: unknown) {
 			if (killErr instanceof Error && (killErr as NodeJS.ErrnoException).code === 'ESRCH') {
 				return false; // Process no longer exists
 			}
 			return true; // EPERM means process exists but is owned by another user
+		}
+		// A PID being alive is not enough: Windows reuses PIDs aggressively, so after
+		// a reboot or crash a stale lock can appear "owned" by an unrelated new
+		// process, forcing every window into follower mode. Verify the process image
+		// is actually a VS Code/Electron host before trusting it.
+		if (process.platform === 'win32') {
+			return this.isWindowsHostProcess(pid);
+		}
+		return true;
+	}
+
+	/**
+	 * Windows-only check that a PID belongs to a VS Code/Electron host process.
+	 * Uses tasklist's CSV output; on any failure we assume the owner is alive so
+	 * we never break a lock that is genuinely in use.
+	 */
+	private isWindowsHostProcess(pid: number): boolean {
+		try {
+			const out = execFileSync(
+				'tasklist',
+				['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'],
+				{ encoding: 'utf-8', timeout: 5000, windowsHide: true },
+			);
+			// No match → "INFO: No tasks are running which match the specified criteria."
+			if (!out.startsWith('"')) { return false; }
+			const image = (out.split('","')[0] ?? '').replace(/^"/, '').toLowerCase();
+			return /code|codium|electron|windsurf|cursor|kiro|antigravity|vibe|tray/.test(image);
+		} catch {
+			return true; // Can't verify — err on the side of not breaking the lock
 		}
 	}
 

--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -249,12 +249,15 @@ export class CacheManager {
 			}
 			return true; // EPERM means process exists but is owned by another user
 		}
-		// A PID being alive is not enough: Windows reuses PIDs aggressively, so after
-		// a reboot or crash a stale lock can appear "owned" by an unrelated new
-		// process, forcing every window into follower mode. Verify the process image
-		// is actually a VS Code/Electron host before trusting it.
+		// A PID being alive is not enough on its own: Windows reuses PIDs
+		// aggressively, so after a reboot or crash a stale lock can appear "owned" by
+		// an unrelated new process, forcing every window into follower mode. On
+		// Windows, only treat the lock as live when the PID's image is an
+		// Electron-family host OR the current process itself (tests / same-process
+		// re-acquire). A live but clearly-foreign image (e.g. cmd.exe) means the
+		// PID was recycled and the lock is stale.
 		if (process.platform === 'win32') {
-			return this.isWindowsHostProcess(pid);
+			return pid === process.pid || this.isWindowsHostProcess(pid);
 		}
 		return true;
 	}

--- a/vscode-extension/test/unit/cacheManager-snapshot.test.ts
+++ b/vscode-extension/test/unit/cacheManager-snapshot.test.ts
@@ -167,6 +167,29 @@ test('refresh lock and cache lock are independent files', async () => {
 	await m.releaseCacheLock();
 });
 
+// Windows reuses PIDs aggressively: after a reboot a leftover lock file can point
+// at a PID now owned by an unrelated process. The stale-lock check must not trust
+// a live PID whose image is not a VS Code/Electron host.
+test('refresh lock: breaks stale lock owned by a recycled non-host PID (win32)', { skip: process.platform !== 'win32' }, async () => {
+	const dir = tmpDir();
+	const holder = makeManager(dir);
+	assert.equal(await holder.acquireRefreshLock(), true);
+
+	// Simulate a reboot: overwrite the lock with a fresh timestamp but point the
+	// PID at cmd.exe, which is alive and guaranteed not to be an editor host.
+	const lockPath = holder.getRefreshLockPath();
+	const cmdPid: number = (require('node:child_process') as typeof import('node:child_process'))
+		.spawn('cmd.exe', ['/c', 'ping -n 30 127.0.0.1 >nul'], { windowsHide: true }).pid!;
+	try {
+		fs.writeFileSync(lockPath, JSON.stringify({ sessionId: 'old-session', pid: cmdPid, timestamp: Date.now() }));
+		const fresh = makeManager(dir);
+		assert.equal(await fresh.acquireRefreshLock(), true, 'recycled non-host PID must be treated as stale');
+		await fresh.releaseRefreshLock();
+	} finally {
+		try { process.kill(cmdPid); } catch { /* already exited */ }
+	}
+});
+
 // ---------------------------------------------------------------------------
 // loadCacheFromStorage (disk-based)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request improves the reliability of lock handling and follower resync logic in the VS Code extension, especially on Windows. The main focus is on preventing stale lock files from blocking cache refreshes after a system reboot or crash, and ensuring followers have enough time to synchronize with the leader in large workspaces.

**Lock handling improvements (Windows-specific):**
* Enhanced the process check in `CacheManager` to verify that a PID in a lock file actually belongs to a VS Code/Electron host process, not just any running process. This prevents stale locks from unrelated processes (e.g., after a reboot) from blocking cache refreshes. The check uses `tasklist` to confirm the process image name. [[1]](diffhunk://#diff-ec0fadc6925779c474894558e1e2cb5dbb380aeceaeb624621e12f4a6690a651R9) [[2]](diffhunk://#diff-ec0fadc6925779c474894558e1e2cb5dbb380aeceaeb624621e12f4a6690a651L245-R280)
* Added a new unit test to verify that the refresh lock is correctly broken if a recycled PID belongs to a non-host process, ensuring the extension can recover from stale locks on Windows.

**Follower resync logic improvements:**
* Increased the maximum number of follower resync retries from 4 to 24, allowing up to 6 minutes for the leader to publish a snapshot in large workspaces. This prevents followers from displaying incomplete stats during cold starts.
* Added a log message to inform when a follower is operating with a cold cache and will resync once the leader publishes its snapshot, improving debuggability.