### PR TITLE
chore: bump versions for release (vscode-extension)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the VS Code extension will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-08-17
+
+### Features
+- 2 additional friendly tool names from community issue #1823 (#1824)
+
+### Bug Fixes
+- Recognize Copilot App's `<repo>.worktrees` worktree layout in path/repo detection (#1827)
+- Fix Recent Sessions view stuck on "Loading..." for non-Today periods (#1826)
+- Fix initial scan showing 0 tokens for today on cold boot with multiple windows and stale refresh-lock recycling (#1825, #1822)
+
+### Chores
+- Sync latest model data (#1796)
+
 ## [0.17.1] - 2026-07-31
 
 ### Bug Fixes

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@azure/arm-resources": "^8.0.0",
         "@azure/arm-resources-subscriptions": "^3.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ai-engineering-fluency",
   "displayName": "AI Engineering Fluency",
   "description": "Track your AI Engineering Fluency — daily and monthly token usage, cost estimates, and AI fluency insights in VS Code.",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {


### PR DESCRIPTION
## Release prep — version bump

This PR bumps the VS Code extension version for the next release.

| Component | Old version | New version |
|-----------|-------------|-------------|
| VS Code extension | v0.17.1 | v0.17.2 |

### Changes since v0.17.1

**Features**
- 2 additional friendly tool names from community issue #1823 (#1824)

**Bug Fixes**
- Recognize Copilot App's `<repo>.worktrees` worktree layout in path/repo detection (#1827)
- Fix Recent Sessions view stuck on "Loading..." for non-Today periods (#1826)
- Fix initial scan showing 0 tokens for today on cold boot with multiple windows and stale refresh-lock recycling (#1825, #1822)

**Chores**
- Sync latest model data (#1796)

### After merging, run this workflow:

- **Extensions - Release** (`release.yml`) — publishes VS Code extension v0.17.2. Run with `vscode_only=true` since only the VS Code extension changed.