### PR TITLE
fix: break corrupt/empty lock files instead of following forever

### DIFF
--- a/vscode-extension/src/backend/services/syncLock.ts
+++ b/vscode-extension/src/backend/services/syncLock.ts
@@ -43,9 +43,7 @@ export class SyncLock {
 		});
 		try {
 			await fs.promises.mkdir(path.dirname(lockPath), { recursive: true });
-			const fd = await fs.promises.open(lockPath, 'wx');
-			await fd.writeFile(lockContent);
-			await fd.close();
+			await fs.promises.writeFile(lockPath, lockContent, { flag: 'wx' });
 			return true;
 		} catch (err: any) {
 			if (err.code !== 'EEXIST') {
@@ -55,7 +53,14 @@ export class SyncLock {
 			// Lock file exists — check if it belongs to a different server or is stale
 			try {
 				const content = await fs.promises.readFile(lockPath, 'utf-8');
-				const lock = JSON.parse(content);
+				const lock = this.parseLockContent(content);
+				if (!lock) {
+					// Corrupt/empty lock (owner killed between atomic create and
+					// write): the staleness check can never run on unparseable
+					// content, so it would block every sync attempt forever.
+					this.log('Sync lock: breaking corrupt lock (unparseable content)');
+					return this.breakAndRewrite(lockPath, lockContent);
+				}
 				// Different server URL → the lock does not apply to this instance.
 				if (serverUrl && lock.serverUrl && lock.serverUrl !== serverUrl) {
 					this.log(`Sync lock: lock is held for a different server (${lock.serverUrl}), proceeding for ${serverUrl}`);
@@ -63,19 +68,31 @@ export class SyncLock {
 				}
 				if (Date.now() - lock.timestamp > SyncLock.STALE_MS) {
 					this.log('Sync lock: breaking stale lock from another window');
-					await fs.promises.unlink(lockPath);
-					try {
-						const fd = await fs.promises.open(lockPath, 'wx');
-						await fd.writeFile(lockContent);
-						await fd.close();
-						return true;
-					} catch {
-						return false;
-					}
+					return this.breakAndRewrite(lockPath, lockContent);
 				}
 			} catch {
 				// Lock file may have been deleted by its owner
 			}
+			return false;
+		}
+	}
+
+	private parseLockContent(content: string): { sessionId?: unknown; timestamp: number; serverUrl?: string } | undefined {
+		try {
+			const lock = JSON.parse(content);
+			if (!lock || typeof lock !== 'object' || typeof lock.timestamp !== 'number') { return undefined; }
+			return lock;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private async breakAndRewrite(lockPath: string, lockContent: string): Promise<boolean> {
+		try {
+			await fs.promises.unlink(lockPath);
+			await fs.promises.writeFile(lockPath, lockContent, { flag: 'wx' });
+			return true;
+		} catch {
 			return false;
 		}
 	}

--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -229,9 +229,11 @@ export class CacheManager {
 
 	private async writeLockFile(lockPath: string): Promise<boolean> {
 		try {
-			const fd = await fs.promises.open(lockPath, 'wx');
-			await fd.writeFile(JSON.stringify({ sessionId: vscode.env.sessionId, pid: process.pid, timestamp: Date.now() }));
-			await fd.close();
+			await fs.promises.writeFile(
+				lockPath,
+				JSON.stringify({ sessionId: vscode.env.sessionId, pid: process.pid, timestamp: Date.now() }),
+				{ flag: 'wx' },
+			);
 			return true;
 		} catch (err: unknown) {
 			if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'EEXIST') { throw err; }
@@ -286,7 +288,16 @@ export class CacheManager {
 	private async handleExistingLock(lockPath: string): Promise<boolean> {
 		try {
 			const content = await fs.promises.readFile(lockPath, 'utf-8');
-			const lock = JSON.parse(content);
+			const lock = this.parseLockContent(content);
+			if (!lock) {
+				// Corrupt/empty lock (e.g. owner killed between atomic create and
+				// write). The staleness checks below can never run on unparseable
+				// content, so without this branch the file would block every
+				// acquire attempt forever, forcing all windows into follower mode.
+				this.deps.log('Breaking corrupt cache lock (unparseable content)');
+				await fs.promises.unlink(lockPath);
+				return this.writeLockFile(lockPath);
+			}
 			const staleThreshold = 5 * 60 * 1000;
 			const ownerAlive = this.checkOwnerAlive(lock.pid);
 			const isTimestampStale = Date.now() - lock.timestamp > staleThreshold;
@@ -299,6 +310,16 @@ export class CacheManager {
 			// Can't read lock file — might have been deleted by the owner already
 		}
 		return false;
+	}
+
+	private parseLockContent(content: string): { sessionId?: unknown; pid?: unknown; timestamp: number } | undefined {
+		try {
+			const lock = JSON.parse(content);
+			if (!lock || typeof lock !== 'object' || typeof lock.timestamp !== 'number') { return undefined; }
+			return lock;
+		} catch {
+			return undefined;
+		}
 	}
 
 	/**

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -1332,6 +1332,30 @@ test('acquireSyncLock breaks stale lock', async () => {
 	}
 });
 
+test('acquireSyncLock breaks corrupt (empty) lock file', async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-test-'));
+	try {
+		const lockPath = path.join(dir, 'backend_sync.lock');
+		// A writer killed between atomic create and content write leaves a
+		// 0-byte lock; unparseable content must be treated as stale or the
+		// lock blocks every sync attempt forever.
+		fs.writeFileSync(lockPath, '');
+
+		const mockContext = {
+			globalStorageUri: { fsPath: dir },
+		};
+		const svc = makeService({ context: mockContext as any });
+
+		const acquired = await (svc as any).acquireSyncLock();
+		assert.equal(acquired, true, 'empty lock must be treated as stale');
+
+		const content = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+		assert.equal(content.sessionId, vscode.env.sessionId);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test('acquireSyncLock returns false when same server URL is locked by another session', async () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-test-'));
 	try {

--- a/vscode-extension/test/unit/cacheManager-snapshot.test.ts
+++ b/vscode-extension/test/unit/cacheManager-snapshot.test.ts
@@ -190,6 +190,42 @@ test('refresh lock: breaks stale lock owned by a recycled non-host PID (win32)',
 	}
 });
 
+// A writer killed between the atomic create and the content write leaves a
+// 0-byte (or otherwise unparseable) lock behind. JSON.parse throwing used to be
+// swallowed by the same catch that handles "owner deleted the file", so the
+// corrupt lock blocked every acquire attempt forever and forced all windows
+// into follower mode.
+test('refresh lock: breaks corrupt (empty) lock file left by a crashed writer', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+	fs.writeFileSync(m.getRefreshLockPath(), '');
+	assert.equal(await m.acquireRefreshLock(), true, 'empty lock must be treated as stale');
+	const content = JSON.parse(fs.readFileSync(m.getRefreshLockPath(), 'utf-8'));
+	assert.equal(typeof content.timestamp, 'number', 'lock must be rewritten with valid content');
+	await m.releaseRefreshLock();
+});
+
+test('refresh lock: breaks lock file with invalid JSON or missing fields', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+
+	fs.writeFileSync(m.getRefreshLockPath(), '{not json');
+	assert.equal(await m.acquireRefreshLock(), true, 'invalid JSON lock must be treated as stale');
+	await m.releaseRefreshLock();
+
+	fs.writeFileSync(m.getRefreshLockPath(), JSON.stringify({ sessionId: 'old-session' }));
+	assert.equal(await m.acquireRefreshLock(), true, 'lock without timestamp must be treated as stale');
+	await m.releaseRefreshLock();
+});
+
+test('cache lock: breaks corrupt (empty) lock file', async () => {
+	const dir = tmpDir();
+	const m = makeManager(dir);
+	fs.writeFileSync(m.getCacheLockPath(), '');
+	assert.equal(await m.acquireCacheLock(), true, 'empty cache lock must be treated as stale');
+	await m.releaseCacheLock();
+});
+
 // ---------------------------------------------------------------------------
 // loadCacheFromStorage (disk-based)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

On a machine with a single VS Code window open, the extension permanently ran in **follower mode**, showing partial, near-zero stats in the status bar and webview (e.g. Current Month = 0 tokens mid-month). Root cause: a lock holder killed between the atomic `open(path, 'wx')` (which creates the file) and the content write leaves a **0-byte lock file** behind. The JSON.parse error from reading it was swallowed by the same `catch` that handles "owner already deleted the file", so the staleness/orphan checks never ran and the corrupt lock blocked **every** acquire attempt, forever.

On the reporting machine this had happened to four locks: `refresh_prod.lock` (stuck since July 21, causing the permanent follower mode), `cache_prod.lock` (stuck since May 5, silently blocking all cache snapshot saves, so follower resync could never recover), and the same two locks in the stable Code edition (blocking backend sharing sync since May 12).

## What changed

- `cacheManager.ts` / `syncLock.ts`: unparseable or field-less lock content is now treated as stale -- logged, unlinked, and rewritten. Genuine ENOENT races still return `false` as before.
- Lock creation now uses a single `writeFile(..., { flag: 'wx' })` instead of open/write/close, narrowing the crash window and fixing an fd leak when the write throws.
- Added 4 regression tests covering empty locks, invalid JSON, and missing fields, for both the refresh/cache locks and the backend sync lock.

## Validation

- `npm run compile` and `npm run compile-tests` pass
- All 96 tests in `cacheManager-snapshot` + `backend-syncService` suites pass, including the new corrupt-lock tests
- Deleting the corrupt locks on the affected machine immediately restored leader behavior

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>