### PR TITLE
fix: remove bogus "these-models" entry from model data files

### DIFF
--- a/src/modelPricing.json
+++ b/src/modelPricing.json
@@ -1225,15 +1225,6 @@
       ],
       "cachedInputCostPerMillion": 0.5
     },
-    "these-models": {
-      "inputCostPerMillion": 0.0,
-      "outputCostPerMillion": 0.0,
-      "category": "xAI Grok models",
-      "tier": "standard",
-      "displayNames": [
-        "these models"
-      ]
-    },
     "mai-code-1.1-flash": {
       "inputCostPerMillion": 0.2,
       "outputCostPerMillion": 1.2,

--- a/src/tokenEstimators.json
+++ b/src/tokenEstimators.json
@@ -90,7 +90,6 @@
     "grok-4.5": 0.25,
     "gemini-3.7-flash": 0.25,
     "grok-4.6": 0.25,
-    "these-models": 0.25,
     "mai-code-1.1-flash": 0.25,
     "kimi-k3": 0.25
   }


### PR DESCRIPTION
## Summary

Removes the bogus `"these-models"` model entry that was introduced by the automated model-data sync in commit `b1ef65d4` (PR #1796):

- `src/tokenEstimators.json` — removed `"these-models": 0.25`
- `src/modelPricing.json` — removed the full `"these-models"` entry ($0.00 pricing, category `xAI Grok models`)

`"these-models"` is not a real model ID.

## Root cause

The bug was **upstream**, not in this repo's sync code. The notifier's `data/models.json` at the sync's recorded source SHA (`8cd4d177`) contained a literal `"these models"` key (provider xAI, no pricing) due to a parsing glitch in [rajbos/github-copilot-model-notifier](https://github.com/rajbos/github-copilot-model-notifier). `scripts/update-model-data.py` faithfully propagated it.

Upstream has already fixed it: notifier commit [`08f0db1e`](https://github.com/rajbos/github-copilot-model-notifier/commit/08f0db1e) — *"Fix bogus xAI 'these models' entry, group Current Models table by provider"*. Current upstream `main` no longer contains the key, so future syncs will not reintroduce it. No changes to the sync script in this PR.

## Scope check

Verified the key does **not** appear anywhere else: not in the committed Visual Studio webview copies (`visualstudio-extension/src/AIEngineeringFluency/webview/*.json`), the CLI, or the desktop app.

## Validation

- `npm run lint:json` — all 15 JSON files valid
- `npm run compile` (vscode-extension) — 0 errors, only the 2 pre-existing complexity warnings in `extension.ts` (baseline)
- `npm run test:node` (vscode-extension) — all tests pass (incl. `tokenEstimation.test.js`, `usageAnalysis.test.js`)
- `npm run test:unit` (cli) — 23/23 pass (incl. `sharedLogicContract.test.ts`)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>