### PR TITLE
fix: recognize Copilot App's "<repo>.worktrees" worktree layout

### DIFF
--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -51,31 +51,40 @@ export function normalizePathForDedup(
 
 /**
  * Normalize a session workspace path up to its parent repository root by stripping a trailing
- * agent-worktree segment created by Copilot CLI or Claude Code:
+ * agent-worktree segment created by Copilot CLI, Claude Code, or the Copilot App:
  *   "<repo>/copilot-worktrees/<name>[/...]"      -> "<repo>"
  *   "<repo>/.claude/worktrees/<name>[/...]"       -> "<repo>"
+ *   "<parent>/<repo>.worktrees/<name>[/...]"      -> "<parent>/<repo>"
+ * The last form is the Copilot App's own default (and a common convention used by its
+ * customizable "Worktree location" setting, added in v1.1.4 - see
+ * https://github.com/github/app/releases/tag/v1.1.4); since that setting is a free-form path
+ * template, this only recognizes the "<repo>.worktrees" naming rather than every possible value.
  * This lets the worktree scanner cover the whole repo (finding sibling worktrees) instead of a
- * single worktree subfolder. The original path is returned unchanged when neither pattern is
- * present, and the input's separator style is preserved.
+ * single worktree subfolder. The original path is returned unchanged when no pattern matches,
+ * and the input's separator style is preserved.
  */
 export function normalizeToRepoRoot(p: string): string {
 	const copilot = p.match(/^(.+?)[\\/]copilot-worktrees[\\/][^\\/]+(?:[\\/].*)?$/i);
 	if (copilot) { return copilot[1]; }
 	const claude = p.match(/^(.+?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]+(?:[\\/].*)?$/i);
 	if (claude) { return claude[1]; }
+	const dotWorktrees = p.match(/^(.+?)([\\/])([^\\/]+?)\.worktrees\2[^\\/]+(?:\2.*)?$/i);
+	if (dotWorktrees) { return `${dotWorktrees[1]}${dotWorktrees[2]}${dotWorktrees[3]}`; }
 	return p;
 }
 
 /**
  * Derive a repository display name from a session's workspace/cwd path.
  *
- * Two agent-worktree layouts exist and place the repo folder on opposite sides of
- * the "copilot-worktrees" marker:
+ * Multiple agent-worktree layouts exist and place the repo folder on opposite sides of
+ * the "copilot-worktrees" marker, or fold it into the marker segment itself:
  *   - Copilot CLI app store:  "<home>/.copilot/copilot-worktrees/<repo>/<worktree>[/...]" -> "<repo>"
  *     (the repo folder comes *after* the marker)
  *   - User-repo / Claude:     "<repo>/copilot-worktrees/<name>[/...]"                     -> "<repo>"
  *     "<repo>/.claude/worktrees/<name>[/...]"                                             -> "<repo>"
  *     (the repo folder comes *before* the marker; handled by normalizeToRepoRoot)
+ *   - Copilot App:            "<parent>/<repo>.worktrees/<name>[/...]"                    -> "<repo>"
+ *     (the repo folder name has the marker as a suffix; handled by normalizeToRepoRoot)
  *
  * Using a plain path.basename() on an app-store worktree path yields the worktree
  * name (e.g. "rajbos-supreme-carnival") instead of the repository — this helper

--- a/vscode-extension/test/unit/utils-pathUtils.test.ts
+++ b/vscode-extension/test/unit/utils-pathUtils.test.ts
@@ -173,6 +173,27 @@ test('normalizeToRepoRoot: ignores an unrelated "worktrees" folder without the .
 	);
 });
 
+test('normalizeToRepoRoot: strips Copilot App "<repo>.worktrees" sibling folder (Windows)', () => {
+	assert.equal(
+		normalizeToRepoRoot('C:\\Users\\me\\repos\\rajbos\\proj.worktrees\\copilot-worktree-2026-02-07T20-38-48'),
+		'C:\\Users\\me\\repos\\rajbos\\proj'
+	);
+});
+
+test('normalizeToRepoRoot: strips Copilot App "<repo>.worktrees" sibling folder (POSIX)', () => {
+	assert.equal(
+		normalizeToRepoRoot('/home/me/repos/rajbos/proj.worktrees/copilot-worktree-2026-02-07T20-38-48'),
+		'/home/me/repos/rajbos/proj'
+	);
+});
+
+test('normalizeToRepoRoot: strips trailing sub-path below a "<repo>.worktrees" worktree name', () => {
+	assert.equal(
+		normalizeToRepoRoot('/home/me/repos/rajbos/proj.worktrees/copilot-worktree-abc/src/app'),
+		'/home/me/repos/rajbos/proj'
+	);
+});
+
 // getRepoNameFromWorkspacePath tests
 test('getRepoNameFromWorkspacePath: app-store worktree resolves to the repo folder, not the worktree name', () => {
 	assert.equal(
@@ -213,6 +234,13 @@ test('getRepoNameFromWorkspacePath: plain repo path returns its basename', () =>
 	assert.equal(
 		getRepoNameFromWorkspacePath('C:\\Users\\me\\repos\\my-repo'),
 		'my-repo'
+	);
+});
+
+test('getRepoNameFromWorkspacePath: Copilot App "<repo>.worktrees" layout resolves to the repo, not the worktree name', () => {
+	assert.equal(
+		getRepoNameFromWorkspacePath('C:\\Users\\me\\repos\\rajbos\\proj.worktrees\\copilot-worktree-2026-02-07T20-38-48'),
+		'proj'
 	);
 });
 


### PR DESCRIPTION
## Summary
- The GitHub Copilot App (v1.1.4+) added a configurable "Worktree location" setting under Settings > Sessions (see [release notes](https://github.com/github/app/releases/tag/v1.1.4)). Since it's a free-form path template, we can't special-case every possible value, but the app's actual on-disk layout (confirmed via `~/.copilot/vscode.session.worktree.jsonl`) is a sibling `<repo>.worktrees/<worktree-name>` folder — distinct from the `copilot-worktrees` and `.claude/worktrees` layouts already handled in `pathUtils.ts`.
- `normalizeToRepoRoot` and `getRepoNameFromWorkspacePath` in `src/utils/pathUtils.ts` now recognize this `<parent>/<repo>.worktrees/<name>[/...]` pattern and resolve it to the actual repo, instead of falling back to the worktree folder name (or the last path segment).
- This keeps worktree-session grouping and repository-name display correct for users on the Copilot App's new default worktree layout.

## Why
Fixes #1807 — without this, sessions run from a Copilot App worktree using the new layout were attributed to a worktree folder name instead of the real repository, breaking grouping/display.

## Test plan
- [x] Added 4 new unit tests in `vscode-extension/test/unit/utils-pathUtils.test.ts` covering the new layout (Windows/POSIX paths, nested sub-paths, repo-name extraction).
- [x] Full `vscode-extension` unit test suite passes (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)